### PR TITLE
Added "outputData" div to Mobile html template.

### DIFF
--- a/WebPlayer/Mobile/Play.aspx
+++ b/WebPlayer/Mobile/Play.aspx
@@ -149,6 +149,7 @@
 
         <div id="gameContent">
             <div id="divOutput">
+                <div id="outputData" style="display: none" data-divcount="0"></div>
                 <h1 id="gameTitle">
                     Loading...</h1>
             </div>


### PR DESCRIPTION
This _should_ fix a problem where menus do not disappear and HideOutputSection generally doesn't work on the iPad. The output divs all had name "divOutputAlignNan" because the outputData div did not exist to track the current div count. This meant that all output ended up in the first "divOutputAlignNan" div. I'm surprised it worked as well as it did!
