### PR TITLE
added notfirst functionality to text processor in coreoutput.aslx

### DIFF
--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -176,6 +176,9 @@
     else if (StartsWith(section, "once:")) {
       return (ProcessTextCommand_Once(section, data))
     }
+    else if (StartsWith(section, "notfirst:")) {
+      return (ProcessTextCommand_NotFirst(section, data))
+    }
     else if (StartsWith(section, "random:")) {
       return (ProcessTextCommand_Random(section, data))
     }
@@ -341,6 +344,27 @@
     }
     else {
       return ("")
+    }
+  </function>
+
+  <function name="ProcessTextCommand_NotFirst" parameters="section, data" type="string">
+    if (not HasAttribute(game, "textprocessor_seen")) {
+      game.textprocessor_seen = NewDictionary()
+    }
+    fulltext = StringDictionaryItem(data, "fulltext")
+    if (not DictionaryContains(game.textprocessor_seen, fulltext)) {
+      onceSectionsInThisText = NewList()
+      dictionary add (game.textprocessor_seen, fulltext, onceSectionsInThisText)
+    }
+    else {
+      onceSectionsInThisText = DictionaryItem(game.textprocessor_seen, fulltext)
+    }
+    if (not ListContains(onceSectionsInThisText, section)) {
+      list add (onceSectionsInThisText, section)
+      return ("")
+    }
+    else {
+      return (ProcessTextSection(Mid(section, 10), data))
     }
   </function>
   


### PR DESCRIPTION
This commit adds the ability to only output text if this is not the first time to the text processor, following a request on the forum.

Added a new function "ProcessTextCommand_NotFirst", which will return an empty string the first time, and the given string any other time. The function is basically "ProcessTextCommand_Once" with the last couple of lines swapped around (kind of).

Added three lines to "ProcessTextCommand", which will conditionally invoke "ProcessTextCommand_NotFirst".

No tests included, but I have tested it for my own game.