### PR TITLE
Look & lookdir regex improvements

### DIFF
--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -145,8 +145,8 @@
   <template name="ContinueLabel">Continue...</template>
 
   <template templatetype="command" name="go"><![CDATA[^go to (?<exit>.*)$|^go (?<exit>.*)$|^(?<exit>north|east|south|west|northeast|northwest|southeast|southwest|in|out|up|down|n|e|s|w|ne|nw|se|sw|o|u|d)$]]></template>
-  <template templatetype="command" name="lookdir"><![CDATA[^look (?<exit>north|east|south|west|northeast|northwest|southeast|southwest|out|up|down|n|e|s|w|ne|nw|se|sw|o|u|d)$]]></template>
-  <template templatetype="command" name="look">^look$|^l$</template>
+  <template templatetype="command" name="lookdir"><![CDATA[^look (?<exit>(?:n|s)(?:e|w)?)|out|up|down|(?:nor|sou)th(?:east|west)?$]]></template>
+  <template templatetype="command" name="look">^(?:l|look)(?: around(?: you(?:rself)?)?)?$</template>
   <verbtemplate name="lookat">look at</verbtemplate>
   <verbtemplate name="lookat">x</verbtemplate>
   <verbtemplate name="lookat">examine</verbtemplate>


### PR DESCRIPTION
- Adjusted "look" regex to allow for commonly used permutations. (look around you, L around, etc)
- More common look directions should now perform slightly faster than before, while otherwise performing the same.