### PR TITLE
Update playercore.js

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -737,9 +737,15 @@ function disableAllCommandLinks() {
     });
 }
 
+
+//Modified by mrangel and KV,and added by KV 10\20/2017
+//This keeps the divOutputAlign count in order after clearing the screen
+// and saves the cleared text, which can be accessed to print or save
+// a game transcript later.
 function clearScreen() {
+    $("#divOutput").append("<hr />");
+    $("#divOutput").children().css("display", "none");
     $("#divOutput").css("min-height", 0);
-    $("#divOutput").html("");
     createNewDiv("left");
     beginningOfCurrentTurnScrollPosition = 0;
     setTimeout(function () {


### PR DESCRIPTION
Modified the clear screen function on lines 741 - 754

This keeps the ```divOutputAlign``` numbering system in order after clearing the screen and saving.

It also hides the cleared text rather than deleting it.  This will allow us to produce a game transcript.  

mrangel has already written a script that allows a transcript to be downloaded while playing online.  (It works in Chrome and Firefox right now.)  I am working on getting the desktop player to play along, too.