### PR TITLE
Fixed EditorTextProcessorImage template

### DIFF
--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -857,7 +857,6 @@
   <template name="EditorTextProcessorNotHere">If not in room</template>
   <template name="EditorTextProcessorRandomText">Random text</template>
   <template name="EditorTextProcessorImage">Image</template>
-  <template name="EditorTextProcessorImage">Bild</template>
   <template name="EditorScriptObjectsInventory">Inventory</template>
   <template name="EditorScriptObjectsMove">Move</template>
   <template name="EditorScriptObjectsShow">Show</template>


### PR DESCRIPTION
EditorTextProcessorImage had a double entry.  The extra was on line 860, and it was setting the value to "Bild", which is what was displayed in Quest.