### PR TITLE
Fix bug in playAudio() function

### DIFF
--- a/WebPlayer/playerweb.js
+++ b/WebPlayer/playerweb.js
@@ -51,18 +51,23 @@ function playMp3(filename, sync, looped) {
     playAudio(filename, "mp3", sync, looped);
 }
 
+var showCommandDiv = isElementVisible("#txtCommandDiv");
 function playAudio(filename, format, sync, looped) {
     _currentPlayer = "jplayer";
 
     $("#jquery_jplayer").unbind($.jPlayer.event.ended);
 
     if (looped) {
-        // TO DO: This works in Firefox. In Chrome the event does fire but the audio doesn't restart.
+        // This works in Firefox and Chrome.
         endFunction = function () { $("#jquery_jplayer").jPlayer("play"); };
     }
     else if (sync) {
+        // Added the following line to set the variable properly. 3-4-2018
+		showCommandDiv = isElementVisible("#txtCommandDiv");
         _waitingForSoundToFinish = true;
-        endFunction = function () { finishSync($("#txtCommandDiv").is(":visible")); };
+        // Altered finishSync to use the showCommandDiv variable.
+        // It was using txtCommandDiv visibility, which the last line sets to false!
+        endFunction = function () { finishSync(showCommandDiv); };
         $("#txtCommandDiv").hide();
     }
     else {


### PR DESCRIPTION
This fixes a bug that keeps the game from resuming after a synced sound has finished playing.

Line 54: Added showCommandDiv, a boolean variable which finishSync() checked, although it did not exist.

Lines 55-83:  playAudio()
Changes are noted in the code.

Basically, finishSync() was set up to check whether showCommandDiv was true or false and that variable did not exist, which caused problems.

Also, the 'onended' function on the sound was set up to call finishSync() using the current visibility of txtCommandDiv, which the playAudio() function hides!

---
I tested this in Firefox and Chrome.

(I also changed the TODO message stating looping doesn't work in Chrome yet, because it does work now.)