### PR TITLE
Adding and modifying multiple things

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -745,14 +745,32 @@ function disableAllCommandLinks() {
     });
 }
 
+// Modified by KV to handle the transcript
+var transcriptEnabled = true;
+var clearedOnce = false;
 function clearScreen() {
-    $("#divOutput").css("min-height", 0);
-    $("#divOutput").html("");
-    createNewDiv("left");
-    beginningOfCurrentTurnScrollPosition = 0;
-    setTimeout(function () {
-        $("html,body").scrollTop(0);
-    }, 100);
+    if (!transcriptEnabled) {
+        $("#divOutput").css("min-height", 0);
+        $("#divOutput").html("");
+        createNewDiv("left");
+        beginningOfCurrentTurnScrollPosition = 0;
+        setTimeout(function () {
+            $("html,body").scrollTop(0);
+        }, 100);
+    } else {
+        $("#divOutput").append("<hr class='clearedAbove' />");
+		  if (!clearedOnce) {
+			addText('<style>#divOutput > .clearedScreen { display: none; }</style>');
+        }
+        clearedOnce = true;
+        $('#divOutput').children().addClass('clearedScreen');
+        $('#divOutput').css('min-height', 0);
+        createNewDiv('left');
+        beginningOfCurrentTurnScrollPosition = 0;
+        setTimeout(function () {
+            $('html,body').scrollTop(0);
+        }, 100);
+    }
 }
 
 function keyPressCode(e) {
@@ -1405,9 +1423,11 @@ function showTranscript() {
         modal: true,
     });
     $('#transcriptdata').html($('#divOutput').html());
-    $("#transcriptdata *").attr('style', '').attr('color', '');
-    transcriptDialog.dialog("open");
-
+    $("#transcriptdata a").addClass("disabled");
+	transcriptDialog.dialog("open");
+	setTimeout(function () {
+	    $("#transcriptdata a").addClass("disabled");
+	}, 1);
 };
 
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1147,6 +1147,78 @@ $(function () {
 // ***********
 // Section added by KV
 
+
+function isMobilePlayer() {
+    if (typeof (currentTab) === 'string') {
+        return true;
+    }
+    return false;
+};
+
+function showPopup(title, text) {
+    $('#msgboxCaption').html(text);
+
+    var msgboxOptions = {
+        modal: true,
+        autoOpen: false,
+        title: title,
+        buttons: [
+			{
+			    text: 'OK',
+			    click: function () { $(this).dialog('close'); }
+			},
+        ],
+        closeOnEscape: false,
+    };
+
+    $('#msgbox').dialog(msgboxOptions);
+    $('#msgbox').dialog('open');
+};
+
+function showPopupCustomSize(title, text, width, height) {
+    $('#msgboxCaption').html(text);
+
+    var msgboxOptions = {
+        modal: true,
+        autoOpen: false,
+        title: title,
+        width: width,
+        height: height,
+        buttons: [
+			{
+			    text: 'OK',
+			    click: function () { $(this).dialog('close'); }
+			},
+        ],
+        closeOnEscape: false,
+    };
+
+    $('#msgbox').dialog(msgboxOptions);
+    $('#msgbox').dialog('open');
+};
+
+function showPopupFullscreen(title, text) {
+    $('#msgboxCaption').html(text);
+
+    var msgboxOptions = {
+        modal: true,
+        autoOpen: false,
+        title: title,
+        width: $(window).width(),
+        height: $(window).height(),
+        buttons: [
+			{
+			    text: 'OK',
+			    click: function () { $(this).dialog('close'); }
+			},
+        ],
+        closeOnEscape: false,
+    };
+
+    $('#msgbox').dialog(msgboxOptions);
+    $('#msgbox').dialog('open');
+};
+
 // Make it easy to print messages.
 //var msg = addTextAndScroll;
     
@@ -1299,6 +1371,61 @@ function getTimeAndDateForLog(){
 };
     
 // **********************************
+
+// TRANSCRIPT FUNCTIONS
+
+var transcriptVar = "";
+function addTranscriptEntry(text) {
+    transcriptVar += text;
+};
+
+
+function showTranscript() {
+    var transcriptDivString = "";
+    transcriptDivString += "<div ";
+    transcriptDivString += "id='transcript-dialog' ";
+    transcriptDivString += "style='display:none;'>";
+    transcriptDivString += "<div id='transcriptdata'></div></div>";
+    addText(transcriptDivString);
+    var transcriptDialog = $("#transcript-dialog").dialog({
+        autoOpen: false,
+        width: 600,
+        height: 500,
+        title: "Transcript",
+        buttons: {
+            Ok: function () {
+                $(this).dialog("close");
+                $(this).remove();
+            },
+            Print: function () {
+                printTranscriptDiv();
+            },
+        },
+        show: { effect: "fadeIn", duration: 500 },
+        modal: true,
+    });
+    $('#transcriptdata').html($('#divOutput').html());
+    $("#transcriptdata *").attr('style', '').attr('color', '');
+    transcriptDialog.dialog("open");
+
+};
+
+
+
+function printTranscriptDiv() {
+    var iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    iframe.contentWindow.document.write($("#transcriptdata").html());
+    iframe.contentWindow.print();
+    document.body.removeChild(iframe);
+    $("#transcript-dialog").dialog("close");
+    $("#transcript-dialog").remove();
+};
+
+
+// ***********************************
+
+
 
 // GRID FUNCTIONS ***********************************************************************************************************************
 

--- a/WebPlayer/grid.js
+++ b/WebPlayer/grid.js
@@ -61,11 +61,6 @@ function onMouseDrag(event) {
     updateOffset(event.delta);
 }
 
-var _respondToGridClicks = false;
-
-function respondToGridClicks(flag) {
-    _respondToGridClicks = flag;
-}
 
 function onMouseUp(event) {
     if (_respondToGridClicks) {

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -745,14 +745,32 @@ function disableAllCommandLinks() {
     });
 }
 
+// Modified by KV to handle the transcript
+var transcriptEnabled = true;
+var clearedOnce = false;
 function clearScreen() {
-    $("#divOutput").css("min-height", 0);
-    $("#divOutput").html("");
-    createNewDiv("left");
-    beginningOfCurrentTurnScrollPosition = 0;
-    setTimeout(function () {
-        $("html,body").scrollTop(0);
-    }, 100);
+    if (!transcriptEnabled) {
+        $("#divOutput").css("min-height", 0);
+        $("#divOutput").html("");
+        createNewDiv("left");
+        beginningOfCurrentTurnScrollPosition = 0;
+        setTimeout(function () {
+            $("html,body").scrollTop(0);
+        }, 100);
+    } else {
+        $("#divOutput").append("<hr class='clearedAbove' />");
+		  if (!clearedOnce) {
+			addText('<style>#divOutput > .clearedScreen { display: none; }</style>');
+        }
+        clearedOnce = true;
+        $('#divOutput').children().addClass('clearedScreen');
+        $('#divOutput').css('min-height', 0);
+        createNewDiv('left');
+        beginningOfCurrentTurnScrollPosition = 0;
+        setTimeout(function () {
+            $('html,body').scrollTop(0);
+        }, 100);
+    }
 }
 
 function keyPressCode(e) {
@@ -1405,9 +1423,11 @@ function showTranscript() {
         modal: true,
     });
     $('#transcriptdata').html($('#divOutput').html());
-    $("#transcriptdata *").attr('style', '').attr('color', '');
-    transcriptDialog.dialog("open");
-
+    $("#transcriptdata a").addClass("disabled");
+	transcriptDialog.dialog("open");
+	setTimeout(function () {
+	    $("#transcriptdata a").addClass("disabled");
+	}, 1);
 };
 
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -484,6 +484,14 @@ function updateLocation(text) {
     $("#location").html(text);
 }
 
+
+// Used in grid.js, but defined here so it can be set during startup
+_respondToGridClicks = false;
+
+function respondToGridClicks(flag) {
+    _respondToGridClicks = flag;
+}
+
 function updateList(listName, listData) {
     var listElement = "";
     var buttonPrefix = "";
@@ -647,7 +655,7 @@ function setCurrentDiv(div) {
     $("#outputData").attr("data-currentdiv", div);
 }
 
-var _divCount = -1;
+var _divCount = -1; 
 
 function getDivCount() {
     if (_divCount < 1) {
@@ -1135,6 +1143,289 @@ $(function () {
         return false;
     });
 });
+    
+// ***********
+// Section added by KV
+
+
+function isMobilePlayer() {
+    if (typeof (currentTab) === 'string') {
+        return true;
+    }
+    return false;
+};
+
+function showPopup(title, text) {
+    $('#msgboxCaption').html(text);
+
+    var msgboxOptions = {
+        modal: true,
+        autoOpen: false,
+        title: title,
+        buttons: [
+			{
+			    text: 'OK',
+			    click: function () { $(this).dialog('close'); }
+			},
+        ],
+        closeOnEscape: false,
+    };
+
+    $('#msgbox').dialog(msgboxOptions);
+    $('#msgbox').dialog('open');
+};
+
+function showPopupCustomSize(title, text, width, height) {
+    $('#msgboxCaption').html(text);
+
+    var msgboxOptions = {
+        modal: true,
+        autoOpen: false,
+        title: title,
+        width: width,
+        height: height,
+        buttons: [
+			{
+			    text: 'OK',
+			    click: function () { $(this).dialog('close'); }
+			},
+        ],
+        closeOnEscape: false,
+    };
+
+    $('#msgbox').dialog(msgboxOptions);
+    $('#msgbox').dialog('open');
+};
+
+function showPopupFullscreen(title, text) {
+    $('#msgboxCaption').html(text);
+
+    var msgboxOptions = {
+        modal: true,
+        autoOpen: false,
+        title: title,
+        width: $(window).width(),
+        height: $(window).height(),
+        buttons: [
+			{
+			    text: 'OK',
+			    click: function () { $(this).dialog('close'); }
+			},
+        ],
+        closeOnEscape: false,
+    };
+
+    $('#msgbox').dialog(msgboxOptions);
+    $('#msgbox').dialog('open');
+};
+
+// Make it easy to print messages.
+//var msg = addTextAndScroll;
+    
+// Log functions
+var logVar = "";
+function addLogEntry(text){
+  logVar += getTimeAndDateForLog() + ' ' + text+"NEW_LINE";
+};
+
+function showLog(){
+  var logDivString = "";
+  logDivString += "<div ";
+  logDivString += "id='log-dialog' ";
+  logDivString += "style='display:none;;'>";
+  logDivString += "<textarea id='logdata' rows='13'";
+  logDivString += "  cols='49'></textarea></div>";
+  addText(logDivString);
+  if(webPlayer){
+    var logDialog = $("#log-dialog").dialog({
+      autoOpen: false,
+      width: 600,
+      height: 500,
+      title: "Log",
+      buttons: {
+        Ok: function() {
+          $(this).dialog("close");
+        },
+        Print: function(){
+          $(this).dialog("close");
+          showLogDiv();
+          printLogDiv();
+        },
+        Save: function(){
+          $(this).dialog("close");
+          saveLog();
+        },
+      },
+      show: { effect: "fadeIn", duration: 500 },
+      // The modal setting keeps the player from interacting with anything besides the dialog window.
+      //  (The log will not update while open without adding a turn script.  I prefer this.)
+      modal: true,
+    });
+  }else{
+    var logDialog = $("#log-dialog").dialog({
+    autoOpen: false,
+    width: 600,
+    height: 500,
+    title: "Log",
+    buttons: {
+      Ok: function() {
+        $(this).dialog("close");
+      },
+      Print: function(){
+        $(this).dialog("close");
+        showLogDiv();
+        printLogDiv();
+      },
+    },
+    show: { effect: "fadeIn", duration: 500 },
+    // The modal setting keeps the player from interacting with anything besides the dialog window.
+    //  (The log will not update while open without adding a turn script.  I prefer this.)
+    modal: true,
+  });
+  }
+  $('textarea#logdata').val(logVar.replace(/NEW_LINE/g,"\n"));
+  logDialog.dialog("open");
+};
+
+var logDivIsSetUp = false;
+
+var logDivToAdd = "";
+logDivToAdd += "<div ";
+logDivToAdd += "id='log-div' ";
+logDivToAdd += "style='display:none;'>";
+logDivToAdd += "<a class='do-not-print-with-log' ";
+logDivToAdd += "href='' onclick='hideLogDiv()'>RETURN TO THE GAME</a>  ";
+logDivToAdd += "<a class='do-not-print-with-log' href='' ";
+logDivToAdd += "onclick='printLogDiv();'>PRINT</a> ";
+logDivToAdd += "<div id='log-contents-div' '></div></div>";
+
+function setupLogDiv(){
+  addText(logDivToAdd);
+  $("#log-div").insertBefore($("#dialog"));
+  logDivIsSetUp = true;
+};
+
+function showLogDiv(){
+    if(!logDivIsSetUp){
+     setupLogDiv(); 
+    }
+	$(".do-not-print-with-log").show();
+	$("#log-contents-div").html(logVar.replace(/NEW_LINE/g,"<br/>"));
+	$("#log-div").show();
+	$("#gameBorder").hide();
+};
+
+function hideLogDiv(){
+	$("#log-div").hide();
+	$("#gameBorder").show();
+};
+
+function printLogDiv(){
+  if(typeof(document.title) !== "undefined"){
+    var docTitleBak = document.title;
+  }else{
+    var docTitleBak = "title";
+  }
+  document.title = "log.txt" ;
+  $('.do-not-print-with-log').hide();
+  print();
+  $('.do-not-print-with-log').show();
+  document.title = docTitleBak;
+};
+
+
+function saveLog(){
+  if(webPlayer){
+    var href = "data:text/plain,"+logVar.replace(/NEW_LINE/g,"\n");
+    addTextAndScroll("<a download='log.txt' href='"+href+"' id='log-save-link'>Click here to save the log if your pop-up blocker stopped the download.</a>");
+    document.getElementById("log-save-link").addEventListener ("click", function (e) {e.stopPropagation();});
+    document.getElementById("log-save-link").click();
+  }else{
+    alert("This function is only available while playing online.");
+  }
+ };
+
+function getTimeAndDateForLog(){
+	var today = new Date();
+	var dd = today.getDate();
+	var mm = today.getMonth()+1;
+	var yyyy = today.getFullYear();
+	var hrs = today.getHours();
+	var mins = today.getMinutes();
+	var secs = today.getSeconds();
+	today = mm + '/' + dd + '/' + yyyy;
+	if(hrs>12) {
+	  ampm = 'AM';
+	  hrs = '0' + '' + hrs - 12
+	}else{
+	  ampm = 'PM';
+	} 
+	if (mins<10) {
+	  mins = '0'+mins;
+	} 
+	if(secs<10) {
+	  secs = '0' + secs;
+	}
+	time = hrs + ':' + mins + ':' + secs + ' ' + ampm;
+	return today + ' ' + time;
+};
+    
+// **********************************
+
+// TRANSCRIPT FUNCTIONS
+
+var transcriptVar = "";
+function addTranscriptEntry(text) {
+    transcriptVar += text;
+};
+
+
+function showTranscript() {
+    var transcriptDivString = "";
+    transcriptDivString += "<div ";
+    transcriptDivString += "id='transcript-dialog' ";
+    transcriptDivString += "style='display:none;'>";
+    transcriptDivString += "<div id='transcriptdata'></div></div>";
+    addText(transcriptDivString);
+    var transcriptDialog = $("#transcript-dialog").dialog({
+        autoOpen: false,
+        width: 600,
+        height: 500,
+        title: "Transcript",
+        buttons: {
+            Ok: function () {
+                $(this).dialog("close");
+                $(this).remove();
+            },
+            Print: function () {
+                printTranscriptDiv();
+            },
+        },
+        show: { effect: "fadeIn", duration: 500 },
+        modal: true,
+    });
+    $('#transcriptdata').html($('#divOutput').html());
+    $("#transcriptdata *").attr('style', '').attr('color', '');
+    transcriptDialog.dialog("open");
+
+};
+
+
+
+function printTranscriptDiv() {
+    var iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    iframe.contentWindow.document.write($("#transcriptdata").html());
+    iframe.contentWindow.print();
+    document.body.removeChild(iframe);
+    $("#transcript-dialog").dialog("close");
+    $("#transcript-dialog").remove();
+};
+
+
+// ***********************************
+
+
 
 // GRID FUNCTIONS ***********************************************************************************************************************
 

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -51,7 +51,7 @@
     if (LengthOf(game.backgroundimage) > 0) {
       SetBackgroundImage (game.backgroundimage)
     }
-    JS.SetCompassDirections(Join(game.compassdirections, ";"))
+    JS.setCompassDirections(Join(game.compassdirections, ";"))
     JS.setInterfaceString("InventoryLabel", "[InventoryLabel]")
     JS.setInterfaceString("StatusLabel", "[StatusLabel]")
     JS.setInterfaceString("PlacesObjectsLabel", "[PlacesObjectsLabel]")

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -273,6 +273,10 @@
       UpdateStatusAttributes
       UpdateObjectLinks
     }
+    // Added by KV to use the old JS clearScreen if the transcript is disabled
+    if (GetBoolean(game, "notranscript")){
+      JS.eval("transcriptEnabled = false;")
+    }
     ]]>
   </function>
   

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -72,12 +72,12 @@
     ]]>
   </function>
 
-  <!-- take command modified by KV to exclude objects with not_all set to true from TAKE ALL -->
+  <!-- take command modified by KV to exclude objects with notall set to true from TAKE ALL -->
   <command name="take" template="take">
     <multipleobjects type="script">
       game.pov.currentcommandpendingobjectscope = NewObjectList()
       objlist = ListExclude(ScopeVisibleNotHeldNotScenery(), game.pov)
-      objlist = ListExclude(objlist, FilterByAttribute(objlist,"not_all",true))
+      objlist = ListExclude(objlist, FilterByAttribute(objlist,"notall",true))
       foreach (obj, objlist) {
         if (obj.parent = game.pov.parent and not DoesInherit(obj, "npc_type")) {
           list add(game.pov.currentcommandpendingobjectscope, obj)

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -72,12 +72,12 @@
     ]]>
   </function>
 
-  <!-- take command modified by KV to exclude objects with notall set to true from TAKE ALL -->
+  <!-- take command modified by KV to exclude objects with not_all set to true from TAKE ALL -->
   <command name="take" template="take">
     <multipleobjects type="script">
       game.pov.currentcommandpendingobjectscope = NewObjectList()
       objlist = ListExclude(ScopeVisibleNotHeldNotScenery(), game.pov)
-      objlist = ListExclude(objlist, FilterByAttribute(objlist,"notall",true))
+      objlist = ListExclude(objlist, FilterByAttribute(objlist,"not_all",true))
       foreach (obj, objlist) {
         if (obj.parent = game.pov.parent and not DoesInherit(obj, "npc_type")) {
           list add(game.pov.currentcommandpendingobjectscope, obj)
@@ -887,8 +887,7 @@
 
   <!-- added by KV -->
 
-  <command name="version_cmd">
-    <pattern>version;info;about</pattern>
+  <command name="version_cmd" pattern="[version_cmd]">
     <script>
       <![CDATA[
       table = "<table style='padding:9px;border:1px solid black;'>"
@@ -904,19 +903,27 @@
     </script>
   </command>
 
-  <command name="log_cmd">
-    <pattern>log;view log;display log;view the log;display the log</pattern>
+  <command name="log_cmd" pattern="[log_cmd]">
     <script>
       game.notarealturn = true
-      JS.showLog ()
+      if (not GetBoolean(game, "nohtmllog")){
+        JS.showLog ()
+      }
+      else {
+        msg ("This game has no in-game log.")
+      }
     </script>
   </command>
 
-  <command name="view_transcript_cmd">
-    <pattern>transcript;script;view script;view transcript;display transcript;view the transcript;display the transcript</pattern>
+  <command name="view_transcript_cmd" pattern="[view_transcript_cmd]">
     <script>
       game.notarealturn = true
-      JS.showTranscript ()
+      if (not GetBoolean(game, "notranscript")){
+        JS.showTranscript ()
+      }
+      else {
+        msg ("This game has no transcript feature.")
+      }
     </script>
   </command>
   

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -1,5 +1,6 @@
 ﻿<library>
 
+  <!-- lookat modified by KV to include timesexamined attribute -->
   <command name="lookat" template="lookat">
     <![CDATA[
     if (GetBoolean(object, "hidechildren")) {
@@ -7,7 +8,11 @@
     }
     
     if (TypeOf(object, "look") = "script") {
+      if (not HasAttribute(object,"timesexamined")){
+        object.timesexamined = 0
+      }
       do (object, "look")
+      object.timesexamined = object.timesexamined + 1
     }
     else {
       lookdesc = ""
@@ -34,7 +39,12 @@
       if (isDark and not GetBoolean(object, "lightsource")) {
         lookdesc = DynamicTemplate("LookAtDarkness", object)
       }
-      
+      else {
+        if (not HasAttribute(object,"timesexamined")){
+          object.timesexamined = 0
+        }
+        object.timesexamined = object.timesexamined + 1
+      }
       msg (lookdesc)
     }
     
@@ -62,10 +72,13 @@
     ]]>
   </function>
 
+  <!-- take command modified by KV to exclude objects with not_all set to true from TAKE ALL -->
   <command name="take" template="take">
     <multipleobjects type="script">
       game.pov.currentcommandpendingobjectscope = NewObjectList()
-      foreach (obj, ListExclude(ScopeVisibleNotHeldNotScenery(), game.pov)) {
+      objlist = ListExclude(ScopeVisibleNotHeldNotScenery(), game.pov)
+      objlist = ListExclude(objlist, FilterByAttribute(objlist,"not_all",true))
+      foreach (obj, objlist) {
         if (obj.parent = game.pov.parent and not DoesInherit(obj, "npc_type")) {
           list add(game.pov.currentcommandpendingobjectscope, obj)
         }
@@ -92,7 +105,7 @@
       }
     </script>
   </command>
-
+  
   <function name="DoTake" parameters="object, ismultiple">
     prefix = ""
     if (ismultiple) {
@@ -871,14 +884,39 @@
   <command name="xyzzy" pattern="[xyzzy]">msg (Template("DefaultXyzzy"))</command>
   <command name="help" pattern="[help]">msg (Template("DefaultHelp"))</command>
   <command name="save" pattern="[save]">request (RequestSave, "")</command>
-  
-  <command name="version" pattern="version">msg ("Version: " + game.version)</command>
-  
+
+  <!-- added by KV -->
+
+  <command name="version_cmd">
+    <pattern>version;info;about</pattern>
+    <script>
+      <![CDATA[
+      table = "<table style='padding:9px;border:1px solid black;'>"
+      table = table + "<tr><td>TITLE: </td><td>" + game.gamename + "</td></tr>"
+      if (HasAttribute (game, "author")) {
+        table = table + "<tr><td>AUTHOR: </td><td>" + game.author + "</td></tr>"
+      }
+      table = table + "<tr><td>VERSION: </td><td>" + game.version + "</td></tr>"
+      table = table + "<tr><td>IFID: </td><td>" + game.gameid + "</td></tr>"
+      table = table + "</table>"
+      msg (table)
+    ]]>
+    </script>
+  </command>
+
   <command name="log_cmd">
     <pattern>log;view log;display log;view the log;display the log</pattern>
     <script>
       game.notarealturn = true
       JS.showLog ()
+    </script>
+  </command>
+
+  <command name="view_transcript_cmd">
+    <pattern>transcript;script;view script;view transcript;display transcript;view the transcript;display the transcript</pattern>
+    <script>
+      game.notarealturn = true
+      JS.showTranscript ()
     </script>
   </command>
   

--- a/WorldModel/WorldModel/Core/CoreEditor.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditor.aslx
@@ -16,7 +16,9 @@
   <template name="EditorImageFormats">*.jpg;*.jpeg;*.png;*.gif</template>
   <template name="HTMLColorNames">AliceBlue;AntiqueWhite;Aqua;Aquamarine;Azure;Beige;Bisque;Black;BlanchedAlmond;Blue;BlueViolet;Brown;BurlyWood;CadetBlue;Chartreuse;Chocolate;Coral;CornflowerBlue;Cornsilk;Crimson;Cyan;DarkBlue;DarkCyan;DarkGoldenRod;DarkGray;DarkGrey;DarkGreen;DarkKhaki;DarkMagenta;DarkOliveGreen;Darkorange;DarkOrchid;DarkRed;DarkSalmon;DarkSeaGreen;DarkSlateBlue;DarkSlateGray;DarkSlateGrey;DarkTurquoise;DarkViolet;DeepPink;DeepSkyBlue;DimGray;DimGrey;DodgerBlue;FireBrick;FloralWhite;ForestGreen;Fuchsia;Gainsboro;GhostWhite;Gold;GoldenRod;Gray;Grey;Green;GreenYellow;HoneyDew;HotPink;IndianRed ;Indigo ;Ivory;Khaki;Lavender;LavenderBlush;LawnGreen;LemonChiffon;LightBlue;LightCoral;LightCyan;LightGoldenRodYellow;LightGray;LightGrey;LightGreen;LightPink;LightSalmon;LightSeaGreen;LightSkyBlue;LightSlateGray;LightSlateGrey;LightSteelBlue;LightYellow;Lime;LimeGreen;Linen;Magenta;Maroon;MediumAquaMarine;MediumBlue;MediumOrchid;MediumPurple;MediumSeaGreen;MediumSlateBlue;MediumSpringGreen;MediumTurquoise;MediumVioletRed;MidnightBlue;MintCream;MistyRose;Moccasin;NavajoWhite;Navy;OldLace;Olive;OliveDrab;Orange;OrangeRed;Orchid;PaleGoldenRod;PaleGreen;PaleTurquoise;PaleVioletRed;PapayaWhip;PeachPuff;Peru;Pink;Plum;PowderBlue;Purple;Red;RosyBrown;RoyalBlue;SaddleBrown;Salmon;SandyBrown;SeaGreen;SeaShell;Sienna;Silver;SkyBlue;SlateBlue;SlateGray;SlateGrey;Snow;SpringGreen;SteelBlue;Tan;Teal;Thistle;Tomato;Turquoise;Violet;Wheat;White;WhiteSmoke;Yellow;YellowGreen</template>
 
-  <type name="editor_room"/>
+  <type name="editor_room">
+    <isroom />
+  </type>
   <type name="editor_object"/>
   <type name="editor_player">
     <feature_player />

--- a/WorldModel/WorldModel/Core/CoreEditorObjectInventory.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectInventory.aslx
@@ -40,7 +40,7 @@
     <control>
       <controltype>checkbox</controltype>
       <caption>Object is excluded when entering TAKE ALL</caption>
-      <attribute>notall</attribute>
+      <attribute>not_all</attribute>
       <mustnotinherit>editor_room</mustnotinherit>
     </control>
 

--- a/WorldModel/WorldModel/Core/CoreEditorObjectInventory.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectInventory.aslx
@@ -40,7 +40,7 @@
     <control>
       <controltype>checkbox</controltype>
       <caption>Object is excluded when entering TAKE ALL</caption>
-      <attribute>not_all</attribute>
+      <attribute>notall</attribute>
       <mustnotinherit>editor_room</mustnotinherit>
     </control>
 

--- a/WorldModel/WorldModel/Core/CoreEditorObjectInventory.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectInventory.aslx
@@ -39,7 +39,7 @@
 
     <control>
       <controltype>checkbox</controltype>
-      <caption>Object is included when entering TAKE ALL</caption>
+      <caption>Object is excluded when entering TAKE ALL</caption>
       <attribute>not_all</attribute>
       <mustnotinherit>editor_room</mustnotinherit>
     </control>

--- a/WorldModel/WorldModel/Core/CoreEditorObjectInventory.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectInventory.aslx
@@ -38,6 +38,13 @@
     </control>
 
     <control>
+      <controltype>checkbox</controltype>
+      <caption>Object is included when entering TAKE ALL</caption>
+      <attribute>not_all</attribute>
+      <mustnotinherit>editor_room</mustnotinherit>
+    </control>
+
+    <control>
       <controltype>title</controltype>
       <caption>[EditorObjectInventoryDrop]</caption>
     </control>

--- a/WorldModel/WorldModel/Core/CoreEditorObjectSetup.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectSetup.aslx
@@ -61,6 +61,12 @@
     </control>
 
     <control>
+      <controltype>checkbox</controltype>
+      <caption>Object is a room</caption>
+      <attribute>isroom</attribute>
+    </control>
+
+    <control>
       <mustnotinherit>editor_room</mustnotinherit>
       <controltype>dropdowntypes</controltype>
       <caption>[EditorObjectSetupType]</caption>

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -526,4 +526,51 @@
     return (l)
   </function>
 
+
+  <!-- Added by KV -->
+
+  <function name="AllRooms" type="objectlist">
+    return (FilterByAttribute(AllObjects(),"isroom",true))
+  </function>
+
+  <function name="DictionaryAdd" parameters="dict, key, val">
+    if (dict = null) {
+      Log ("DictionaryAdd ERROR:  Dictionary does not exist!")
+      return (false)
+    }
+    if (not DictionaryContains(dict,key)) {
+      dictionary add (dict, key, val)
+    }
+    else {
+      if (not DictionaryItem(dict,key) = val) {
+        dictionary remove (dict, key)
+        dictionary add (dict, key, val)
+      }
+    }
+  </function>
+
+  <function name="DictionaryRemove" parameters="dict, key">
+    if (dict = null) {
+      Log ("DictionaryAdd ERROR:  Dictionary does not exist!")
+      return (false)
+    }
+    if (DictionaryContains(dict,key)) {
+      dictionary remove (dict, key)
+    }
+  </function>
+
+  <function name="DbgLog" parameters="txt">
+    if(GetBoolean(game,"debugging")){
+      Log("DEBUGGING:  "+txt)
+    }
+  </function>
+
+  <function name="DbgMsg" parameters="txt">
+    <![CDATA[
+    if(GetBoolean(game,"debugging")){
+      msg("<br/><p style='color:blue;font-weight:bold;'>DEBUGGING:  "+txt+"</p><br/>")
+    }
+  ]]>
+  </function>
+
 </library>

--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -897,7 +897,9 @@
   
   <function name="Log" parameters="text">
     request (Log, text)
-    JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry("+text+"); };")
+    if (not GetBoolean(game, "nohtmllog")){
+      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry("+text+"); };")
+    }
   </function>
 
   <function name="SetBackgroundImage" parameters="filename">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -238,6 +238,7 @@
     <feature_lightdark type="boolean">false</feature_lightdark>
     <visited type="boolean">false</visited>
     <hasbeenmoved type="boolean">false</hasbeenmoved>
+    <timesexamined type="int">0</timesexamined>
   </type>
 
   <type name="defaultexit">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -239,6 +239,7 @@
     <visited type="boolean">false</visited>
     <hasbeenmoved type="boolean">false</hasbeenmoved>
     <timesexamined type="int">0</timesexamined>
+    <not_all type="boolean">false</not_all>
   </type>
 
   <type name="defaultexit">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -239,7 +239,7 @@
     <visited type="boolean">false</visited>
     <hasbeenmoved type="boolean">false</hasbeenmoved>
     <timesexamined type="int">0</timesexamined>
-    <not_all type="boolean">false</not_all>
+    <notall type="boolean">false</notall>
   </type>
 
   <type name="defaultexit">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -91,7 +91,9 @@
     <feature_advancedscripts type="boolean">false</feature_advancedscripts>
     <deactivatecommandlinks type="boolean">false</deactivatecommandlinks>
     <multiplecommands type="boolean">false</multiplecommands>
-    <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg</publishfileextensions>
+    <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
+    <nohtmllog type="boolean">false</nohtmllog>
+    <notranscript type="boolean">false</notranscript>
   </type>
 
   <type name="theme_novella">
@@ -239,7 +241,7 @@
     <visited type="boolean">false</visited>
     <hasbeenmoved type="boolean">false</hasbeenmoved>
     <timesexamined type="int">0</timesexamined>
-    <notall type="boolean">false</notall>
+    <not_all type="boolean">false</not_all>
   </type>
 
   <type name="defaultexit">

--- a/WorldModel/WorldModel/Core/Languages/Dansk.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Dansk.aslx
@@ -358,5 +358,8 @@
       }
     }
   </function>
-
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
@@ -547,6 +547,9 @@
 	}
 	return (getZehner)
 	]]>
-</function>	
-  
+</function>
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -446,4 +446,8 @@
   ]]>
   </function>
   
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Espanol.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Espanol.aslx
@@ -696,5 +696,8 @@
 		  return ("o")
 		}
     </function>
-
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Esperanto.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Esperanto.aslx
@@ -267,4 +267,8 @@
     return (Left(verb, Len(verb)-1)) + "u")
   </function>
 
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Francais.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Francais.aslx
@@ -296,5 +296,9 @@
     // TO DO: This should be implemented for any verbs passed to WriteVerb in templates above
     return (verb)
   </function>
-
+  
+<!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Icelandic.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Icelandic.aslx
@@ -366,4 +366,8 @@
     }
   </function>
 
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Italiano.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Italiano.aslx
@@ -561,5 +561,8 @@ Feel free to let comments and tips on http://www.textadventures.co.uk/forum/view
              return ("")
           }
        </function>   
-
+<!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Nederlands.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Nederlands.aslx
@@ -200,5 +200,9 @@
   <function name="GetDefaultPrefix" type="string" parameters="obj">
     return ("een")
   </function>
-  
+
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Norsk.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Norsk.aslx
@@ -320,4 +320,8 @@
       }
     }
   </function>
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Portugues-Portugal.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Portugues-Portugal.aslx
@@ -727,4 +727,8 @@
 
     }
   </function>
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Portugues.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Portugues.aslx
@@ -621,4 +621,8 @@
 
     }
   </function>
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Romana.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Romana.aslx
@@ -685,5 +685,8 @@
       }
     }
   </function>
-
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Russian.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Russian.aslx
@@ -548,6 +548,9 @@ This is first version done by Daria Mikhaylova, Yeshi Namkhai. It manages declin
           } else {
              return ("")
           }
-  </function>   
-
+  </function>
+  <!-- Added by KV -->
+  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(view |display |show |)(the |)(script|transcript)$</template>
+  <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
 </library>

--- a/WorldModel/WorldModel/Core/Templates/Dansk.template
+++ b/WorldModel/WorldModel/Core/Templates/Dansk.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Deutsch.template
+++ b/WorldModel/WorldModel/Core/Templates/Deutsch.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/English.template
+++ b/WorldModel/WorldModel/Core/Templates/English.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Espanol.template
+++ b/WorldModel/WorldModel/Core/Templates/Espanol.template
@@ -11,6 +11,7 @@
 
   <object name="lugar">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="jugador">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Esperanto.template
+++ b/WorldModel/WorldModel/Core/Templates/Esperanto.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Francais.template
+++ b/WorldModel/WorldModel/Core/Templates/Francais.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Greek.template
+++ b/WorldModel/WorldModel/Core/Templates/Greek.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Icelandic.template
+++ b/WorldModel/WorldModel/Core/Templates/Icelandic.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Italiano.template
+++ b/WorldModel/WorldModel/Core/Templates/Italiano.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="defaultplayer" />

--- a/WorldModel/WorldModel/Core/Templates/Nederlands.template
+++ b/WorldModel/WorldModel/Core/Templates/Nederlands.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Norsk.template
+++ b/WorldModel/WorldModel/Core/Templates/Norsk.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Portugues-Portugal.template
+++ b/WorldModel/WorldModel/Core/Templates/Portugues-Portugal.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Portugues.template
+++ b/WorldModel/WorldModel/Core/Templates/Portugues.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Romana.template
+++ b/WorldModel/WorldModel/Core/Templates/Romana.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Russian.template
+++ b/WorldModel/WorldModel/Core/Templates/Russian.template
@@ -11,6 +11,7 @@
 
   <object name="room">
     <inherit name="editor_room" />
+    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />


### PR DESCRIPTION
Added to playercore.js

```isMobilePlayer()```

Returns a boolean.

```showPopup(title, text)```

Creates and prints a dialog element (like a popup)

```showPopupCustomSize(title, text, width, height)```

Creates and prints a dialog element (like a popup) with custom height and width.

```showPopupFullscreen(title, text)```

Creates and prints a full screen dialog element (like a popup)

**Transcript functions:**

From line 1375 to 1426

```showTranscript()```

Displays the transcript in a dialog element.

```printTranscriptDiv()```

Sends the text in the transcript dialog element to the printer.

---
Changes to CoreCommands:

Modified ```lookat``` to increment the new attribute ```timesexamined``` (when looking is successful)

Modified ```take``` to exclude objects with ```not_all``` set to true

Modified ```version_cmd``` (now it lists more details)

Added ```view_transcript_cmd```

---
Changes to CoreEditor:

Added the ```isroom``` attribute to the **editor_room** type.

---
Changes to CoreEditorObjectInventory:

Added a checkbox to toggle ```not_all```  (This does not effect ```npc_type``` settings!)

![image](https://user-images.githubusercontent.com/30656341/38463724-88d86a8a-3ac6-11e8-8066-4681176511f6.png)


---
Changes to CoreEditorObjectSetup:

Added control checkbox to toggle ```isroom``` (just in case the object's room settings are changed after object creation)

![image](https://user-images.githubusercontent.com/30656341/38463728-8eb6fcaa-3ac6-11e8-9231-8c46e84dd4ae.png)


---
Added to CoreFunctions:

```AllRooms()```

Returns an object list of all objects with ```isroom``` set to true.

```DictionaryAdd()```

Adds an item to a dictionary if the dictionary exists.  If the dictionary does not exist, a Log entry is added (an error is not thrown!).

If the dictionary already contains the key, the value will be overwritten!

```DictionaryRemove()```

If a dictionary exists and the key exists, this will remove the key.  (No errors will be thrown!)

```DbgLog()```

Adds log entry if game.debugging is set to true.

```DbgMsg()```

Prints a message if game.debugging is set to true.

---
Change to CoreTypes:

Added ```timesexamined``` integer attribute on **defaultobject**, set to 0

---
EVERY LANGUAGE TEMPLATE:

Added ```isroom``` attribute (set to true) on the **room** object.

---
CoreEditorObjectInventory:

Corrected a typo in my last commit (all included in this pull request, methinks).

---
CoreTypes:

Added ```not_all``` attribute set to false on **defaultobject**.

---
NOTE: 

For some reason, grid.js and playercore.js are updated after my first build when I fork Quest. It looks like the grid-clicking functions get moved from file to file, but I don't mess with either one.  (Everything still seems to work as far as grid-clicking is concerned, too.)


---
Core.aslx:

Line 54

Changed ```JS.SetCompass...``` to ```JS.setCompass...```

---
This passes all 87 tests, and test game produces a valid save file.

---
# NOTE CONCERNING JS DIALOG FUNCTIONS (including log and transcript)

I have no way to test these on a Mac, iPhone, or iPad.

Also, might it be a good idea to include an attribute to toggle whether or not the log can be accessed during play?