### PR TITLE
Update CoreDescriptions.aslx

### DIFF
--- a/WorldModel/WorldModel/Core/CoreDescriptions.aslx
+++ b/WorldModel/WorldModel/Core/CoreDescriptions.aslx
@@ -368,12 +368,12 @@
 
   <function name="GetListDisplayAlias" type="string" parameters="obj">
     <![CDATA[
+    // Modified by KV
     if (HasString(obj, "listalias")) {
-      // Modified by KV
       result = ProcessText(obj.listalias)
     }
     else {
-      result = GetDisplayAlias(obj)
+      result = ProcessText(GetDisplayAlias(obj))
     }
     return (result)
   ]]>


### PR DESCRIPTION
Modified ```GetListDisplayAlias``` (again)

Line 376:  Now sends the alias through ```ProcessText()```, even if there is no ```listalias``` attribute.

Allows us to use an alias like this:
```book ({either book.isopen:open|closed})```

![image](https://user-images.githubusercontent.com/30656341/38766794-d869d888-3f9c-11e8-836a-3ef74e4078f5.png)