### PR TITLE
Splitter in attribute tab on half of window size

### DIFF
--- a/EditorControls/WFAttributesControl.cs
+++ b/EditorControls/WFAttributesControl.cs
@@ -15,6 +15,7 @@ namespace TextAdventures.Quest.EditorControls
         public WFAttributesControl()
         {
             InitializeComponent();
+            ctlSplitContainer.SplitterDistance = ctlSplitContainerMain.Size.Width / 2;
 
             ctlMultiControl.Dirty += ctlMultiControl_Dirty;
             ctlMultiControl.RequestParentElementEditorSave += ctlMultiControl_RequestParentElementEditorSave;


### PR DESCRIPTION
Set the splitter in the attribute tab to half the window size to make the assignments easier to use.