### PR TITLE
Change to v580

### DIFF
--- a/EditorControllerTests/test.aslx
+++ b/EditorControllerTests/test.aslx
@@ -1,4 +1,4 @@
-<asl version="550">
+<asl version="580">
   <!--  
   <include ref="English.aslx"/>
   <include ref="Core.aslx"/>

--- a/WebPlayer/WebPlayer.csproj
+++ b/WebPlayer/WebPlayer.csproj
@@ -300,8 +300,8 @@
     <Content Include="Mobile\KeepAlive.ashx" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
     <Content Include="App_Data\51Degrees.dat" />
+    <Content Include="packages.config" />
     <Content Include="51Degrees.config" />
     <None Include="Properties\PublishProfiles\*.pubxml" />
     <Content Include="Views\Resume\Index.cshtml" />

--- a/WorldModel/WorldModel/Core/Templates/Dansk.template
+++ b/WorldModel/WorldModel/Core/Templates/Dansk.template
@@ -1,4 +1,4 @@
-﻿<asl version="550">
+﻿<asl version="580">
 
   <include ref="Dansk.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Deutsch.template
+++ b/WorldModel/WorldModel/Core/Templates/Deutsch.template
@@ -1,4 +1,4 @@
-﻿<asl version="550">
+﻿<asl version="580">
 
   <include ref="Deutsch.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/English.template
+++ b/WorldModel/WorldModel/Core/Templates/English.template
@@ -1,4 +1,4 @@
-﻿<asl version="550">
+﻿<asl version="580">
 
   <include ref="English.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Esperanto.template
+++ b/WorldModel/WorldModel/Core/Templates/Esperanto.template
@@ -1,4 +1,4 @@
-<asl version="550">
+<asl version="580">
 
   <include ref="Esperanto.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Icelandic.template
+++ b/WorldModel/WorldModel/Core/Templates/Icelandic.template
@@ -1,4 +1,4 @@
-﻿<asl version="550">
+﻿<asl version="580">
 
   <include ref="Icelandic.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Nederlands.template
+++ b/WorldModel/WorldModel/Core/Templates/Nederlands.template
@@ -1,4 +1,4 @@
-﻿<asl version="550">
+﻿<asl version="580">
 
   <include ref="Nederlands.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Norsk.template
+++ b/WorldModel/WorldModel/Core/Templates/Norsk.template
@@ -1,4 +1,4 @@
-﻿<asl version="550">
+﻿<asl version="580">
 
   <include ref="Norsk.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/GameLoader/GameLoader.cs
+++ b/WorldModel/WorldModel/GameLoader/GameLoader.cs
@@ -49,6 +49,7 @@ namespace TextAdventures.Quest
             {"530", WorldModelVersion.v530},
             {"540", WorldModelVersion.v540},
             {"550", WorldModelVersion.v550},
+            {"580", WorldModelVersion.v580},
         };
 
         public GameLoader(WorldModel worldModel, LoadMode mode, bool? isCompiled = null)

--- a/WorldModel/WorldModel/GameLoader/GameSaver.cs
+++ b/WorldModel/WorldModel/GameLoader/GameSaver.cs
@@ -80,8 +80,8 @@ namespace TextAdventures.Quest
             writer.WriteStartElement("asl");
             if (mode == SaveMode.Editor)
             {
-                m_worldModel.Version = WorldModelVersion.v550;
-                m_worldModel.VersionString = "550";
+                m_worldModel.Version = WorldModelVersion.v580;
+                m_worldModel.VersionString = "580";
             }
             writer.WriteAttributeString("version", m_worldModel.VersionString);
 

--- a/WorldModel/WorldModel/Scripts/ReturnScript.cs
+++ b/WorldModel/WorldModel/Scripts/ReturnScript.cs
@@ -45,7 +45,7 @@ namespace TextAdventures.Quest.Scripts
         public override void Execute(Context c)
         {
             c.ReturnValue = m_returnValue.Execute(c);
-            if (m_worldModel.Version >= WorldModelVersion.v550) c.IsReturned = true;
+            if (m_worldModel.Version >= WorldModelVersion.v580) c.IsReturned = true;
         }
 
         public override string Save()

--- a/WorldModel/WorldModel/WorldModel.cs
+++ b/WorldModel/WorldModel/WorldModel.cs
@@ -38,7 +38,8 @@ namespace TextAdventures.Quest
         v520,
         v530,
         v540,
-        v550
+        v550,
+        v580
     }
 
     public class WorldModel : IASL, IASLDebug, IASLTimer

--- a/WorldModel/WorldModel/WorldModel.csproj
+++ b/WorldModel/WorldModel/WorldModel.csproj
@@ -334,7 +334,7 @@
     <None Include="Core\CoreWearable.aslx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-	<None Include="Core\CoreDevMode.aslx">
+    <None Include="Core\CoreDevMode.aslx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Core\GamebookCore.aslx">

--- a/WorldModelTests/savetest.aslx
+++ b/WorldModelTests/savetest.aslx
@@ -1,4 +1,4 @@
-﻿<asl version="550">
+﻿<asl version="580">
   <include ref="English.aslx" />
   <include ref="Core.aslx" />
   <game name="savetest"/>

--- a/WorldModelTests/walkthrough.aslx
+++ b/WorldModelTests/walkthrough.aslx
@@ -1,4 +1,4 @@
-<asl version="550">
+<asl version="580">
   <include ref="English.aslx" />
   <include ref="Core.aslx" />
   <game name="assert">


### PR DESCRIPTION
Due to recent changes in the C# code, previous versions of Quest will not be able to handle newly created games.  The ASL version change will prevent previous versions of Quest from attempting to open these files.

---
Please, feel free to close this without merging if this is not the route you'd like to take.