### PR TITLE
FIX call declaring gameName var in InitInterface

### DIFF
--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -33,7 +33,9 @@
   <function name="InitInterface">
     <![CDATA[
     // Added by KV for transcript
-    JS.eval("var gameName = '"+game.gamename+"';var transcriptName = gameName;")
+    // Use JSSafe to remove any offensive characters!  - KV   May 27, 2018
+    jsgamename = JSSafe(game.gamename)
+    JS.eval ("var gameName = '"+jsgamename+"';var transcriptName = gameName;")
     if (GetBoolean(game,"savetranscript")){
       JS.eval("var savingTranscript = true;")
       JS.replaceTranscriptString(game.transcriptstring)


### PR DESCRIPTION
Now using JSSafe to remove any offensive characters when sending the gameName variable to JS in InitInterface.

Otherwise, single apostrophes (and who knows what else) will cause errors in the browser from the moment play begins.

Example problem title: Pixie's Quest