### PR TITLE
Update CoreOutput.aslx

### DIFF
--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -849,10 +849,13 @@
   <function name="Log" parameters="text">
     <![CDATA[
     //request (Log, text)
+    // Replacing double quotes with 2 single quotes
+    text = Replace(text, "\"", "''")
+    // Changing syntax from single quotes to escaped double quotes to allow single quotes in log entries
     if (not GetBoolean(game, "nohtmllog")){
-      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry('"+text+"'); };")
+      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\""+text+"\"); };")
     }
-    JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){var s = '"+text+"';WriteToLog(s);}")
+    JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){var s = \""+text+"\";WriteToLog(s);}")
     ]]>
   </function>
 


### PR DESCRIPTION
Fixed issue with double and single quotation marks in Log entries.

This fix prevents browser errors.