### PR TITLE
Fix transcript_off_cmd and Remove unused attribute

### DIFF
--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -909,7 +909,6 @@
 
   <command name="log_cmd" pattern="[log_cmd]">
     <script>
-      game.notarealturn = true
       if (not GetBoolean(game, "nohtmllog")){
         JS.showLog ()
       }
@@ -922,7 +921,6 @@
 
   <command name="view_transcript_cmd" pattern="[view_transcript_cmd]">
     <script>
-      game.notarealturn = true
       if (not GetBoolean(game, "notranscript")){
         JS.showTranscript ()
       }
@@ -933,11 +931,9 @@
     </script>
   </command>
 
-  <command name="transcript_on_cmd">
-    <pattern type="string">^(transcript|script)( on|)$|^enable (script|transcript)$</pattern>
+  <command name="transcript_on_cmd" pattern="[transcript_on_cmd]">
     <script>
       <![CDATA[
-      game.notarealturn = true
       if (not GetBoolean(game, "notranscript")) {
         if (not GetBoolean(game,"savetranscript")) {
           msg ("Please enter a filename.  (<b>  \"-transcript.html\" will be appended to this filename.)<br/>  <i>(The file will be saved in \"Documents\\Quest Transcripts\".)</i></b>")
@@ -977,15 +973,14 @@
 
   <command name="transcript_off_cmd" pattern="[transcript_off_cmd]">
     <script>
-      game.notarealturn = true
-      if (not GetBoolean(game, "notranscript")){
-        if (GetBoolean(game,"savetranscript")){
+      if (not GetBoolean(game, "notranscript")) {
+        if (GetBoolean(game,"savetranscript")) {
           game.savetranscript = false
-          JS.eval("var saveTranscript = false;")
-          msg("Transcript disabled.")
+          JS.eval ("var savingTranscript = false;")
+          msg ("Transcript disabled.")
         }
-        else{
-          msg("The transcript is already disabled.")
+        else {
+          msg ("The transcript is already disabled.")
         }
       }
       else {
@@ -1007,7 +1002,6 @@
           JS.eval("if(webPlayer){window.location.reload();}else if (typeof(RestartGame) != 'undefined'){RestartGame();}else{addTextAndScroll('Try pressing CTRL+R.')};")
         }
         else {
-          game.notarealturn = true
           game.suppressturnscripts = true
         }
       }


### PR DESCRIPTION
I had the wrong JS variable in the transcript_off_command, and the transcript did not stop when disabled!  (Sorry!  The variable name is ```savingTranscript``` in JS, and the Quest attribute is ```savetranscript```.  I got confused.  Note that I can't use ```saveTranscript``` in JS because that is the name of my function.)

---
I also fixed the command patterns for each of these, replacing the English pattern with the template.  (I'd fixed this in my game, so when I copied my code to the commit, it had the English pattern copied into my code.)

---
I also removed quite a few lines of code where I was setting ```game.notarealturn``` to true.