### PR TITLE
Fix DisableTranscript function

### DIFF
--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -590,8 +590,9 @@
   
   <function name="DisableTranscript">
     game.notranscript = true
-    JS.eval("enableTranscript = false;")
+    JS.eval("savingTranscript = false;")
   </function>
+  
   <function name="DisableHtmlLog">
     game.nohtmllog = true
   </function>


### PR DESCRIPTION
Changed the JS variable name in this script to ```savingTranscript``` so the transcript will actually be disabled.