### PR TITLE
Fix major bug concerning transcript

### DIFF
--- a/Player/PlayerHTML.vb
+++ b/Player/PlayerHTML.vb
@@ -126,6 +126,9 @@ Public Class PlayerHTML
         My.Computer.FileSystem.WriteAllText(logPath + "\" + gameName + "-log.txt", data + Environment.NewLine, True)
     End Sub
     Private Sub SaveTranscript(data As String)
+        ' NOTE FROM KV:
+        '   I disabled or removed all the Quest and JS functions concerning this, but I will leave this code in here.
+        '   This way, someone could simply add the Quest and JS functions to their game if they wished to use this functionality.
         Dim mgameName = Split(CurrentGame.Filename, "\")(Split(CurrentGame.Filename, "\").Length - 1)
         mgameName = mgameName.Replace(".aslx", "")
         Dim transcriptPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\Quest Transcripts"

--- a/Player/desktopplayer.js
+++ b/Player/desktopplayer.js
@@ -23,9 +23,11 @@ function RestartGame() {
 
 // SaveTranscript added by KV to write/append to GAMENAME-transcript.html in Documents\Quest Transcripts
 function SaveTranscript(data) {
-    data = data + "<style>*{color:black !important;background:white !important;text-align:left !important}</style>";
-    if (!webPlayer && transcriptString != '') { UIEvent("SaveTranscript", data); }
-    transcriptString += data;
+    //data = data + "<style>*{color:black !important;background:white !important;text-align:left !important}</style>";
+    //if (!webPlayer && transcriptString != '') { UIEvent("SaveTranscript", data); }
+    //transcriptString += data;
+    // DEPRECATED
+    //   Do nothing. Leaving this here to avoid possible errors. - KV
 }
 
 // Added by KV to write/append to GAMENAME-log.txt in Documents\Quest Logs

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -621,18 +621,10 @@ function addTextAndScroll(text) {
     scrollToEnd();
 }
 
-// These 2 variables added by KV for the transcript
-var savingTranscript = false;
-var transcriptString = "";
-
-// This function altered by KV for the transcript
+// This function altered by KV to remove old transcript code.
 function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
-    }
-    if (savingTranscript) {
-        SaveTranscript(text);
-        ASLEvent("UpdateTranscriptString", text);
     }
     getCurrentDiv().append(text);
     $("#divOutput").css("min-height", $("#divOutput").height());
@@ -1447,61 +1439,6 @@ function getTimeAndDateForLog(){
 	return today + ' ' + time;
 };
     
-// **********************************
-// TRANSCRIPT FUNCTIONS
-
-// This function is for loading a saved game
-function replaceTranscriptString(data) {
-    transcriptString = data;
-}
-
-function showTranscript() {
-    var transcriptDivString = "";
-    transcriptDivString += "<div ";
-    transcriptDivString += "id='transcript-dialog' ";
-    transcriptDivString += "style='display:none;'>";
-    transcriptDivString += "<div id='transcriptdata'></div></div>";
-    addText(transcriptDivString);
-    var transcriptDialog = $("#transcript-dialog").dialog({
-        autoOpen: false,
-        width: 600,
-        height: 500,
-        title: "Transcript",
-        buttons: {
-            Ok: function () {
-                $(this).dialog("close");
-                $(this).remove();
-            },
-            Print: function () {
-                printTranscriptDiv();
-                $(this).dialog("close");
-                $(this).remove();
-            },
-        },
-        show: { effect: "fadeIn", duration: 500 },
-        modal: true,
-    });
-    $('#transcriptdata').html(transcriptString);
-    $("#transcriptdata a").addClass("disabled");
-    transcriptDialog.dialog("open");
-    setTimeout(function () {
-        $("#transcriptdata a").addClass("disabled");
-    }, 1);
-};
-
-function printTranscriptDiv() {
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    iframe.contentWindow.document.write($("#transcriptdata").html());
-    iframe.contentWindow.print();
-    document.body.removeChild(iframe);
-    $("#transcript-dialog").dialog("close");
-    $("#transcript-dialog").remove();
-};
-
-// ***********************************
-
-
 
 // GRID FUNCTIONS ***********************************************************************************************************************
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -621,18 +621,10 @@ function addTextAndScroll(text) {
     scrollToEnd();
 }
 
-// These 2 variables added by KV for the transcript
-var savingTranscript = false;
-var transcriptString = "";
-
-// This function altered by KV for the transcript
+// This function altered by KV to remove the old transcript code
 function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
-    }
-    if (savingTranscript) {
-        SaveTranscript(text);
-        ASLEvent("UpdateTranscriptString", text);
     }
     getCurrentDiv().append(text);
     $("#divOutput").css("min-height", $("#divOutput").height());
@@ -1450,53 +1442,17 @@ function getTimeAndDateForLog(){
 // **********************************
 // TRANSCRIPT FUNCTIONS
 
-// This function is for loading a saved game
-function replaceTranscriptString(data) {
-    transcriptString = data;
+// SaveTranscript left here, doing nothing, to avoid possible errors. - KV
+function SaveTranscript(data) {
+    //data = data + "<style>*{color:black !important;background:white !important;text-align:left !important}</style>";
+    //if (!webPlayer && transcriptString != '') { UIEvent("SaveTranscript", data); }
+    //transcriptString += data;
+    // DEPRECATED
+    //   Do nothing.
 }
 
 function showTranscript() {
-    var transcriptDivString = "";
-    transcriptDivString += "<div ";
-    transcriptDivString += "id='transcript-dialog' ";
-    transcriptDivString += "style='display:none;'>";
-    transcriptDivString += "<div id='transcriptdata'></div></div>";
-    addText(transcriptDivString);
-    var transcriptDialog = $("#transcript-dialog").dialog({
-        autoOpen: false,
-        width: 600,
-        height: 500,
-        title: "Transcript",
-        buttons: {
-            Ok: function () {
-                $(this).dialog("close");
-                $(this).remove();
-            },
-            Print: function () {
-                printTranscriptDiv();
-                $(this).dialog("close");
-                $(this).remove();
-            },
-        },
-        show: { effect: "fadeIn", duration: 500 },
-        modal: true,
-    });
-    $('#transcriptdata').html(transcriptString);
-    $("#transcriptdata a").addClass("disabled");
-    transcriptDialog.dialog("open");
-    setTimeout(function () {
-        $("#transcriptdata a").addClass("disabled");
-    }, 1);
-};
-
-function printTranscriptDiv() {
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    iframe.contentWindow.document.write($("#transcriptdata").html());
-    iframe.contentWindow.print();
-    document.body.removeChild(iframe);
-    $("#transcript-dialog").dialog("close");
-    $("#transcript-dialog").remove();
+    showScrollback()
 };
 
 // ***********************************

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -32,15 +32,6 @@
   
   <function name="InitInterface">
     <![CDATA[
-    // Added by KV for transcript
-    // Use JSSafe to remove any offensive characters!  - KV   May 27, 2018
-    jsgamename = JSSafe(game.gamename)
-    JS.eval ("var gameName = '"+jsgamename+"';var transcriptName = gameName;")
-    if (GetBoolean(game,"savetranscript")){
-      JS.eval("var savingTranscript = true;")
-      JS.replaceTranscriptString(game.transcriptstring)
-    }
-    // End of addition by KV for transcript
     if (game.setcustomwidth) {
       JS.setGameWidth (game.customwidth)
     }
@@ -285,10 +276,6 @@
       }
       UpdateStatusAttributes
       UpdateObjectLinks
-    }
-    // Added by KV to use the old JS clearScreen if the transcript is disabled
-    if (GetBoolean(game, "notranscript")){
-      JS.eval("transcriptEnabled = false;")
     }
     game.runturnscripts = false
     FinishTurn

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -969,70 +969,30 @@
 
   <command name="view_transcript_cmd" pattern="[view_transcript_cmd]">
     <script>
-      if (not GetBoolean(game, "notranscript")){
-        JS.showTranscript ()
-      }
-      else {
-        msg ("This game has no transcript feature.")
-      }
+      JS.showScrollback ()
       game.suppressturnscripts = true
     </script>
   </command>
 
   <command name="transcript_on_cmd" pattern="[transcript_on_cmd]">
     <script>
-      <![CDATA[
-      if (not GetBoolean(game, "notranscript")) {
-        if (not GetBoolean(game,"savetranscript")) {
-          msg ("Please enter a filename.  (<b>  \"-transcript.html\" will be appended to this filename.)<br/>  <i>(The file will be saved in \"Documents\\Quest Transcripts\".)</i></b>")
-          JS.eval ("$('input#txtCommand').val(transcriptName);")
-          get input {
-            filename = Trim(result)
-            if (not filename = "") {
-              JS.eval ("transcriptName = '"+filename+"';")
-            }
-            JS.eval ("savingTranscript = true;")
-            game.savetranscript = true
-            pre = "<hr/>Transcript enabled for:<br/>"
-            s = "<b>TITLE: </b>" + game.gamename + "<br/>"
-            if (HasAttribute (game, "author")) {
-              s = s + "<b>AUTHOR: </b>" + game.author + "<br/>"
-            }
-            s = s + "<b>VERSION: </b>" + game.version + "<br/>"
-            s = s + "<b>IFID: </b>" + game.gameid + "<br/>"
-            s = s + "<br/>"
-            s = pre + s
-            msg("")
-            msg (s)
-            msg ("<br/><b><i>[  Enter </i>SCRIPT OFF<i> to disable the transcript.  ]</i></b>")
-          }
-        }
-        else {
-          msg ("The transcript is already enabled.")
-        }
-      }
-      else {
+      if (GetBoolean(game, "notranscript")) {
         msg ("This game has no transcript feature.")
       }
+      else {
+        msg ("The transcript doesn't turn on or off. It is always available.")
+      }
       game.suppressturnscripts = true
-    ]]>
     </script>
   </command>
 
   <command name="transcript_off_cmd" pattern="[transcript_off_cmd]">
     <script>
-      if (not GetBoolean(game, "notranscript")) {
-        if (GetBoolean(game,"savetranscript")) {
-          game.savetranscript = false
-          JS.eval ("var savingTranscript = false;")
-          msg ("Transcript disabled.")
-        }
-        else {
-          msg ("The transcript is already disabled.")
-        }
+      if (GetBoolean(game, "notranscript")) {
+        msg ("This game has no transcript feature.")
       }
       else {
-        msg ("This game has no transcript feature.")
+        msg ("The transcript doesn't turn on or off. It is always available.")
       }
       game.suppressturnscripts = true
     </script>
@@ -1040,7 +1000,9 @@
 
   <function name="UpdateTranscriptString" parameters="data">
     game.suppressturnscripts = true
-    game.transcriptstring = game.transcriptstring + data
+    //game.transcriptstring = game.transcriptstring + data
+    // DEPRECATED
+    //   Do nothing. Just keeping this function here to avoid possible errors. - KV
   </function>
   
   <command name="restart" pattern="^restart$">

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -610,6 +610,8 @@
   <function name="DisableTranscript">
     game.notranscript = true
     JS.eval("savingTranscript = false;")
+    // DEPRECATED
+    // Leaving function here to avoid possible errors. - KV
   </function>
   
   <function name="DisableHtmlLog">

--- a/WorldModel/WorldModel/Core/Languages/Dansk.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Dansk.aslx
@@ -327,7 +327,10 @@
   <dynamictemplate name="DefaultTellTo">WriteVerb(object, "do") + " ingenting."</dynamictemplate>
 
   <template templatetype="command" name="log_cmd">^log$|^se log$|^vis log$</template>
-  <template templatetype="command" name="transcript_on_cmd">^scriptet$</template>
+  <!-- Not sure about adding "on" to transcript_on_cmd, but they have "off" for transcript_off_cmd
+         and I want "scriptet" to simply open the transcript. I hope "on" doesn't translate awkardly here.
+         The internet says this translates fine. - KV -->
+  <template templatetype="command" name="transcript_on_cmd">^scriptet on$</template>
   <template templatetype="command" name="transcript_off_cmd">^scriptet off$</template>
   <template templatetype="command" name="view_transcript_cmd">^(se |vis |)(scriptet)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|om)$</template>

--- a/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
@@ -544,9 +544,9 @@
 </function>
 
   <template templatetype="command" name="log_cmd">^(zeige |zeig |)(log|protokoll)$</template>
-  <template templatetype="command" name="transcript_on_cmd">^(transkript|skript)( an|)$|^aktiviere (skript|transkript)$</template>
-  <template templatetype="command" name="transcript_off_cmd">^(transkript|skript) aus$|^deaktiviere (skript|transkript)$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(zeige|zeig) (das |)(skript|transkript)$</template>
+  <template templatetype="command" name="transcript_on_cmd">^(transkript|skript) an$|^aktiviere (skript|transkript)$</template>
+  <template templatetype="command" name="transcript_off_cmd">^transkript|skript) aus$|^deaktiviere (skript|transkript)$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(transkript|skript)$|^(zeige|zeig) (das |)(skript|transkript)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|über)$</template>  
 
   <template name="DevModeErrorWrongFormat">Das ist leider das falsche Format.</template>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -488,9 +488,9 @@
   
   <!-- Added by KV -->
   <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
-  <template templatetype="command" name="transcript_on_cmd">^(transcript|script)( on|)$|^enable (script|transcript)$</template>
-  <template templatetype="command" name="transcript_off_cmd">^(transcript|script) off$|^disable (script|transcript)$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(view|display|show) (the |)(script|transcript)$</template>
+  <template templatetype="command" name="transcript_on_cmd">^(transcript|script|scrollback) on$|^enable (script|transcript|scrollback)$</template>
+  <template templatetype="command" name="transcript_off_cmd">^(transcript|script|scrollback) off$|^disable (script|transcript|scrollback)$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(scrollback|transcript|script)$|^(view|display|show) (the |)(script|transcript|scrollback)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
   
   <!-- DevMode templates moved here by KV to avoid issues with gamebooks-->

--- a/WorldModel/WorldModel/Core/Languages/Greek.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Greek.aslx
@@ -384,9 +384,9 @@
 
     <template templatetype="command" name="log_cmd">^αρχείο$|^δες αρχείο$|^δείξε αρχείο$</template>
   <!-- Modified by KV -->
-  <template templatetype="command" name="transcript_on_cmd">^ιστορικό$|^ιστορικό ενεργό$</template>
+  <template templatetype="command" name="transcript_on_cmd">^ιστορικό ενεργό$</template>
   <template templatetype="command" name="transcript_off_cmd">^ιστορικό ανενεργό$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(δες|δείξε) (το |)ιστορικό$</template>
+  <template templatetype="command" name="view_transcript_cmd">^ιστορικό$|^(δες|δείξε) (το |)ιστορικό$</template>
   <!-- END of modification by KV -->
   <template templatetype="command" name="version_cmd">^(έκδοση|πληροφορίες|σχετικά)$</template>
 

--- a/WorldModel/WorldModel/Core/Languages/Italiano.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Italiano.aslx
@@ -414,9 +414,9 @@ Feel free to let comments and tips on http://www.textadventures.co.uk/forum/view
   <template templatetype="command" name="save">^salva$</template>
 
   <template templatetype="command" name="log_cmd">^(diario|vedi diario|mostra diario)$</template>
-  <template templatetype="command" name="transcript_on_cmd">^trascrizione$</template>
+  <template templatetype="command" name="transcript_on_cmd">^accende trascrizione$</template>
   <template templatetype="command" name="transcript_off_cmd">^trascrizione off$|^spegni trascrizione$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(vedi|mostra|visualizza|) (la |)trascrizione$</template>
+  <template templatetype="command" name="view_transcript_cmd">^(la |)trascrizione$|^(vedi|mostra|visualizza|) (la |)trascrizione$</template>
   <template templatetype="command" name="version_cmd">^(versione|info)$</template>
   
   <template name="DefaultHelp"><![CDATA[<u>Aiuto rapido</u><br/><br/>

--- a/docs/transcript.md
+++ b/docs/transcript.md
@@ -3,35 +3,22 @@ layout: index
 title: Transcripts
 ---
 
-As of Quest 5.8 there is a fully functional transcript feature. A transcript is a recording of everything the player types and the game prints, and can be very useful when beta-testing, for example.
+As of Quest 5.8 there is a fully functional transcript feature. A transcript is a recording of everything the game prints, and can be very useful when beta-testing, for example.
 
-To turn the transcript on, use any of these commands during play.
+The transcript is automatically stored in the game's HTML code by Quest.
+
+You can view the transcript at any time during play, using one of these comnmands. The transcript will appear in a pop-up window. You can print the transcript too.
 
 SCRIPT
 TRANSCRIPT
-SCRIPT ON
-TRANSCRIPT ON
-ENABLE SCRIPT
-ENABLE TRANSCRIPT
-
-If it is already enabled, Quest will print, "The transcript is already enabled."
-
-To stop the transcript:
-
-SCRIPT OFF
-TRANSCRIPT OFF
-DISABLE SCRIPT
-DISABLE TRANSCRIPT
-
-You can view the transcript at any time, using one of these comnmands. The transcript will appear in a pop-up window. You can print the trascript too.
-
+SCROLLBACK
 SHOW SCRIPT
 VIEW SCRIPT
 SHOW TRANSCRIPT
 VIEW TRANSCRIPT
+SHOW SCROLLBACK
+VIEW SCROLLBACK
 
-If using the desktop player (as of the upcoming 5.8.0 release), transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the HTML format. When double-clicked, the transcript should open in the user's default browser.
-
-CSS is added to align everything to the left. The background is set to white and the color to black. Be aware that the transcript may have a few strange-looking areas, depending on what all HTML and CSS code you have in a game (we are fixing every issue we come across, but it is hard to foresee what code a Quest game may include!).
+CSS is added to set the background to white. Be aware that the transcript may have a few strange-looking areas, depending on what all HTML and CSS code you have in a game (we are fixing every issue we come across, but it is hard to foresee what code a Quest game may include!).
 
 Note that during play you can type a * and then some text, and Quest will ignore it. This is useful for when you want to comment on something, such as a bug you have found. The comment will appear in the transcript (and can be searched for as it starts with a *), but you will not confuse the game with your weird command.


### PR DESCRIPTION
This removes the majority of the code related to the transcript.

Currently, enabling a transcript crashes online games, and it stops all turns scripts from firing while it is enabled in the desktop player.

There is a totally separate, existing function in playercore.js named `showScrollback()` which handles displaying and printing the transcript all by itself. All I left intact besides that JS function are the commands and templates to view the transcript.

I altered docs\transcript.md to reflect these changes.

I also removed or disabled all the Quest and JS functions to save the transcript to a local file in the desktop version, because this slows the games down tremendously in practice.

I left the code in Player\PlayerHTML.vb to handle it if someone wanted to add the code to Quest and JS to use this feature. That way, no one would have to rebuild the project in Visual Studio just to use that functionality.

---
Double check me on the Dansk `transcript_on_cmd` change I made. The internet says it translates correctly everywhere I looked it up.