### PR TITLE
kv-3-log-rehab (Log Redux (Bug Fix))

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -357,15 +357,23 @@ function SetBackgroundOpacity(opacity) {
 }
 
 function setBackground(col) {
+    /* If '#rgb', convert to '#rrggbb'*/
+    /* https://github.com/textadventures/quest/issues/1052 */
+    if (col.charAt(0) === "#") && col.length == 4) {
+        var colBak = "" + col + "";
+        newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
+        col = newCol || col;
+        console.warn("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
+    }
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
     rgbCol = hexToRgb(col);
     var cssBackground = "rgba(" + rgbCol.r + "," + rgbCol.g + "," + rgbCol.b + "," + _backgroundOpacity + ")";
     $("#gameBorder").css("background-color", cssBackground);
-
     $("#gamePanel").css("background-color", col);
     $("#gridPanel").css("background-color", col);
 }
+
 
 function setPanelHeight() {
     if (_showGrid) return;

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1304,85 +1304,19 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Make it easy to print messages.
-//var msg = addTextAndScroll;
-    
 // Log functions
-var logVar = "";
-function addLogEntry(text){
-  logVar += getTimeAndDateForLog() + ' ' + text+"NEW_LINE";
-};
+var logArr = [];
 
-function showLog(){
-  var logDivString = "";
-  logDivString += "<div ";
-  logDivString += "id='log-dialog' ";
-  logDivString += "style='display:none;;'>";
-  logDivString += "<textarea id='logdata' rows='13'";
-  logDivString += "  cols='49'></textarea></div>";
-  addText(logDivString);
-  if(webPlayer){
-    var logDialog = $("#log-dialog").dialog({
-      autoOpen: false,
-      width: 600,
-      height: 500,
-      title: "Log",
-      buttons: {
-        Ok: function() {
-          $(this).dialog("close");
-        },
-        Print: function(){
-          $(this).dialog("close");
-          showLogDiv();
-          printLogDiv();
-        },
-        Save: function(){
-          $(this).dialog("close");
-          saveLog();
-        },
-      },
-      show: { effect: "fadeIn", duration: 500 },
-      // The modal setting keeps the player from interacting with anything besides the dialog window.
-      //  (The log will not update while open without adding a turn script.  I prefer this.)
-      modal: true,
-    });
-  }else{
-    var logDialog = $("#log-dialog").dialog({
-    autoOpen: false,
-    width: 600,
-    height: 500,
-    title: "Log",
-    buttons: {
-      Ok: function() {
-        $(this).dialog("close");
-      },
-      Print: function(){
-        $(this).dialog("close");
-        showLogDiv();
-        printLogDiv();
-      },
-    },
-    show: { effect: "fadeIn", duration: 500 },
-    // The modal setting keeps the player from interacting with anything besides the dialog window.
-    //  (The log will not update while open without adding a turn script.  I prefer this.)
-    modal: true,
-  });
+function addLogEntry(text){
+  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
+  if (logDivIsSetUp){
+     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
   }
-  $('textarea#logdata').val(logVar.replace(/NEW_LINE/g,"\n"));
-  logDialog.dialog("open");
 };
 
 var logDivIsSetUp = false;
 
-var logDivToAdd = "";
-logDivToAdd += "<div ";
-logDivToAdd += "id='log-div' ";
-logDivToAdd += "style='display:none;'>";
-logDivToAdd += "<a class='do-not-print-with-log' ";
-logDivToAdd += "href='' onclick='hideLogDiv()'>RETURN TO THE GAME</a>  ";
-logDivToAdd += "<a class='do-not-print-with-log' href='' ";
-logDivToAdd += "onclick='printLogDiv();'>PRINT</a> ";
-logDivToAdd += "<div id='log-contents-div' '></div></div>";
+var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
 
 function setupLogDiv(){
   addText(logDivToAdd);
@@ -1390,19 +1324,22 @@ function setupLogDiv(){
   logDivIsSetUp = true;
 };
 
-function showLogDiv(){
-    if(!logDivIsSetUp){
-     setupLogDiv(); 
-    }
-	$(".do-not-print-with-log").show();
-	$("#log-contents-div").html(logVar.replace(/NEW_LINE/g,"<br/>"));
-	$("#log-div").show();
-	$("#gameBorder").hide();
+function showLog(){
+  if(!logDivIsSetUp){
+    setupLogDiv(); 
+  }
+  hideLogDiv()
+  $(".do-not-print-with-log").show();
+  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
+  if (platform !== "mobile"){
+    $('#log-div').show().insertAfter($('#txtCommandDiv'));
+  } else {
+  $('#log-div').show().insertAfter($('#inputBar')) 
+  }
 };
 
 function hideLogDiv(){
-	$("#log-div").hide();
-	$("#gameBorder").show();
+  $("#log-div").hide();
 };
 
 function printLogDiv(){
@@ -1413,48 +1350,21 @@ function printLogDiv(){
   }
   document.title = "log.txt" ;
   $('.do-not-print-with-log').hide();
+  $("#gameBorder").hide();
+  $('#log-div').insertBefore($("#gameBorder"));
   print();
   $('.do-not-print-with-log').show();
+  $('#log-div').appendTo($("#divOutput"));
+  $("#gameBorder").show();
   document.title = docTitleBak;
 };
 
-
-function saveLog(){
-  if(webPlayer){
-    var href = "data:text/plain,"+logVar.replace(/NEW_LINE/g,"\n");
-    addTextAndScroll("<a download='log.txt' href='"+href+"' id='log-save-link'>Click here to save the log if your pop-up blocker stopped the download.</a>");
-    document.getElementById("log-save-link").addEventListener ("click", function (e) {e.stopPropagation();});
-    document.getElementById("log-save-link").click();
-  }else{
-    alert("This function is only available while playing online.");
-  }
- };
-
 function getTimeAndDateForLog(){
-	var today = new Date();
-	var dd = today.getDate();
-	var mm = today.getMonth()+1;
-	var yyyy = today.getFullYear();
-	var hrs = today.getHours();
-	var mins = today.getMinutes();
-	var secs = today.getSeconds();
-	today = mm + '/' + dd + '/' + yyyy;
-	if(hrs>12) {
-	  ampm = 'PM';
-	  hrs = '0' + '' + hrs - 12
-	}else{
-	  ampm = 'AM';
-	} 
-	if (mins<10) {
-	  mins = '0'+mins;
-	} 
-	if(secs<10) {
-	  secs = '0' + secs;
-	}
-	time = hrs + ':' + mins + ':' + secs + ' ' + ampm;
-	return today + ' ' + time;
+  var date = new Date();
+  var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
+  return currentDateTime;
 };
-    
+
 // **********************************
 // TRANSCRIPT FUNCTIONS
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -359,7 +359,7 @@ function SetBackgroundOpacity(opacity) {
 function setBackground(col) {
     /* If '#rgb', convert to '#rrggbb'*/
     /* https://github.com/textadventures/quest/issues/1052 */
-    if (col.charAt(0) === "#") && col.length == 4) {
+    if (col.charAt(0) === "#" && col.length == 4) {
         var colBak = "" + col + "";
         newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
         col = newCol || col;

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -357,15 +357,23 @@ function SetBackgroundOpacity(opacity) {
 }
 
 function setBackground(col) {
+    /* If '#rgb', convert to '#rrggbb'*/
+    /* https://github.com/textadventures/quest/issues/1052 */
+    if (col.charAt(0) === "#") && col.length == 4) {
+        var colBak = "" + col + "";
+        newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
+        col = newCol || col;
+        console.warn("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
+    }
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
     rgbCol = hexToRgb(col);
     var cssBackground = "rgba(" + rgbCol.r + "," + rgbCol.g + "," + rgbCol.b + "," + _backgroundOpacity + ")";
     $("#gameBorder").css("background-color", cssBackground);
-
     $("#gamePanel").css("background-color", col);
     $("#gridPanel").css("background-color", col);
 }
+
 
 function setPanelHeight() {
     if (_showGrid) return;

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1304,85 +1304,19 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Make it easy to print messages.
-//var msg = addTextAndScroll;
-    
 // Log functions
-var logVar = "";
-function addLogEntry(text){
-  logVar += getTimeAndDateForLog() + ' ' + text+"NEW_LINE";
-};
+var logArr = [];
 
-function showLog(){
-  var logDivString = "";
-  logDivString += "<div ";
-  logDivString += "id='log-dialog' ";
-  logDivString += "style='display:none;;'>";
-  logDivString += "<textarea id='logdata' rows='13'";
-  logDivString += "  cols='49'></textarea></div>";
-  addText(logDivString);
-  if(webPlayer){
-    var logDialog = $("#log-dialog").dialog({
-      autoOpen: false,
-      width: 600,
-      height: 500,
-      title: "Log",
-      buttons: {
-        Ok: function() {
-          $(this).dialog("close");
-        },
-        Print: function(){
-          $(this).dialog("close");
-          showLogDiv();
-          printLogDiv();
-        },
-        Save: function(){
-          $(this).dialog("close");
-          saveLog();
-        },
-      },
-      show: { effect: "fadeIn", duration: 500 },
-      // The modal setting keeps the player from interacting with anything besides the dialog window.
-      //  (The log will not update while open without adding a turn script.  I prefer this.)
-      modal: true,
-    });
-  }else{
-    var logDialog = $("#log-dialog").dialog({
-    autoOpen: false,
-    width: 600,
-    height: 500,
-    title: "Log",
-    buttons: {
-      Ok: function() {
-        $(this).dialog("close");
-      },
-      Print: function(){
-        $(this).dialog("close");
-        showLogDiv();
-        printLogDiv();
-      },
-    },
-    show: { effect: "fadeIn", duration: 500 },
-    // The modal setting keeps the player from interacting with anything besides the dialog window.
-    //  (The log will not update while open without adding a turn script.  I prefer this.)
-    modal: true,
-  });
+function addLogEntry(text){
+  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
+  if (logDivIsSetUp){
+     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
   }
-  $('textarea#logdata').val(logVar.replace(/NEW_LINE/g,"\n"));
-  logDialog.dialog("open");
 };
 
 var logDivIsSetUp = false;
 
-var logDivToAdd = "";
-logDivToAdd += "<div ";
-logDivToAdd += "id='log-div' ";
-logDivToAdd += "style='display:none;'>";
-logDivToAdd += "<a class='do-not-print-with-log' ";
-logDivToAdd += "href='' onclick='hideLogDiv()'>RETURN TO THE GAME</a>  ";
-logDivToAdd += "<a class='do-not-print-with-log' href='' ";
-logDivToAdd += "onclick='printLogDiv();'>PRINT</a> ";
-logDivToAdd += "<div id='log-contents-div' '></div></div>";
+var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
 
 function setupLogDiv(){
   addText(logDivToAdd);
@@ -1390,19 +1324,22 @@ function setupLogDiv(){
   logDivIsSetUp = true;
 };
 
-function showLogDiv(){
-    if(!logDivIsSetUp){
-     setupLogDiv(); 
-    }
-	$(".do-not-print-with-log").show();
-	$("#log-contents-div").html(logVar.replace(/NEW_LINE/g,"<br/>"));
-	$("#log-div").show();
-	$("#gameBorder").hide();
+function showLog(){
+  if(!logDivIsSetUp){
+    setupLogDiv(); 
+  }
+  hideLogDiv()
+  $(".do-not-print-with-log").show();
+  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
+  if (platform !== "mobile"){
+    $('#log-div').show().insertAfter($('#txtCommandDiv'));
+  } else {
+  $('#log-div').show().insertAfter($('#inputBar')) 
+  }
 };
 
 function hideLogDiv(){
-	$("#log-div").hide();
-	$("#gameBorder").show();
+  $("#log-div").hide();
 };
 
 function printLogDiv(){
@@ -1413,48 +1350,21 @@ function printLogDiv(){
   }
   document.title = "log.txt" ;
   $('.do-not-print-with-log').hide();
+  $("#gameBorder").hide();
+  $('#log-div').insertBefore($("#gameBorder"));
   print();
   $('.do-not-print-with-log').show();
+  $('#log-div').appendTo($("#divOutput"));
+  $("#gameBorder").show();
   document.title = docTitleBak;
 };
 
-
-function saveLog(){
-  if(webPlayer){
-    var href = "data:text/plain,"+logVar.replace(/NEW_LINE/g,"\n");
-    addTextAndScroll("<a download='log.txt' href='"+href+"' id='log-save-link'>Click here to save the log if your pop-up blocker stopped the download.</a>");
-    document.getElementById("log-save-link").addEventListener ("click", function (e) {e.stopPropagation();});
-    document.getElementById("log-save-link").click();
-  }else{
-    alert("This function is only available while playing online.");
-  }
- };
-
 function getTimeAndDateForLog(){
-	var today = new Date();
-	var dd = today.getDate();
-	var mm = today.getMonth()+1;
-	var yyyy = today.getFullYear();
-	var hrs = today.getHours();
-	var mins = today.getMinutes();
-	var secs = today.getSeconds();
-	today = mm + '/' + dd + '/' + yyyy;
-	if(hrs>12) {
-	  ampm = 'PM';
-	  hrs = '0' + '' + hrs - 12
-	}else{
-	  ampm = 'AM';
-	} 
-	if (mins<10) {
-	  mins = '0'+mins;
-	} 
-	if(secs<10) {
-	  secs = '0' + secs;
-	}
-	time = hrs + ':' + mins + ':' + secs + ' ' + ampm;
-	return today + ' ' + time;
+  var date = new Date();
+  var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
+  return currentDateTime;
 };
-    
+
 // **********************************
 // TRANSCRIPT FUNCTIONS
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -359,7 +359,7 @@ function SetBackgroundOpacity(opacity) {
 function setBackground(col) {
     /* If '#rgb', convert to '#rrggbb'*/
     /* https://github.com/textadventures/quest/issues/1052 */
-    if (col.charAt(0) === "#") && col.length == 4) {
+    if (col.charAt(0) === "#" && col.length == 4) {
         var colBak = "" + col + "";
         newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
         col = newCol || col;

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -878,6 +878,7 @@
   <verb template="climb" property="climb" response="DefaultClimb"/>
   <verb template="drink" property="drink" response="DefaultDrink"/>
   <verb template="eat" property="eat" response="DefaultEat"/>
+  <verb name="enter" template="enter" property="enter_verb" displayverb="[enter]" response="DefaultEnter"/>
   <verb template="hit" property="hit" response="DefaultHit"/>
   <verb template="kill" property="kill" response="DefaultKill"/>
   <verb template="kiss" property="kiss" response="DefaultKiss"/>

--- a/WorldModel/WorldModel/Core/CoreEditorObjectVerbs.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectVerbs.aslx
@@ -61,7 +61,7 @@
         </item>
         <item>
           <key>enter</key>
-          <value>Use a command, rather than a verb, to allow the player to enter this object.</value>
+          <value>Input the verb name as "enter_verb". It will appear as "enter" to the player.</value>
         </item>
       </clashmessages>
       <defaultexpression>[EditorVerbDefaultExpression]</defaultexpression>

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -615,6 +615,11 @@
   <function name="DisableHtmlLog">
     game.nohtmllog = true
   </function>
+  
+  <function name="ClearHtmlLog">
+    JS.eval("$(\"#log-div\").html(\"\").hide(); logArr = [];")
+  </function>
+
 
   <function name="QuickParams" parameters="key1, value1, key2, value2, key3, value3" type="dictionary">
     d = NewDictionary()

--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -872,18 +872,21 @@
     ]]>
   </function>
 
-  <function name="Log" parameters="text">
-    <![CDATA[
-    //request (Log, text)
+  <function name="Log" parameters="text"><![CDATA[
+    //Use the log window in the desktop player, if available.
+    request (Log, text)
     // Replacing double quotes with 2 single quotes
     text = Replace(text, "\"", "''")
-    // Changing syntax from single quotes to escaped double quotes to allow single quotes in log entries
     if (not GetBoolean(game, "nohtmllog")){
-      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\""+text+"\"); };")
+      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\"" + text + "\"); };")
     }
-    JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){var s = \""+text+"\";WriteToLog(s);}")
-    ]]>
-  </function>
+    if (GetBoolean (game, "writelogtofile")){
+      JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){ WriteToLog(\"" + text + "\");}")
+    }
+    if (GetBoolean (game, "useconsolelog")){
+      JS.eval("console.log(getTimeAndDateForLog() + \" : " + text + "\");")
+    }
+  ]]></function>
 
   <function name="SetBackgroundImage" parameters="filename">
     JS.SetBackgroundImage(GetFileURL(filename))

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -92,7 +92,9 @@
     <deactivatecommandlinks type="boolean">false</deactivatecommandlinks>
     <multiplecommands type="boolean">false</multiplecommands>
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
-    <nohtmllog type="boolean">false</nohtmllog>
+    <nohtmllog/>
+    <writelogtofile type="boolean">false</writelogtofile>
+    <useconsolelog type="boolean">false</useconsolelog>
     <notranscript type="boolean">false</notranscript>
     <suppressturnscripts/>
     <!-- Scripts used by the text processor -->

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -512,13 +512,12 @@
   <dynamictemplate name="DevModeErrorCantFindObject">"The object with the name '" + text + "' cannot be found."</dynamictemplate>
   <dynamictemplate name="DevModeErrorCantFindAttribute">"The attribute with the name '" + text + "' cannot be found."</dynamictemplate>
 
-  <!-- Need a special verb in English because of the name collision with the "enter" script rooms use -->
-  <verb name="enter_verb">
-    <pattern>enter #object#</pattern>
-    <property>enterverb</property>
-    <defaultexpression>"You can't enter "+object.article+"."</defaultexpression>
-    <scope>notheld</scope>
-  </verb>
+  <verbtemplate name="enter">enter</verbtemplate>
+  <verbtemplate name="enter">go in</verbtemplate>
+  <verbtemplate name="enter">go into</verbtemplate>
+  <verbtemplate name="enter">get in</verbtemplate>
+  <verbtemplate name="enter">get into</verbtemplate>
+  <dynamictemplate name="DefaultEnter">WriteVerb(game.pov, "can't") + " enter " + object.article + "."</dynamictemplate>
   
   
 </library>


### PR DESCRIPTION
The old log is still in Quest 5.8. There is even still a button for it, but it just opens a blank window.

It was left that way because the plan was to deprecate the `request` script, but that ended up being a no-go due to backwards compatibility.

---
- Reinstated the old log functionality

- Replaced concatenated string in JS with an array.

- Replaced the jQuery-UI popup (which messed up walkthroughs) with a normal HTML element, just beneath the command input element, with buttons to hide or print the log.

- Added Quest function `ClearHtmlLog()` to empty the array and the HTML and hide the log div.

- `game.nohtmllog` is set to `true` by default. Change it to `false` to enable the in-game log.

- `game.writelogtofile` is set to `false` by default. Change it to true to write/append directly to a file in "Documents\Quest Logs" when using the desktop player, which comes in very handy if a game freezes or crashes!

- `game.useconsolelog` is set to `false` by default. Change it to `true` to have the log send messages to the HTML dev tools console log.
