### PR TITLE
kv-4-transcript-repair

### DIFF
--- a/Player/Player.vb
+++ b/Player/Player.vb
@@ -792,7 +792,8 @@ Public Class Player
     End Sub
 
     Private Sub ctlPlayerHtml_SendEvent(eventName As String, param As String) Handles ctlPlayerHtml.SendEvent
-        If RecordWalkthrough IsNot Nothing Then
+        ' Don't save the step if calling WhereAmI or any event starting with NoEventFunc
+        If RecordWalkthrough IsNot Nothing And Not eventName.StartsWith("WhereAmI") And Not eventName.StartsWith("NoEventFunc") Then
             m_recordedWalkthrough.Add("event:" + eventName + ";" + param)
         End If
         m_game.SendEvent(eventName, param)

--- a/Player/PlayerHTML.vb
+++ b/Player/PlayerHTML.vb
@@ -143,15 +143,15 @@ Public Class PlayerHTML
         If Not System.IO.Directory.Exists(transcriptPath) = True Then
             System.IO.Directory.CreateDirectory(transcriptPath)
         End If
-        If Not System.IO.File.Exists(transcriptPath + "\" + mgameName + "-transcript.html") = True Then
+        If Not System.IO.File.Exists(transcriptPath + "\" + mgameName + "-transcript.txt") = True Then
             Dim file As System.IO.FileStream
-            file = System.IO.File.Create(transcriptPath + "\" + mgameName + "-transcript.html")
+            file = System.IO.File.Create(transcriptPath + "\" + mgameName + "-transcript.txt")
             file.Close()
         End If
         If data.Contains("___SCRIPTDATA___") Then
             data = Split(data, "___SCRIPTDATA___")(1)
         End If
-        My.Computer.FileSystem.WriteAllText(transcriptPath + "\" + mgameName + "-transcript.html", data, True)
+        My.Computer.FileSystem.WriteAllText(transcriptPath + "\" + mgameName + "-transcript.txt", data, True)
 
     End Sub
     Private Sub RestartGame(data As String)

--- a/Player/PlayerHTML.vb
+++ b/Player/PlayerHTML.vb
@@ -129,7 +129,7 @@ Public Class PlayerHTML
         Dim mgameName = ""
         Dim scriptname = "DEFAULT_"
         ' In playercore.js: WriteToTranscript (transcriptName + "___SCRIPTDATA___" + text)
-        ' That could be changed to just WriteToTranscript(text) to ignore the transcript name entered by the player.
+        ' If WriteToTranscript(text) is used, this will ignore the transcript name and use the game's file name.
         If data.Contains("___SCRIPTDATA___") Then
             scriptname = Split(data, "___SCRIPTDATA___")(0)
         End If
@@ -151,7 +151,7 @@ Public Class PlayerHTML
         If data.Contains("___SCRIPTDATA___") Then
             data = Split(data, "___SCRIPTDATA___")(1)
         End If
-        My.Computer.FileSystem.WriteAllText(transcriptPath + "\" + mgameName + "-transcript.txt", data, True)
+        My.Computer.FileSystem.WriteAllText(transcriptPath + "\" + mgameName + "-transcript.txt", Replace(data, "@@@NEW_LINE@@@", Environment.NewLine), True)
 
     End Sub
     Private Sub RestartGame(data As String)

--- a/Player/PlayerHTML.vb
+++ b/Player/PlayerHTML.vb
@@ -105,8 +105,8 @@ Public Class PlayerHTML
             ' Added by KV
             Case "RestartGame"
                 RestartGame(args)
-            Case "SaveTranscript"
-                SaveTranscript(args)
+            Case "WriteToTranscript"
+                WriteToTranscript(args)
             Case "WriteToLog"
                 WriteToLog(args)
         End Select
@@ -125,9 +125,20 @@ Public Class PlayerHTML
         End If
         My.Computer.FileSystem.WriteAllText(logPath + "\" + gameName + "-log.txt", data + Environment.NewLine, True)
     End Sub
-    Private Sub SaveTranscript(data As String)
-        Dim mgameName = Split(CurrentGame.Filename, "\")(Split(CurrentGame.Filename, "\").Length - 1)
-        mgameName = mgameName.Replace(".aslx", "")
+    Private Sub WriteToTranscript(data As String)
+        Dim mgameName = ""
+        Dim scriptname = "DEFAULT_"
+        ' In playercore.js: WriteToTranscript (transcriptName + "___SCRIPTDATA___" + text)
+        ' That could be changed to just WriteToTranscript(text) to ignore the transcript name entered by the player.
+        If data.Contains("___SCRIPTDATA___") Then
+            scriptname = Split(data, "___SCRIPTDATA___")(0)
+        End If
+        If scriptname = "DEFAULT_" Then
+          mgameName = Split(CurrentGame.Filename, "\")(Split(CurrentGame.Filename, "\").Length - 1)
+          mgameName = mgameName.Replace(".aslx", "")
+        Else
+          mgameName = scriptname
+        End If
         Dim transcriptPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\Quest Transcripts"
         If Not System.IO.Directory.Exists(transcriptPath) = True Then
             System.IO.Directory.CreateDirectory(transcriptPath)
@@ -136,6 +147,9 @@ Public Class PlayerHTML
             Dim file As System.IO.FileStream
             file = System.IO.File.Create(transcriptPath + "\" + mgameName + "-transcript.html")
             file.Close()
+        End If
+        If data.Contains("___SCRIPTDATA___") Then
+            data = Split(data, "___SCRIPTDATA___")(1)
         End If
         My.Computer.FileSystem.WriteAllText(transcriptPath + "\" + mgameName + "-transcript.html", data, True)
 

--- a/Player/WalkthroughRunner.vb
+++ b/Player/WalkthroughRunner.vb
@@ -43,7 +43,13 @@
                     Dim eventData As String() = cmd.Substring(6).Split(New Char() {";"c}, 2)
                     Dim eventName As String = eventData(0)
                     Dim param As String = eventData(1)
-                    m_game.SendEvent(eventName, param)
+                    ' Make sure not to call WhereAmI or NoEventFunc*
+                    If Not eventName = "WhereAmI" And Not eventName.StartsWith("NoEventFunc") Then
+                        m_game.SendEvent(eventName, param)
+                    Else
+                        ' ignore
+                        'WriteLine("<p>[WALKTHROUGH]: Ignoring event: '" + eventName + "'.</p>")
+                    End If
                 Else
                     m_game.SendCommand(cmd)
                 End If

--- a/Player/desktopplayer.js
+++ b/Player/desktopplayer.js
@@ -15,16 +15,16 @@ function ASLEvent(event, parameter) {
     UIEvent("ASLEvent", event + ";" + parameter);
 }
 
-
 // RestartGame added by KV
 function RestartGame() {
     UIEvent("RestartGame", "");
 }
 
-// WriteToTranscript added by KV to write/append to GAMENAME-transcript.html in Documents\Quest Transcripts
+// WriteToTranscript added by KV to write/append to GAMENAME-transcript.txt in Documents\Quest Transcripts
 function WriteToTranscript(data) {
   if (data != '' && typeof (data) == 'string') {
-    UIEvent("WriteToTranscript", data + "<style>*{color:black !important;background:white !important;text-align:left !important}</style>");
+    //UIEvent("WriteToTranscript", data + "<style>*{color:black !important;background:white !important;text-align:left !important}</style>");
+    UIEvent("WriteToTranscript", data);
   }
 }
 
@@ -34,6 +34,7 @@ function WriteToLog(data) {
         UIEvent("WriteToLog", getTimeAndDateForLog() + " " + data);
     }
 }
+
 
 function goUrl(href) {
     UIEvent("GoURL", href);

--- a/Player/desktopplayer.js
+++ b/Player/desktopplayer.js
@@ -21,16 +21,16 @@ function RestartGame() {
     UIEvent("RestartGame", "");
 }
 
-// SaveTranscript added by KV to write/append to GAMENAME-transcript.html in Documents\Quest Transcripts
-function SaveTranscript(data) {
-    data = data + "<style>*{color:black !important;background:white !important;text-align:left !important}</style>";
-    if (!webPlayer && transcriptString != '') { UIEvent("SaveTranscript", data); }
-    transcriptString += data;
+// WriteToTranscript added by KV to write/append to GAMENAME-transcript.html in Documents\Quest Transcripts
+function WriteToTranscript(data) {
+  if (data != '' && typeof (data) == 'string') {
+    UIEvent("WriteToTranscript", data + "<style>*{color:black !important;background:white !important;text-align:left !important}</style>");
+  }
 }
 
 // Added by KV to write/append to GAMENAME-log.txt in Documents\Quest Logs
 function WriteToLog(data) {
-    if (!webPlayer && data != '' && typeof (data) == 'string') {
+    if (data != '' && typeof (data) == 'string') {
         UIEvent("WriteToLog", getTimeAndDateForLog() + " " + data);
     }
 }

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -795,40 +795,7 @@ function clearScreen() {
     }
 }
 
-// Scrollback functions added by KV
-/**
-  * The player can view the game's text in a pop-up window.
-  * To change the title of the pop-up window, you can do this after calling showScrollback: $("#scrollback-dialog").dialog({title:"TITLE"});
-  * This will include cleared text if saveClearedText is set to true (saveClearedText is false by default).
-  * Setting noScrollback to true will disable this. (noScrollback is false by default)
-  */
-function showScrollback() {
-  if (noScrollback) return;
-  addText("<div id='scrollback-dialog' style='display:none; color:black !important; background-color:white !important; font-family:sans-serif !important;background:white !important;text-align:left !important;'><div id='scrollbackdata'></div></div>");
-  var scrollbackDialog = $("#scrollback-dialog").dialog({
-    autoOpen: false,
-    width: 600,
-    height: 500,
-    title: "Scrollback",
-    buttons: {
-      Ok: function () {
-        $(this).dialog("close");
-        $(this).remove();
-      },
-      Print: function () {
-        printScrollback();
-      },
-    },
-    show: { effect: "fadeIn", duration: 500 },
-    modal: true,
-  });
-  $('#scrollbackdata').html($('#divOutput').html());
-  $("#scrollbackdata a").addClass("disabled");
-  scrollbackDialog.dialog("open");
-  setTimeout(function () {
-    $("#scrollbackdata a").addClass("disabled");
-  }, 1);
-};
+// Scrollback function added by KV
 
 /**
  * The player can print the game's text or save as PDF.
@@ -1248,70 +1215,6 @@ function isMobilePlayer() {
     return (platform === "mobile");
 };
 
-function showPopup(title, text) {
-    $('#msgboxCaption').html(text);
-
-    var msgboxOptions = {
-        modal: true,
-        autoOpen: false,
-        title: title,
-        buttons: [
-			{
-			    text: 'OK',
-			    click: function () { $(this).dialog('close'); }
-			},
-        ],
-        closeOnEscape: false,
-    };
-
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
-};
-
-function showPopupCustomSize(title, text, width, height) {
-    $('#msgboxCaption').html(text);
-
-    var msgboxOptions = {
-        modal: true,
-        autoOpen: false,
-        title: title,
-        width: width,
-        height: height,
-        buttons: [
-			{
-			    text: 'OK',
-			    click: function () { $(this).dialog('close'); }
-			},
-        ],
-        closeOnEscape: false,
-    };
-
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
-};
-
-function showPopupFullscreen(title, text) {
-    $('#msgboxCaption').html(text);
-
-    var msgboxOptions = {
-        modal: true,
-        autoOpen: false,
-        title: title,
-        width: $(window).width(),
-        height: $(window).height(),
-        buttons: [
-			{
-			    text: 'OK',
-			    click: function () { $(this).dialog('close'); }
-			},
-        ],
-        closeOnEscape: false,
-    };
-
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
-};
-
 /**
   * Added by KV for using the JS console for the Quest log when game.useconsolelog is set to true.
   *
@@ -1328,7 +1231,7 @@ function getTimeAndDateForLog(){
 /**
   * Added by KV
   *
-  * This will write/append to an HTML document in Documents\Quest Transcripts
+  * This will write/append to a TXT document in Documents\Quest Transcripts
   *  if using the desktop player and the the player has the transcript enabled
   *  and if noTranscript is not set to true (it is false by default).
   *
@@ -1336,7 +1239,7 @@ function getTimeAndDateForLog(){
 */
 function writeToTranscript(text){
   if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
-    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + text);
+    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $(text.replace(/<br\/>/g,"\r\n").replace(/<br>/g,"\r\n").replace(/<br \/>/g,"\r\n")).text() + "\r\n");
   }
 }
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -357,15 +357,23 @@ function SetBackgroundOpacity(opacity) {
 }
 
 function setBackground(col) {
+    /* If '#rgb', convert to '#rrggbb'*/
+    /* https://github.com/textadventures/quest/issues/1052 */
+    if (col.charAt(0) === "#") && col.length == 4) {
+        var colBak = "" + col + "";
+        newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
+        col = newCol || col;
+        console.warn("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
+    }
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
     rgbCol = hexToRgb(col);
     var cssBackground = "rgba(" + rgbCol.r + "," + rgbCol.g + "," + rgbCol.b + "," + _backgroundOpacity + ")";
     $("#gameBorder").css("background-color", cssBackground);
-
     $("#gamePanel").css("background-color", col);
     $("#gridPanel").css("background-color", col);
 }
+
 
 function setPanelHeight() {
     if (_showGrid) return;

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1239,10 +1239,66 @@ function getTimeAndDateForLog(){
 */
 function writeToTranscript(text){
   if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
-    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"\r\n").replace(/<br>/g,"\r\n").replace(/<br \/>/g,"\r\n") + "</div>").text() + "\r\n");
+    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());
   }
 }
 
+/**
+  * This will enable the transcript unless noTranscript is set to true.
+  * 
+  * @param {name} text If this is defined, the transcriptName will be set to this.
+*/
+function enableTranscript(name){
+  if (noTranscript) return;
+  transcriptName = name || transcriptName;
+  transcriptEnabled = true;
+}
+
+/**
+  * This will disable the transcript.
+  * 
+  * @param {name} text If this is defined, the transcriptName will be set to this.
+*/
+function disableTranscript(){
+  transcriptEnabled = false;
+}
+
+/**
+  * This will completely kill the transcript.
+  * 
+  * @param {name} text If this is defined, the transcriptName will be set to this.
+*/
+function killTranscript(){
+  noTranscript = true;
+  disableTranscript();
+}
+
+/**
+  * Make it easy to control transcript settings from Quest.
+  * 
+  * @param {name} text If this is defined, the transcriptName will be set to this.
+*/
+function setTranscriptStatus(status){
+  switch (status){
+    case "enabled":
+    case "enable":
+      initiateTranscript();
+      break;
+    case "disabled":
+    case "disable":
+      disableTranscript();
+      break;
+    case "none":
+    case "killed":
+      killTranscript();
+      break;
+    case "alive":
+      noTranscript = false;
+  }
+}
+
+/**
+  * 
 /**
   * This function was missing from the webplayer in Quest 5.8.0
   * Leaving this here as a fallback
@@ -1253,7 +1309,6 @@ function SaveTranscript(text){
   console.log("[QUEST]: SaveTranscript has been deprecated. Using writeToTranscript instead.");
   writeToTranscript(text);  
 }
-
 
 // GRID FUNCTIONS ***********************************************************************************************************************
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1304,85 +1304,19 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Make it easy to print messages.
-//var msg = addTextAndScroll;
-    
 // Log functions
-var logVar = "";
-function addLogEntry(text){
-  logVar += getTimeAndDateForLog() + ' ' + text+"NEW_LINE";
-};
+var logArr = [];
 
-function showLog(){
-  var logDivString = "";
-  logDivString += "<div ";
-  logDivString += "id='log-dialog' ";
-  logDivString += "style='display:none;;'>";
-  logDivString += "<textarea id='logdata' rows='13'";
-  logDivString += "  cols='49'></textarea></div>";
-  addText(logDivString);
-  if(webPlayer){
-    var logDialog = $("#log-dialog").dialog({
-      autoOpen: false,
-      width: 600,
-      height: 500,
-      title: "Log",
-      buttons: {
-        Ok: function() {
-          $(this).dialog("close");
-        },
-        Print: function(){
-          $(this).dialog("close");
-          showLogDiv();
-          printLogDiv();
-        },
-        Save: function(){
-          $(this).dialog("close");
-          saveLog();
-        },
-      },
-      show: { effect: "fadeIn", duration: 500 },
-      // The modal setting keeps the player from interacting with anything besides the dialog window.
-      //  (The log will not update while open without adding a turn script.  I prefer this.)
-      modal: true,
-    });
-  }else{
-    var logDialog = $("#log-dialog").dialog({
-    autoOpen: false,
-    width: 600,
-    height: 500,
-    title: "Log",
-    buttons: {
-      Ok: function() {
-        $(this).dialog("close");
-      },
-      Print: function(){
-        $(this).dialog("close");
-        showLogDiv();
-        printLogDiv();
-      },
-    },
-    show: { effect: "fadeIn", duration: 500 },
-    // The modal setting keeps the player from interacting with anything besides the dialog window.
-    //  (The log will not update while open without adding a turn script.  I prefer this.)
-    modal: true,
-  });
+function addLogEntry(text){
+  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
+  if (logDivIsSetUp){
+     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
   }
-  $('textarea#logdata').val(logVar.replace(/NEW_LINE/g,"\n"));
-  logDialog.dialog("open");
 };
 
 var logDivIsSetUp = false;
 
-var logDivToAdd = "";
-logDivToAdd += "<div ";
-logDivToAdd += "id='log-div' ";
-logDivToAdd += "style='display:none;'>";
-logDivToAdd += "<a class='do-not-print-with-log' ";
-logDivToAdd += "href='' onclick='hideLogDiv()'>RETURN TO THE GAME</a>  ";
-logDivToAdd += "<a class='do-not-print-with-log' href='' ";
-logDivToAdd += "onclick='printLogDiv();'>PRINT</a> ";
-logDivToAdd += "<div id='log-contents-div' '></div></div>";
+var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
 
 function setupLogDiv(){
   addText(logDivToAdd);
@@ -1390,19 +1324,22 @@ function setupLogDiv(){
   logDivIsSetUp = true;
 };
 
-function showLogDiv(){
-    if(!logDivIsSetUp){
-     setupLogDiv(); 
-    }
-	$(".do-not-print-with-log").show();
-	$("#log-contents-div").html(logVar.replace(/NEW_LINE/g,"<br/>"));
-	$("#log-div").show();
-	$("#gameBorder").hide();
+function showLog(){
+  if(!logDivIsSetUp){
+    setupLogDiv(); 
+  }
+  hideLogDiv()
+  $(".do-not-print-with-log").show();
+  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
+  if (platform !== "mobile"){
+    $('#log-div').show().insertAfter($('#txtCommandDiv'));
+  } else {
+  $('#log-div').show().insertAfter($('#inputBar')) 
+  }
 };
 
 function hideLogDiv(){
-	$("#log-div").hide();
-	$("#gameBorder").show();
+  $("#log-div").hide();
 };
 
 function printLogDiv(){
@@ -1413,48 +1350,21 @@ function printLogDiv(){
   }
   document.title = "log.txt" ;
   $('.do-not-print-with-log').hide();
+  $("#gameBorder").hide();
+  $('#log-div').insertBefore($("#gameBorder"));
   print();
   $('.do-not-print-with-log').show();
+  $('#log-div').appendTo($("#divOutput"));
+  $("#gameBorder").show();
   document.title = docTitleBak;
 };
 
-
-function saveLog(){
-  if(webPlayer){
-    var href = "data:text/plain,"+logVar.replace(/NEW_LINE/g,"\n");
-    addTextAndScroll("<a download='log.txt' href='"+href+"' id='log-save-link'>Click here to save the log if your pop-up blocker stopped the download.</a>");
-    document.getElementById("log-save-link").addEventListener ("click", function (e) {e.stopPropagation();});
-    document.getElementById("log-save-link").click();
-  }else{
-    alert("This function is only available while playing online.");
-  }
- };
-
 function getTimeAndDateForLog(){
-	var today = new Date();
-	var dd = today.getDate();
-	var mm = today.getMonth()+1;
-	var yyyy = today.getFullYear();
-	var hrs = today.getHours();
-	var mins = today.getMinutes();
-	var secs = today.getSeconds();
-	today = mm + '/' + dd + '/' + yyyy;
-	if(hrs>12) {
-	  ampm = 'PM';
-	  hrs = '0' + '' + hrs - 12
-	}else{
-	  ampm = 'AM';
-	} 
-	if (mins<10) {
-	  mins = '0'+mins;
-	} 
-	if(secs<10) {
-	  secs = '0' + secs;
-	}
-	time = hrs + ':' + mins + ':' + secs + ' ' + ampm;
-	return today + ' ' + time;
+  var date = new Date();
+  var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
+  return currentDateTime;
 };
-    
+
 // **********************************
 // TRANSCRIPT FUNCTIONS
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1239,7 +1239,7 @@ function getTimeAndDateForLog(){
 */
 function writeToTranscript(text){
   if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
-    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $(text.replace(/<br\/>/g,"\r\n").replace(/<br>/g,"\r\n").replace(/<br \/>/g,"\r\n")).text() + "\r\n");
+    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"\r\n").replace(/<br>/g,"\r\n").replace(/<br \/>/g,"\r\n") + "</div>").text() + "\r\n");
   }
 }
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1304,61 +1304,7 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Log functions
-var logArr = [];
-
-function addLogEntry(text){
-  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
-  if (logDivIsSetUp){
-     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
-  }
-};
-
-var logDivIsSetUp = false;
-
-var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
-
-function setupLogDiv(){
-  addText(logDivToAdd);
-  $("#log-div").insertBefore($("#dialog"));
-  logDivIsSetUp = true;
-};
-
-function showLog(){
-  if(!logDivIsSetUp){
-    setupLogDiv(); 
-  }
-  hideLogDiv()
-  $(".do-not-print-with-log").show();
-  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
-  if (platform !== "mobile"){
-    $('#log-div').show().insertAfter($('#txtCommandDiv'));
-  } else {
-  $('#log-div').show().insertAfter($('#inputBar')) 
-  }
-};
-
-function hideLogDiv(){
-  $("#log-div").hide();
-};
-
-function printLogDiv(){
-  if(typeof(document.title) !== "undefined"){
-    var docTitleBak = document.title;
-  }else{
-    var docTitleBak = "title";
-  }
-  document.title = "log.txt" ;
-  $('.do-not-print-with-log').hide();
-  $("#gameBorder").hide();
-  $('#log-div').insertBefore($("#gameBorder"));
-  print();
-  $('.do-not-print-with-log').show();
-  $('#log-div').appendTo($("#divOutput"));
-  $("#gameBorder").show();
-  document.title = docTitleBak;
-};
-
+// Log function
 function getTimeAndDateForLog(){
   var date = new Date();
   var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -359,7 +359,7 @@ function SetBackgroundOpacity(opacity) {
 function setBackground(col) {
     /* If '#rgb', convert to '#rrggbb'*/
     /* https://github.com/textadventures/quest/issues/1052 */
-    if (col.charAt(0) === "#") && col.length == 4) {
+    if (col.charAt(0) === "#" && col.length == 4) {
         var colBak = "" + col + "";
         newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
         col = newCol || col;

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -363,7 +363,7 @@ function setBackground(col) {
         var colBak = "" + col + "";
         newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
         col = newCol || col;
-        console.warn("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
+        console.log("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
     }
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
@@ -629,18 +629,16 @@ function addTextAndScroll(text) {
     scrollToEnd();
 }
 
-// These 2 variables added by KV for the transcript
-var savingTranscript = false;
-var transcriptString = "";
-
+var transcriptEnabled = false;
+var noTranscript = false;
 // This function altered by KV for the transcript
 function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
     }
-    if (savingTranscript) {
-        SaveTranscript(text);
-        ASLEvent("UpdateTranscriptString", text);
+    // Only attempt writeToTranscript() if this is the desktop player.
+    if (!webPlayer && platform == "desktop" && transcriptEnabled && !noTranscript) {
+        writeToTranscript(text);
     }
     getCurrentDiv().append(text);
     $("#divOutput").css("min-height", $("#divOutput").height());
@@ -767,7 +765,10 @@ function disableAllCommandLinks() {
 }
 
 // Modified by KV to handle the scrollback feature
-var saveClearedText = true;
+// Changing saveClearedText to false by default, due to performance issues.
+var saveClearedText = false;
+// Authors can change noScrollback to true to disable the scrollback functions.
+var noScrollback = false;
 var clearedOnce = false;
 function clearScreen() {
     if (!saveClearedText) {
@@ -795,49 +796,60 @@ function clearScreen() {
 }
 
 // Scrollback functions added by KV
-
+/**
+  * The player can view the game's text in a pop-up window.
+  * To change the title of the pop-up window, you can do this after calling showScrollback: $("#scrollback-dialog").dialog({title:"TITLE"});
+  * This will include cleared text if saveClearedText is set to true (saveClearedText is false by default).
+  * Setting noScrollback to true will disable this. (noScrollback is false by default)
+  */
 function showScrollback() {
-    var scrollbackDivString = "";
-    scrollbackDivString += "<div ";
-    scrollbackDivString += "id='scrollback-dialog' ";
-    scrollbackDivString += "style='display:none;'>";
-    scrollbackDivString += "<div id='scrollbackdata'></div></div>";
-    addText(scrollbackDivString);
-    var scrollbackDialog = $("#scrollback-dialog").dialog({
-        autoOpen: false,
-        width: 600,
-        height: 500,
-        title: "Scrollback",
-        buttons: {
-            Ok: function () {
-                $(this).dialog("close");
-                $(this).remove();
-            },
-            Print: function () {
-                printScrollbackDiv();
-            },
-        },
-        show: { effect: "fadeIn", duration: 500 },
-        modal: true,
-    });
-    $('#scrollbackdata').html($('#divOutput').html());
+  if (noScrollback) return;
+  addText("<div id='scrollback-dialog' style='display:none; color:black !important; background-color:white !important; font-family:sans-serif !important;background:white !important;text-align:left !important;'><div id='scrollbackdata'></div></div>");
+  var scrollbackDialog = $("#scrollback-dialog").dialog({
+    autoOpen: false,
+    width: 600,
+    height: 500,
+    title: "Scrollback",
+    buttons: {
+      Ok: function () {
+        $(this).dialog("close");
+        $(this).remove();
+      },
+      Print: function () {
+        printScrollback();
+      },
+    },
+    show: { effect: "fadeIn", duration: 500 },
+    modal: true,
+  });
+  $('#scrollbackdata').html($('#divOutput').html());
+  $("#scrollbackdata a").addClass("disabled");
+  scrollbackDialog.dialog("open");
+  setTimeout(function () {
     $("#scrollbackdata a").addClass("disabled");
-    scrollbackDialog.dialog("open");
-    setTimeout(function () {
-        $("#scrollbackdata a").addClass("disabled");
-    }, 1);
+  }, 1);
 };
 
-
-
-function printScrollbackDiv() {
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    iframe.contentWindow.document.write($("#scrollbackdata").html());
-    iframe.contentWindow.print();
-    document.body.removeChild(iframe);
-    $("#scrollback-dialog").dialog("close");
-    $("#scrollback-dialog").remove();
+/**
+ * The player can print the game's text or save as PDF.
+ * This will include cleared text if saveClearedText is set to true (saveClearedText is false by default).
+ * Setting noScrollback to true will disable this. (noScrollback is false by default)
+ */
+function printScrollback() {
+  if (noScrollback) return;
+  addText("<div id='scrollback-hider' style='display:none; color:black !important; background-color:white !important; font-family:sans-serif !important;background:white !important;text-align:left !important;'><div id='scrollbackdata'></div></div>");
+  $('#scrollbackdata').html($('#divOutput').html());
+  $("#scrollbackdata a").addClass("disabled");
+  setTimeout(function () {
+      $("#scrollbackdata a").addClass("disabled");
+  }, 1);
+  var iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  iframe.contentWindow.document.write($("#scrollbackdata").html());
+  iframe.contentWindow.print();
+  document.body.removeChild(iframe);
+  $("#scrollback-dialog").dialog("close");
+  $("#scrollback-dialog").remove();
 };
 
 function keyPressCode(e) {
@@ -1232,12 +1244,8 @@ $(function () {
 // ***********
 // Section added by KV
 
-
 function isMobilePlayer() {
-    if (typeof (currentTab) === 'string') {
-        return true;
-    }
-    return false;
+    return (platform === "mobile");
 };
 
 function showPopup(title, text) {
@@ -1304,67 +1312,44 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Log function
+/**
+  * Added by KV for using the JS console for the Quest log when game.useconsolelog is set to true.
+  *
+  * @return {string} currentDateTime Time and date in format just like the Quest desktop log window
+*/
 function getTimeAndDateForLog(){
   var date = new Date();
   var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
   return currentDateTime;
 };
 
-// **********************************
-// TRANSCRIPT FUNCTIONS
+// TRANSCRIPT STUFF
 
-// This function is for loading a saved game
-function replaceTranscriptString(data) {
-    transcriptString = data;
+/**
+  * Added by KV
+  *
+  * This will write/append to an HTML document in Documents\Quest Transcripts
+  *  if using the desktop player and the the player has the transcript enabled
+  *  and if noTranscript is not set to true (it is false by default).
+  *
+  * @param {string} text The string to be written to the file
+*/
+function writeToTranscript(text){
+  if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
+    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + text);
+  }
 }
 
-function showTranscript() {
-    var transcriptDivString = "";
-    transcriptDivString += "<div ";
-    transcriptDivString += "id='transcript-dialog' ";
-    transcriptDivString += "style='display:none;'>";
-    transcriptDivString += "<div id='transcriptdata'></div></div>";
-    addText(transcriptDivString);
-    var transcriptDialog = $("#transcript-dialog").dialog({
-        autoOpen: false,
-        width: 600,
-        height: 500,
-        title: "Transcript",
-        buttons: {
-            Ok: function () {
-                $(this).dialog("close");
-                $(this).remove();
-            },
-            Print: function () {
-                printTranscriptDiv();
-                $(this).dialog("close");
-                $(this).remove();
-            },
-        },
-        show: { effect: "fadeIn", duration: 500 },
-        modal: true,
-    });
-    $('#transcriptdata').html(transcriptString);
-    $("#transcriptdata a").addClass("disabled");
-    transcriptDialog.dialog("open");
-    setTimeout(function () {
-        $("#transcriptdata a").addClass("disabled");
-    }, 1);
-};
-
-function printTranscriptDiv() {
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    iframe.contentWindow.document.write($("#transcriptdata").html());
-    iframe.contentWindow.print();
-    document.body.removeChild(iframe);
-    $("#transcript-dialog").dialog("close");
-    $("#transcript-dialog").remove();
-};
-
-// ***********************************
-
+/**
+  * This function was missing from the webplayer in Quest 5.8.0
+  * Leaving this here as a fallback
+  * 
+  * @param {string} text The line(s) of text being printed
+*/
+function SaveTranscript(text){
+  console.log("[QUEST]: SaveTranscript has been deprecated. Using writeToTranscript instead.");
+  writeToTranscript(text);  
+}
 
 
 // GRID FUNCTIONS ***********************************************************************************************************************

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -259,3 +259,28 @@ function saveGameResponse(data) {
         }
     });
 }
+
+/**
+  * Adding this to this file because it exists in desktopplayer.js
+  *
+  * It is doing nothing here if called, except disabling the transcript. It is mainly here just so it is defined.
+  *
+  * @param {string} text This would print to the transcript file if this were the desktop player. It is ignored here.
+*/
+function WriteToTranscript (text) {
+  console.log("[QUEST]: Call to WriteToTranscript ignored. Feature only available in the desktop version of Quest. Disabling the transcript.");
+  var noTranscript = true;
+  var transcriptEnabled = false;
+}
+
+/**
+  * Adding this to this file because it exists in desktopplayer.js
+  *
+  * It is doing nothing here if called, but it is here just so it is defined.
+  *
+  * @param {data} text This would print to the log file if this were the desktop player. It is ignored here.
+*/
+function WriteToLog(data){
+  /* Do nothing at all. */
+  return;
+}

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -795,40 +795,7 @@ function clearScreen() {
     }
 }
 
-// Scrollback functions added by KV
-/**
-  * The player can view the game's text in a pop-up window.
-  * To change the title of the pop-up window, you can do this after calling showScrollback: $("#scrollback-dialog").dialog({title:"TITLE"});
-  * This will include cleared text if saveClearedText is set to true (saveClearedText is false by default).
-  * Setting noScrollback to true will disable this. (noScrollback is false by default)
-  */
-function showScrollback() {
-  if (noScrollback) return;
-  addText("<div id='scrollback-dialog' style='display:none; color:black !important; background-color:white !important; font-family:sans-serif !important;background:white !important;text-align:left !important;'><div id='scrollbackdata'></div></div>");
-  var scrollbackDialog = $("#scrollback-dialog").dialog({
-    autoOpen: false,
-    width: 600,
-    height: 500,
-    title: "Scrollback",
-    buttons: {
-      Ok: function () {
-        $(this).dialog("close");
-        $(this).remove();
-      },
-      Print: function () {
-        printScrollback();
-      },
-    },
-    show: { effect: "fadeIn", duration: 500 },
-    modal: true,
-  });
-  $('#scrollbackdata').html($('#divOutput').html());
-  $("#scrollbackdata a").addClass("disabled");
-  scrollbackDialog.dialog("open");
-  setTimeout(function () {
-    $("#scrollbackdata a").addClass("disabled");
-  }, 1);
-};
+// Scrollback function added by KV
 
 /**
  * The player can print the game's text or save as PDF.
@@ -1248,70 +1215,6 @@ function isMobilePlayer() {
     return (platform === "mobile");
 };
 
-function showPopup(title, text) {
-    $('#msgboxCaption').html(text);
-
-    var msgboxOptions = {
-        modal: true,
-        autoOpen: false,
-        title: title,
-        buttons: [
-			{
-			    text: 'OK',
-			    click: function () { $(this).dialog('close'); }
-			},
-        ],
-        closeOnEscape: false,
-    };
-
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
-};
-
-function showPopupCustomSize(title, text, width, height) {
-    $('#msgboxCaption').html(text);
-
-    var msgboxOptions = {
-        modal: true,
-        autoOpen: false,
-        title: title,
-        width: width,
-        height: height,
-        buttons: [
-			{
-			    text: 'OK',
-			    click: function () { $(this).dialog('close'); }
-			},
-        ],
-        closeOnEscape: false,
-    };
-
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
-};
-
-function showPopupFullscreen(title, text) {
-    $('#msgboxCaption').html(text);
-
-    var msgboxOptions = {
-        modal: true,
-        autoOpen: false,
-        title: title,
-        width: $(window).width(),
-        height: $(window).height(),
-        buttons: [
-			{
-			    text: 'OK',
-			    click: function () { $(this).dialog('close'); }
-			},
-        ],
-        closeOnEscape: false,
-    };
-
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
-};
-
 /**
   * Added by KV for using the JS console for the Quest log when game.useconsolelog is set to true.
   *
@@ -1328,7 +1231,7 @@ function getTimeAndDateForLog(){
 /**
   * Added by KV
   *
-  * This will write/append to an HTML document in Documents\Quest Transcripts
+  * This will write/append to a TXT document in Documents\Quest Transcripts
   *  if using the desktop player and the the player has the transcript enabled
   *  and if noTranscript is not set to true (it is false by default).
   *
@@ -1336,7 +1239,7 @@ function getTimeAndDateForLog(){
 */
 function writeToTranscript(text){
   if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
-    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + text);
+    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $(text.replace(/<br\/>/g,"\r\n").replace(/<br>/g,"\r\n").replace(/<br \/>/g,"\r\n")).text() + "\r\n");
   }
 }
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -357,15 +357,23 @@ function SetBackgroundOpacity(opacity) {
 }
 
 function setBackground(col) {
+    /* If '#rgb', convert to '#rrggbb'*/
+    /* https://github.com/textadventures/quest/issues/1052 */
+    if (col.charAt(0) === "#") && col.length == 4) {
+        var colBak = "" + col + "";
+        newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
+        col = newCol || col;
+        console.warn("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
+    }
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
     rgbCol = hexToRgb(col);
     var cssBackground = "rgba(" + rgbCol.r + "," + rgbCol.g + "," + rgbCol.b + "," + _backgroundOpacity + ")";
     $("#gameBorder").css("background-color", cssBackground);
-
     $("#gamePanel").css("background-color", col);
     $("#gridPanel").css("background-color", col);
 }
+
 
 function setPanelHeight() {
     if (_showGrid) return;

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1304,85 +1304,19 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Make it easy to print messages.
-//var msg = addTextAndScroll;
-    
 // Log functions
-var logVar = "";
-function addLogEntry(text){
-  logVar += getTimeAndDateForLog() + ' ' + text+"NEW_LINE";
-};
+var logArr = [];
 
-function showLog(){
-  var logDivString = "";
-  logDivString += "<div ";
-  logDivString += "id='log-dialog' ";
-  logDivString += "style='display:none;;'>";
-  logDivString += "<textarea id='logdata' rows='13'";
-  logDivString += "  cols='49'></textarea></div>";
-  addText(logDivString);
-  if(webPlayer){
-    var logDialog = $("#log-dialog").dialog({
-      autoOpen: false,
-      width: 600,
-      height: 500,
-      title: "Log",
-      buttons: {
-        Ok: function() {
-          $(this).dialog("close");
-        },
-        Print: function(){
-          $(this).dialog("close");
-          showLogDiv();
-          printLogDiv();
-        },
-        Save: function(){
-          $(this).dialog("close");
-          saveLog();
-        },
-      },
-      show: { effect: "fadeIn", duration: 500 },
-      // The modal setting keeps the player from interacting with anything besides the dialog window.
-      //  (The log will not update while open without adding a turn script.  I prefer this.)
-      modal: true,
-    });
-  }else{
-    var logDialog = $("#log-dialog").dialog({
-    autoOpen: false,
-    width: 600,
-    height: 500,
-    title: "Log",
-    buttons: {
-      Ok: function() {
-        $(this).dialog("close");
-      },
-      Print: function(){
-        $(this).dialog("close");
-        showLogDiv();
-        printLogDiv();
-      },
-    },
-    show: { effect: "fadeIn", duration: 500 },
-    // The modal setting keeps the player from interacting with anything besides the dialog window.
-    //  (The log will not update while open without adding a turn script.  I prefer this.)
-    modal: true,
-  });
+function addLogEntry(text){
+  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
+  if (logDivIsSetUp){
+     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
   }
-  $('textarea#logdata').val(logVar.replace(/NEW_LINE/g,"\n"));
-  logDialog.dialog("open");
 };
 
 var logDivIsSetUp = false;
 
-var logDivToAdd = "";
-logDivToAdd += "<div ";
-logDivToAdd += "id='log-div' ";
-logDivToAdd += "style='display:none;'>";
-logDivToAdd += "<a class='do-not-print-with-log' ";
-logDivToAdd += "href='' onclick='hideLogDiv()'>RETURN TO THE GAME</a>  ";
-logDivToAdd += "<a class='do-not-print-with-log' href='' ";
-logDivToAdd += "onclick='printLogDiv();'>PRINT</a> ";
-logDivToAdd += "<div id='log-contents-div' '></div></div>";
+var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
 
 function setupLogDiv(){
   addText(logDivToAdd);
@@ -1390,19 +1324,22 @@ function setupLogDiv(){
   logDivIsSetUp = true;
 };
 
-function showLogDiv(){
-    if(!logDivIsSetUp){
-     setupLogDiv(); 
-    }
-	$(".do-not-print-with-log").show();
-	$("#log-contents-div").html(logVar.replace(/NEW_LINE/g,"<br/>"));
-	$("#log-div").show();
-	$("#gameBorder").hide();
+function showLog(){
+  if(!logDivIsSetUp){
+    setupLogDiv(); 
+  }
+  hideLogDiv()
+  $(".do-not-print-with-log").show();
+  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
+  if (platform !== "mobile"){
+    $('#log-div').show().insertAfter($('#txtCommandDiv'));
+  } else {
+  $('#log-div').show().insertAfter($('#inputBar')) 
+  }
 };
 
 function hideLogDiv(){
-	$("#log-div").hide();
-	$("#gameBorder").show();
+  $("#log-div").hide();
 };
 
 function printLogDiv(){
@@ -1413,48 +1350,21 @@ function printLogDiv(){
   }
   document.title = "log.txt" ;
   $('.do-not-print-with-log').hide();
+  $("#gameBorder").hide();
+  $('#log-div').insertBefore($("#gameBorder"));
   print();
   $('.do-not-print-with-log').show();
+  $('#log-div').appendTo($("#divOutput"));
+  $("#gameBorder").show();
   document.title = docTitleBak;
 };
 
-
-function saveLog(){
-  if(webPlayer){
-    var href = "data:text/plain,"+logVar.replace(/NEW_LINE/g,"\n");
-    addTextAndScroll("<a download='log.txt' href='"+href+"' id='log-save-link'>Click here to save the log if your pop-up blocker stopped the download.</a>");
-    document.getElementById("log-save-link").addEventListener ("click", function (e) {e.stopPropagation();});
-    document.getElementById("log-save-link").click();
-  }else{
-    alert("This function is only available while playing online.");
-  }
- };
-
 function getTimeAndDateForLog(){
-	var today = new Date();
-	var dd = today.getDate();
-	var mm = today.getMonth()+1;
-	var yyyy = today.getFullYear();
-	var hrs = today.getHours();
-	var mins = today.getMinutes();
-	var secs = today.getSeconds();
-	today = mm + '/' + dd + '/' + yyyy;
-	if(hrs>12) {
-	  ampm = 'PM';
-	  hrs = '0' + '' + hrs - 12
-	}else{
-	  ampm = 'AM';
-	} 
-	if (mins<10) {
-	  mins = '0'+mins;
-	} 
-	if(secs<10) {
-	  secs = '0' + secs;
-	}
-	time = hrs + ':' + mins + ':' + secs + ' ' + ampm;
-	return today + ' ' + time;
+  var date = new Date();
+  var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
+  return currentDateTime;
 };
-    
+
 // **********************************
 // TRANSCRIPT FUNCTIONS
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1304,61 +1304,7 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Log functions
-var logArr = [];
-
-function addLogEntry(text){
-  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
-  if (logDivIsSetUp){
-     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
-  }
-};
-
-var logDivIsSetUp = false;
-
-var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
-
-function setupLogDiv(){
-  addText(logDivToAdd);
-  $("#log-div").insertBefore($("#dialog"));
-  logDivIsSetUp = true;
-};
-
-function showLog(){
-  if(!logDivIsSetUp){
-    setupLogDiv(); 
-  }
-  hideLogDiv()
-  $(".do-not-print-with-log").show();
-  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
-  if (platform !== "mobile"){
-    $('#log-div').show().insertAfter($('#txtCommandDiv'));
-  } else {
-  $('#log-div').show().insertAfter($('#inputBar')) 
-  }
-};
-
-function hideLogDiv(){
-  $("#log-div").hide();
-};
-
-function printLogDiv(){
-  if(typeof(document.title) !== "undefined"){
-    var docTitleBak = document.title;
-  }else{
-    var docTitleBak = "title";
-  }
-  document.title = "log.txt" ;
-  $('.do-not-print-with-log').hide();
-  $("#gameBorder").hide();
-  $('#log-div').insertBefore($("#gameBorder"));
-  print();
-  $('.do-not-print-with-log').show();
-  $('#log-div').appendTo($("#divOutput"));
-  $("#gameBorder").show();
-  document.title = docTitleBak;
-};
-
+// Log function
 function getTimeAndDateForLog(){
   var date = new Date();
   var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -359,7 +359,7 @@ function SetBackgroundOpacity(opacity) {
 function setBackground(col) {
     /* If '#rgb', convert to '#rrggbb'*/
     /* https://github.com/textadventures/quest/issues/1052 */
-    if (col.charAt(0) === "#") && col.length == 4) {
+    if (col.charAt(0) === "#" && col.length == 4) {
         var colBak = "" + col + "";
         newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
         col = newCol || col;

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1239,10 +1239,9 @@ function getTimeAndDateForLog(){
 */
 function writeToTranscript(text){
   if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
-    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $(text.replace(/<br\/>/g,"\r\n").replace(/<br>/g,"\r\n").replace(/<br \/>/g,"\r\n")).text() + "\r\n");
+    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"\r\n").replace(/<br>/g,"\r\n").replace(/<br \/>/g,"\r\n") + "</div>").text() + "\r\n");
   }
 }
-
 /**
   * This function was missing from the webplayer in Quest 5.8.0
   * Leaving this here as a fallback

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -363,7 +363,7 @@ function setBackground(col) {
         var colBak = "" + col + "";
         newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
         col = newCol || col;
-        console.warn("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
+        console.log("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
     }
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
@@ -629,18 +629,16 @@ function addTextAndScroll(text) {
     scrollToEnd();
 }
 
-// These 2 variables added by KV for the transcript
-var savingTranscript = false;
-var transcriptString = "";
-
+var transcriptEnabled = false;
+var noTranscript = false;
 // This function altered by KV for the transcript
 function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
     }
-    if (savingTranscript) {
-        SaveTranscript(text);
-        ASLEvent("UpdateTranscriptString", text);
+    // Only attempt writeToTranscript() if this is the desktop player.
+    if (!webPlayer && platform == "desktop" && transcriptEnabled && !noTranscript) {
+        writeToTranscript(text);
     }
     getCurrentDiv().append(text);
     $("#divOutput").css("min-height", $("#divOutput").height());
@@ -767,7 +765,10 @@ function disableAllCommandLinks() {
 }
 
 // Modified by KV to handle the scrollback feature
-var saveClearedText = true;
+// Changing saveClearedText to false by default, due to performance issues.
+var saveClearedText = false;
+// Authors can change noScrollback to true to disable the scrollback functions.
+var noScrollback = false;
 var clearedOnce = false;
 function clearScreen() {
     if (!saveClearedText) {
@@ -795,49 +796,60 @@ function clearScreen() {
 }
 
 // Scrollback functions added by KV
-
+/**
+  * The player can view the game's text in a pop-up window.
+  * To change the title of the pop-up window, you can do this after calling showScrollback: $("#scrollback-dialog").dialog({title:"TITLE"});
+  * This will include cleared text if saveClearedText is set to true (saveClearedText is false by default).
+  * Setting noScrollback to true will disable this. (noScrollback is false by default)
+  */
 function showScrollback() {
-    var scrollbackDivString = "";
-    scrollbackDivString += "<div ";
-    scrollbackDivString += "id='scrollback-dialog' ";
-    scrollbackDivString += "style='display:none;'>";
-    scrollbackDivString += "<div id='scrollbackdata'></div></div>";
-    addText(scrollbackDivString);
-    var scrollbackDialog = $("#scrollback-dialog").dialog({
-        autoOpen: false,
-        width: 600,
-        height: 500,
-        title: "Scrollback",
-        buttons: {
-            Ok: function () {
-                $(this).dialog("close");
-                $(this).remove();
-            },
-            Print: function () {
-                printScrollbackDiv();
-            },
-        },
-        show: { effect: "fadeIn", duration: 500 },
-        modal: true,
-    });
-    $('#scrollbackdata').html($('#divOutput').html());
+  if (noScrollback) return;
+  addText("<div id='scrollback-dialog' style='display:none; color:black !important; background-color:white !important; font-family:sans-serif !important;background:white !important;text-align:left !important;'><div id='scrollbackdata'></div></div>");
+  var scrollbackDialog = $("#scrollback-dialog").dialog({
+    autoOpen: false,
+    width: 600,
+    height: 500,
+    title: "Scrollback",
+    buttons: {
+      Ok: function () {
+        $(this).dialog("close");
+        $(this).remove();
+      },
+      Print: function () {
+        printScrollback();
+      },
+    },
+    show: { effect: "fadeIn", duration: 500 },
+    modal: true,
+  });
+  $('#scrollbackdata').html($('#divOutput').html());
+  $("#scrollbackdata a").addClass("disabled");
+  scrollbackDialog.dialog("open");
+  setTimeout(function () {
     $("#scrollbackdata a").addClass("disabled");
-    scrollbackDialog.dialog("open");
-    setTimeout(function () {
-        $("#scrollbackdata a").addClass("disabled");
-    }, 1);
+  }, 1);
 };
 
-
-
-function printScrollbackDiv() {
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    iframe.contentWindow.document.write($("#scrollbackdata").html());
-    iframe.contentWindow.print();
-    document.body.removeChild(iframe);
-    $("#scrollback-dialog").dialog("close");
-    $("#scrollback-dialog").remove();
+/**
+ * The player can print the game's text or save as PDF.
+ * This will include cleared text if saveClearedText is set to true (saveClearedText is false by default).
+ * Setting noScrollback to true will disable this. (noScrollback is false by default)
+ */
+function printScrollback() {
+  if (noScrollback) return;
+  addText("<div id='scrollback-hider' style='display:none; color:black !important; background-color:white !important; font-family:sans-serif !important;background:white !important;text-align:left !important;'><div id='scrollbackdata'></div></div>");
+  $('#scrollbackdata').html($('#divOutput').html());
+  $("#scrollbackdata a").addClass("disabled");
+  setTimeout(function () {
+      $("#scrollbackdata a").addClass("disabled");
+  }, 1);
+  var iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  iframe.contentWindow.document.write($("#scrollbackdata").html());
+  iframe.contentWindow.print();
+  document.body.removeChild(iframe);
+  $("#scrollback-dialog").dialog("close");
+  $("#scrollback-dialog").remove();
 };
 
 function keyPressCode(e) {
@@ -1232,12 +1244,8 @@ $(function () {
 // ***********
 // Section added by KV
 
-
 function isMobilePlayer() {
-    if (typeof (currentTab) === 'string') {
-        return true;
-    }
-    return false;
+    return (platform === "mobile");
 };
 
 function showPopup(title, text) {
@@ -1304,67 +1312,44 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Log function
+/**
+  * Added by KV for using the JS console for the Quest log when game.useconsolelog is set to true.
+  *
+  * @return {string} currentDateTime Time and date in format just like the Quest desktop log window
+*/
 function getTimeAndDateForLog(){
   var date = new Date();
   var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
   return currentDateTime;
 };
 
-// **********************************
-// TRANSCRIPT FUNCTIONS
+// TRANSCRIPT STUFF
 
-// This function is for loading a saved game
-function replaceTranscriptString(data) {
-    transcriptString = data;
+/**
+  * Added by KV
+  *
+  * This will write/append to an HTML document in Documents\Quest Transcripts
+  *  if using the desktop player and the the player has the transcript enabled
+  *  and if noTranscript is not set to true (it is false by default).
+  *
+  * @param {string} text The string to be written to the file
+*/
+function writeToTranscript(text){
+  if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
+    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + text);
+  }
 }
 
-function showTranscript() {
-    var transcriptDivString = "";
-    transcriptDivString += "<div ";
-    transcriptDivString += "id='transcript-dialog' ";
-    transcriptDivString += "style='display:none;'>";
-    transcriptDivString += "<div id='transcriptdata'></div></div>";
-    addText(transcriptDivString);
-    var transcriptDialog = $("#transcript-dialog").dialog({
-        autoOpen: false,
-        width: 600,
-        height: 500,
-        title: "Transcript",
-        buttons: {
-            Ok: function () {
-                $(this).dialog("close");
-                $(this).remove();
-            },
-            Print: function () {
-                printTranscriptDiv();
-                $(this).dialog("close");
-                $(this).remove();
-            },
-        },
-        show: { effect: "fadeIn", duration: 500 },
-        modal: true,
-    });
-    $('#transcriptdata').html(transcriptString);
-    $("#transcriptdata a").addClass("disabled");
-    transcriptDialog.dialog("open");
-    setTimeout(function () {
-        $("#transcriptdata a").addClass("disabled");
-    }, 1);
-};
-
-function printTranscriptDiv() {
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    iframe.contentWindow.document.write($("#transcriptdata").html());
-    iframe.contentWindow.print();
-    document.body.removeChild(iframe);
-    $("#transcript-dialog").dialog("close");
-    $("#transcript-dialog").remove();
-};
-
-// ***********************************
-
+/**
+  * This function was missing from the webplayer in Quest 5.8.0
+  * Leaving this here as a fallback
+  * 
+  * @param {string} text The line(s) of text being printed
+*/
+function SaveTranscript(text){
+  console.log("[QUEST]: SaveTranscript has been deprecated. Using writeToTranscript instead.");
+  writeToTranscript(text);  
+}
 
 
 // GRID FUNCTIONS ***********************************************************************************************************************

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1239,9 +1239,66 @@ function getTimeAndDateForLog(){
 */
 function writeToTranscript(text){
   if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
-    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"\r\n").replace(/<br>/g,"\r\n").replace(/<br \/>/g,"\r\n") + "</div>").text() + "\r\n");
+    WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());
   }
 }
+
+/**
+  * This will enable the transcript unless noTranscript is set to true.
+  * 
+  * @param {name} text If this is defined, the transcriptName will be set to this.
+*/
+function enableTranscript(name){
+  if (noTranscript) return;
+  transcriptName = name || transcriptName;
+  transcriptEnabled = true;
+}
+
+/**
+  * This will disable the transcript.
+  * 
+  * @param {name} text If this is defined, the transcriptName will be set to this.
+*/
+function disableTranscript(){
+  transcriptEnabled = false;
+}
+
+/**
+  * This will completely kill the transcript.
+  * 
+  * @param {name} text If this is defined, the transcriptName will be set to this.
+*/
+function killTranscript(){
+  noTranscript = true;
+  disableTranscript();
+}
+
+/**
+  * Make it easy to control transcript settings from Quest.
+  * 
+  * @param {name} text If this is defined, the transcriptName will be set to this.
+*/
+function setTranscriptStatus(status){
+  switch (status){
+    case "enabled":
+    case "enable":
+      initiateTranscript();
+      break;
+    case "disabled":
+    case "disable":
+      disableTranscript();
+      break;
+    case "none":
+    case "killed":
+      killTranscript();
+      break;
+    case "alive":
+      noTranscript = false;
+  }
+}
+
+/**
+  * 
 /**
   * This function was missing from the webplayer in Quest 5.8.0
   * Leaving this here as a fallback
@@ -1252,7 +1309,6 @@ function SaveTranscript(text){
   console.log("[QUEST]: SaveTranscript has been deprecated. Using writeToTranscript instead.");
   writeToTranscript(text);  
 }
-
 
 // GRID FUNCTIONS ***********************************************************************************************************************
 

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -33,13 +33,10 @@
   <function name="InitInterface">
     <![CDATA[
     // Added by KV for transcript
-    // Use JSSafe to remove any offensive characters!  - KV   May 27, 2018
+    JS.whereAmI()
+    // Use JSSafe to remove any offensive characters
     jsgamename = JSSafe(game.gamename)
-    JS.eval ("var gameName = '"+jsgamename+"';var transcriptName = gameName;")
-    if (GetBoolean(game,"savetranscript")){
-      JS.eval("var savingTranscript = true;")
-      JS.replaceTranscriptString(game.transcriptstring)
-    }
+    JS.eval ("var gameName = '" + jsgamename + "'; var transcriptName = gameName;")
     // End of addition by KV for transcript
     if (game.setcustomwidth) {
       JS.setGameWidth (game.customwidth)
@@ -286,9 +283,11 @@
       UpdateStatusAttributes
       UpdateObjectLinks
     }
-    // Added by KV to use the old JS clearScreen if the transcript is disabled
     if (GetBoolean(game, "notranscript")){
-      JS.eval("transcriptEnabled = false;")
+      KillTranscript
+    }
+    if (GetBoolean (game, "saveclearedtext")){
+      JS.eval("var saveClearedText = true;")
     }
     game.runturnscripts = false
     FinishTurn

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -33,6 +33,7 @@
   <function name="InitInterface">
     <![CDATA[
     // Added by KV for transcript
+    // The walkthrough has been modified to ignore this event when recording or running.
     JS.whereAmI()
     // Use JSSafe to remove any offensive characters
     jsgamename = JSSafe(game.gamename)
@@ -229,6 +230,15 @@
   
   <function name="StartGame">
     <![CDATA[
+    // Added by KV here in case someone enables the transcript up front to record everything including the title.
+    transcript_triggered = false
+    if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript")){
+      if (not HasAttribute (game, "transcriptname")){
+        game.transcriptname = game.gamename
+      }
+      EnableTranscript
+      transcript_triggered = true
+    }
     StartTurnOutputSection
     if (game.showtitle) {
       JS.StartOutputSection ("title")
@@ -283,11 +293,21 @@
       UpdateStatusAttributes
       UpdateObjectLinks
     }
-    if (GetBoolean(game, "notranscript")){
-      KillTranscript
-    }
     if (GetBoolean (game, "saveclearedtext")){
       JS.eval("var saveClearedText = true;")
+    }
+    else {
+      JS.eval("var saveClearedText = false;")
+    }
+    // Added by KV once more here, in case someone enabled the transcript in the start script or an _initialise_ script.
+    if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript") and not transcript_triggered){
+      if (not HasAttribute (game, "transcriptname")){
+        game.transcriptname = game.gamename
+      }
+      EnableTranscript
+    }
+    if (GetBoolean(game, "notranscript")){
+      KillTranscript
     }
     game.runturnscripts = false
     FinishTurn

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -878,6 +878,7 @@
   <verb template="climb" property="climb" response="DefaultClimb"/>
   <verb template="drink" property="drink" response="DefaultDrink"/>
   <verb template="eat" property="eat" response="DefaultEat"/>
+  <verb name="enter" template="enter" property="enter_verb" displayverb="[enter]" response="DefaultEnter"/>
   <verb template="hit" property="hit" response="DefaultHit"/>
   <verb template="kill" property="kill" response="DefaultKill"/>
   <verb template="kiss" property="kiss" response="DefaultKiss"/>

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -1002,9 +1002,6 @@
                 }
                 msg ("> " + game.transcriptname)
                 EnableTranscript
-                msg ("")
-                msg (DynamicTemplate("TranscriptEnabledMessage"))
-                msg (DynamicTemplate("ToDisableTranscript"))
               }
             }
             else {

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -991,7 +991,7 @@
                 EnableTranscript
                 msg ("")
                 msg (DynamicTemplate("TranscriptEnabledMessage"))
-                msg (Template("ToDisableTranscript"))
+                msg (DynamicTemplate("ToDisableTranscript"))
               }
             }
             else {

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -956,82 +956,76 @@
     ]]></script>
   </command>
 
-  <command name="view_transcript_cmd" pattern="[view_transcript_cmd]">
-    <script>
-      if (not GetBoolean(game, "notranscript")){
-        JS.showTranscript ()
-      }
-      else {
-        msg ("This game has no transcript feature.")
-      }
-      game.suppressturnscripts = true
-    </script>
-  </command>
-
   <command name="transcript_on_cmd" pattern="[transcript_on_cmd]">
     <script>
       <![CDATA[
-      if (not GetBoolean(game, "notranscript")) {
-        if (not GetBoolean(game,"savetranscript")) {
-          msg ("Please enter a filename.  (<b>  \"-transcript.html\" will be appended to this filename.)<br/>  <i>(The file will be saved in \"Documents\\Quest Transcripts\".)</i></b>")
-          JS.eval ("$('input#txtCommand').val(transcriptName);")
-          get input {
-            filename = Trim(result)
-            if (not filename = "") {
-              JS.eval ("transcriptName = '"+filename+"';")
-            }
-            JS.eval ("savingTranscript = true;")
-            game.savetranscript = true
-            pre = "<hr/>Transcript enabled for:<br/>"
-            s = "<b>TITLE: </b>" + game.gamename + "<br/>"
-            if (HasAttribute (game, "author")) {
-              s = s + "<b>AUTHOR: </b>" + game.author + "<br/>"
-            }
-            s = s + "<b>VERSION: </b>" + game.version + "<br/>"
-            s = s + "<b>IFID: </b>" + game.gameid + "<br/>"
-            s = s + "<br/>"
-            s = pre + s
-            msg("")
-            msg (s)
-            msg ("<br/><b><i>[  Enter </i>SCRIPT OFF<i> to disable the transcript.  ]</i></b>")
-          }
-        }
-        else {
-          msg ("The transcript is already enabled.")
-        }
+      // NOTE TO AUTHORS:
+      // If you don't want players to be able to enable a transcript to write to a local file when using the desktop player, set game.notranscript to true.
+      if ( GetBoolean(game, "notranscript")) {
+        msg (Template("NoTranscriptFeature"))
       }
       else {
-        msg ("This game has no transcript feature.")
+        if ( GetBoolean(game,"transcriptenabled")) {
+          msg (Template("TranscriptAlreadyEnabled"))
+        }
+        else {
+          if (not HasAttribute (game, "questplatform")) {
+            // Run whereAmI(). Things should work on the next attempt!
+            JS.whereAmI ()
+            msg (Template("TranscriptTryAgain"))
+          }
+          else {
+            if (game.questplatform = "desktop") {
+              msg (Template("TranscriptEnterFilename"))
+              // This puts the current JS value of transcriptName in the text input box.
+              // This is set to game.gamename by default when play begins.
+              JS.eval ("$('input#txtCommand').val(transcriptName);")
+              get input {
+                filename = GetWindowsSafeName(result)
+                game.transcriptname = game.gamename
+                if (not filename = "") {
+                  JS.eval ("transcriptName = '" + filename + "';")
+                  game.transcriptname = filename
+                }
+                msg ("> " + game.transcriptname)
+                EnableTranscript
+                msg ("")
+                msg (DynamicTemplate("TranscriptEnabledMessage"))
+                msg (Template("ToDisableTranscript"))
+              }
+            }
+            else {
+              msg (Template("TranscriptDesktopOnly"))
+            }
+          }
+        }
       }
-      game.suppressturnscripts = true
+      SuppressTurnscripts
     ]]>
     </script>
   </command>
 
   <command name="transcript_off_cmd" pattern="[transcript_off_cmd]">
     <script>
-      if (not GetBoolean(game, "notranscript")) {
-        if (GetBoolean(game,"savetranscript")) {
-          game.savetranscript = false
-          JS.eval ("var savingTranscript = false;")
-          msg ("Transcript disabled.")
-        }
-        else {
-          msg ("The transcript is already disabled.")
-        }
+      if (GetBoolean(game, "notranscript") or not game.questplatform = "desktop") {
+        // Kill it, just in case.
+        KillTranscript
+        msg (Template("NoTranscriptFeature"))
       }
       else {
-        msg ("This game has no transcript feature.")
+        if (GetBoolean(game,"transcriptenabled")) {
+          msg (Template("TranscriptDisabled"))
+        }
+        else {
+          msg (Template("TranscriptAlreadyDisabled"))
+        }
       }
-      game.suppressturnscripts = true
+      // Disable it anyway, just in case.
+      DisableTranscript
+      SuppressTurnscripts
     </script>
   </command>
 
-  <function name="UpdateTranscriptString" parameters="data">
-    game.suppressturnscripts = true
-    game.transcriptstring = game.transcriptstring + data
-  </function>
-  
   <command name="restart" pattern="^restart$">
     <script>
       Ask (Template("WantRestartGame")){
@@ -1054,4 +1048,5 @@
       return (prefix + DynamicTemplate("ObjectNotOpen", obj))
     }
   </function>
+
 </library>

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -961,6 +961,7 @@
       <![CDATA[
       // NOTE TO AUTHORS:
       // If you don't want players to be able to enable a transcript to write to a local file when using the desktop player, set game.notranscript to true.
+      SuppressTurnscripts
       if ( GetBoolean(game, "notranscript")) {
         msg (Template("NoTranscriptFeature"))
       }
@@ -972,6 +973,17 @@
           if (not HasAttribute (game, "questplatform")) {
             // Run whereAmI(). Things should work on the next attempt!
             JS.whereAmI ()
+            //Set up a counter, just in case.
+            if (not HasAttribute (game, "transcript_retries")){
+              game.transcript_retries = 0
+            }
+            game.transcript_retries = game.transcript_retries + 1
+            if (game.transcript_retries > 3){
+              KillTranscript
+              msg (Template("TranscriptExcessiveRetries"))
+              JS.eval("if (webPlayer) { addTextAndScroll (\"<br/>" + Template("TranscriptDesktopOnly") + "<br/><br/>\");}")
+              return ("")
+            }
             msg (Template("TranscriptTryAgain"))
           }
           else {
@@ -981,6 +993,7 @@
               // This is set to game.gamename by default when play begins.
               JS.eval ("$('input#txtCommand').val(transcriptName);")
               get input {
+                JS.eval ("$('input#txtCommand').val(\"\");")
                 filename = GetWindowsSafeName(result)
                 game.transcriptname = game.gamename
                 if (not filename = "") {
@@ -1000,7 +1013,6 @@
           }
         }
       }
-      SuppressTurnscripts
     ]]>
     </script>
   </command>

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -956,18 +956,6 @@
     ]]></script>
   </command>
 
-  <command name="log_cmd" pattern="[log_cmd]">
-    <script>
-      if (not GetBoolean(game, "nohtmllog")){
-        JS.showLog ()
-      }
-      else {
-        msg ("This game has no in-game log.")
-      }
-      game.suppressturnscripts = true
-    </script>
-  </command>
-
   <command name="view_transcript_cmd" pattern="[view_transcript_cmd]">
     <script>
       if (not GetBoolean(game, "notranscript")){

--- a/WorldModel/WorldModel/Core/CoreEditorObjectVerbs.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectVerbs.aslx
@@ -61,7 +61,7 @@
         </item>
         <item>
           <key>enter</key>
-          <value>Use a command, rather than a verb, to allow the player to enter this object.</value>
+          <value>Input the verb name as "enter_verb". It will appear as "enter" to the player.</value>
         </item>
       </clashmessages>
       <defaultexpression>[EditorVerbDefaultExpression]</defaultexpression>

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -232,7 +232,7 @@
   ]]>
   </function>
   
-  <function name="ShowMenuResponse" parameters="option">
+  <function name="ShowMenuResponse" parameters="option"><![CDATA[
     if (game.menucallback = null) {
       error ("Unexpected menu response")
     }
@@ -246,10 +246,16 @@
         game.runturnscripts = true
       }
       game.disambiguating = false
+      // Added by KV to write the result to the transcript if game.echocommands is false.
+      if (not GetBoolean(game, "echocommands")){
+        if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
+          JS.writeToTranscript("&gt; " + SafeXML(result) + "&gt;br&lt;")
+        }
+      }
       invoke (script, parameters)
       FinishTurn
     }
-  </function>
+  ]]></function>
   
   <function name="EscapeQuotes" parameters="s" type="string">
     s = Replace(s, "\"", "@@@doublequote@@@")
@@ -607,11 +613,35 @@
   ]]>
   </function>
   
-  <function name="DisableTranscript">
-    game.notranscript = true
-    JS.eval("savingTranscript = false;")
+  <function name="EnableTranscript">
+    game.transcriptenabled = true
+    JS.eval("var transcriptEnabled = true;")
   </function>
-
+  
+  <function name="DisableTranscript">
+    game.transcriptenabled = false
+    JS.eval("var transcriptEnabled = false;")
+  </function>
+  
+  <function name="KillTranscript">
+    game.notranscript = true
+    JS.eval("var noTranscript = true;")
+    DisableTranscript
+  </function>
+  <function name="GetWindowsSafeName" parameters="dirty" type="string"><![CDATA[
+    if (StartsWith(dirty, ".")) {
+      dirty = Mid (dirty, 2, LengthOf (dirty) -1)
+    }
+    clean = Trim(Replace(Replace(Replace(Replace(Replace(Replace(Replace(Replace(Replace(dirty, "\"", "''"), "<", "_"), ">", "_"), ":", "_"), "/", "_"), "\\", "_"), "|", "_"), "?", "_"), "*", "_"))
+    changed_something = false
+    if (not clean = dirty) {
+      changed_something = true
+    }
+    if (StartsWith(clean, ".")) {
+      clean = GetWindowsSafeName(clean)
+    }
+    return (clean)
+  ]]></function>
   <function name="QuickParams" parameters="key1, value1, key2, value2, key3, value3" type="dictionary">
     d = NewDictionary()
     dictionary add (d, key1, value1)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -592,7 +592,7 @@
 
   <function name="DictionaryRemove" parameters="dict, key">
     if (dict = null or TypeOf(dict)="object") {
-      error ("DictionaryAdd:  Dictionary does not exist!")
+      error ("DictionaryRemove:  Dictionary does not exist!")
     }
     if (DictionaryContains(dict, key)) {
       dictionary remove (dict, key)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -249,7 +249,10 @@
       // Added by KV to write the result to the transcript if game.echocommands is false.
       if (not GetBoolean(game, "echocommands")){
         if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
-          JS.writeToTranscript("> " + SafeXML(UnescapeQuotes(option)) + "<br/>")
+          JS.writeToTranscript("<span><br/>> " + SafeXML(UnescapeQuotes(option)) + "</span>")
+          if (game.command_newline) {
+            JS.writeToTranscript("<span><br/></span>")
+          }
         }
       }
       invoke (script, parameters)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -615,6 +615,11 @@
   <function name="DisableHtmlLog">
     game.nohtmllog = true
   </function>
+  
+  <function name="ClearHtmlLog">
+    JS.eval("$(\"#log-div\").html(\"\").hide(); logArr = [];")
+  </function>
+
 
   <function name="QuickParams" parameters="key1, value1, key2, value2, key3, value3" type="dictionary">
     d = NewDictionary()

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -246,15 +246,6 @@
         game.runturnscripts = true
       }
       game.disambiguating = false
-      // Added by KV to write the result to the transcript if game.echocommands is false.
-      if (not GetBoolean(game, "echocommands")){
-        if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
-          JS.writeToTranscript("<span><br/>> " + SafeXML(UnescapeQuotes(option)) + "</span>")
-          if (game.command_newline) {
-            JS.writeToTranscript("<span><br/></span>")
-          }
-        }
-      }
       invoke (script, parameters)
       FinishTurn
     }
@@ -617,20 +608,31 @@
   </function>
   
   <function name="EnableTranscript">
+    if (not HasAttribute (game, "transcriptname")){
+      game.transcriptname = game.gamename
+    }
     game.transcriptenabled = true
-    JS.eval("var transcriptEnabled = true;")
+    JS.enableTranscript(game.transcriptname)
+    msg ("")
+    msg (DynamicTemplate("TranscriptEnabledMessage"))
+    // Don't print the next line in the transcript.
+    JS.disableTranscript()
+    msg (DynamicTemplate("ToDisableTranscript"))
+    JS.enableTranscript(game.transcriptname)
+    msg("")
   </function>
   
   <function name="DisableTranscript">
     game.transcriptenabled = false
-    JS.eval("var transcriptEnabled = false;")
+    JS.disableTranscript()
   </function>
   
   <function name="KillTranscript">
     game.notranscript = true
-    JS.eval("var noTranscript = true;")
+    JS.killTranscript()
     DisableTranscript
   </function>
+  
   <function name="GetWindowsSafeName" parameters="dirty" type="string"><![CDATA[
     if (StartsWith(dirty, ".")) {
       dirty = Mid (dirty, 2, LengthOf (dirty) -1)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -249,7 +249,7 @@
       // Added by KV to write the result to the transcript if game.echocommands is false.
       if (not GetBoolean(game, "echocommands")){
         if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
-          JS.writeToTranscript("&gt; " + SafeXML(result) + "&gt;br&lt;")
+          JS.writeToTranscript("> " + SafeXML(UnescapeQuotes(option)) + "<br/>")
         }
       }
       invoke (script, parameters)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -611,15 +611,6 @@
     game.notranscript = true
     JS.eval("savingTranscript = false;")
   </function>
-  
-  <function name="DisableHtmlLog">
-    game.nohtmllog = true
-  </function>
-  
-  <function name="ClearHtmlLog">
-    JS.eval("$(\"#log-div\").html(\"\").hide(); logArr = [];")
-  </function>
-
 
   <function name="QuickParams" parameters="key1, value1, key2, value2, key3, value3" type="dictionary">
     d = NewDictionary()

--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -872,18 +872,21 @@
     ]]>
   </function>
 
-  <function name="Log" parameters="text">
-    <![CDATA[
-    //request (Log, text)
+  <function name="Log" parameters="text"><![CDATA[
+    //Use the log window in the desktop player, if available.
+    request (Log, text)
     // Replacing double quotes with 2 single quotes
     text = Replace(text, "\"", "''")
-    // Changing syntax from single quotes to escaped double quotes to allow single quotes in log entries
     if (not GetBoolean(game, "nohtmllog")){
-      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\""+text+"\"); };")
+      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\"" + text + "\"); };")
     }
-    JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){var s = \""+text+"\";WriteToLog(s);}")
-    ]]>
-  </function>
+    if (GetBoolean (game, "writelogtofile")){
+      JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){ WriteToLog(\"" + text + "\");}")
+    }
+    if (GetBoolean (game, "useconsolelog")){
+      JS.eval("console.log(getTimeAndDateForLog() + \" : " + text + "\");")
+    }
+  ]]></function>
 
   <function name="SetBackgroundImage" parameters="filename">
     JS.SetBackgroundImage(GetFileURL(filename))

--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -873,18 +873,15 @@
   </function>
 
   <function name="Log" parameters="text"><![CDATA[
-    //Use the log window in the desktop player, if available.
+    // Use the log window in the desktop player. If not using the desktop player, this does nothing.
     request (Log, text)
-    // Replacing double quotes with 2 single quotes
-    text = Replace(text, "\"", "''")
-    if (not GetBoolean(game, "nohtmllog")){
-      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\"" + text + "\"); };")
-    }
+    // Write to a file in "Documents\Quest Logs" if game.writelogtofile is true (default is false)
     if (GetBoolean (game, "writelogtofile")){
-      JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){ WriteToLog(\"" + text + "\");}")
+      JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){ WriteToLog(\"" + Replace(text, "\"", "''") + "\");}")
     }
+    // Use the console log if game.useconsolelog is true (default is false)
     if (GetBoolean (game, "useconsolelog")){
-      JS.eval("console.log(getTimeAndDateForLog() + \" : " + text + "\");")
+      JS.eval("console.log(getTimeAndDateForLog() + \"" + Replace(text, "\"", "''") + "\");")
     }
   ]]></function>
 

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -64,7 +64,7 @@
         else {
           // Added by KV to write the command to the transcript if game.echocommands is false.
           if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
-            JS.writeToTranscript("&gt; " + SafeXML(command) + "&gt;br&lt;")
+            JS.writeToTranscript("&gt; " + SafeXML(command) + "\r\n")
           }
         }
         if (game.command_newline) {

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -64,7 +64,7 @@
         else {
           // Added by KV to write the command to the transcript if game.echocommands is false.
           if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
-            JS.writeToTranscript("&gt; " + SafeXML(command) + "\r\n")
+            JS.writeToTranscript("<span>&gt; " + SafeXML(command) + "</span>")
           }
         }
         if (game.command_newline) {

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -61,6 +61,12 @@
             OutputTextRaw ("&gt; " + SafeXML(command))
           }
         }
+        else {
+          // Added by KV to write the command to the transcript if game.echocommands is false.
+          if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
+            JS.writeToTranscript("&gt; " + SafeXML(command) + "&gt;br&lt;")
+          }
+        }
         if (game.command_newline) {
           msg ("")
         }

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -64,7 +64,7 @@
         else {
           // Added by KV to write the command to the transcript if game.echocommands is false.
           if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
-            JS.writeToTranscript("<span>&gt; " + SafeXML(command) + "</span>")
+            JS.writeToTranscript("<span><br/>> " + SafeXML(command) + "<br/></span>")
           }
         }
         if (game.command_newline) {

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -36,7 +36,7 @@
         game.suppressturnscripts = true
         msg ("")
         msg (SafeXML (command))
-        msg("Noted.")
+        msg(Template("Noted"))
 	// Added for Quest 5.8    - KV
 	FinishTurn
       }

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -92,7 +92,6 @@
     <deactivatecommandlinks type="boolean">false</deactivatecommandlinks>
     <multiplecommands type="boolean">false</multiplecommands>
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
-    <nohtmllog/>
     <writelogtofile type="boolean">false</writelogtofile>
     <useconsolelog type="boolean">false</useconsolelog>
     <notranscript type="boolean">false</notranscript>

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -96,6 +96,22 @@
     <useconsolelog type="boolean">false</useconsolelog>
     <notranscript type="boolean">false</notranscript>
     <transcriptenabled type="boolean">false</transcriptenabled>
+    <changedtranscriptenabled type="script">
+      if (game.transcriptenabled = true){
+        JS.enableTranscript()
+      }
+      else if (game.transcriptenabled = false){
+        JS.disableTranscript()
+      }
+    </changedtranscriptenabled>
+    <changednotranscript type="script">
+      if (game.notranscript = true){
+        KillTranscript
+      }
+      else if (game.notranscript = false) {
+        JS.setTranscriptStatus("alive");
+      }
+    </changednotranscript>
     <suppressturnscripts/>
     <!-- Scripts used by the text processor -->
     <textprocessorcommands type="scriptdictionary">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -95,6 +95,7 @@
     <writelogtofile type="boolean">false</writelogtofile>
     <useconsolelog type="boolean">false</useconsolelog>
     <notranscript type="boolean">false</notranscript>
+    <transcriptenabled type="boolean">false</transcriptenabled>
     <suppressturnscripts/>
     <!-- Scripts used by the text processor -->
     <textprocessorcommands type="scriptdictionary">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -92,7 +92,9 @@
     <deactivatecommandlinks type="boolean">false</deactivatecommandlinks>
     <multiplecommands type="boolean">false</multiplecommands>
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
-    <nohtmllog type="boolean">false</nohtmllog>
+    <nohtmllog/>
+    <writelogtofile type="boolean">false</writelogtofile>
+    <useconsolelog type="boolean">false</useconsolelog>
     <notranscript type="boolean">false</notranscript>
     <suppressturnscripts/>
     <!-- Scripts used by the text processor -->

--- a/WorldModel/WorldModel/Core/Languages/Dansk.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Dansk.aslx
@@ -326,7 +326,6 @@
   <template templatetype="command" name="save">^gem$</template>
   <dynamictemplate name="DefaultTellTo">WriteVerb(object, "do") + " ingenting."</dynamictemplate>
 
-  <template templatetype="command" name="log_cmd">^log$|^se log$|^vis log$</template>
   <template templatetype="command" name="transcript_on_cmd">^scriptet$</template>
   <template templatetype="command" name="transcript_off_cmd">^scriptet off$</template>
   <template templatetype="command" name="view_transcript_cmd">^(se |vis |)(scriptet)$</template>

--- a/WorldModel/WorldModel/Core/Languages/Dansk.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Dansk.aslx
@@ -329,6 +329,8 @@
   <template templatetype="command" name="transcript_on_cmd">^scriptet$</template>
   <template templatetype="command" name="transcript_off_cmd">^scriptet off$</template>
   <template templatetype="command" name="version_cmd">^(version|info|om)$</template>
+  
+  <template name="TranscriptOffAllCaps">SCRIPTET OFF</template>
 
   <dynamictemplate name="WearSuccessful">"Du tager " + object.article + " på."</dynamictemplate>
   <dynamictemplate name="WearUnsuccessful">"Du kan ikke tage " + object.article + " på."</dynamictemplate>

--- a/WorldModel/WorldModel/Core/Languages/Dansk.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Dansk.aslx
@@ -328,7 +328,6 @@
 
   <template templatetype="command" name="transcript_on_cmd">^scriptet$</template>
   <template templatetype="command" name="transcript_off_cmd">^scriptet off$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(se |vis |)(scriptet)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|om)$</template>
 
   <dynamictemplate name="WearSuccessful">"Du tager " + object.article + " på."</dynamictemplate>

--- a/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
@@ -564,5 +564,7 @@
   <template name="DevModeComSelfTestFailed">Die Zuordnung, wie sie nach dem Kommando sein sollte ist inkorrekt.</template>
   <dynamictemplate name="DevModeErrorCantFindObject">"Das Objekt mit dem Namen '" + text + "' kann nicht gefunden werden."</dynamictemplate>
   <dynamictemplate name="DevModeErrorCantFindAttribute">"Das Attribut mit dem Namen '" + text + "' kann nicht gefunden werden."</dynamictemplate>
-
+  
+  <!-- Added by KV -->
+  <template name="TranscriptOffAllCaps">TRANSKRIPT AUS</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
@@ -2,7 +2,8 @@
   <!-- Contributed by Pertex -->
   <!-- nicht übersetzte Templates werden aus der English.aslx übernommen -->
   <include ref="English.aslx"/>
-  
+  <!-- In case new English templates are ever added. -->
+  <include ref="EditorEnglish.aslx"/>
   <!-- Contributed by SoonGames -->
   <include ref="EditorDeutsch.aslx"/>
   
@@ -564,7 +565,26 @@
   <template name="DevModeComSelfTestFailed">Die Zuordnung, wie sie nach dem Kommando sein sollte ist inkorrekt.</template>
   <dynamictemplate name="DevModeErrorCantFindObject">"Das Objekt mit dem Namen '" + text + "' kann nicht gefunden werden."</dynamictemplate>
   <dynamictemplate name="DevModeErrorCantFindAttribute">"Das Attribut mit dem Namen '" + text + "' kann nicht gefunden werden."</dynamictemplate>
-  
+  <template name="EditorGameEnableDevMode">Entwicklermodus (Hinzufügen von erweiterten Befehlen zum Testen des Spiels)</template>
+  <template name="EditorGameDevMode">Entwicklermodus</template>
+  <template name="EditorGameDevModeInfoRelease">Wichtig: Vor Veröffentlichung des Spiels muss der Entwicklermodus deaktiviert werden!</template>  
+  <template name="EditorGameDevModeInfoCommands">Es stehen im laufenden Spiel erweiterte Kommandos zur Verfügung. Geben Sie '#?' ein um weitere Informationen zu erhalten.</template>
+  <template name="EditorGameDevModeOptions">Optionen</template>
+  <template name="EditorGameDevModeChangePov">Einen anderen Spieler wählen</template>
+  <template name="EditorGameDevModePov">Spieler</template>
+  <template name="EditorGameDevModeChangePovPos">Eine andere Position des Spielers wählen</template>
+  <template name="EditorGameDevModePlace">Ort</template>
+  <template name="EditorGameDevModeSetInitScript">Ein Initialisierungsscript für den Entwicklermodus verwenden</template>
+  <template name="EditorGameDevModeInitScript">Initialisierungsscript für den Entwicklermodus</template>
+  <template name="EditorGameDevModeShowDebugTable">Zeige Debugtabelle</template>
+  <template name="EditorGameDevModeSetVerbs">Verben des Entwicklungsmodus in die Verbliste der Objekte hinzufügen</template>
+  <template name="EditorGameDevModeShowInfos">Ausgaben des Entwicklungsmodus anzeigen</template>  
+  <template name="EditorGameDevModeOwnFontColour">Eigene Schriftfarbe für die Ausgabe des Entwicklermodus verwenden</template>
+  <template name="EditorGameDevModeFontColour">Schriftfarbe für die Ausgaben des Entwicklermodus</template>
+  <template name="EditorGameDevModeOn">Aktiviert</template>
+  <template name="EditorGameDevModeOff">Deaktiviert</template>
+  <template name="EditorGameDevModeAttributes">Attributes</template>
+  <template name="EditorGameDevModeDescriptionAttribute"><![CDATA[In "Key" wird das Objekt mit dem zugehörigen Attribut eingetragen (z. B. game.showtitle oder player.look). In "Value" wird die Zuweisung eingetragen. Es ist möglich Strings ("Hallo Welt!"), Boolean (true oder false), Integer (15), Double (25.55), Lists (["Hallo","Welt","!"]) und Dictionarys ({H:"Hallo",W:"Welt"} zu erstellen.)]]></template>
   <!-- Added by KV -->
   <template name="TranscriptOffAllCaps">TRANSKRIPT AUS</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
@@ -543,7 +543,6 @@
 	]]>
 </function>
 
-  <template templatetype="command" name="log_cmd">^(zeige |zeig |)(log|protokoll)$</template>
   <template templatetype="command" name="transcript_on_cmd">^(transkript|skript)( an|)$|^aktiviere (skript|transkript)$</template>
   <template templatetype="command" name="transcript_off_cmd">^(transkript|skript) aus$|^deaktiviere (skript|transkript)$</template>
   <template templatetype="command" name="view_transcript_cmd">^(zeige|zeig) (das |)(skript|transkript)$</template>

--- a/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
@@ -545,7 +545,6 @@
 
   <template templatetype="command" name="transcript_on_cmd">^(transkript|skript)( an|)$|^aktiviere (skript|transkript)$</template>
   <template templatetype="command" name="transcript_off_cmd">^(transkript|skript) aus$|^deaktiviere (skript|transkript)$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(zeige|zeig) (das |)(skript|transkript)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|über)$</template>  
 
   <template name="DevModeErrorWrongFormat">Das ist leider das falsche Format.</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorDeutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorDeutsch.aslx
@@ -3,26 +3,7 @@
 <library type="editor">
   <template name="EditorDefault">Standard</template>
   <template name="EditorObjectWearableAdjVerbs">Die Inventarverben den Zuständen anpassen</template>
-  <template name="EditorGameEnableDevMode">Entwicklermodus (Hinzufügen von erweiterten Befehlen zum Testen des Spiels)</template>
-  <template name="EditorGameDevMode">Entwicklermodus</template>
-  <template name="EditorGameDevModeInfoRelease">Wichtig: Vor Veröffentlichung des Spiels muss der Entwicklermodus deaktiviert werden!</template>  
-  <template name="EditorGameDevModeInfoCommands">Es stehen im laufenden Spiel erweiterte Kommandos zur Verfügung. Geben Sie '#?' ein um weitere Informationen zu erhalten.</template>
-  <template name="EditorGameDevModeOptions">Optionen</template>
-  <template name="EditorGameDevModeChangePov">Einen anderen Spieler wählen</template>
-  <template name="EditorGameDevModePov">Spieler</template>
-  <template name="EditorGameDevModeChangePovPos">Eine andere Position des Spielers wählen</template>
-  <template name="EditorGameDevModePlace">Ort</template>
-  <template name="EditorGameDevModeSetInitScript">Ein Initialisierungsscript für den Entwicklermodus verwenden</template>
-  <template name="EditorGameDevModeInitScript">Initialisierungsscript für den Entwicklermodus</template>
-  <template name="EditorGameDevModeShowDebugTable">Zeige Debugtabelle</template>
-  <template name="EditorGameDevModeSetVerbs">Verben des Entwicklungsmodus in die Verbliste der Objekte hinzufügen</template>
-  <template name="EditorGameDevModeShowInfos">Ausgaben des Entwicklungsmodus anzeigen</template>  
-  <template name="EditorGameDevModeOwnFontColour">Eigene Schriftfarbe für die Ausgabe des Entwicklermodus verwenden</template>
-  <template name="EditorGameDevModeFontColour">Schriftfarbe für die Ausgaben des Entwicklermodus</template>
-  <template name="EditorGameDevModeOn">Aktiviert</template>
-  <template name="EditorGameDevModeOff">Deaktiviert</template>
-  <template name="EditorGameDevModeAttributes">Attributes</template>
-  <template name="EditorGameDevModeDescriptionAttribute"><![CDATA[In "Key" wird das Objekt mit dem zugehörigen Attribut eingetragen (z. B. game.showtitle oder player.look). In "Value" wird die Zuweisung eingetragen. Es ist möglich Strings ("Hallo Welt!"), Boolean (true oder false), Integer (15), Double (25.55), Lists (["Hallo","Welt","!"]) und Dictionarys ({H:"Hallo",W:"Welt"} zu erstellen.)]]></template>
+  <!-- Moved all DevMode templates to Deutsch.aslx to avoid issues with gamebooks. -->
   <template name="EditorScriptsTurnScriptsSuppressurnscript">Turn-Skripte unterdrücken</template>
   <template name="EditorGBScriptWhenEnteringPage">Skript starten bei Seitenaufruf</template>
   <template name="EditorGBClearScreenBetweenEachPage">Bildschirm zwischen jeder Seite leeren</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -1,26 +1,11 @@
 <library type="editor">
   <template name="EditorDefault">Default</template>
   <template name="EditorObjectWearableAdjVerbs">Adapting the inventory verbs to the states</template>
-  <template name="EditorGameEnableDevMode">Show DevMode options</template>
-  <template name="EditorGameDevMode">DevMode</template>
-  <template name="EditorGameDevModeInfoRelease">Important: Before releasing the game DevMode must be deactivated!</template>
-  <template name="EditorGameDevModeInfoCommands">Enhanced commands are available in the current game. Enter '#?' to get more information.</template>
-  <template name="EditorGameDevModeOptions">Options</template>
-  <template name="EditorGameDevModeChangePov">Select another player</template>
-  <template name="EditorGameDevModeChangePovPos">Select another starting location for the player</template>
-  <template name="EditorGameDevModePov">Player</template>
-  <template name="EditorGameDevModePlace">Location</template>
-  <template name="EditorGameDevModeSetInitScript">Use an initialization script for DevMode</template>
-  <template name="EditorGameDevModeInitScript">Initialization script for DevMode</template>
-  <template name="EditorGameDevModeShowDebugTable">Show debugtable</template>
-  <template name="EditorGameDevModeSetVerbs">Add DevMode verbs to the verb list of objects</template>
-  <template name="EditorGameDevModeShowInfos">Display DevMode output</template>
-  <template name="EditorGameDevModeOwnFontColour">Use your own font color for DevMode output</template>
-  <template name="EditorGameDevModeFontColour">Font color for DevMode output</template>
-  <template name="EditorGameDevModeOn">Active</template>
-  <template name="EditorGameDevModeOff">Inactive</template>
-  <template name="EditorGameDevModeAttributes">Attributes</template>
-  <template name="EditorGameDevModeDescriptionAttribute"><![CDATA[Enter the object with the corresponding attribute in "Key" (e. g. game.showtitle or player.look). The assignment is entered in "Value". It is possible to create Strings ("Hello World!"), Boolean (true or false), Integer (15), Double (25.55), Listen (["Hello","World","!"]) and Dictionarys ({H:"Hello",W:"World"}.)]]></template>
+
+  <!--
+      DevMode templates moved to English.aslx to avoid issues with gamebooks.
+  -->
+  
   <template name="EditorGBScriptWhenEnteringPage">Script when entering page</template>
   <template name="EditorGBClearScreenBetweenEachPage">Clear screen between each page</template>
   <template name="EditorGBColour">Colour</template>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -512,13 +512,12 @@
   <dynamictemplate name="DevModeErrorCantFindObject">"The object with the name '" + text + "' cannot be found."</dynamictemplate>
   <dynamictemplate name="DevModeErrorCantFindAttribute">"The attribute with the name '" + text + "' cannot be found."</dynamictemplate>
 
-  <!-- Need a special verb in English because of the name collision with the "enter" script rooms use -->
-  <verb name="enter_verb">
-    <pattern>enter #object#</pattern>
-    <property>enterverb</property>
-    <defaultexpression>"You can't enter "+object.article+"."</defaultexpression>
-    <scope>notheld</scope>
-  </verb>
+  <verbtemplate name="enter">enter</verbtemplate>
+  <verbtemplate name="enter">go in</verbtemplate>
+  <verbtemplate name="enter">go into</verbtemplate>
+  <verbtemplate name="enter">get in</verbtemplate>
+  <verbtemplate name="enter">get into</verbtemplate>
+  <dynamictemplate name="DefaultEnter">WriteVerb(game.pov, "can't") + " enter " + object.article + "."</dynamictemplate>
   
   
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -487,7 +487,6 @@
   
   
   <!-- Added by KV -->
-  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
   <template templatetype="command" name="transcript_on_cmd">^(transcript|script)( on|)$|^enable (script|transcript)$</template>
   <template templatetype="command" name="transcript_off_cmd">^(transcript|script) off$|^disable (script|transcript)$</template>
   <template templatetype="command" name="view_transcript_cmd">^(view|display|show) (the |)(script|transcript)$</template>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -523,7 +523,7 @@
   <template name="TranscriptDesktopOnly">This feature is only available in the Quest desktop player.</template>
   <template name="TranscriptDisabled">Transcript disabled.</template>
   <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
-  <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  \"-transcript.html\" will be appended to this filename.)<br/>  <i>(The file will be saved in \"Documents\\Quest Transcripts\\\".)</i></b>]]></template>
+  <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  "-transcript.html" will be appended to this filename.)<br/>  <i>(The file will be saved in "Documents\Quest Transcripts\".)</i></b>]]></template>
   <template name="ToDisableTranscript"><![CDATA[<br/><b><i>[  Enter </i>{command:SCRIPT OFF}<i> to disable the transcript.  ]</i></b>]]></template>
   <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Transcript enabled for:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + "<br/><br/>"]]></dynamictemplate>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -494,6 +494,27 @@
   
   
   <!-- DevMode templates moved here by KV to avoid issues with gamebooks-->
+  <template name="EditorGameEnableDevMode">Show DevMode options</template>
+  <template name="EditorGameDevMode">DevMode</template>
+  <template name="EditorGameDevModeInfoRelease">Important: Before releasing the game DevMode must be deactivated!</template>
+  <template name="EditorGameDevModeInfoCommands">Enhanced commands are available in the current game. Enter '#?' to get more information.</template>
+  <template name="EditorGameDevModeOptions">Options</template>
+  <template name="EditorGameDevModeChangePov">Select another player</template>
+  <template name="EditorGameDevModeChangePovPos">Select another starting location for the player</template>
+  <template name="EditorGameDevModePov">Player</template>
+  <template name="EditorGameDevModePlace">Location</template>
+  <template name="EditorGameDevModeSetInitScript">Use an initialization script for DevMode</template>
+  <template name="EditorGameDevModeInitScript">Initialization script for DevMode</template>
+  <template name="EditorGameDevModeShowDebugTable">Show debugtable</template>
+  <template name="EditorGameDevModeSetVerbs">Add DevMode verbs to the verb list of objects</template>
+  <template name="EditorGameDevModeShowInfos">Display DevMode output</template>
+  <template name="EditorGameDevModeOwnFontColour">Use your own font color for DevMode output</template>
+  <template name="EditorGameDevModeFontColour">Font color for DevMode output</template>
+  <template name="EditorGameDevModeOn">Active</template>
+  <template name="EditorGameDevModeOff">Inactive</template>
+  <template name="EditorGameDevModeAttributes">Attributes</template>
+  <template name="EditorGameDevModeDescriptionAttribute"><![CDATA[Enter the object with the corresponding attribute in "Key" (e. g. game.showtitle or player.look). The assignment is entered in "Value". It is possible to create Strings ("Hello World!"), Boolean (true or false), Integer (15), Double (25.55), Listen (["Hello","World","!"]) and Dictionarys ({H:"Hello",W:"World"}.)]]></template>
+  
   <template name="DevModeErrorWrongFormat">That's the wrong format.</template>
   <template name="DevModeErrorObjectNotRecognised">The object was not found.</template>
   <template name="DevModeErrorWrongTyp">That's the wrong type.</template>
@@ -521,14 +542,15 @@
   
   <template name="NoTranscriptFeature">This game has no transcript feature.</template>
   <template name="TranscriptAlreadyEnabled">The transcript is already enabled.</template>
-  <template name="TranscriptTryAgain">Sorry, an error occurred. Please try again.</template>
-  <template name="TranscriptDesktopOnly">This feature is only available in the Quest desktop player.</template>
+  <template name="TranscriptTryAgain">An error occurred while detecting the Quest player's platform. Please try again.</template>
+  <template name="TranscriptDesktopOnly">Sorry, but this feature is only available in the Quest desktop player.</template>
   <template name="TranscriptDisabled">Transcript disabled.</template>
   <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
-  <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  "-transcript.html" will be appended to this filename.)<br/>  <i>(The file will be saved in "Documents\Quest Transcripts\".)</i></b>]]></template>
-  <dynamictemplate name="ToDisableTranscript"><![CDATA["<br/><b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
-  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Transcript enabled for:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + "<br/><br/>"]]></dynamictemplate>
+  <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  "-transcript.txt" will be appended to this filename.)<br/>  <i>(The file will be saved in "Documents\Quest Transcripts\".)</i></b>]]></template>
+  <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
+  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Transcript enabled for:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + ""]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSCRIPT OFF</template>
+  <template name="TranscriptExcessiveRetries">transcript_on_cmd: Excessive retry attempts. The transcript feature has been disabled.</template>
   
   <template name="Noted">Noted.</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -491,6 +491,8 @@
   <template templatetype="command" name="transcript_off_cmd">^(transcript|script) off$|^disable (script|transcript)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
   
+  
+  
   <!-- DevMode templates moved here by KV to avoid issues with gamebooks-->
   <template name="DevModeErrorWrongFormat">That's the wrong format.</template>
   <template name="DevModeErrorObjectNotRecognised">The object was not found.</template>
@@ -524,6 +526,9 @@
   <template name="TranscriptDisabled">Transcript disabled.</template>
   <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
   <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  "-transcript.html" will be appended to this filename.)<br/>  <i>(The file will be saved in "Documents\Quest Transcripts\".)</i></b>]]></template>
-  <template name="ToDisableTranscript"><![CDATA[<br/><b><i>[  Enter </i>{command:SCRIPT OFF}<i> to disable the transcript.  ]</i></b>]]></template>
+  <dynamictemplate name="ToDisableTranscript"><![CDATA["<br/><b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
   <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Transcript enabled for:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + "<br/><br/>"]]></dynamictemplate>
+  <template name="TranscriptOffAllCaps">TRANSCRIPT OFF</template>
+  
+  <template name="Noted">Noted.</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -489,7 +489,6 @@
   <!-- Added by KV -->
   <template templatetype="command" name="transcript_on_cmd">^(transcript|script)( on|)$|^enable (script|transcript)$</template>
   <template templatetype="command" name="transcript_off_cmd">^(transcript|script) off$|^disable (script|transcript)$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(view|display|show) (the |)(script|transcript)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
   
   <!-- DevMode templates moved here by KV to avoid issues with gamebooks-->
@@ -518,5 +517,13 @@
   <verbtemplate name="enter">get into</verbtemplate>
   <dynamictemplate name="DefaultEnter">WriteVerb(game.pov, "can't") + " enter " + object.article + "."</dynamictemplate>
   
-  
+  <template name="NoTranscriptFeature">This game has no transcript feature.</template>
+  <template name="TranscriptAlreadyEnabled">The transcript is already enabled.</template>
+  <template name="TranscriptTryAgain">Sorry, an error occurred. Please try again.</template>
+  <template name="TranscriptDesktopOnly">This feature is only available in the Quest desktop player.</template>
+  <template name="TranscriptDisabled">Transcript disabled.</template>
+  <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
+  <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  \"-transcript.html\" will be appended to this filename.)<br/>  <i>(The file will be saved in \"Documents\\Quest Transcripts\\\".)</i></b>]]></template>
+  <template name="ToDisableTranscript"><![CDATA[<br/><b><i>[  Enter </i>{command:SCRIPT OFF}<i> to disable the transcript.  ]</i></b>]]></template>
+  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Transcript enabled for:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + "<br/><br/>"]]></dynamictemplate>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -544,11 +544,11 @@
   <template name="TranscriptAlreadyEnabled">The transcript is already enabled.</template>
   <template name="TranscriptTryAgain">An error occurred while detecting the Quest player's platform. Please try again.</template>
   <template name="TranscriptDesktopOnly">Sorry, but this feature is only available in the Quest desktop player.</template>
-  <template name="TranscriptDisabled">Transcript disabled.</template>
+  <template name="TranscriptDisabled">End of transcript.</template>
   <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
   <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  "-transcript.txt" will be appended to this filename.)<br/>  <i>(The file will be saved in "Documents\Quest Transcripts\".)</i></b>]]></template>
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
-  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Transcript enabled for:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + ""]]></dynamictemplate>
+  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start of a transcript of:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + ""]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSCRIPT OFF</template>
   <template name="TranscriptExcessiveRetries">transcript_on_cmd: Excessive retry attempts. The transcript feature has been disabled.</template>
   

--- a/WorldModel/WorldModel/Core/Languages/Greek.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Greek.aslx
@@ -382,7 +382,6 @@
     <template templatetype="command" name="help">^βοήθεια$|^\?$</template>
     <template templatetype="command" name="save">^σώσε$|^αποθήκευσε$</template>
 
-    <template templatetype="command" name="log_cmd">^αρχείο$|^δες αρχείο$|^δείξε αρχείο$</template>
   <!-- Modified by KV -->
   <template templatetype="command" name="transcript_on_cmd">^ιστορικό$|^ιστορικό ενεργό$</template>
   <template templatetype="command" name="transcript_off_cmd">^ιστορικό ανενεργό$</template>

--- a/WorldModel/WorldModel/Core/Languages/Greek.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Greek.aslx
@@ -385,6 +385,8 @@
   <!-- Modified by KV -->
   <template templatetype="command" name="transcript_on_cmd">^ιστορικό$|^ιστορικό ενεργό$</template>
   <template templatetype="command" name="transcript_off_cmd">^ιστορικό ανενεργό$</template>
+  
+  <template name="TranscriptOffAllCaps">ιστορικό ανενεργό</template>
   <!-- END of modification by KV -->
   <template templatetype="command" name="version_cmd">^(έκδοση|πληροφορίες|σχετικά)$</template>
 

--- a/WorldModel/WorldModel/Core/Languages/Greek.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Greek.aslx
@@ -385,7 +385,6 @@
   <!-- Modified by KV -->
   <template templatetype="command" name="transcript_on_cmd">^ιστορικό$|^ιστορικό ενεργό$</template>
   <template templatetype="command" name="transcript_off_cmd">^ιστορικό ανενεργό$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(δες|δείξε) (το |)ιστορικό$</template>
   <!-- END of modification by KV -->
   <template templatetype="command" name="version_cmd">^(έκδοση|πληροφορίες|σχετικά)$</template>
 

--- a/WorldModel/WorldModel/Core/Languages/Italiano.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Italiano.aslx
@@ -415,7 +415,6 @@ Feel free to let comments and tips on http://www.textadventures.co.uk/forum/view
 
   <template templatetype="command" name="transcript_on_cmd">^trascrizione$</template>
   <template templatetype="command" name="transcript_off_cmd">^trascrizione off$|^spegni trascrizione$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(vedi|mostra|visualizza|) (la |)trascrizione$</template>
   <template templatetype="command" name="version_cmd">^(versione|info)$</template>
   
   <template name="DefaultHelp"><![CDATA[<u>Aiuto rapido</u><br/><br/>

--- a/WorldModel/WorldModel/Core/Languages/Italiano.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Italiano.aslx
@@ -417,6 +417,8 @@ Feel free to let comments and tips on http://www.textadventures.co.uk/forum/view
   <template templatetype="command" name="transcript_off_cmd">^trascrizione off$|^spegni trascrizione$</template>
   <template templatetype="command" name="version_cmd">^(versione|info)$</template>
   
+  <template name="TranscriptOffAllCaps">TRASCRIZIONE OFF</template>
+  
   <template name="DefaultHelp"><![CDATA[<u>Aiuto rapido</u><br/><br/>
 <b>- Oggetti:</b>  Prova a scrivere GUARDA (l'oggetto o la persona)..., PARLA CON..., PRENDI..., LASCIA..., APRI..., DAI (qualcosa) A (qualcuno)..., USA... (qualcosa) SU/CON (qualcuno)...<br/>
 <b>- Inventario:</b>  Guarda sulla destra cosa stai portando con te, oppure digita: I, INV oppure INVENTORY.<br/>

--- a/WorldModel/WorldModel/Core/Languages/Italiano.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Italiano.aslx
@@ -413,7 +413,6 @@ Feel free to let comments and tips on http://www.textadventures.co.uk/forum/view
   <template templatetype="command" name="help">^aiuto$|^\?$</template>
   <template templatetype="command" name="save">^salva$</template>
 
-  <template templatetype="command" name="log_cmd">^(diario|vedi diario|mostra diario)$</template>
   <template templatetype="command" name="transcript_on_cmd">^trascrizione$</template>
   <template templatetype="command" name="transcript_off_cmd">^trascrizione off$|^spegni trascrizione$</template>
   <template templatetype="command" name="view_transcript_cmd">^(vedi|mostra|visualizza|) (la |)trascrizione$</template>

--- a/docs/transcript.md
+++ b/docs/transcript.md
@@ -7,7 +7,7 @@ As of Quest 5.8, if using the desktop player, there is a fully functional transc
 
 A transcript is a recording of everything the player types and the game prints, and can be very useful when beta-testing, for example.
 
-Transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the HTML format. When double-clicked, the transcript should open in the user's default browser.
+Transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the TXT format.
 
 To turn the transcript on, use any of these commands during play.
 
@@ -28,7 +28,5 @@ DISABLE SCRIPT
 DISABLE TRANSCRIPT
 
 
-
-CSS is added to align everything to the left. The background is set to white and the color to black. Be aware that the transcript may have a few strange-looking areas, depending on what all HTML and CSS code you have in a game (we are fixing every issue we come across, but it is hard to foresee what code a Quest game may include!).
 
 Note that during play you can type a \* and then some text, and Quest will ignore it. This is useful for when you want to comment on something, such as a bug you have found. The comment will appear in the transcript (and can be searched for as it starts with a \*), but you will not confuse the game with your weird command.

--- a/docs/transcript.md
+++ b/docs/transcript.md
@@ -3,7 +3,11 @@ layout: index
 title: Transcripts
 ---
 
-As of Quest 5.8 there is a fully functional transcript feature. A transcript is a recording of everything the player types and the game prints, and can be very useful when beta-testing, for example.
+As of Quest 5.8, if using the desktop player, there is a fully functional transcript feature.
+
+A transcript is a recording of everything the player types and the game prints, and can be very useful when beta-testing, for example.
+
+Transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the HTML format. When double-clicked, the transcript should open in the user's default browser.
 
 To turn the transcript on, use any of these commands during play.
 
@@ -23,15 +27,8 @@ TRANSCRIPT OFF
 DISABLE SCRIPT
 DISABLE TRANSCRIPT
 
-You can view the transcript at any time, using one of these comnmands. The transcript will appear in a pop-up window. You can print the trascript too.
 
-SHOW SCRIPT
-VIEW SCRIPT
-SHOW TRANSCRIPT
-VIEW TRANSCRIPT
-
-If using the desktop player (as of the upcoming 5.8.0 release), transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the HTML format. When double-clicked, the transcript should open in the user's default browser.
 
 CSS is added to align everything to the left. The background is set to white and the color to black. Be aware that the transcript may have a few strange-looking areas, depending on what all HTML and CSS code you have in a game (we are fixing every issue we come across, but it is hard to foresee what code a Quest game may include!).
 
-Note that during play you can type a * and then some text, and Quest will ignore it. This is useful for when you want to comment on something, such as a bug you have found. The comment will appear in the transcript (and can be searched for as it starts with a *), but you will not confuse the game with your weird command.
+Note that during play you can type a \* and then some text, and Quest will ignore it. This is useful for when you want to comment on something, such as a bug you have found. The comment will appear in the transcript (and can be searched for as it starts with a \*), but you will not confuse the game with your weird command.


### PR DESCRIPTION
There is a game-crashing bug in the transcript code I submitted for Quest 5.8.0.

If playing online and the transcript is enabled, the game completely crashes (because `SaveTranscript` is only in desktop.js, and is therefore undefined in the web player).

If playing in the desktop and the transcript is enabled, all turn scripts stop working completely and if a walkthrough is being recorded, the recorded steps are the HTML being output to the game.

ALSO, there was a JS string variable named `transcriptString` which got larger and larger when adding the current text for the transcript every time text printed to the game. This obviously slowed things down. Plus, this text was also sent by `ASLEvent` to update `game.transcriptstring` each time text printed along with everything else.

Also, the updated `clearScreen()` function in playercore.js was set up to save the cleared text and hide it rather than deleting it. This also negatively effected game performance exponentially as play progressed. The JS boolean `saveClearedText` is now set to false by default.

Finally, if the VIEW TRANSCRIPT command was run while recording a walkthrough, the jQuery-UI popup would break the walkthrough during playback.

The in-game HTML transcript feature has now been removed. There is no VIEW TRANSCRIPT command anymore. There is no longer a `transcriptString` JS variable, nor is there a `game.transcriptstring` attribute.

The only way the transcript will work now is if the game is being played in the desktop player. It will save the transcript, and append it, every time text prints to the screen, to an HTML file in "Documents\Quest Transcripts", just as in 5.8.0. Except I also fixed my error in PlayerHTML.vb to make the file save under the transcript name the player chooses when enabling the transcript.

I added a "fallback" of each function I added to Player\desktopplayer.js to WebPlayer\player.js. These functions do nothing and serve no purpose except to avoid possible errors due to being undefined.

Also added a bit of code in `HandleCommand` <s>and `ShowMenuResponse`</s> to add the player's command to the transcript if `game.echocommand` is `false`.

Updated the transcript doc page to reflect the changes.

I triple checked things every way I could imagine in the desktop build as well as using VS to test the web player and the mobile version, but I haven't had anyone else test it. So, test it out, please.

---
I almost forgot:

If `saveClearedText` is changed to `true`, it will save the cleared text in #divOutput rather than dumping it.

The `printScrollback()` JS function is still present. Calling it will use the player's device to print the everything in #divOutput (whether via a printer or saving it to PDF). 

Again, the scroll back will not contain any cleared text unless `saveClearedText` is changed from `false` to `true`.

The scrollback JS functions are pretty much hidden, but an author could easily add code to allow their use in their game.

---
All apologies to everyone for the bugs I introduced in Quest 5.8.0. I believe I have now fixed them all.

---
Closes #1054 