### PR TITLE
kv-6-transcript-redo

### DIFF
--- a/Player/Player.vb
+++ b/Player/Player.vb
@@ -792,7 +792,8 @@ Public Class Player
     End Sub
 
     Private Sub ctlPlayerHtml_SendEvent(eventName As String, param As String) Handles ctlPlayerHtml.SendEvent
-        If RecordWalkthrough IsNot Nothing Then
+        ' Don't save the step if calling WhereAmI or any event starting with NoEventFunc
+        If RecordWalkthrough IsNot Nothing And Not eventName.StartsWith("WhereAmI") And Not eventName.StartsWith("NoEventFunc") Then
             m_recordedWalkthrough.Add("event:" + eventName + ";" + param)
         End If
         m_game.SendEvent(eventName, param)

--- a/Player/PlayerHTML.vb
+++ b/Player/PlayerHTML.vb
@@ -105,8 +105,8 @@ Public Class PlayerHTML
             ' Added by KV
             Case "RestartGame"
                 RestartGame(args)
-            Case "SaveTranscript"
-                SaveTranscript(args)
+            Case "WriteToTranscript"
+                WriteToTranscript(args)
             Case "WriteToLog"
                 WriteToLog(args)
         End Select
@@ -125,19 +125,33 @@ Public Class PlayerHTML
         End If
         My.Computer.FileSystem.WriteAllText(logPath + "\" + gameName + "-log.txt", data + Environment.NewLine, True)
     End Sub
-    Private Sub SaveTranscript(data As String)
-        Dim mgameName = Split(CurrentGame.Filename, "\")(Split(CurrentGame.Filename, "\").Length - 1)
-        mgameName = mgameName.Replace(".aslx", "")
+    Private Sub WriteToTranscript(data As String)
+        Dim mgameName = ""
+        Dim scriptname = "DEFAULT_"
+        ' In playercore.js: WriteToTranscript (transcriptName + "___SCRIPTDATA___" + text)
+        ' If WriteToTranscript(text) is used, this will ignore the transcript name and use the game's file name.
+        If data.Contains("___SCRIPTDATA___") Then
+            scriptname = Split(data, "___SCRIPTDATA___")(0)
+        End If
+        If scriptname = "DEFAULT_" Then
+          mgameName = Split(CurrentGame.Filename, "\")(Split(CurrentGame.Filename, "\").Length - 1)
+          mgameName = mgameName.Replace(".aslx", "")
+        Else
+          mgameName = scriptname
+        End If
         Dim transcriptPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\Quest Transcripts"
         If Not System.IO.Directory.Exists(transcriptPath) = True Then
             System.IO.Directory.CreateDirectory(transcriptPath)
         End If
-        If Not System.IO.File.Exists(transcriptPath + "\" + mgameName + "-transcript.html") = True Then
+        If Not System.IO.File.Exists(transcriptPath + "\" + mgameName + "-transcript.txt") = True Then
             Dim file As System.IO.FileStream
-            file = System.IO.File.Create(transcriptPath + "\" + mgameName + "-transcript.html")
+            file = System.IO.File.Create(transcriptPath + "\" + mgameName + "-transcript.txt")
             file.Close()
         End If
-        My.Computer.FileSystem.WriteAllText(transcriptPath + "\" + mgameName + "-transcript.html", data, True)
+        If data.Contains("___SCRIPTDATA___") Then
+            data = Split(data, "___SCRIPTDATA___")(1)
+        End If
+        My.Computer.FileSystem.WriteAllText(transcriptPath + "\" + mgameName + "-transcript.txt", Replace(data, "@@@NEW_LINE@@@", Environment.NewLine), True)
 
     End Sub
     Private Sub RestartGame(data As String)

--- a/Player/PlayerHTML.vb
+++ b/Player/PlayerHTML.vb
@@ -105,6 +105,8 @@ Public Class PlayerHTML
             ' Added by KV
             Case "RestartGame"
                 RestartGame(args)
+            Case "SaveTranscript"
+                WriteToTranscript(args)
             Case "WriteToTranscript"
                 WriteToTranscript(args)
             Case "WriteToLog"

--- a/Player/PlayerHTML.vb
+++ b/Player/PlayerHTML.vb
@@ -115,8 +115,11 @@ Public Class PlayerHTML
         Dim logPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\Quest Logs"
         Dim gameName = Split(CurrentGame.Filename, "\")(Split(CurrentGame.Filename, "\").Length - 1)
         gameName = gameName.Replace(".aslx", "")
-        If Not System.IO.Directory.Exists(logPath) = True Then
+        If Not System.IO.Directory.Exists(logPath) = True Or data.Contains("@@@OVERWRITEFILE@@@") Then
             System.IO.Directory.CreateDirectory(logPath)
+            If data.Contains("@@@OVERWRITEFILE@@@") Then
+                data = Replace(data, "@@@OVERWRITEFILE@@@", "")
+            End If
         End If
         If Not System.IO.File.Exists(logPath + "\" + gameName + "-log.txt") = True Then
             Dim file As System.IO.FileStream
@@ -143,10 +146,13 @@ Public Class PlayerHTML
         If Not System.IO.Directory.Exists(transcriptPath) = True Then
             System.IO.Directory.CreateDirectory(transcriptPath)
         End If
-        If Not System.IO.File.Exists(transcriptPath + "\" + mgameName + "-transcript.txt") = True Then
+        If Not System.IO.File.Exists(transcriptPath + "\" + mgameName + "-transcript.txt") = True Or data.Contains("@@@OVERWRITEFILE@@@") Then
             Dim file As System.IO.FileStream
             file = System.IO.File.Create(transcriptPath + "\" + mgameName + "-transcript.txt")
             file.Close()
+            If data.Contains("@@@OVERWRITEFILE@@@") Then
+                data = Replace(data, "@@@OVERWRITEFILE@@@", "")
+            End If
         End If
         If data.Contains("___SCRIPTDATA___") Then
             data = Split(data, "___SCRIPTDATA___")(1)

--- a/Player/WalkthroughRunner.vb
+++ b/Player/WalkthroughRunner.vb
@@ -19,6 +19,8 @@
     End Sub
 
     Public Sub Run()
+        ' Set game.questplatform to desktop, just in case someone enables the transcript in a walkthrough step
+        m_game.SendEvent ("WhereAmI", "desktop")
         For Each cmd As String In m_gameDebug.Walkthroughs.Walkthroughs(m_walkthrough).Steps
             If m_cancelled Then Exit For
 
@@ -43,7 +45,13 @@
                     Dim eventData As String() = cmd.Substring(6).Split(New Char() {";"c}, 2)
                     Dim eventName As String = eventData(0)
                     Dim param As String = eventData(1)
-                    m_game.SendEvent(eventName, param)
+                    ' Make sure not to call WhereAmI or NoEventFunc* (the latter included to create a way to abuse this)
+                    If Not eventName = "WhereAmI" And Not eventName.StartsWith("NoEventFunc") Then
+                        m_game.SendEvent(eventName, param)
+                    Else
+                        ' ignore
+                        'WriteLine("<p>[WALKTHROUGH]: Ignoring event: '" + eventName + "'.</p>")
+                    End If
                 Else
                     m_game.SendCommand(cmd)
                 End If

--- a/Player/WalkthroughRunner.vb
+++ b/Player/WalkthroughRunner.vb
@@ -19,8 +19,6 @@
     End Sub
 
     Public Sub Run()
-        ' Set game.questplatform to desktop, just in case someone enables the transcript in a walkthrough step
-        m_game.SendEvent ("WhereAmI", "desktop")
         For Each cmd As String In m_gameDebug.Walkthroughs.Walkthroughs(m_walkthrough).Steps
             If m_cancelled Then Exit For
 

--- a/Player/desktopplayer.js
+++ b/Player/desktopplayer.js
@@ -21,16 +21,16 @@ function RestartGame() {
     UIEvent("RestartGame", "");
 }
 
-// SaveTranscript added by KV to write/append to GAMENAME-transcript.html in Documents\Quest Transcripts
-function SaveTranscript(data) {
-    data = data + "<style>*{color:black !important;background:white !important;text-align:left !important}</style>";
-    if (!webPlayer && transcriptString != '') { UIEvent("SaveTranscript", data); }
-    transcriptString += data;
+// WriteToTranscript added by KV to write/append to GAMENAME-transcript.txt in Documents\Quest Transcripts
+function WriteToTranscript(data) {
+  if (data != '' && typeof (data) == 'string') {
+    UIEvent("WriteToTranscript", data);
+  }
 }
 
 // Added by KV to write/append to GAMENAME-log.txt in Documents\Quest Logs
 function WriteToLog(data) {
-    if (!webPlayer && data != '' && typeof (data) == 'string') {
+    if (data != '' && typeof (data) == 'string') {
         UIEvent("WriteToLog", getTimeAndDateForLog() + " " + data);
     }
 }

--- a/PlayerController/playercore.htm
+++ b/PlayerController/playercore.htm
@@ -2,8 +2,8 @@
     <div id="status" class="ui-widget-header">
         <div id="controlButtons">
             <button type="button" id="cmdExitFullScreen" style="display: none">Exit Full Screen</button>
-            <button type="button" id="cmdSave">Save</button>
-            <button type="button" id="showTranscripts" style="padding: 6px !important" onclick="showTranscripts();">Transcripts</button>
+            <button type="button" id="cmdSave" style="display: none">Save</button>
+            <button type="button" id="showTranscripts" style="display: none; padding: 6px !important" onclick="showTranscripts();">Transcripts</button>
         </div>
         <div id="location">
         </div>

--- a/PlayerController/playercore.htm
+++ b/PlayerController/playercore.htm
@@ -2,7 +2,8 @@
     <div id="status" class="ui-widget-header">
         <div id="controlButtons">
             <button type="button" id="cmdExitFullScreen" style="display: none">Exit Full Screen</button>
-            <button type="button" id="cmdSave" style="display: none">Save</button>
+            <button type="button" id="cmdSave">Save</button>
+            <button type="button" id="showTranscripts" style="padding: 6px !important" onclick="showTranscripts();">Transcripts</button>
         </div>
         <div id="location">
         </div>

--- a/PlayerController/playercore.htm
+++ b/PlayerController/playercore.htm
@@ -3,7 +3,6 @@
         <div id="controlButtons">
             <button type="button" id="cmdExitFullScreen" style="display: none">Exit Full Screen</button>
             <button type="button" id="cmdSave" style="display: none">Save</button>
-            <button type="button" id="showTranscripts" style="display: none; padding: 6px !important" onclick="showTranscripts();">Transcripts</button>
         </div>
         <div id="location">
         </div>

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -638,8 +638,7 @@ function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
     }
-    // Only attempt writeToTranscript() if this is the desktop player.
-    if (!webPlayer && platform == "desktop" && transcriptEnabled && !noTranscript) {
+    if (transcriptEnabled && !noTranscript) {
         writeToTranscript(text);
     }
     getCurrentDiv().append(text);
@@ -817,8 +816,6 @@ function printScrollback() {
   iframe.contentWindow.document.write($("#scrollbackdata").html());
   iframe.contentWindow.print();
   document.body.removeChild(iframe);
-  $("#scrollback-dialog").dialog("close");
-  $("#scrollback-dialog").remove();
 };
 
 function keyPressCode(e) {
@@ -1240,7 +1237,7 @@ function getTimeAndDateForLog(){
   * @param {string} text The string to be written to the file
 */
 function writeToTranscript(text){
-  if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
+  if (!noTranscript && transcriptEnabled) {
     WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());
   }
 }

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -631,14 +631,14 @@ function addTextAndScroll(text) {
 
 // These 2 variables added by KV for the transcript
 var transcriptEnabled = false;
-var noTranscript = false;
+var transcriptProhibited = false;
 
 // This function altered by KV for the transcript
 function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
     }
-    if (transcriptEnabled && !noTranscript) {
+    if (transcriptEnabled && !transcriptProhibited) {
         writeToTranscript(text);
     }
     getCurrentDiv().append(text);
@@ -1232,23 +1232,23 @@ function getTimeAndDateForLog(){
   *
   * This will write/append to a TXT document in Documents\Quest Transcripts
   *  if using the desktop player and the the player has the transcript enabled
-  *  and if noTranscript is not set to true (it is false by default).
+  *  and if transcriptProhibited is not set to true (it is false by default).
   *
   * @param {string} text The string to be written to the file
 */
 function writeToTranscript(text){
-  if (!noTranscript && transcriptEnabled) {
+  if (!transcriptProhibited && transcriptEnabled) {
     WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());
   }
 }
 
 /**
-  * This will enable the transcript unless noTranscript is set to true.
+  * This will enable the transcript unless transcriptProhibited is set to true.
   * 
   * @param {name} text If this is defined, the transcriptName will be set to this.
 */
 function enableTranscript(name){
-  if (noTranscript) return;
+  if (transcriptProhibited) return;
   transcriptName = name || transcriptName;
   transcriptEnabled = true;
 }
@@ -1266,7 +1266,7 @@ function disableTranscript(){
   * 
 */
 function killTranscript(){
-  noTranscript = true;
+  transcriptProhibited = true;
   disableTranscript();
 }
 
@@ -1279,7 +1279,7 @@ function setTranscriptStatus(status){
   switch (status){
     case "enabled":
     case "enable":
-      initiateTranscript();
+      enableTranscript();
       break;
     case "disabled":
     case "disable":
@@ -1290,7 +1290,7 @@ function setTranscriptStatus(status){
       killTranscript();
       break;
     case "alive":
-      noTranscript = false;
+      transcriptProhibited = false;
   }
 }
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1245,22 +1245,22 @@ function writeToTranscript(text){
     for (var key in Object.keys(faker.getElementsByTagName('img'))){
       var elem = faker.getElementsByTagName('img')[key];
       if (elem != null) {
-        var altProp = $(faker.getElementsByTagName('img')[key]).attr('alt');
-        text = text.replace(elem.outerHTML, altProp);
+        var altProp = $(faker.getElementsByTagName('img')[key]).attr('alt') || "";
+        text = text.replace(elem.outerHTML, altProp) || text;
       }
     }
     for (var key in Object.keys(faker.getElementsByTagName('area'))){
       var elem = faker.getElementsByTagName('area')[key];
       if (elem != null) {
-        var altProp = $(faker.getElementsByTagName('area')[key]).attr('alt');
-        text = text.replace(elem.outerHTML, altProp);
+        var altProp = $(faker.getElementsByTagName('area')[key]).attr('alt') || "";
+        text = text.replace(elem.outerHTML, altProp) || text;
       }
     }
     for (var key in Object.keys(faker.getElementsByTagName('input'))){
       var elem = faker.getElementsByTagName('input')[key];
       if (elem != null) {
-        var altProp = $(faker.getElementsByTagName('input')[key]).attr('alt');
-        text = text.replace(elem.outerHTML, altProp);
+        var altProp = $(faker.getElementsByTagName('input')[key]).attr('alt') || "";
+        text = text.replace(elem.outerHTML, altProp) || text;
       }
     }
     WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -357,15 +357,23 @@ function SetBackgroundOpacity(opacity) {
 }
 
 function setBackground(col) {
+    /* If '#rgb', convert to '#rrggbb'*/
+    /* https://github.com/textadventures/quest/issues/1052 */
+    if (col.charAt(0) === "#") && col.length == 4) {
+        var colBak = "" + col + "";
+        newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
+        col = newCol || col;
+        console.warn("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
+    }
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
     rgbCol = hexToRgb(col);
     var cssBackground = "rgba(" + rgbCol.r + "," + rgbCol.g + "," + rgbCol.b + "," + _backgroundOpacity + ")";
     $("#gameBorder").css("background-color", cssBackground);
-
     $("#gamePanel").css("background-color", col);
     $("#gridPanel").css("background-color", col);
 }
+
 
 function setPanelHeight() {
     if (_showGrid) return;

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1334,6 +1334,17 @@ function SaveTranscript(text){
   writeToTranscript(text);  
 }
 
+var transcriptUrl = 'Play.aspx?id=4wqdac8qd0sf7-ilff8mia';
+// Another fallback to avoid errors
+function showTranscript(){
+  if (webPlayer){
+    addTextAndScroll('Your transcripts are saved to the localStorage in your browser. You can view, download, or delete them here: <a href="' + transcriptUrl + '" target="_blank">Your Transcripts</a><br/>');
+  }
+  else {
+    addTextAndScroll('Your transcripts are saved to "Documents\\Quest Transcripts\\".<br/>');
+  }
+};
+
 // ***********************************
 
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1304,85 +1304,19 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Make it easy to print messages.
-//var msg = addTextAndScroll;
-    
 // Log functions
-var logVar = "";
-function addLogEntry(text){
-  logVar += getTimeAndDateForLog() + ' ' + text+"NEW_LINE";
-};
+var logArr = [];
 
-function showLog(){
-  var logDivString = "";
-  logDivString += "<div ";
-  logDivString += "id='log-dialog' ";
-  logDivString += "style='display:none;;'>";
-  logDivString += "<textarea id='logdata' rows='13'";
-  logDivString += "  cols='49'></textarea></div>";
-  addText(logDivString);
-  if(webPlayer){
-    var logDialog = $("#log-dialog").dialog({
-      autoOpen: false,
-      width: 600,
-      height: 500,
-      title: "Log",
-      buttons: {
-        Ok: function() {
-          $(this).dialog("close");
-        },
-        Print: function(){
-          $(this).dialog("close");
-          showLogDiv();
-          printLogDiv();
-        },
-        Save: function(){
-          $(this).dialog("close");
-          saveLog();
-        },
-      },
-      show: { effect: "fadeIn", duration: 500 },
-      // The modal setting keeps the player from interacting with anything besides the dialog window.
-      //  (The log will not update while open without adding a turn script.  I prefer this.)
-      modal: true,
-    });
-  }else{
-    var logDialog = $("#log-dialog").dialog({
-    autoOpen: false,
-    width: 600,
-    height: 500,
-    title: "Log",
-    buttons: {
-      Ok: function() {
-        $(this).dialog("close");
-      },
-      Print: function(){
-        $(this).dialog("close");
-        showLogDiv();
-        printLogDiv();
-      },
-    },
-    show: { effect: "fadeIn", duration: 500 },
-    // The modal setting keeps the player from interacting with anything besides the dialog window.
-    //  (The log will not update while open without adding a turn script.  I prefer this.)
-    modal: true,
-  });
+function addLogEntry(text){
+  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
+  if (logDivIsSetUp){
+     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
   }
-  $('textarea#logdata').val(logVar.replace(/NEW_LINE/g,"\n"));
-  logDialog.dialog("open");
 };
 
 var logDivIsSetUp = false;
 
-var logDivToAdd = "";
-logDivToAdd += "<div ";
-logDivToAdd += "id='log-div' ";
-logDivToAdd += "style='display:none;'>";
-logDivToAdd += "<a class='do-not-print-with-log' ";
-logDivToAdd += "href='' onclick='hideLogDiv()'>RETURN TO THE GAME</a>  ";
-logDivToAdd += "<a class='do-not-print-with-log' href='' ";
-logDivToAdd += "onclick='printLogDiv();'>PRINT</a> ";
-logDivToAdd += "<div id='log-contents-div' '></div></div>";
+var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
 
 function setupLogDiv(){
   addText(logDivToAdd);
@@ -1390,19 +1324,22 @@ function setupLogDiv(){
   logDivIsSetUp = true;
 };
 
-function showLogDiv(){
-    if(!logDivIsSetUp){
-     setupLogDiv(); 
-    }
-	$(".do-not-print-with-log").show();
-	$("#log-contents-div").html(logVar.replace(/NEW_LINE/g,"<br/>"));
-	$("#log-div").show();
-	$("#gameBorder").hide();
+function showLog(){
+  if(!logDivIsSetUp){
+    setupLogDiv(); 
+  }
+  hideLogDiv()
+  $(".do-not-print-with-log").show();
+  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
+  if (platform !== "mobile"){
+    $('#log-div').show().insertAfter($('#txtCommandDiv'));
+  } else {
+  $('#log-div').show().insertAfter($('#inputBar')) 
+  }
 };
 
 function hideLogDiv(){
-	$("#log-div").hide();
-	$("#gameBorder").show();
+  $("#log-div").hide();
 };
 
 function printLogDiv(){
@@ -1413,48 +1350,21 @@ function printLogDiv(){
   }
   document.title = "log.txt" ;
   $('.do-not-print-with-log').hide();
+  $("#gameBorder").hide();
+  $('#log-div').insertBefore($("#gameBorder"));
   print();
   $('.do-not-print-with-log').show();
+  $('#log-div').appendTo($("#divOutput"));
+  $("#gameBorder").show();
   document.title = docTitleBak;
 };
 
-
-function saveLog(){
-  if(webPlayer){
-    var href = "data:text/plain,"+logVar.replace(/NEW_LINE/g,"\n");
-    addTextAndScroll("<a download='log.txt' href='"+href+"' id='log-save-link'>Click here to save the log if your pop-up blocker stopped the download.</a>");
-    document.getElementById("log-save-link").addEventListener ("click", function (e) {e.stopPropagation();});
-    document.getElementById("log-save-link").click();
-  }else{
-    alert("This function is only available while playing online.");
-  }
- };
-
 function getTimeAndDateForLog(){
-	var today = new Date();
-	var dd = today.getDate();
-	var mm = today.getMonth()+1;
-	var yyyy = today.getFullYear();
-	var hrs = today.getHours();
-	var mins = today.getMinutes();
-	var secs = today.getSeconds();
-	today = mm + '/' + dd + '/' + yyyy;
-	if(hrs>12) {
-	  ampm = 'PM';
-	  hrs = '0' + '' + hrs - 12
-	}else{
-	  ampm = 'AM';
-	} 
-	if (mins<10) {
-	  mins = '0'+mins;
-	} 
-	if(secs<10) {
-	  secs = '0' + secs;
-	}
-	time = hrs + ':' + mins + ':' + secs + ' ' + ampm;
-	return today + ' ' + time;
+  var date = new Date();
+  var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
+  return currentDateTime;
 };
-    
+
 // **********************************
 // TRANSCRIPT FUNCTIONS
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -630,8 +630,8 @@ function addTextAndScroll(text) {
 }
 
 // These variables added by KV for the transcript
-var transcriptEnabled = false;
-var transcriptProhibited = false;
+var savingTranscript = false;
+var noTranscript = false;
 var transcriptName = "";
 
 // This function altered by KV for the transcript
@@ -641,7 +641,7 @@ function addText(text) {
     }
     getCurrentDiv().append(text);
     $("#divOutput").css("min-height", $("#divOutput").height());
-    if (transcriptEnabled && !transcriptProhibited) {
+    if (savingTranscript && !noTranscript) {
       writeToTranscript(text);
     }
 }
@@ -1233,12 +1233,12 @@ function getTimeAndDateForLog(){
   *
   * This will write/append to a TXT document in Documents\Quest Transcripts
   *  if using the desktop player and the the player has the transcript enabled
-  *  and if transcriptProhibited is not set to true (it is false by default).
+  *  and if noTranscript is not set to true (it is false by default).
   *
   * @param {string} text The string to be written to the file
 */
 function writeToTranscript(text){
-  if (!transcriptProhibited && transcriptEnabled) {
+  if (!noTranscript && savingTranscript) {
     var faker = document.createElement('div');
     faker.innerHTML = text;
     text = faker.innerHTML;
@@ -1268,14 +1268,14 @@ function writeToTranscript(text){
 }
 
 /**
-  * This will enable the transcript unless transcriptProhibited is set to true.
+  * This will enable the transcript unless noTranscript is set to true.
   * 
   * @param {name} text If this is defined, the transcriptName will be set to this.
 */
 function enableTranscript(name){
-  if (transcriptProhibited) return;
+  if (noTranscript) return;
   transcriptName = name || transcriptName || gameName;
-  transcriptEnabled = true;
+  savingTranscript = true;
 }
 
 /**
@@ -1283,7 +1283,7 @@ function enableTranscript(name){
   * 
 */
 function disableTranscript(){
-  transcriptEnabled = false;
+  savingTranscript = false;
 }
 
 /**
@@ -1291,7 +1291,7 @@ function disableTranscript(){
   * 
 */
 function killTranscript(){
-  transcriptProhibited = true;
+  noTranscript = true;
   disableTranscript();
 }
 
@@ -1315,12 +1315,11 @@ function setTranscriptStatus(status){
       killTranscript();
       break;
     case "allowed":
-      transcriptProhibited = false;
+      noTranscript = false;
   }
 }
 
-/**
-  * 
+var showedSaveTranscriptWarning = false;
 /**
   * This function was missing from the webplayer in Quest 5.8.0
   * Leaving this here as a fallback
@@ -1328,7 +1327,10 @@ function setTranscriptStatus(status){
   * @param {string} text The line(s) of text being printed
 */
 function SaveTranscript(text){
-  console.log("[QUEST]: SaveTranscript has been deprecated. Using writeToTranscript instead.");
+  if(!showedSaveTranscriptWarning){
+    console.log("[QUEST]: SaveTranscript has been deprecated. Using writeToTranscript instead.");
+    showedSaveTranscriptWarning = true;
+  }
   writeToTranscript(text);  
 }
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -629,20 +629,21 @@ function addTextAndScroll(text) {
     scrollToEnd();
 }
 
-// These 2 variables added by KV for the transcript
+// These variables added by KV for the transcript
 var transcriptEnabled = false;
 var transcriptProhibited = false;
+var transcriptName = "";
 
 // This function altered by KV for the transcript
 function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
     }
-    if (transcriptEnabled && !transcriptProhibited) {
-        writeToTranscript(text);
-    }
     getCurrentDiv().append(text);
     $("#divOutput").css("min-height", $("#divOutput").height());
+    if (transcriptEnabled && !transcriptProhibited) {
+      writeToTranscript(text);
+    }
 }
 
 function createNewDiv(alignment) {
@@ -1238,6 +1239,30 @@ function getTimeAndDateForLog(){
 */
 function writeToTranscript(text){
   if (!transcriptProhibited && transcriptEnabled) {
+    var faker = document.createElement('div');
+    faker.innerHTML = text;
+    text = faker.innerHTML;
+    for (var key in Object.keys(faker.getElementsByTagName('img'))){
+      var elem = faker.getElementsByTagName('img')[key];
+      if (elem != null) {
+        var altProp = $(faker.getElementsByTagName('img')[key]).attr('alt');
+        text = text.replace(elem.outerHTML, altProp);
+      }
+    }
+    for (var key in Object.keys(faker.getElementsByTagName('area'))){
+      var elem = faker.getElementsByTagName('area')[key];
+      if (elem != null) {
+        var altProp = $(faker.getElementsByTagName('area')[key]).attr('alt');
+        text = text.replace(elem.outerHTML, altProp);
+      }
+    }
+    for (var key in Object.keys(faker.getElementsByTagName('input'))){
+      var elem = faker.getElementsByTagName('input')[key];
+      if (elem != null) {
+        var altProp = $(faker.getElementsByTagName('input')[key]).attr('alt');
+        text = text.replace(elem.outerHTML, altProp);
+      }
+    }
     WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());
   }
 }
@@ -1249,7 +1274,7 @@ function writeToTranscript(text){
 */
 function enableTranscript(name){
   if (transcriptProhibited) return;
-  transcriptName = name || transcriptName;
+  transcriptName = name || transcriptName || gameName;
   transcriptEnabled = true;
 }
 
@@ -1278,18 +1303,18 @@ function killTranscript(){
 function setTranscriptStatus(status){
   switch (status){
     case "enabled":
-    case "enable":
-      enableTranscript();
+      var name = transcriptName || gameName;
+      enableTranscript(name);
       break;
     case "disabled":
-    case "disable":
       disableTranscript();
       break;
+    case "prohibited":
     case "none":
     case "killed":
       killTranscript();
       break;
-    case "alive":
+    case "allowed":
       transcriptProhibited = false;
   }
 }

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1304,61 +1304,7 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Log functions
-var logArr = [];
-
-function addLogEntry(text){
-  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
-  if (logDivIsSetUp){
-     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
-  }
-};
-
-var logDivIsSetUp = false;
-
-var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
-
-function setupLogDiv(){
-  addText(logDivToAdd);
-  $("#log-div").insertBefore($("#dialog"));
-  logDivIsSetUp = true;
-};
-
-function showLog(){
-  if(!logDivIsSetUp){
-    setupLogDiv(); 
-  }
-  hideLogDiv()
-  $(".do-not-print-with-log").show();
-  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
-  if (platform !== "mobile"){
-    $('#log-div').show().insertAfter($('#txtCommandDiv'));
-  } else {
-  $('#log-div').show().insertAfter($('#inputBar')) 
-  }
-};
-
-function hideLogDiv(){
-  $("#log-div").hide();
-};
-
-function printLogDiv(){
-  if(typeof(document.title) !== "undefined"){
-    var docTitleBak = document.title;
-  }else{
-    var docTitleBak = "title";
-  }
-  document.title = "log.txt" ;
-  $('.do-not-print-with-log').hide();
-  $("#gameBorder").hide();
-  $('#log-div').insertBefore($("#gameBorder"));
-  print();
-  $('.do-not-print-with-log').show();
-  $('#log-div').appendTo($("#divOutput"));
-  $("#gameBorder").show();
-  document.title = docTitleBak;
-};
-
+// Log function
 function getTimeAndDateForLog(){
   var date = new Date();
   var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -359,7 +359,7 @@ function SetBackgroundOpacity(opacity) {
 function setBackground(col) {
     /* If '#rgb', convert to '#rrggbb'*/
     /* https://github.com/textadventures/quest/issues/1052 */
-    if (col.charAt(0) === "#") && col.length == 4) {
+    if (col.charAt(0) === "#" && col.length == 4) {
         var colBak = "" + col + "";
         newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
         col = newCol || col;

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1256,7 +1256,6 @@ function enableTranscript(name){
 /**
   * This will disable the transcript.
   * 
-  * @param {name} text If this is defined, the transcriptName will be set to this.
 */
 function disableTranscript(){
   transcriptEnabled = false;
@@ -1265,7 +1264,6 @@ function disableTranscript(){
 /**
   * This will completely kill the transcript.
   * 
-  * @param {name} text If this is defined, the transcriptName will be set to this.
 */
 function killTranscript(){
   noTranscript = true;
@@ -1275,7 +1273,7 @@ function killTranscript(){
 /**
   * Make it easy to control transcript settings from Quest.
   * 
-  * @param {name} text If this is defined, the transcriptName will be set to this.
+  * @param {name} status The state the transcript will be set to.
 */
 function setTranscriptStatus(status){
   switch (status){

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1215,17 +1215,37 @@ function isMobilePlayer() {
     return (platform === "mobile");
 };
 
-/**
-  * Added by KV for using the JS console for the Quest log when game.useconsolelog is set to true.
-  *
-  * @return {string} currentDateTime Time and date in format just like the Quest desktop log window
-*/
+// Log functions
+
+// Fallback for Quest 5.8.0
+function addLogEntry(text){
+  // Just pass it along to the console log.
+  console.log(getTimeAndDateForLog() + ' ' + text);
+}
+
+// Fallback for Quest 5.8.0 -- there was a way to view the log in-game (because the Log window no longer functioned at that time)
+function showLog(){
+  var sArr = ["The <code>showLog</code> function has been deprecated."];
+  if(!webPlayer){
+    sArr.push(" Use Quest's built-in Log window instead.");
+  }
+  else if (!isMobilePlayer()){
+    sArr.push(" Try looking in your HTML dev tools console. There may be log entries there, depending on the game.");
+  }
+  addTextAndScroll(sArr.join("") + "<br/>");
+}
+
+// Fallback for Quest 5.8.0 (just in case)
+// Nothing will ever be done with this.
+var logVar = "";
+
 function getTimeAndDateForLog(){
   var date = new Date();
   var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
   return currentDateTime;
 };
 
+// **********************************
 // TRANSCRIPT STUFF
 
 /**

--- a/WebPlayer/Mobile/Play.aspx
+++ b/WebPlayer/Mobile/Play.aspx
@@ -141,7 +141,6 @@
                     <button type="button" id="cmdRestart">Restart</button>
                     <button type="button" id="cmdUndo">Undo</button>
                     <button type="button" id="cmdWait">Wait</button>
-                    <button type="button" id="showTranscripts" style="padding: 6px !important" onclick="showTranscripts();">Transcripts</button>
                 </div>
             </div>
         </div>

--- a/WebPlayer/Mobile/Play.aspx
+++ b/WebPlayer/Mobile/Play.aspx
@@ -141,6 +141,7 @@
                     <button type="button" id="cmdRestart">Restart</button>
                     <button type="button" id="cmdUndo">Undo</button>
                     <button type="button" id="cmdWait">Wait</button>
+                    <button type="button" id="showTranscripts" style="padding: 6px !important" onclick="showTranscripts();">Transcripts</button>
                 </div>
             </div>
         </div>

--- a/WebPlayer/Play.aspx.cs
+++ b/WebPlayer/Play.aspx.cs
@@ -76,6 +76,9 @@ namespace WebPlayer
             {
                 case 1:
                     string initialText = await LoadGameForRequest();
+                    if (initialText == null){
+                      initialText = "No game found.";
+                    }
                     if (m_player == null)
                     {
                         tmrInit.Enabled = false;
@@ -112,8 +115,15 @@ namespace WebPlayer
                     if (fileManager != null)
                     {
                         var result = await fileManager.GetFileForID(id);
-                        gameFile = result.Filename;
-                        isCompiled = result.IsCompiled;
+                        if (result == null)
+                        {
+                          gameFile = null;
+                        }
+                        else 
+                        {
+                          gameFile = result.Filename;
+                          isCompiled = result.IsCompiled;
+                        }
                     }
                 }
             }

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -268,14 +268,14 @@ function saveGameResponse(data) {
   * @param {string} text This is added to the transcriptData item in localStorage
 */
 function WriteToTranscript(data){
-  if (transcriptProhibited){
+  if (noTranscript){
     // Do nothing.
     return;
   }
   if (!isLocalStorageAvailable()){
     console.error("There is no localStorage. Disabling transcript functionality.");
-    transcriptProhibited = true;
-    transcriptEnabled = false;
+    noTranscript = true;
+    savingTranscript = false;
     return;
   }
   var tName = transcriptName || "Transcript";

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -25,6 +25,7 @@ function init(url, gameSessionLogId) {
     apiRoot = url;
     $("#jquery_jplayer").jPlayer({ supplied: "wav, mp3" });
     setInterval(keepSessionAlive, 60000);
+    $("#showTranscripts").show();
 
     if ($_GET["id"].substr(0, 7) === "editor/") return;
 

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -269,13 +269,13 @@ function saveGameResponse(data) {
   * @param {string} text This is added to the transcriptData item in localStorage
 */
 function WriteToTranscript(data){
-  if (noTranscript){
+  if (transcriptProhibited){
     // Do nothing.
     return;
   }
   if (!isLocalStorageAvailable()){
     console.error("There is no localStorage. Disabling transcript functionality.");
-    noTranscript = true;
+    transcriptProhibited = true;
     transcriptEnabled = false;
     return;
   }
@@ -310,12 +310,13 @@ function showTranscripts(){
   var choices = [];
   for (var e in localStorage) {
     if (e.startsWith("questtranscript-")){
-      choices.push("<span id=\"" + e + "\" class=\"transcript-choice\"><a name=\"" + e + "\" href=\"#\" onclick=\"openTranscript(this.name);\" class=\"transcript-link\">" + e.replace(/questtranscript-/,"") + "</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href=\"#\"  name=\"" + e + "\" onclick=\"removeTscript(this.name);\" class=\"transcript-delete\">DELETE</a></span>")
+      choices.push("<span id=\"" + e + "\" class=\"transcript-choice\"><a name=\"" + e + "\" href=\"#\" onclick=\"openTranscript(this.name);\" class=\"transcript-link\">" + e.replace(/questtranscript-/,"") + "</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href=\"#\"  name=\"" + e + "\" onclick=\"removeTscript(this.name);\" class=\"transcript-delete\">DELETE</a></span>")
     }
   }
-  var choicesScript = "<script>var wnd;var tName = \"\";function openTranscript(tsn){ var tscriptData = \"\";  tscriptData = localStorage.getItem(tsn).replace(/@@@NEW_LINE@@@/g,\"<br/>\") || \"No transcript data found.\";  wnd = window.open(\"about:blank\", \"\", \"_blank\");  wnd.document.write(tscriptData);  wnd.document.title = tsn.replace(/questtranscript-/,\"\") + \" - Transcript\";};function removeTscript(tscript){console.log(tscript);var result = window.confirm(\"Delete this transcript?\");if (result){ localStorage.removeItem(tscript); document.getElementById(tscript).remove(); }};</script>";
+  var choicesStyle = "<style>.transcript-choice { border: 1px solid black; padding: 4px;}</style>";
+  var choicesScript = "<script>var wnd;var tName = \"\";function openTranscript(tsn){ var tscriptData = \"\";  tscriptData = localStorage.getItem(tsn).replace(/@@@NEW_LINE@@@/g,\"<br/>\") || \"No transcript data found.\";  wnd = window.open(\"about:blank\", \"\", \"_blank\");  wnd.document.write(tscriptData);  wnd.document.title = tsn.replace(/questtranscript-/,\"\") + \" - Transcript\";};function removeTscript(tscript){console.log(tscript);var result = window.confirm(\"Delete this transcript?\");if (result){ localStorage.removeItem(tscript); document.getElementById(tscript).style.display = \"none\"; }};</script>";
   tscriptWindow = window.open("about:blank", "", "_blank");
-  tscriptWindow.document.write("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><div id=\"main-holder\"><h3 id=\"your-transcripts\">Your Transcripts</h3><br/><div id=\"choices-holder\">" + choices.join("<br/>") + "</div></div>" + choicesScript);
+  tscriptWindow.document.write("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">" + choicesStyle + "<div id=\"main-holder\"><h3 id=\"your-transcripts\">Your Transcripts</h3><br/><div id=\"choices-holder\">" + choices.join("<br/>") + "</div></div>" + choicesScript);
   tscriptWindow.document.title = tName + "Your Transcripts";
 }
 

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -25,7 +25,6 @@ function init(url, gameSessionLogId) {
     apiRoot = url;
     $("#jquery_jplayer").jPlayer({ supplied: "wav, mp3" });
     setInterval(keepSessionAlive, 60000);
-    $("#showTranscripts").show();
 
     if ($_GET["id"].substr(0, 7) === "editor/") return;
 
@@ -279,6 +278,9 @@ function WriteToTranscript(data){
     transcriptEnabled = false;
     return;
   }
+  /*
+   * TODO: Does this name string need to be JS safe???
+  */
   var tName = transcriptName || "Transcript";
   if (data.indexOf("___SCRIPTDATA___") > -1) {
     tName = data.split("___SCRIPTDATA___")[0].trim() || tName;
@@ -286,50 +288,6 @@ function WriteToTranscript(data){
   }
   var oldData = localStorage.getItem("questtranscript-" + tName) || "";
   localStorage.setItem("questtranscript-" + tName, oldData + data);
-}
-
-var wnd;
-var tName = "";
-
-function openTranscript(tsn){
-  if (!isLocalStorageAvailable()){
-    return;
-  }
-  var tscriptData = "";
-  tscriptData = "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">" + localStorage.getItem(tsn).replace(/@@@NEW_LINE@@@/g,"<br/>") || "No transcript data found.";
-  wnd = window.open("about:blank", "", "_blank");
-  wnd.document.write(tscriptData);
-  wnd.document.title = tsn.replace(/questtranscript-/,"") + " - Transcript";
-}
-
-var tscriptWindow;
-function showTranscripts(){
-  if (!isLocalStorageAvailable()){
-    return;
-  }
-  var choices = [];
-  for (var e in localStorage) {
-    if (e.startsWith("questtranscript-")){
-      choices.push("<span id=\"" + e + "\" class=\"transcript-choice\"><a name=\"" + e + "\" href=\"#\" onclick=\"openTranscript(this.name);\" class=\"transcript-link\">" + e.replace(/questtranscript-/,"") + "</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href=\"#\"  name=\"" + e + "\" onclick=\"removeTscript(this.name);\" class=\"transcript-delete\">DELETE</a></span>")
-    }
-  }
-  var choicesStyle = "<style>.transcript-choice { border: 1px solid black; padding: 4px;}</style>";
-  var choicesScript = "<script>var wnd;var tName = \"\";function openTranscript(tsn){ var tscriptData = \"\";  tscriptData = localStorage.getItem(tsn).replace(/@@@NEW_LINE@@@/g,\"<br/>\") || \"No transcript data found.\";  wnd = window.open(\"about:blank\", \"\", \"_blank\");  wnd.document.write(tscriptData);  wnd.document.title = tsn.replace(/questtranscript-/,\"\") + \" - Transcript\";};function removeTscript(tscript){console.log(tscript);var result = window.confirm(\"Delete this transcript?\");if (result){ localStorage.removeItem(tscript); document.getElementById(tscript).style.display = \"none\"; }};</script>";
-  tscriptWindow = window.open("about:blank", "", "_blank");
-  tscriptWindow.document.write("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">" + choicesStyle + "<div id=\"main-holder\"><h3 id=\"your-transcripts\">Your Transcripts</h3><br/><div id=\"choices-holder\">" + choices.join("<br/>") + "</div></div>" + choicesScript);
-  tscriptWindow.document.title = tName + "Your Transcripts";
-}
-
-/* https://stackoverflow.com/a/16427747 */
-function isLocalStorageAvailable(){
-    var test = 'test';
-    try {
-        localStorage.setItem(test, test);
-        localStorage.removeItem(test);
-        return true;
-    } catch(e) {
-        return false;
-    }
 }
 
 

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -259,3 +259,28 @@ function saveGameResponse(data) {
         }
     });
 }
+
+/**
+  * Adding this to this file because it exists in desktopplayer.js
+  *
+  * It is doing nothing here if called, except disabling the transcript. It is mainly here just so it is defined.
+  *
+  * @param {string} text This would print to the transcript file if this were the desktop player. It is ignored here.
+*/
+function WriteToTranscript (text) {
+  console.log("[QUEST]: Call to WriteToTranscript ignored. Feature only available in the desktop version of Quest. Disabling the transcript.");
+  var noTranscript = true;
+  var transcriptEnabled = false;
+}
+
+/**
+  * Adding this to this file because it exists in desktopplayer.js
+  *
+  * It is doing nothing here if called, but it is here just so it is defined.
+  *
+  * @param {data} text This would print to the log file if this were the desktop player. It is ignored here.
+*/
+function WriteToLog(data){
+  /* Do nothing at all. */
+  return;
+}

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -295,7 +295,28 @@ function WriteToTranscript(data){
   localStorage.setItem("questtranscript-" + tName, oldData + data);
 }
 
+// Make sure localStorage is available, hopefully without throwing any errors!
 
+/* https://stackoverflow.com/a/16427747 */
+function isLocalStorageAvailable(){
+    var test = 'test';
+    try {
+        localStorage.setItem(test, test);
+        localStorage.removeItem(test);
+        return true;
+    } catch(e) {
+        return false;
+    }
+}
+
+
+// NOTE:
+// There is a Quest game on the site to handle viewing of transcipts for all online users:
+// https://play.textadventures.co.uk/Play.aspx?id=4wqdac8qd0sf7-ilff8mia
+
+
+
+// END OF TRANSCRIPT FUNCTIONS
 
 /**
   * Adding this to this file because it exists in desktopplayer.js

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -260,18 +260,77 @@ function saveGameResponse(data) {
     });
 }
 
+
+// Added by KV  
 /**
-  * Adding this to this file because it exists in desktopplayer.js
+  * Writes data to the transcript's item in localStorage.
   *
-  * It is doing nothing here if called, except disabling the transcript. It is mainly here just so it is defined.
-  *
-  * @param {string} text This would print to the transcript file if this were the desktop player. It is ignored here.
+  * @param {string} text This is added to the transcriptData item in localStorage
 */
-function WriteToTranscript (text) {
-  console.log("[QUEST]: Call to WriteToTranscript ignored. Feature only available in the desktop version of Quest. Disabling the transcript.");
-  var noTranscript = true;
-  var transcriptEnabled = false;
+function WriteToTranscript(data){
+  if (noTranscript){
+    // Do nothing.
+    return;
+  }
+  if (!isLocalStorageAvailable()){
+    console.error("There is no localStorage. Disabling transcript functionality.");
+    noTranscript = true;
+    transcriptEnabled = false;
+    return;
+  }
+  var tName = transcriptName || "Transcript";
+  if (data.indexOf("___SCRIPTDATA___") > -1) {
+    tName = data.split("___SCRIPTDATA___")[0].trim() || tName;
+    data = data.split("___SCRIPTDATA___")[1];
+  }
+  var oldData = localStorage.getItem("questtranscript-" + tName) || "";
+  localStorage.setItem("questtranscript-" + tName, oldData + data);
 }
+
+var wnd;
+var tName = "";
+
+function openTranscript(tsn){
+  if (!isLocalStorageAvailable()){
+    return;
+  }
+  var tscriptData = "";
+  tscriptData = "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">" + localStorage.getItem(tsn).replace(/@@@NEW_LINE@@@/g,"<br/>") || "No transcript data found.";
+  wnd = window.open("about:blank", "", "_blank");
+  wnd.document.write(tscriptData);
+  wnd.document.title = tsn.replace(/questtranscript-/,"") + " - Transcript";
+}
+
+var tscriptWindow;
+function showTranscripts(){
+  if (!isLocalStorageAvailable()){
+    return;
+  }
+  var choices = [];
+  for (var e in localStorage) {
+    if (e.startsWith("questtranscript-")){
+      choices.push("<span id=\"" + e + "\" class=\"transcript-choice\"><a name=\"" + e + "\" href=\"#\" onclick=\"openTranscript(this.name);\" class=\"transcript-link\">" + e.replace(/questtranscript-/,"") + "</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href=\"#\"  name=\"" + e + "\" onclick=\"removeTscript(this.name);\" class=\"transcript-delete\">DELETE</a></span>")
+    }
+  }
+  var choicesScript = "<script>var wnd;var tName = \"\";function openTranscript(tsn){ var tscriptData = \"\";  tscriptData = localStorage.getItem(tsn).replace(/@@@NEW_LINE@@@/g,\"<br/>\") || \"No transcript data found.\";  wnd = window.open(\"about:blank\", \"\", \"_blank\");  wnd.document.write(tscriptData);  wnd.document.title = tsn.replace(/questtranscript-/,\"\") + \" - Transcript\";};function removeTscript(tscript){console.log(tscript);var result = window.confirm(\"Delete this transcript?\");if (result){ localStorage.removeItem(tscript); document.getElementById(tscript).remove(); }};</script>";
+  tscriptWindow = window.open("about:blank", "", "_blank");
+  tscriptWindow.document.write("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><div id=\"main-holder\"><h3 id=\"your-transcripts\">Your Transcripts</h3><br/><div id=\"choices-holder\">" + choices.join("<br/>") + "</div></div>" + choicesScript);
+  tscriptWindow.document.title = tName + "Your Transcripts";
+}
+
+/* https://stackoverflow.com/a/16427747 */
+function isLocalStorageAvailable(){
+    var test = 'test';
+    try {
+        localStorage.setItem(test, test);
+        localStorage.removeItem(test);
+        return true;
+    } catch(e) {
+        return false;
+    }
+}
+
+
 
 /**
   * Adding this to this file because it exists in desktopplayer.js

--- a/WebPlayer/player.js
+++ b/WebPlayer/player.js
@@ -278,15 +278,20 @@ function WriteToTranscript(data){
     transcriptEnabled = false;
     return;
   }
-  /*
-   * TODO: Does this name string need to be JS safe???
-  */
   var tName = transcriptName || "Transcript";
+  var overwrite = false;
+  if (data.indexOf("@@@OVERWRITEFILE@@@") > -1){
+    overwrite = true;
+    data = data.replace("@@@OVERWRITEFILE@@@", "");
+  }
   if (data.indexOf("___SCRIPTDATA___") > -1) {
     tName = data.split("___SCRIPTDATA___")[0].trim() || tName;
     data = data.split("___SCRIPTDATA___")[1];
   }
-  var oldData = localStorage.getItem("questtranscript-" + tName) || "";
+  var oldData = "";
+  if (!overwrite){
+    oldData = localStorage.getItem("questtranscript-" + tName) || "";
+  }
   localStorage.setItem("questtranscript-" + tName, oldData + data);
 }
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -631,14 +631,14 @@ function addTextAndScroll(text) {
 
 // These 2 variables added by KV for the transcript
 var transcriptEnabled = false;
-var noTranscript = false;
+var transcriptProhibited = false;
 
 // This function altered by KV for the transcript
 function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
     }
-    if (transcriptEnabled && !noTranscript) {
+    if (transcriptEnabled && !transcriptProhibited) {
         writeToTranscript(text);
     }
     getCurrentDiv().append(text);
@@ -1232,23 +1232,23 @@ function getTimeAndDateForLog(){
   *
   * This will write/append to a TXT document in Documents\Quest Transcripts
   *  if using the desktop player and the the player has the transcript enabled
-  *  and if noTranscript is not set to true (it is false by default).
+  *  and if transcriptProhibited is not set to true (it is false by default).
   *
   * @param {string} text The string to be written to the file
 */
 function writeToTranscript(text){
-  if (!noTranscript && transcriptEnabled) {
+  if (!transcriptProhibited && transcriptEnabled) {
     WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());
   }
 }
 
 /**
-  * This will enable the transcript unless noTranscript is set to true.
+  * This will enable the transcript unless transcriptProhibited is set to true.
   * 
   * @param {name} text If this is defined, the transcriptName will be set to this.
 */
 function enableTranscript(name){
-  if (noTranscript) return;
+  if (transcriptProhibited) return;
   transcriptName = name || transcriptName;
   transcriptEnabled = true;
 }
@@ -1256,7 +1256,6 @@ function enableTranscript(name){
 /**
   * This will disable the transcript.
   * 
-  * @param {name} text If this is defined, the transcriptName will be set to this.
 */
 function disableTranscript(){
   transcriptEnabled = false;
@@ -1265,23 +1264,22 @@ function disableTranscript(){
 /**
   * This will completely kill the transcript.
   * 
-  * @param {name} text If this is defined, the transcriptName will be set to this.
 */
 function killTranscript(){
-  noTranscript = true;
+  transcriptProhibited = true;
   disableTranscript();
 }
 
 /**
   * Make it easy to control transcript settings from Quest.
   * 
-  * @param {name} text If this is defined, the transcriptName will be set to this.
+  * @param {name} status The state the transcript will be set to.
 */
 function setTranscriptStatus(status){
   switch (status){
     case "enabled":
     case "enable":
-      initiateTranscript();
+      enableTranscript();
       break;
     case "disabled":
     case "disable":
@@ -1292,7 +1290,7 @@ function setTranscriptStatus(status){
       killTranscript();
       break;
     case "alive":
-      noTranscript = false;
+      transcriptProhibited = false;
   }
 }
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -638,8 +638,7 @@ function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
     }
-    // Only attempt writeToTranscript() if this is the desktop player.
-    if (!webPlayer && platform == "desktop" && transcriptEnabled && !noTranscript) {
+    if (transcriptEnabled && !noTranscript) {
         writeToTranscript(text);
     }
     getCurrentDiv().append(text);
@@ -817,8 +816,6 @@ function printScrollback() {
   iframe.contentWindow.document.write($("#scrollbackdata").html());
   iframe.contentWindow.print();
   document.body.removeChild(iframe);
-  $("#scrollback-dialog").dialog("close");
-  $("#scrollback-dialog").remove();
 };
 
 function keyPressCode(e) {
@@ -1240,7 +1237,7 @@ function getTimeAndDateForLog(){
   * @param {string} text The string to be written to the file
 */
 function writeToTranscript(text){
-  if (!webPlayer && platform === "desktop" && typeof WriteToTranscript !== "undefined" && !noTranscript && transcriptEnabled) {
+  if (!noTranscript && transcriptEnabled) {
     WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());
   }
 }

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1245,22 +1245,22 @@ function writeToTranscript(text){
     for (var key in Object.keys(faker.getElementsByTagName('img'))){
       var elem = faker.getElementsByTagName('img')[key];
       if (elem != null) {
-        var altProp = $(faker.getElementsByTagName('img')[key]).attr('alt');
-        text = text.replace(elem.outerHTML, altProp);
+        var altProp = $(faker.getElementsByTagName('img')[key]).attr('alt') || "";
+        text = text.replace(elem.outerHTML, altProp) || text;
       }
     }
     for (var key in Object.keys(faker.getElementsByTagName('area'))){
       var elem = faker.getElementsByTagName('area')[key];
       if (elem != null) {
-        var altProp = $(faker.getElementsByTagName('area')[key]).attr('alt');
-        text = text.replace(elem.outerHTML, altProp);
+        var altProp = $(faker.getElementsByTagName('area')[key]).attr('alt') || "";
+        text = text.replace(elem.outerHTML, altProp) || text;
       }
     }
     for (var key in Object.keys(faker.getElementsByTagName('input'))){
       var elem = faker.getElementsByTagName('input')[key];
       if (elem != null) {
-        var altProp = $(faker.getElementsByTagName('input')[key]).attr('alt');
-        text = text.replace(elem.outerHTML, altProp);
+        var altProp = $(faker.getElementsByTagName('input')[key]).attr('alt') || "";
+        text = text.replace(elem.outerHTML, altProp) || text;
       }
     }
     WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -357,15 +357,23 @@ function SetBackgroundOpacity(opacity) {
 }
 
 function setBackground(col) {
+    /* If '#rgb', convert to '#rrggbb'*/
+    /* https://github.com/textadventures/quest/issues/1052 */
+    if (col.charAt(0) === "#") && col.length == 4) {
+        var colBak = "" + col + "";
+        newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
+        col = newCol || col;
+        console.warn("[QUEST](playercore.js): setBackground() changed \"" + colBak + "\" to \"" + col + "\".")
+    }
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
     rgbCol = hexToRgb(col);
     var cssBackground = "rgba(" + rgbCol.r + "," + rgbCol.g + "," + rgbCol.b + "," + _backgroundOpacity + ")";
     $("#gameBorder").css("background-color", cssBackground);
-
     $("#gamePanel").css("background-color", col);
     $("#gridPanel").css("background-color", col);
 }
+
 
 function setPanelHeight() {
     if (_showGrid) return;

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1334,6 +1334,17 @@ function SaveTranscript(text){
   writeToTranscript(text);  
 }
 
+var transcriptUrl = 'Play.aspx?id=4wqdac8qd0sf7-ilff8mia';
+// Another fallback to avoid errors
+function showTranscript(){
+  if (webPlayer){
+    addTextAndScroll('Your transcripts are saved to the localStorage in your browser. You can view, download, or delete them here: <a href="' + transcriptUrl + '" target="_blank">Your Transcripts</a><br/>');
+  }
+  else {
+    addTextAndScroll('Your transcripts are saved to "Documents\\Quest Transcripts\\".<br/>');
+  }
+};
+
 // ***********************************
 
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1304,85 +1304,19 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Make it easy to print messages.
-//var msg = addTextAndScroll;
-    
 // Log functions
-var logVar = "";
-function addLogEntry(text){
-  logVar += getTimeAndDateForLog() + ' ' + text+"NEW_LINE";
-};
+var logArr = [];
 
-function showLog(){
-  var logDivString = "";
-  logDivString += "<div ";
-  logDivString += "id='log-dialog' ";
-  logDivString += "style='display:none;;'>";
-  logDivString += "<textarea id='logdata' rows='13'";
-  logDivString += "  cols='49'></textarea></div>";
-  addText(logDivString);
-  if(webPlayer){
-    var logDialog = $("#log-dialog").dialog({
-      autoOpen: false,
-      width: 600,
-      height: 500,
-      title: "Log",
-      buttons: {
-        Ok: function() {
-          $(this).dialog("close");
-        },
-        Print: function(){
-          $(this).dialog("close");
-          showLogDiv();
-          printLogDiv();
-        },
-        Save: function(){
-          $(this).dialog("close");
-          saveLog();
-        },
-      },
-      show: { effect: "fadeIn", duration: 500 },
-      // The modal setting keeps the player from interacting with anything besides the dialog window.
-      //  (The log will not update while open without adding a turn script.  I prefer this.)
-      modal: true,
-    });
-  }else{
-    var logDialog = $("#log-dialog").dialog({
-    autoOpen: false,
-    width: 600,
-    height: 500,
-    title: "Log",
-    buttons: {
-      Ok: function() {
-        $(this).dialog("close");
-      },
-      Print: function(){
-        $(this).dialog("close");
-        showLogDiv();
-        printLogDiv();
-      },
-    },
-    show: { effect: "fadeIn", duration: 500 },
-    // The modal setting keeps the player from interacting with anything besides the dialog window.
-    //  (The log will not update while open without adding a turn script.  I prefer this.)
-    modal: true,
-  });
+function addLogEntry(text){
+  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
+  if (logDivIsSetUp){
+     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
   }
-  $('textarea#logdata').val(logVar.replace(/NEW_LINE/g,"\n"));
-  logDialog.dialog("open");
 };
 
 var logDivIsSetUp = false;
 
-var logDivToAdd = "";
-logDivToAdd += "<div ";
-logDivToAdd += "id='log-div' ";
-logDivToAdd += "style='display:none;'>";
-logDivToAdd += "<a class='do-not-print-with-log' ";
-logDivToAdd += "href='' onclick='hideLogDiv()'>RETURN TO THE GAME</a>  ";
-logDivToAdd += "<a class='do-not-print-with-log' href='' ";
-logDivToAdd += "onclick='printLogDiv();'>PRINT</a> ";
-logDivToAdd += "<div id='log-contents-div' '></div></div>";
+var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
 
 function setupLogDiv(){
   addText(logDivToAdd);
@@ -1390,19 +1324,22 @@ function setupLogDiv(){
   logDivIsSetUp = true;
 };
 
-function showLogDiv(){
-    if(!logDivIsSetUp){
-     setupLogDiv(); 
-    }
-	$(".do-not-print-with-log").show();
-	$("#log-contents-div").html(logVar.replace(/NEW_LINE/g,"<br/>"));
-	$("#log-div").show();
-	$("#gameBorder").hide();
+function showLog(){
+  if(!logDivIsSetUp){
+    setupLogDiv(); 
+  }
+  hideLogDiv()
+  $(".do-not-print-with-log").show();
+  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
+  if (platform !== "mobile"){
+    $('#log-div').show().insertAfter($('#txtCommandDiv'));
+  } else {
+  $('#log-div').show().insertAfter($('#inputBar')) 
+  }
 };
 
 function hideLogDiv(){
-	$("#log-div").hide();
-	$("#gameBorder").show();
+  $("#log-div").hide();
 };
 
 function printLogDiv(){
@@ -1413,48 +1350,21 @@ function printLogDiv(){
   }
   document.title = "log.txt" ;
   $('.do-not-print-with-log').hide();
+  $("#gameBorder").hide();
+  $('#log-div').insertBefore($("#gameBorder"));
   print();
   $('.do-not-print-with-log').show();
+  $('#log-div').appendTo($("#divOutput"));
+  $("#gameBorder").show();
   document.title = docTitleBak;
 };
 
-
-function saveLog(){
-  if(webPlayer){
-    var href = "data:text/plain,"+logVar.replace(/NEW_LINE/g,"\n");
-    addTextAndScroll("<a download='log.txt' href='"+href+"' id='log-save-link'>Click here to save the log if your pop-up blocker stopped the download.</a>");
-    document.getElementById("log-save-link").addEventListener ("click", function (e) {e.stopPropagation();});
-    document.getElementById("log-save-link").click();
-  }else{
-    alert("This function is only available while playing online.");
-  }
- };
-
 function getTimeAndDateForLog(){
-	var today = new Date();
-	var dd = today.getDate();
-	var mm = today.getMonth()+1;
-	var yyyy = today.getFullYear();
-	var hrs = today.getHours();
-	var mins = today.getMinutes();
-	var secs = today.getSeconds();
-	today = mm + '/' + dd + '/' + yyyy;
-	if(hrs>12) {
-	  ampm = 'PM';
-	  hrs = '0' + '' + hrs - 12
-	}else{
-	  ampm = 'AM';
-	} 
-	if (mins<10) {
-	  mins = '0'+mins;
-	} 
-	if(secs<10) {
-	  secs = '0' + secs;
-	}
-	time = hrs + ':' + mins + ':' + secs + ' ' + ampm;
-	return today + ' ' + time;
+  var date = new Date();
+  var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
+  return currentDateTime;
 };
-    
+
 // **********************************
 // TRANSCRIPT FUNCTIONS
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -630,8 +630,8 @@ function addTextAndScroll(text) {
 }
 
 // These variables added by KV for the transcript
-var transcriptEnabled = false;
-var transcriptProhibited = false;
+var savingTranscript = false;
+var noTranscript = false;
 var transcriptName = "";
 
 // This function altered by KV for the transcript
@@ -641,7 +641,7 @@ function addText(text) {
     }
     getCurrentDiv().append(text);
     $("#divOutput").css("min-height", $("#divOutput").height());
-    if (transcriptEnabled && !transcriptProhibited) {
+    if (savingTranscript && !noTranscript) {
       writeToTranscript(text);
     }
 }
@@ -1233,12 +1233,12 @@ function getTimeAndDateForLog(){
   *
   * This will write/append to a TXT document in Documents\Quest Transcripts
   *  if using the desktop player and the the player has the transcript enabled
-  *  and if transcriptProhibited is not set to true (it is false by default).
+  *  and if noTranscript is not set to true (it is false by default).
   *
   * @param {string} text The string to be written to the file
 */
 function writeToTranscript(text){
-  if (!transcriptProhibited && transcriptEnabled) {
+  if (!noTranscript && savingTranscript) {
     var faker = document.createElement('div');
     faker.innerHTML = text;
     text = faker.innerHTML;
@@ -1268,14 +1268,14 @@ function writeToTranscript(text){
 }
 
 /**
-  * This will enable the transcript unless transcriptProhibited is set to true.
+  * This will enable the transcript unless noTranscript is set to true.
   * 
   * @param {name} text If this is defined, the transcriptName will be set to this.
 */
 function enableTranscript(name){
-  if (transcriptProhibited) return;
+  if (noTranscript) return;
   transcriptName = name || transcriptName || gameName;
-  transcriptEnabled = true;
+  savingTranscript = true;
 }
 
 /**
@@ -1283,7 +1283,7 @@ function enableTranscript(name){
   * 
 */
 function disableTranscript(){
-  transcriptEnabled = false;
+  savingTranscript = false;
 }
 
 /**
@@ -1291,7 +1291,7 @@ function disableTranscript(){
   * 
 */
 function killTranscript(){
-  transcriptProhibited = true;
+  noTranscript = true;
   disableTranscript();
 }
 
@@ -1315,12 +1315,11 @@ function setTranscriptStatus(status){
       killTranscript();
       break;
     case "allowed":
-      transcriptProhibited = false;
+      noTranscript = false;
   }
 }
 
-/**
-  * 
+var showedSaveTranscriptWarning = false;
 /**
   * This function was missing from the webplayer in Quest 5.8.0
   * Leaving this here as a fallback
@@ -1328,7 +1327,10 @@ function setTranscriptStatus(status){
   * @param {string} text The line(s) of text being printed
 */
 function SaveTranscript(text){
-  console.log("[QUEST]: SaveTranscript has been deprecated. Using writeToTranscript instead.");
+  if(!showedSaveTranscriptWarning){
+    console.log("[QUEST]: SaveTranscript has been deprecated. Using writeToTranscript instead.");
+    showedSaveTranscriptWarning = true;
+  }
   writeToTranscript(text);  
 }
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -629,20 +629,21 @@ function addTextAndScroll(text) {
     scrollToEnd();
 }
 
-// These 2 variables added by KV for the transcript
+// These variables added by KV for the transcript
 var transcriptEnabled = false;
 var transcriptProhibited = false;
+var transcriptName = "";
 
 // This function altered by KV for the transcript
 function addText(text) {
     if (getCurrentDiv() == null) {
         createNewDiv("left");
     }
-    if (transcriptEnabled && !transcriptProhibited) {
-        writeToTranscript(text);
-    }
     getCurrentDiv().append(text);
     $("#divOutput").css("min-height", $("#divOutput").height());
+    if (transcriptEnabled && !transcriptProhibited) {
+      writeToTranscript(text);
+    }
 }
 
 function createNewDiv(alignment) {
@@ -1238,6 +1239,30 @@ function getTimeAndDateForLog(){
 */
 function writeToTranscript(text){
   if (!transcriptProhibited && transcriptEnabled) {
+    var faker = document.createElement('div');
+    faker.innerHTML = text;
+    text = faker.innerHTML;
+    for (var key in Object.keys(faker.getElementsByTagName('img'))){
+      var elem = faker.getElementsByTagName('img')[key];
+      if (elem != null) {
+        var altProp = $(faker.getElementsByTagName('img')[key]).attr('alt');
+        text = text.replace(elem.outerHTML, altProp);
+      }
+    }
+    for (var key in Object.keys(faker.getElementsByTagName('area'))){
+      var elem = faker.getElementsByTagName('area')[key];
+      if (elem != null) {
+        var altProp = $(faker.getElementsByTagName('area')[key]).attr('alt');
+        text = text.replace(elem.outerHTML, altProp);
+      }
+    }
+    for (var key in Object.keys(faker.getElementsByTagName('input'))){
+      var elem = faker.getElementsByTagName('input')[key];
+      if (elem != null) {
+        var altProp = $(faker.getElementsByTagName('input')[key]).attr('alt');
+        text = text.replace(elem.outerHTML, altProp);
+      }
+    }
     WriteToTranscript(transcriptName + "___SCRIPTDATA___" + $("<div>" + text.replace(/<br\/>/g,"@@@NEW_LINE@@@").replace(/<br>/g,"@@@NEW_LINE@@@").replace(/<br \/>/g,"@@@NEW_LINE@@@") + "</div>").text());
   }
 }
@@ -1249,7 +1274,7 @@ function writeToTranscript(text){
 */
 function enableTranscript(name){
   if (transcriptProhibited) return;
-  transcriptName = name || transcriptName;
+  transcriptName = name || transcriptName || gameName;
   transcriptEnabled = true;
 }
 
@@ -1278,18 +1303,18 @@ function killTranscript(){
 function setTranscriptStatus(status){
   switch (status){
     case "enabled":
-    case "enable":
-      enableTranscript();
+      var name = transcriptName || gameName;
+      enableTranscript(name);
       break;
     case "disabled":
-    case "disable":
       disableTranscript();
       break;
+    case "prohibited":
     case "none":
     case "killed":
       killTranscript();
       break;
-    case "alive":
+    case "allowed":
       transcriptProhibited = false;
   }
 }

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1304,61 +1304,7 @@ function showPopupFullscreen(title, text) {
     $('#msgbox').dialog('open');
 };
 
-// Log functions
-var logArr = [];
-
-function addLogEntry(text){
-  logArr.push(getTimeAndDateForLog() + ': ' + text + "NEW_LINE");
-  if (logDivIsSetUp){
-     $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
-  }
-};
-
-var logDivIsSetUp = false;
-
-var logDivToAdd = "<div id='log-div' style='display:none;border:1px solid black;padding:12px;min-height:42%; max-height:37vh; overflow-y:scroll;'><button class='do-not-print-with-log' href='' onclick='hideLogDiv()'>HIDE THE LOG</button>&nbsp;&nbsp;&nbsp;&nbsp;<button  class='do-not-print-with-log' href='' onclick='printLogDiv();'>PRINT</button > <hr/> <div id='log-contents-div' '></div></div>";
-
-function setupLogDiv(){
-  addText(logDivToAdd);
-  $("#log-div").insertBefore($("#dialog"));
-  logDivIsSetUp = true;
-};
-
-function showLog(){
-  if(!logDivIsSetUp){
-    setupLogDiv(); 
-  }
-  hideLogDiv()
-  $(".do-not-print-with-log").show();
-  $("#log-contents-div").html(logArr.join("").replace(/NEW_LINE/g,"<br/>"));
-  if (platform !== "mobile"){
-    $('#log-div').show().insertAfter($('#txtCommandDiv'));
-  } else {
-  $('#log-div').show().insertAfter($('#inputBar')) 
-  }
-};
-
-function hideLogDiv(){
-  $("#log-div").hide();
-};
-
-function printLogDiv(){
-  if(typeof(document.title) !== "undefined"){
-    var docTitleBak = document.title;
-  }else{
-    var docTitleBak = "title";
-  }
-  document.title = "log.txt" ;
-  $('.do-not-print-with-log').hide();
-  $("#gameBorder").hide();
-  $('#log-div').insertBefore($("#gameBorder"));
-  print();
-  $('.do-not-print-with-log').show();
-  $('#log-div').appendTo($("#divOutput"));
-  $("#gameBorder").show();
-  document.title = docTitleBak;
-};
-
+// Log function
 function getTimeAndDateForLog(){
   var date = new Date();
   var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -359,7 +359,7 @@ function SetBackgroundOpacity(opacity) {
 function setBackground(col) {
     /* If '#rgb', convert to '#rrggbb'*/
     /* https://github.com/textadventures/quest/issues/1052 */
-    if (col.charAt(0) === "#") && col.length == 4) {
+    if (col.charAt(0) === "#" && col.length == 4) {
         var colBak = "" + col + "";
         newCol = col.replace(/#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])/, '#$1$1$2$2$3$3');
         col = newCol || col;

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -1215,17 +1215,37 @@ function isMobilePlayer() {
     return (platform === "mobile");
 };
 
-/**
-  * Added by KV for using the JS console for the Quest log when game.useconsolelog is set to true.
-  *
-  * @return {string} currentDateTime Time and date in format just like the Quest desktop log window
-*/
+// Log functions
+
+// Fallback for Quest 5.8.0
+function addLogEntry(text){
+  // Just pass it along to the console log.
+  console.log(getTimeAndDateForLog() + ' ' + text);
+}
+
+// Fallback for Quest 5.8.0 -- there was a way to view the log in-game (because the Log window no longer functioned at that time)
+function showLog(){
+  var sArr = ["The <code>showLog</code> function has been deprecated."];
+  if(!webPlayer){
+    sArr.push(" Use Quest's built-in Log window instead.");
+  }
+  else if (!isMobilePlayer()){
+    sArr.push(" Try looking in your HTML dev tools console. There may be log entries there, depending on the game.");
+  }
+  addTextAndScroll(sArr.join("") + "<br/>");
+}
+
+// Fallback for Quest 5.8.0 (just in case)
+// Nothing will ever be done with this.
+var logVar = "";
+
 function getTimeAndDateForLog(){
   var date = new Date();
   var currentDateTime = date.toLocaleString('en-US', { timeZoneName: 'short' }).replace(/,/g, "").replace(/[A-Z][A-Z][A-Z]/g, "");
   return currentDateTime;
 };
 
+// **********************************
 // TRANSCRIPT STUFF
 
 /**

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -221,6 +221,8 @@
     if (HasScript(game, "inituserinterface")) {
       do (game, "inituserinterface")
     }
+    // Adding this for the transcript when loading saved games.
+    JS.eval("transcriptProhibited = " + GetBoolean (game, "transcriptprohibited") + "; transcriptEnabled = " + GetBoolean (game, "transcriptenabled") + ";")
   ]]></function>
 
   <function name="InitUserInterface">
@@ -230,7 +232,7 @@
     <![CDATA[
     // Added by KV here in case someone enables the transcript up front to record everything including the title.
     transcript_triggered = false
-    if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript")){
+    if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "transcriptprohibited")){
       transcript_triggered = true
       EnableTranscript
     }
@@ -295,9 +297,7 @@
       JS.eval("var saveClearedText = false;")
     }
     // Added by KV once more here, in case someone enabled the transcript in the start script or an _initialise_ script.
-    if (not transcript_triggered and GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript")){
-      // TODO: Remove this Log entry!!!
-      Log("second catch.")
+    if (not transcript_triggered and GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "transcriptprohibited")){
       EnableTranscript
     }
     game.runturnscripts = false

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -33,8 +33,6 @@
   <function name="InitInterface">
     <![CDATA[
     // Added by KV for transcript
-    // The walkthrough has been modified to ignore this event when recording or running.
-    JS.whereAmI()
     // Use JSSafe to remove any offensive characters
     jsgamename = JSSafe(game.gamename)
     JS.eval ("var gameName = '" + jsgamename + "'; var transcriptName = gameName;")
@@ -233,11 +231,8 @@
     // Added by KV here in case someone enables the transcript up front to record everything including the title.
     transcript_triggered = false
     if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript")){
-      if (not HasAttribute (game, "transcriptname")){
-        game.transcriptname = game.gamename
-      }
-      EnableTranscript
       transcript_triggered = true
+      EnableTranscript
     }
     StartTurnOutputSection
     if (game.showtitle) {
@@ -300,14 +295,10 @@
       JS.eval("var saveClearedText = false;")
     }
     // Added by KV once more here, in case someone enabled the transcript in the start script or an _initialise_ script.
-    if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript") and not transcript_triggered){
-      if (not HasAttribute (game, "transcriptname")){
-        game.transcriptname = game.gamename
-      }
+    if (not transcript_triggered and GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript")){
+      // TODO: Remove this Log entry!!!
+      Log("second catch.")
       EnableTranscript
-    }
-    if (GetBoolean(game, "notranscript")){
-      KillTranscript
     }
     game.runturnscripts = false
     FinishTurn

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -220,7 +220,7 @@
       do (game, "inituserinterface")
     }
     // Adding this for the transcript when loading saved games.
-    JS.eval("transcriptProhibited = " + LCase(ToString(GetBoolean (game, "transcriptprohibited"))) + "; transcriptEnabled = " + LCase(ToString(GetBoolean (game, "transcriptenabled"))) + ";")
+    JS.eval("noTranscript = " + LCase(ToString(GetBoolean (game, "notranscript"))) + "; savingTranscript = " + LCase(ToString(GetBoolean (game, "savingtranscript"))) + ";")
   ]]></function>
 
   <function name="InitUserInterface">
@@ -230,7 +230,7 @@
     <![CDATA[
     // Added by KV here in case someone enables the transcript up front to record everything including the title.
     transcript_triggered = false
-    if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "transcriptprohibited")){
+    if (GetBoolean (game, "savingtranscript") and not GetBoolean (game, "notranscript")){
       transcript_triggered = true
       EnableTranscript
     }
@@ -295,7 +295,7 @@
       JS.eval("var saveClearedText = false;")
     }
     // Added by KV once more here, in case someone enabled the transcript in the start script or an _initialise_ script.
-    if (not transcript_triggered and GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "transcriptprohibited")){
+    if (not transcript_triggered and GetBoolean (game, "savingtranscript") and not GetBoolean (game, "notranscript")){
       EnableTranscript
     }
     game.runturnscripts = false

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -220,7 +220,7 @@
       do (game, "inituserinterface")
     }
     // Adding this for the transcript when loading saved games.
-    JS.eval("transcriptProhibited = " + GetBoolean (game, "transcriptprohibited") + "; transcriptEnabled = " + GetBoolean (game, "transcriptenabled") + ";")
+    JS.eval("transcriptProhibited = " + LCase(ToString(GetBoolean (game, "transcriptprohibited"))) + "; transcriptEnabled = " + LCase(ToString(GetBoolean (game, "transcriptenabled"))) + ";")
   ]]></function>
 
   <function name="InitUserInterface">

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -33,9 +33,7 @@
   <function name="InitInterface">
     <![CDATA[
     // Added by KV for transcript
-    // Use JSSafe to remove any offensive characters
-    jsgamename = JSSafe(game.gamename)
-    JS.eval ("var gameName = '" + jsgamename + "'; var transcriptName = gameName;")
+    JS.eval ("var gameName = '" + game.gamename + "'; var transcriptName = transcriptName || gameName;")
     // End of addition by KV for transcript
     if (game.setcustomwidth) {
       JS.setGameWidth (game.customwidth)

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -33,13 +33,11 @@
   <function name="InitInterface">
     <![CDATA[
     // Added by KV for transcript
-    // Use JSSafe to remove any offensive characters!  - KV   May 27, 2018
+    // The walkthrough has been modified to ignore this event when recording or running.
+    JS.whereAmI()
+    // Use JSSafe to remove any offensive characters
     jsgamename = JSSafe(game.gamename)
-    JS.eval ("var gameName = '"+jsgamename+"';var transcriptName = gameName;")
-    if (GetBoolean(game,"savetranscript")){
-      JS.eval("var savingTranscript = true;")
-      JS.replaceTranscriptString(game.transcriptstring)
-    }
+    JS.eval ("var gameName = '" + jsgamename + "'; var transcriptName = gameName;")
     // End of addition by KV for transcript
     if (game.setcustomwidth) {
       JS.setGameWidth (game.customwidth)
@@ -232,6 +230,15 @@
   
   <function name="StartGame">
     <![CDATA[
+    // Added by KV here in case someone enables the transcript up front to record everything including the title.
+    transcript_triggered = false
+    if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript")){
+      if (not HasAttribute (game, "transcriptname")){
+        game.transcriptname = game.gamename
+      }
+      EnableTranscript
+      transcript_triggered = true
+    }
     StartTurnOutputSection
     if (game.showtitle) {
       JS.StartOutputSection ("title")
@@ -286,9 +293,21 @@
       UpdateStatusAttributes
       UpdateObjectLinks
     }
-    // Added by KV to use the old JS clearScreen if the transcript is disabled
+    if (GetBoolean (game, "saveclearedtext")){
+      JS.eval("var saveClearedText = true;")
+    }
+    else {
+      JS.eval("var saveClearedText = false;")
+    }
+    // Added by KV once more here, in case someone enabled the transcript in the start script or an _initialise_ script.
+    if (GetBoolean (game, "transcriptenabled") and not GetBoolean (game, "notranscript") and not transcript_triggered){
+      if (not HasAttribute (game, "transcriptname")){
+        game.transcriptname = game.gamename
+      }
+      EnableTranscript
+    }
     if (GetBoolean(game, "notranscript")){
-      JS.eval("transcriptEnabled = false;")
+      KillTranscript
     }
     game.runturnscripts = false
     FinishTurn

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -878,6 +878,7 @@
   <verb template="climb" property="climb" response="DefaultClimb"/>
   <verb template="drink" property="drink" response="DefaultDrink"/>
   <verb template="eat" property="eat" response="DefaultEat"/>
+  <verb name="enter" template="enter" property="enter_verb" displayverb="[enter]" response="DefaultEnter"/>
   <verb template="hit" property="hit" response="DefaultHit"/>
   <verb template="kill" property="kill" response="DefaultKill"/>
   <verb template="kiss" property="kiss" response="DefaultKiss"/>

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -960,15 +960,15 @@
     <script>
       <![CDATA[
       // NOTE TO AUTHORS:
-      // If you don't want players to be able to enable a transcript to write to a local file when using the desktop player, set game.transcriptprohibited to true.
+      // If you don't want players to be able to enable a transcript to write to a local file when using the desktop player, set game.notranscript to true.
       SuppressTurnscripts
-      if ( GetBoolean(game, "transcriptprohibited")) {
+      if ( GetBoolean(game, "notranscript")) {
         msg (Template("NoTranscriptFeature"))
         // Make sure it is set the same in JS
         JS.killTranscript()
       }
       else {
-        if ( GetBoolean(game,"transcriptenabled")) {
+        if ( GetBoolean(game,"savingtranscript")) {
           msg (Template("TranscriptAlreadyEnabled"))
           // Make sure it is enabled in JS, too
           JS.enableTranscript()
@@ -997,13 +997,13 @@
 
   <command name="transcript_off_cmd" pattern="[transcript_off_cmd]">
     <script>
-      if (GetBoolean(game, "transcriptprohibited")) {
+      if (GetBoolean(game, "notranscript")) {
         // Kill it, just to be sure it's dead.
         KillTranscript
         msg (Template("NoTranscriptFeature"))
       }
       else {
-        if (GetBoolean(game,"transcriptenabled")) {
+        if (GetBoolean(game,"savingtranscript")) {
           msg (Template("TranscriptDisabled"))
         }
         else {

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -878,7 +878,7 @@
   <verb template="climb" property="climb" response="DefaultClimb"/>
   <verb template="drink" property="drink" response="DefaultDrink"/>
   <verb template="eat" property="eat" response="DefaultEat"/>
-  <verb name="enter" template="enter" property="enter_verb" displayverb="[enter]" response="DefaultEnter"/>
+  <verb name="enter" template="enter" property="enterverb" displayverb="[enter]" response="DefaultEnter"/>
   <verb template="hit" property="hit" response="DefaultHit"/>
   <verb template="kill" property="kill" response="DefaultKill"/>
   <verb template="kiss" property="kiss" response="DefaultKiss"/>

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -971,7 +971,7 @@
         if ( GetBoolean(game,"savingtranscript")) {
           msg (Template("TranscriptAlreadyEnabled"))
           // Make sure it is enabled in JS, too
-          JS.enableTranscript()
+          JS.eval("if (!noTranscript){transcriptName = name || transcriptName || gameName;  savingTranscript = true};")
         }
         else {
           msg (Template("TranscriptEnterFilename"))

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -960,14 +960,18 @@
     <script>
       <![CDATA[
       // NOTE TO AUTHORS:
-      // If you don't want players to be able to enable a transcript to write to a local file when using the desktop player, set game.notranscript to true.
+      // If you don't want players to be able to enable a transcript to write to a local file when using the desktop player, set game.transcriptprohibited to true.
       SuppressTurnscripts
-      if ( GetBoolean(game, "notranscript")) {
+      if ( GetBoolean(game, "transcriptprohibited")) {
         msg (Template("NoTranscriptFeature"))
+        // Make sure it is set the same in JS
+        JS.killTranscript()
       }
       else {
         if ( GetBoolean(game,"transcriptenabled")) {
           msg (Template("TranscriptAlreadyEnabled"))
+          // Make sure it is enabled in JS, too
+          JS.enableTranscript()
         }
         else {
           msg (Template("TranscriptEnterFilename"))
@@ -993,7 +997,7 @@
 
   <command name="transcript_off_cmd" pattern="[transcript_off_cmd]">
     <script>
-      if (GetBoolean(game, "notranscript")) {
+      if (GetBoolean(game, "transcriptprohibited")) {
         // Kill it, just to be sure it's dead.
         KillTranscript
         msg (Template("NoTranscriptFeature"))

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -956,82 +956,85 @@
     ]]></script>
   </command>
 
-  <command name="view_transcript_cmd" pattern="[view_transcript_cmd]">
-    <script>
-      if (not GetBoolean(game, "notranscript")){
-        JS.showTranscript ()
-      }
-      else {
-        msg ("This game has no transcript feature.")
-      }
-      game.suppressturnscripts = true
-    </script>
-  </command>
-
   <command name="transcript_on_cmd" pattern="[transcript_on_cmd]">
     <script>
       <![CDATA[
-      if (not GetBoolean(game, "notranscript")) {
-        if (not GetBoolean(game,"savetranscript")) {
-          msg ("Please enter a filename.  (<b>  \"-transcript.html\" will be appended to this filename.)<br/>  <i>(The file will be saved in \"Documents\\Quest Transcripts\".)</i></b>")
-          JS.eval ("$('input#txtCommand').val(transcriptName);")
-          get input {
-            filename = Trim(result)
-            if (not filename = "") {
-              JS.eval ("transcriptName = '"+filename+"';")
-            }
-            JS.eval ("savingTranscript = true;")
-            game.savetranscript = true
-            pre = "<hr/>Transcript enabled for:<br/>"
-            s = "<b>TITLE: </b>" + game.gamename + "<br/>"
-            if (HasAttribute (game, "author")) {
-              s = s + "<b>AUTHOR: </b>" + game.author + "<br/>"
-            }
-            s = s + "<b>VERSION: </b>" + game.version + "<br/>"
-            s = s + "<b>IFID: </b>" + game.gameid + "<br/>"
-            s = s + "<br/>"
-            s = pre + s
-            msg("")
-            msg (s)
-            msg ("<br/><b><i>[  Enter </i>SCRIPT OFF<i> to disable the transcript.  ]</i></b>")
-          }
-        }
-        else {
-          msg ("The transcript is already enabled.")
-        }
+      // NOTE TO AUTHORS:
+      // If you don't want players to be able to enable a transcript to write to a local file when using the desktop player, set game.notranscript to true.
+      SuppressTurnscripts
+      if ( GetBoolean(game, "notranscript")) {
+        msg (Template("NoTranscriptFeature"))
       }
       else {
-        msg ("This game has no transcript feature.")
+        if ( GetBoolean(game,"transcriptenabled")) {
+          msg (Template("TranscriptAlreadyEnabled"))
+        }
+        else {
+          if (not HasAttribute (game, "questplatform")) {
+            // Run whereAmI(). Things should work on the next attempt!
+            JS.whereAmI ()
+            //Set up a counter, just in case.
+            if (not HasAttribute (game, "transcript_retries")){
+              game.transcript_retries = 0
+            }
+            game.transcript_retries = game.transcript_retries + 1
+            if (game.transcript_retries > 3){
+              KillTranscript
+              msg (Template("TranscriptExcessiveRetries"))
+              JS.eval("if (webPlayer) { addTextAndScroll (\"<br/>" + Template("TranscriptDesktopOnly") + "<br/><br/>\");}")
+              return ("")
+            }
+            msg (Template("TranscriptTryAgain"))
+          }
+          else {
+            if (game.questplatform = "desktop") {
+              msg (Template("TranscriptEnterFilename"))
+              // This puts the current JS value of transcriptName in the text input box.
+              // This is set to game.gamename by default when play begins.
+              JS.eval ("$('input#txtCommand').val(transcriptName);")
+              get input {
+                JS.eval ("$('input#txtCommand').val(\"\");")
+                filename = GetWindowsSafeName(result)
+                game.transcriptname = game.gamename
+                if (not filename = "") {
+                  JS.eval ("transcriptName = '" + filename + "';")
+                  game.transcriptname = filename
+                }
+                msg ("> " + game.transcriptname)
+                EnableTranscript
+              }
+            }
+            else {
+              msg (Template("TranscriptDesktopOnly"))
+            }
+          }
+        }
       }
-      game.suppressturnscripts = true
     ]]>
     </script>
   </command>
 
   <command name="transcript_off_cmd" pattern="[transcript_off_cmd]">
     <script>
-      if (not GetBoolean(game, "notranscript")) {
-        if (GetBoolean(game,"savetranscript")) {
-          game.savetranscript = false
-          JS.eval ("var savingTranscript = false;")
-          msg ("Transcript disabled.")
-        }
-        else {
-          msg ("The transcript is already disabled.")
-        }
+      if (GetBoolean(game, "notranscript") or not game.questplatform = "desktop") {
+        // Kill it, just in case.
+        KillTranscript
+        msg (Template("NoTranscriptFeature"))
       }
       else {
-        msg ("This game has no transcript feature.")
+        if (GetBoolean(game,"transcriptenabled")) {
+          msg (Template("TranscriptDisabled"))
+        }
+        else {
+          msg (Template("TranscriptAlreadyDisabled"))
+        }
       }
-      game.suppressturnscripts = true
+      // Disable it anyway, just in case.
+      DisableTranscript
+      SuppressTurnscripts
     </script>
   </command>
 
-  <function name="UpdateTranscriptString" parameters="data">
-    game.suppressturnscripts = true
-    game.transcriptstring = game.transcriptstring + data
-  </function>
-  
   <command name="restart" pattern="^restart$">
     <script>
       Ask (Template("WantRestartGame")){
@@ -1054,4 +1057,5 @@
       return (prefix + DynamicTemplate("ObjectNotOpen", obj))
     }
   </function>
+
 </library>

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -970,43 +970,20 @@
           msg (Template("TranscriptAlreadyEnabled"))
         }
         else {
-          if (not HasAttribute (game, "questplatform")) {
-            // Run whereAmI(). Things should work on the next attempt!
-            JS.whereAmI ()
-            //Set up a counter, just in case.
-            if (not HasAttribute (game, "transcript_retries")){
-              game.transcript_retries = 0
+          msg (Template("TranscriptEnterFilename"))
+          // This puts the current JS value of transcriptName in the text input box.
+          // This is set to game.gamename by default when play begins.
+          JS.eval ("$('input#txtCommand').val(transcriptName);")
+          get input {
+            JS.eval ("$('input#txtCommand').val(\"\");")
+            filename = GetWindowsSafeName(result)
+            game.transcriptname = game.gamename
+            if (not filename = "") {
+              JS.eval ("transcriptName = '" + filename + "';")
+              game.transcriptname = filename
             }
-            game.transcript_retries = game.transcript_retries + 1
-            if (game.transcript_retries > 3){
-              KillTranscript
-              msg (Template("TranscriptExcessiveRetries"))
-              JS.eval("if (webPlayer) { addTextAndScroll (\"<br/>" + Template("TranscriptDesktopOnly") + "<br/><br/>\");}")
-              return ("")
-            }
-            msg (Template("TranscriptTryAgain"))
-          }
-          else {
-            if (game.questplatform = "desktop") {
-              msg (Template("TranscriptEnterFilename"))
-              // This puts the current JS value of transcriptName in the text input box.
-              // This is set to game.gamename by default when play begins.
-              JS.eval ("$('input#txtCommand').val(transcriptName);")
-              get input {
-                JS.eval ("$('input#txtCommand').val(\"\");")
-                filename = GetWindowsSafeName(result)
-                game.transcriptname = game.gamename
-                if (not filename = "") {
-                  JS.eval ("transcriptName = '" + filename + "';")
-                  game.transcriptname = filename
-                }
-                msg ("> " + game.transcriptname)
-                EnableTranscript
-              }
-            }
-            else {
-              msg (Template("TranscriptDesktopOnly"))
-            }
+            msg ("> " + game.transcriptname)
+            EnableTranscript
           }
         }
       }
@@ -1016,8 +993,8 @@
 
   <command name="transcript_off_cmd" pattern="[transcript_off_cmd]">
     <script>
-      if (GetBoolean(game, "notranscript") or not game.questplatform = "desktop") {
-        // Kill it, just in case.
+      if (GetBoolean(game, "notranscript")) {
+        // Kill it, just to be sure it's dead.
         KillTranscript
         msg (Template("NoTranscriptFeature"))
       }
@@ -1029,7 +1006,7 @@
           msg (Template("TranscriptAlreadyDisabled"))
         }
       }
-      // Disable it anyway, just in case.
+      // Disable it, no matter what.
       DisableTranscript
       SuppressTurnscripts
     </script>

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -956,18 +956,6 @@
     ]]></script>
   </command>
 
-  <command name="log_cmd" pattern="[log_cmd]">
-    <script>
-      if (not GetBoolean(game, "nohtmllog")){
-        JS.showLog ()
-      }
-      else {
-        msg ("This game has no in-game log.")
-      }
-      game.suppressturnscripts = true
-    </script>
-  </command>
-
   <command name="view_transcript_cmd" pattern="[view_transcript_cmd]">
     <script>
       if (not GetBoolean(game, "notranscript")){

--- a/WorldModel/WorldModel/Core/CoreEditorGame.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorGame.aslx
@@ -174,12 +174,6 @@
         <caption>[EditorGameMultipleCommands]</caption>
         <attribute>multiplecommands</attribute>
       </control>
-      
-      <control>
-        <controltype>checkbox</controltype>
-        <caption>[EditorGameProhibitTranscript]</caption>
-        <attribute>transcriptprohibited</attribute>
-      </control>
 
 
     </tab>

--- a/WorldModel/WorldModel/Core/CoreEditorGame.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorGame.aslx
@@ -173,7 +173,13 @@
         <controltype>checkbox</controltype>
         <caption>[EditorGameMultipleCommands]</caption>
         <attribute>multiplecommands</attribute>
-      </control>	  
+      </control>
+      
+      <control>
+        <controltype>checkbox</controltype>
+        <caption>[EditorGameProhibitTranscript]</caption>
+        <attribute>transcriptprohibited</attribute>
+      </control>
 
 
     </tab>

--- a/WorldModel/WorldModel/Core/CoreEditorObjectVerbs.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectVerbs.aslx
@@ -61,7 +61,7 @@
         </item>
         <item>
           <key>enter</key>
-          <value>Input the verb name as "enter_verb". It will appear as "enter" to the player.</value>
+          <value>Input the verb name as "enterverb". It will appear as "enter" to the player.</value>
         </item>
       </clashmessages>
       <defaultexpression>[EditorVerbDefaultExpression]</defaultexpression>

--- a/WorldModel/WorldModel/Core/CoreEditorObjectVerbs.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectVerbs.aslx
@@ -61,7 +61,7 @@
         </item>
         <item>
           <key>enter</key>
-          <value>Use a command, rather than a verb, to allow the player to enter this object.</value>
+          <value>Input the verb name as "enter_verb". It will appear as "enter" to the player.</value>
         </item>
       </clashmessages>
       <defaultexpression>[EditorVerbDefaultExpression]</defaultexpression>

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -291,6 +291,10 @@
       number = ToInt(input)
       if (number > 0 and number <= ListCount(game.menuoptionskeys)) {
         handled = true
+        // Added by KV to write the command to the transcript if game.echocommand is false and game.transcript_forcecommands exists and is true.
+        if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled") and GetBoolean (game, "transcript_forcecommands")){
+          JS.writeToTranscript("<span><br/>> " + SafeXML(input) + "<br/></span>")
+        }
         ShowMenuResponse(StringListItem(game.menuoptionskeys, number - 1))
       }
     }

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -608,7 +608,7 @@
   </function>
   
   <function name="EnableTranscript"><![CDATA[
-    if (GetBoolean (game, "notranscript")){
+    if (GetBoolean (game, "transcriptprohibited")){
       KillTranscript
     }
     else {
@@ -630,7 +630,7 @@
   </function>
   
   <function name="KillTranscript">
-    game.notranscript = true
+    game.transcriptprohibited = true
     JS.killTranscript()
     DisableTranscript
   </function>

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -292,7 +292,7 @@
       if (number > 0 and number <= ListCount(game.menuoptionskeys)) {
         handled = true
         // Added by KV to write the command to the transcript if game.echocommand is false and game.transcript_forcecommands exists and is true.
-        if (not GetBoolean(game, "transcriptprohibited") and GetBoolean(game, "transcriptenabled") and GetBoolean (game, "transcript_forcecommands")){
+        if (not GetBoolean(game, "notranscript") and GetBoolean(game, "savingtranscript") and GetBoolean (game, "transcript_forcecommands")){
           JS.writeToTranscript("<span><br/>> " + SafeXML(input) + "<br/></span>")
         }
         ShowMenuResponse(StringListItem(game.menuoptionskeys, number - 1))
@@ -615,7 +615,7 @@
   <!--
       <summary>Enables the transcript</summary>
       <remarks>
-        If game.transcriptprohibited is changed to true, the user will NOT be allowed to use the transcript feature.
+        If game.notranscript is changed to true, the user will NOT be allowed to use the transcript feature.
         (This is set to false by default.)
 
         Otherwise, this function will enable the transcript, and each bit of text output by JS.addText()
@@ -623,14 +623,14 @@
       </remarks>
    -->
   <function name="EnableTranscript"><![CDATA[
-    if (GetBoolean (game, "transcriptprohibited")){
+    if (GetBoolean (game, "notranscript")){
       KillTranscript
     }
     else {
       if (not HasAttribute (game, "transcriptname")){
         game.transcriptname = game.gamename
       }
-      game.transcriptenabled = true
+      game.savingtranscript = true
       JS.enableTranscript(game.transcriptname)
       msg ("<br/>" + DynamicTemplate("TranscriptEnabledMessage") + "<br/>")
       // Don't print the next line anymore. Everyone complains about it taking up space.
@@ -648,7 +648,7 @@
       </remarks>
    -->
   <function name="DisableTranscript">
-    game.transcriptenabled = false
+    game.savingtranscript = false
     JS.disableTranscript()
   </function>
   
@@ -656,7 +656,7 @@
       <summary>Completely stop the use of the transcript feature.</summary>
    -->
   <function name="KillTranscript">
-    game.transcriptprohibited = true
+    game.notranscript = true
     JS.killTranscript()
     DisableTranscript
   </function>

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -607,20 +607,22 @@
   ]]>
   </function>
   
-  <function name="EnableTranscript">
-    if (not HasAttribute (game, "transcriptname")){
-      game.transcriptname = game.gamename
+  <function name="EnableTranscript"><![CDATA[
+    if (GetBoolean (game, "notranscript")){
+      KillTranscript
     }
-    game.transcriptenabled = true
-    JS.enableTranscript(game.transcriptname)
-    msg ("")
-    msg (DynamicTemplate("TranscriptEnabledMessage"))
-    // Don't print the next line in the transcript.
-    JS.disableTranscript()
-    msg (DynamicTemplate("ToDisableTranscript"))
-    JS.enableTranscript(game.transcriptname)
-    msg("")
-  </function>
+    else {
+      if (not HasAttribute (game, "transcriptname")){
+        game.transcriptname = game.gamename
+      }
+      game.transcriptenabled = true
+      JS.enableTranscript(game.transcriptname)
+      msg ("<br/>" + DynamicTemplate("TranscriptEnabledMessage") + "<br/>")
+      // Don't print the next line anymore. Everyone complains about it taking up space.
+      //msg (DynamicTemplate("ToDisableTranscript"))
+      //msg("")
+    }
+  ]]></function>
   
   <function name="DisableTranscript">
     game.transcriptenabled = false

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -586,7 +586,7 @@
 
   <function name="DictionaryRemove" parameters="dict, key">
     if (dict = null or TypeOf(dict)="object") {
-      error ("DictionaryAdd:  Dictionary does not exist!")
+      error ("DictionaryRemove:  Dictionary does not exist!")
     }
     if (DictionaryContains(dict, key)) {
       dictionary remove (dict, key)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -631,7 +631,7 @@
         game.transcriptname = game.gamename
       }
       game.savingtranscript = true
-      JS.enableTranscript(game.transcriptname)
+      JS.eval("if (!noTranscript){transcriptName = name || transcriptName || gameName;  savingTranscript = true};")
       msg ("<br/>" + DynamicTemplate("TranscriptEnabledMessage") + "<br/>")
       // Don't print the next line anymore. Everyone complains about it taking up space.
       //msg (DynamicTemplate("ToDisableTranscript"))
@@ -649,7 +649,7 @@
    -->
   <function name="DisableTranscript">
     game.savingtranscript = false
-    JS.disableTranscript()
+    JS.eval("savingTranscript = false;")
   </function>
   
   <!--
@@ -657,7 +657,7 @@
    -->
   <function name="KillTranscript">
     game.notranscript = true
-    JS.killTranscript()
+    JS.eval("savingTranscript = false; noTranscript = true;")
     DisableTranscript
   </function>
   

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -615,6 +615,11 @@
   <function name="DisableHtmlLog">
     game.nohtmllog = true
   </function>
+  
+  <function name="ClearHtmlLog">
+    JS.eval("$(\"#log-div\").html(\"\").hide(); logArr = [];")
+  </function>
+
 
   <function name="QuickParams" parameters="key1, value1, key2, value2, key3, value3" type="dictionary">
     d = NewDictionary()

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -222,7 +222,8 @@
       else {
         error ("ShowMenu cannot handle a " + TypeOf(option))
       }
-      msg (count + ": <a class=\"cmdlink\" style=\"" + style + "\" onclick=\"ASLEvent('ShowMenuResponse','" + EscapeQuotes(optiontag) + "')\">" + optionText + "</a>")
+      //msg (count + ": <a class=\"cmdlink\" style=\"" + style + "\" onclick=\"ASLEvent('ShowMenuResponse','" + EscapeQuotes(optiontag) + "')\">" + optionText + "</a>")
+      msg (count + ": <a class=\"cmdlink\" style=\"" + style + "\" onclick=\"sendCommand('" + count + "')\">" + optionText + "</a>")
     }
     EndOutputSection (outputsection)
     game.menuoptions = options

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -611,15 +611,6 @@
     game.notranscript = true
     JS.eval("savingTranscript = false;")
   </function>
-  
-  <function name="DisableHtmlLog">
-    game.nohtmllog = true
-  </function>
-  
-  <function name="ClearHtmlLog">
-    JS.eval("$(\"#log-div\").html(\"\").hide(); logArr = [];")
-  </function>
-
 
   <function name="QuickParams" parameters="key1, value1, key2, value2, key3, value3" type="dictionary">
     d = NewDictionary()

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -232,7 +232,7 @@
   ]]>
   </function>
   
-  <function name="ShowMenuResponse" parameters="option">
+  <function name="ShowMenuResponse" parameters="option"><![CDATA[
     if (game.menucallback = null) {
       error ("Unexpected menu response")
     }
@@ -249,7 +249,7 @@
       invoke (script, parameters)
       FinishTurn
     }
-  </function>
+  ]]></function>
   
   <function name="EscapeQuotes" parameters="s" type="string">
     s = Replace(s, "\"", "@@@doublequote@@@")
@@ -607,11 +607,46 @@
   ]]>
   </function>
   
-  <function name="DisableTranscript">
-    game.notranscript = true
-    JS.eval("savingTranscript = false;")
+  <function name="EnableTranscript">
+    if (not HasAttribute (game, "transcriptname")){
+      game.transcriptname = game.gamename
+    }
+    game.transcriptenabled = true
+    JS.enableTranscript(game.transcriptname)
+    msg ("")
+    msg (DynamicTemplate("TranscriptEnabledMessage"))
+    // Don't print the next line in the transcript.
+    JS.disableTranscript()
+    msg (DynamicTemplate("ToDisableTranscript"))
+    JS.enableTranscript(game.transcriptname)
+    msg("")
   </function>
-
+  
+  <function name="DisableTranscript">
+    game.transcriptenabled = false
+    JS.disableTranscript()
+  </function>
+  
+  <function name="KillTranscript">
+    game.notranscript = true
+    JS.killTranscript()
+    DisableTranscript
+  </function>
+  
+  <function name="GetWindowsSafeName" parameters="dirty" type="string"><![CDATA[
+    if (StartsWith(dirty, ".")) {
+      dirty = Mid (dirty, 2, LengthOf (dirty) -1)
+    }
+    clean = Trim(Replace(Replace(Replace(Replace(Replace(Replace(Replace(Replace(Replace(dirty, "\"", "''"), "<", "_"), ">", "_"), ":", "_"), "/", "_"), "\\", "_"), "|", "_"), "?", "_"), "*", "_"))
+    changed_something = false
+    if (not clean = dirty) {
+      changed_something = true
+    }
+    if (StartsWith(clean, ".")) {
+      clean = GetWindowsSafeName(clean)
+    }
+    return (clean)
+  ]]></function>
   <function name="QuickParams" parameters="key1, value1, key2, value2, key3, value3" type="dictionary">
     d = NewDictionary()
     dictionary add (d, key1, value1)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -292,7 +292,7 @@
       if (number > 0 and number <= ListCount(game.menuoptionskeys)) {
         handled = true
         // Added by KV to write the command to the transcript if game.echocommand is false and game.transcript_forcecommands exists and is true.
-        if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled") and GetBoolean (game, "transcript_forcecommands")){
+        if (not GetBoolean(game, "transcriptprohibited") and GetBoolean(game, "transcriptenabled") and GetBoolean (game, "transcript_forcecommands")){
           JS.writeToTranscript("<span><br/>> " + SafeXML(input) + "<br/></span>")
         }
         ShowMenuResponse(StringListItem(game.menuoptionskeys, number - 1))
@@ -612,6 +612,16 @@
   ]]>
   </function>
   
+  <!--
+      <summary>Enables the transcript</summary>
+      <remarks>
+        If game.transcriptprohibited is changed to true, the user will NOT be allowed to use the transcript feature.
+        (This is set to false by default.)
+
+        Otherwise, this function will enable the transcript, and each bit of text output by JS.addText()
+        will be written to a file when using the desktop player or to localStorage when using the web player.
+      </remarks>
+   -->
   <function name="EnableTranscript"><![CDATA[
     if (GetBoolean (game, "transcriptprohibited")){
       KillTranscript
@@ -629,17 +639,38 @@
     }
   ]]></function>
   
+  <!--
+      <summary>Disables the transcript</summary>
+      <remarks>
+         "Disable" has been the common terminology since the 1970s.
+       
+         This is really more like putting the transcript on standby until the player enables it again.
+      </remarks>
+   -->
   <function name="DisableTranscript">
     game.transcriptenabled = false
     JS.disableTranscript()
   </function>
   
+  <!--
+      <summary>Completely stop the use of the transcript feature.</summary>
+   -->
   <function name="KillTranscript">
     game.transcriptprohibited = true
     JS.killTranscript()
     DisableTranscript
   </function>
   
+  <!--
+      <summary>DEPRECATED. Left in this state as a fallback to avoid errors.</summary>
+   -->
+  <function name="UpdateTranscriptString" parameters="data">
+    // Do nothing.
+  </function>  
+  
+  <!--
+      <summary>Get a Windows-safe name for the transcript file</summary>
+   -->
   <function name="GetWindowsSafeName" parameters="dirty" type="string"><![CDATA[
     if (StartsWith(dirty, ".")) {
       dirty = Mid (dirty, 2, LengthOf (dirty) -1)
@@ -654,6 +685,7 @@
     }
     return (clean)
   ]]></function>
+  
   <function name="QuickParams" parameters="key1, value1, key2, value2, key3, value3" type="dictionary">
     d = NewDictionary()
     dictionary add (d, key1, value1)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -631,7 +631,7 @@
         game.transcriptname = game.gamename
       }
       game.savingtranscript = true
-      JS.eval("if (!noTranscript){transcriptName = name || transcriptName || gameName;  savingTranscript = true};")
+      JS.eval("if (!noTranscript){transcriptName = '" + game.transcriptname + "'; savingTranscript = true};")
       msg ("<br/>" + DynamicTemplate("TranscriptEnabledMessage") + "<br/>")
       // Don't print the next line anymore. Everyone complains about it taking up space.
       //msg (DynamicTemplate("ToDisableTranscript"))

--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -872,18 +872,21 @@
     ]]>
   </function>
 
-  <function name="Log" parameters="text">
-    <![CDATA[
-    //request (Log, text)
+  <function name="Log" parameters="text"><![CDATA[
+    //Use the log window in the desktop player, if available.
+    request (Log, text)
     // Replacing double quotes with 2 single quotes
     text = Replace(text, "\"", "''")
-    // Changing syntax from single quotes to escaped double quotes to allow single quotes in log entries
     if (not GetBoolean(game, "nohtmllog")){
-      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\""+text+"\"); };")
+      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\"" + text + "\"); };")
     }
-    JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){var s = \""+text+"\";WriteToLog(s);}")
-    ]]>
-  </function>
+    if (GetBoolean (game, "writelogtofile")){
+      JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){ WriteToLog(\"" + text + "\");}")
+    }
+    if (GetBoolean (game, "useconsolelog")){
+      JS.eval("console.log(getTimeAndDateForLog() + \" : " + text + "\");")
+    }
+  ]]></function>
 
   <function name="SetBackgroundImage" parameters="filename">
     JS.SetBackgroundImage(GetFileURL(filename))

--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -873,18 +873,15 @@
   </function>
 
   <function name="Log" parameters="text"><![CDATA[
-    //Use the log window in the desktop player, if available.
+    // Use the log window in the desktop player. If not using the desktop player, this does nothing.
     request (Log, text)
-    // Replacing double quotes with 2 single quotes
-    text = Replace(text, "\"", "''")
-    if (not GetBoolean(game, "nohtmllog")){
-      JS.eval("if(typeof(addLogEntry)===\"function\"){ addLogEntry(\"" + text + "\"); };")
-    }
+    // Write to a file in "Documents\Quest Logs" if game.writelogtofile is true (default is false)
     if (GetBoolean (game, "writelogtofile")){
-      JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){ WriteToLog(\"" + text + "\");}")
+      JS.eval("if(!webPlayer && typeof(WriteToLog)===\"function\"){ WriteToLog(\"" + Replace(text, "\"", "''") + "\");}")
     }
+    // Use the console log if game.useconsolelog is true (default is false)
     if (GetBoolean (game, "useconsolelog")){
-      JS.eval("console.log(getTimeAndDateForLog() + \" : " + text + "\");")
+      JS.eval("console.log(getTimeAndDateForLog() + \"" + Replace(text, "\"", "''") + "\");")
     }
   ]]></function>
 

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -37,8 +37,8 @@
         msg ("")
         msg (SafeXML (command))
         msg(Template("Noted"))
-	// Added for Quest 5.8    - KV
-	FinishTurn
+	      // Added for Quest 5.8    - KV
+	      FinishTurn
       }
       else {    
         shownlink = false
@@ -62,8 +62,8 @@
           }
         }
         else {
-          // Added by KV to write the command to the transcript if game.echocommands is false.
-          if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
+          // Added by KV to write the command to the transcript if game.echocommand is false and game.transcript_forcecommands exists and is true.
+          if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled") and GetBoolean (game, "transcript_forcecommands")){
             JS.writeToTranscript("<span><br/>> " + SafeXML(command) + "<br/></span>")
           }
         }
@@ -129,7 +129,13 @@
   -->
   <function name="HandleSingleCommand" parameters="command">
     <![CDATA[
-    if (LCase(command) = "[Again1]" or LCase(command) = "[Again2]") {
+    if (StartsWith (command, "*")) {
+      // Bypass turn scripts and turn counts, and print "Noted."
+      game.suppressturnscripts = true
+      msg(Template("Noted"))
+      FinishTurn
+    }
+    else if (LCase(command) = "[Again1]" or LCase(command) = "[Again2]") {
       // First handle AGAIN
       if (not game.pov.currentcommand = null) {
         HandleSingleCommand(game.pov.currentcommand)

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -63,7 +63,7 @@
         }
         else {
           // Added by KV to write the command to the transcript if game.echocommand is false and game.transcript_forcecommands exists and is true.
-          if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled") and GetBoolean (game, "transcript_forcecommands")){
+          if (not GetBoolean(game, "transcriptprohibited") and GetBoolean(game, "transcriptenabled") and GetBoolean (game, "transcript_forcecommands")){
             JS.writeToTranscript("<span><br/>> " + SafeXML(command) + "<br/></span>")
           }
         }

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -36,7 +36,7 @@
         game.suppressturnscripts = true
         msg ("")
         msg (SafeXML (command))
-        msg("Noted.")
+        msg(Template("Noted"))
 	// Added for Quest 5.8    - KV
 	FinishTurn
       }
@@ -59,6 +59,12 @@
           if (not shownlink) {
             msg ("")
             OutputTextRaw ("&gt; " + SafeXML(command))
+          }
+        }
+        else {
+          // Added by KV to write the command to the transcript if game.echocommands is false.
+          if (not GetBoolean(game, "notranscript") and GetBoolean(game, "transcriptenabled")){
+            JS.writeToTranscript("<span><br/>> " + SafeXML(command) + "<br/></span>")
           }
         }
         if (game.command_newline) {

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -63,7 +63,7 @@
         }
         else {
           // Added by KV to write the command to the transcript if game.echocommand is false and game.transcript_forcecommands exists and is true.
-          if (not GetBoolean(game, "transcriptprohibited") and GetBoolean(game, "transcriptenabled") and GetBoolean (game, "transcript_forcecommands")){
+          if (not GetBoolean(game, "notranscript") and GetBoolean(game, "savingtranscript") and GetBoolean (game, "transcript_forcecommands")){
             JS.writeToTranscript("<span><br/>> " + SafeXML(command) + "<br/></span>")
           }
         }

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -95,6 +95,7 @@
     <writelogtofile type="boolean">false</writelogtofile>
     <useconsolelog type="boolean">false</useconsolelog>
     <transcriptprohibited type="boolean">false</transcriptprohibited>
+    <transcript_forcecommands type="boolean">false</transcript_forcecommands>
     <transcriptenabled type="boolean">false</transcriptenabled>
     <changedtranscriptenabled type="script">
       if (game.transcriptprohibited){

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -94,34 +94,26 @@
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg</publishfileextensions>
     <writelogtofile type="boolean">false</writelogtofile>
     <useconsolelog type="boolean">false</useconsolelog>
-    <transcriptprohibited type="boolean">false</transcriptprohibited>
+    <notranscript type="boolean">false</notranscript>
     <transcript_forcecommands type="boolean">false</transcript_forcecommands>
-    <transcriptenabled type="boolean">false</transcriptenabled>
-    <changedtranscriptenabled type="script">
-      if (game.transcriptprohibited){
+    <savingtranscript type="boolean">false</savingtranscript>
+    <changedsavingtranscript type="script">
+      if (game.notranscript){
         KillTranscript
       }
-      else if (game.transcriptenabled){
+      else if (game.savingtranscript){
         JS.enableTranscript()
       }
       else{
         JS.disableTranscript()
       }
-    </changedtranscriptenabled>
-    <changedtranscriptprohibited type="script">
-      if (game.transcriptprohibited){
+    </changedsavingtranscript>
+    <changednotranscript type="script">
+      if (game.notranscript){
         KillTranscript
       }
       else {
         JS.setTranscriptStatus("allowed");
-      }
-    </changedtranscriptprohibited>
-    <!-- Fallback for old code: -->
-    <notranscript type="string">deprecated</notranscript>
-    <changednotranscript type="script">
-      // Fallback for this old attribute, just in case.
-      if (HasBoolean (game, "notranscript")){
-        game.transcriptprohibited = game.notranscript
       }
     </changednotranscript>
     <suppressturnscripts/>

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -91,7 +91,7 @@
     <feature_advancedscripts type="boolean">false</feature_advancedscripts>
     <deactivatecommandlinks type="boolean">false</deactivatecommandlinks>
     <multiplecommands type="boolean">false</multiplecommands>
-    <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
+    <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg</publishfileextensions>
     <writelogtofile type="boolean">false</writelogtofile>
     <useconsolelog type="boolean">false</useconsolelog>
     <transcriptprohibited type="boolean">false</transcriptprohibited>
@@ -112,7 +112,7 @@
         KillTranscript
       }
       else {
-        JS.setTranscriptStatus("alive");
+        JS.setTranscriptStatus("allowed");
       }
     </changedtranscriptprohibited>
     <suppressturnscripts/>

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -92,7 +92,6 @@
     <deactivatecommandlinks type="boolean">false</deactivatecommandlinks>
     <multiplecommands type="boolean">false</multiplecommands>
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
-    <nohtmllog/>
     <writelogtofile type="boolean">false</writelogtofile>
     <useconsolelog type="boolean">false</useconsolelog>
     <notranscript type="boolean">false</notranscript>

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -102,10 +102,10 @@
         KillTranscript
       }
       else if (game.savingtranscript){
-        JS.enableTranscript()
+        JS.eval("if (!noTranscript){transcriptName = name || transcriptName || gameName;  savingTranscript = true};")
       }
       else{
-        JS.disableTranscript()
+        JS.eval("savingTranscript = false;")
       }
     </changedsavingtranscript>
     <changednotranscript type="script">
@@ -113,7 +113,7 @@
         KillTranscript
       }
       else {
-        JS.setTranscriptStatus("allowed");
+        JS.eval("noTranscript = false;")
       }
     </changednotranscript>
     <suppressturnscripts/>

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -115,6 +115,14 @@
         JS.setTranscriptStatus("allowed");
       }
     </changedtranscriptprohibited>
+    <!-- Fallback for old code: -->
+    <notranscript type="string">deprecated</notranscript>
+    <changednotranscript type="script">
+      // Fallback for this old attribute, just in case.
+      if (HasBoolean (game, "notranscript")){
+        game.transcriptprohibited = game.notranscript
+      }
+    </changednotranscript>
     <suppressturnscripts/>
     <!-- Scripts used by the text processor -->
     <textprocessorcommands type="scriptdictionary">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -95,6 +95,23 @@
     <writelogtofile type="boolean">false</writelogtofile>
     <useconsolelog type="boolean">false</useconsolelog>
     <notranscript type="boolean">false</notranscript>
+    <transcriptenabled type="boolean">false</transcriptenabled>
+    <changedtranscriptenabled type="script">
+      if (game.transcriptenabled = true){
+        JS.enableTranscript()
+      }
+      else if (game.transcriptenabled = false){
+        JS.disableTranscript()
+      }
+    </changedtranscriptenabled>
+    <changednotranscript type="script">
+      if (game.notranscript = true){
+        KillTranscript
+      }
+      else if (game.notranscript = false) {
+        JS.setTranscriptStatus("alive");
+      }
+    </changednotranscript>
     <suppressturnscripts/>
     <!-- Scripts used by the text processor -->
     <textprocessorcommands type="scriptdictionary">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -92,7 +92,9 @@
     <deactivatecommandlinks type="boolean">false</deactivatecommandlinks>
     <multiplecommands type="boolean">false</multiplecommands>
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
-    <nohtmllog type="boolean">false</nohtmllog>
+    <nohtmllog/>
+    <writelogtofile type="boolean">false</writelogtofile>
+    <useconsolelog type="boolean">false</useconsolelog>
     <notranscript type="boolean">false</notranscript>
     <suppressturnscripts/>
     <!-- Scripts used by the text processor -->

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -94,24 +94,27 @@
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
     <writelogtofile type="boolean">false</writelogtofile>
     <useconsolelog type="boolean">false</useconsolelog>
-    <notranscript type="boolean">false</notranscript>
+    <transcriptprohibited type="boolean">false</transcriptprohibited>
     <transcriptenabled type="boolean">false</transcriptenabled>
     <changedtranscriptenabled type="script">
-      if (game.transcriptenabled = true){
+      if (game.transcriptprohibited){
+        KillTranscript
+      }
+      else if (game.transcriptenabled){
         JS.enableTranscript()
       }
-      else if (game.transcriptenabled = false){
+      else{
         JS.disableTranscript()
       }
     </changedtranscriptenabled>
-    <changednotranscript type="script">
-      if (game.notranscript = true){
+    <changedtranscriptprohibited type="script">
+      if (game.transcriptprohibited){
         KillTranscript
       }
-      else if (game.notranscript = false) {
+      else {
         JS.setTranscriptStatus("alive");
       }
-    </changednotranscript>
+    </changedtranscriptprohibited>
     <suppressturnscripts/>
     <!-- Scripts used by the text processor -->
     <textprocessorcommands type="scriptdictionary">

--- a/WorldModel/WorldModel/Core/Languages/Dansk.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Dansk.aslx
@@ -326,7 +326,6 @@
   <template templatetype="command" name="save">^gem$</template>
   <dynamictemplate name="DefaultTellTo">WriteVerb(object, "do") + " ingenting."</dynamictemplate>
 
-  <template templatetype="command" name="log_cmd">^log$|^se log$|^vis log$</template>
   <template templatetype="command" name="transcript_on_cmd">^scriptet$</template>
   <template templatetype="command" name="transcript_off_cmd">^scriptet off$</template>
   <template templatetype="command" name="view_transcript_cmd">^(se |vis |)(scriptet)$</template>

--- a/WorldModel/WorldModel/Core/Languages/Dansk.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Dansk.aslx
@@ -328,8 +328,9 @@
 
   <template templatetype="command" name="transcript_on_cmd">^scriptet$</template>
   <template templatetype="command" name="transcript_off_cmd">^scriptet off$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(se |vis |)(scriptet)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|om)$</template>
+  
+  <template name="TranscriptOffAllCaps">SCRIPTET OFF</template>
 
   <dynamictemplate name="WearSuccessful">"Du tager " + object.article + " på."</dynamictemplate>
   <dynamictemplate name="WearUnsuccessful">"Du kan ikke tage " + object.article + " på."</dynamictemplate>

--- a/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
@@ -2,7 +2,8 @@
   <!-- Contributed by Pertex -->
   <!-- nicht übersetzte Templates werden aus der English.aslx übernommen -->
   <include ref="English.aslx"/>
-  
+  <!-- In case new English templates are ever added. -->
+  <include ref="EditorEnglish.aslx"/>
   <!-- Contributed by SoonGames -->
   <include ref="EditorDeutsch.aslx"/>
   
@@ -545,7 +546,6 @@
 
   <template templatetype="command" name="transcript_on_cmd">^(transkript|skript)( an|)$|^aktiviere (skript|transkript)$</template>
   <template templatetype="command" name="transcript_off_cmd">^(transkript|skript) aus$|^deaktiviere (skript|transkript)$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(zeige|zeig) (das |)(skript|transkript)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|über)$</template>  
 
   <template name="DevModeErrorWrongFormat">Das ist leider das falsche Format.</template>
@@ -565,5 +565,26 @@
   <template name="DevModeComSelfTestFailed">Die Zuordnung, wie sie nach dem Kommando sein sollte ist inkorrekt.</template>
   <dynamictemplate name="DevModeErrorCantFindObject">"Das Objekt mit dem Namen '" + text + "' kann nicht gefunden werden."</dynamictemplate>
   <dynamictemplate name="DevModeErrorCantFindAttribute">"Das Attribut mit dem Namen '" + text + "' kann nicht gefunden werden."</dynamictemplate>
-
+  <template name="EditorGameEnableDevMode">Entwicklermodus (Hinzufügen von erweiterten Befehlen zum Testen des Spiels)</template>
+  <template name="EditorGameDevMode">Entwicklermodus</template>
+  <template name="EditorGameDevModeInfoRelease">Wichtig: Vor Veröffentlichung des Spiels muss der Entwicklermodus deaktiviert werden!</template>  
+  <template name="EditorGameDevModeInfoCommands">Es stehen im laufenden Spiel erweiterte Kommandos zur Verfügung. Geben Sie '#?' ein um weitere Informationen zu erhalten.</template>
+  <template name="EditorGameDevModeOptions">Optionen</template>
+  <template name="EditorGameDevModeChangePov">Einen anderen Spieler wählen</template>
+  <template name="EditorGameDevModePov">Spieler</template>
+  <template name="EditorGameDevModeChangePovPos">Eine andere Position des Spielers wählen</template>
+  <template name="EditorGameDevModePlace">Ort</template>
+  <template name="EditorGameDevModeSetInitScript">Ein Initialisierungsscript für den Entwicklermodus verwenden</template>
+  <template name="EditorGameDevModeInitScript">Initialisierungsscript für den Entwicklermodus</template>
+  <template name="EditorGameDevModeShowDebugTable">Zeige Debugtabelle</template>
+  <template name="EditorGameDevModeSetVerbs">Verben des Entwicklungsmodus in die Verbliste der Objekte hinzufügen</template>
+  <template name="EditorGameDevModeShowInfos">Ausgaben des Entwicklungsmodus anzeigen</template>  
+  <template name="EditorGameDevModeOwnFontColour">Eigene Schriftfarbe für die Ausgabe des Entwicklermodus verwenden</template>
+  <template name="EditorGameDevModeFontColour">Schriftfarbe für die Ausgaben des Entwicklermodus</template>
+  <template name="EditorGameDevModeOn">Aktiviert</template>
+  <template name="EditorGameDevModeOff">Deaktiviert</template>
+  <template name="EditorGameDevModeAttributes">Attributes</template>
+  <template name="EditorGameDevModeDescriptionAttribute"><![CDATA[In "Key" wird das Objekt mit dem zugehörigen Attribut eingetragen (z. B. game.showtitle oder player.look). In "Value" wird die Zuweisung eingetragen. Es ist möglich Strings ("Hallo Welt!"), Boolean (true oder false), Integer (15), Double (25.55), Lists (["Hallo","Welt","!"]) und Dictionarys ({H:"Hallo",W:"Welt"} zu erstellen.)]]></template>
+  <!-- Added by KV -->
+  <template name="TranscriptOffAllCaps">TRANSKRIPT AUS</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Deutsch.aslx
@@ -543,7 +543,6 @@
 	]]>
 </function>
 
-  <template templatetype="command" name="log_cmd">^(zeige |zeig |)(log|protokoll)$</template>
   <template templatetype="command" name="transcript_on_cmd">^(transkript|skript)( an|)$|^aktiviere (skript|transkript)$</template>
   <template templatetype="command" name="transcript_off_cmd">^(transkript|skript) aus$|^deaktiviere (skript|transkript)$</template>
   <template templatetype="command" name="view_transcript_cmd">^(zeige|zeig) (das |)(skript|transkript)$</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -21,6 +21,7 @@
   <template name="EditorGameDevModeOff">Inactive</template>
   <template name="EditorGameDevModeAttributes">Attributes</template>
   <template name="EditorGameDevModeDescriptionAttribute"><![CDATA[Enter the object with the corresponding attribute in "Key" (e. g. game.showtitle or player.look). The assignment is entered in "Value". It is possible to create Strings ("Hello World!"), Boolean (true or false), Integer (15), Double (25.55), Listen (["Hello","World","!"]) and Dictionarys ({H:"Hello",W:"World"}.)]]></template>
+  <template name="EditorGameProhibitTranscript">Do not allow the player to use the transcript feature.</template>
   <template name="EditorGBScriptWhenEnteringPage">Script when entering page</template>
   <template name="EditorGBClearScreenBetweenEachPage">Clear screen between each page</template>
   <template name="EditorGBColour">Colour</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -21,7 +21,6 @@
   <template name="EditorGameDevModeOff">Inactive</template>
   <template name="EditorGameDevModeAttributes">Attributes</template>
   <template name="EditorGameDevModeDescriptionAttribute"><![CDATA[Enter the object with the corresponding attribute in "Key" (e. g. game.showtitle or player.look). The assignment is entered in "Value". It is possible to create Strings ("Hello World!"), Boolean (true or false), Integer (15), Double (25.55), Listen (["Hello","World","!"]) and Dictionarys ({H:"Hello",W:"World"}.)]]></template>
-  <template name="EditorGameProhibitTranscript">Do not allow the player to use the transcript feature.</template>
   <template name="EditorGBScriptWhenEnteringPage">Script when entering page</template>
   <template name="EditorGBClearScreenBetweenEachPage">Clear screen between each page</template>
   <template name="EditorGBColour">Colour</template>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -512,13 +512,12 @@
   <dynamictemplate name="DevModeErrorCantFindObject">"The object with the name '" + text + "' cannot be found."</dynamictemplate>
   <dynamictemplate name="DevModeErrorCantFindAttribute">"The attribute with the name '" + text + "' cannot be found."</dynamictemplate>
 
-  <!-- Need a special verb in English because of the name collision with the "enter" script rooms use -->
-  <verb name="enter_verb">
-    <pattern>enter #object#</pattern>
-    <property>enterverb</property>
-    <defaultexpression>"You can't enter "+object.article+"."</defaultexpression>
-    <scope>notheld</scope>
-  </verb>
+  <verbtemplate name="enter">enter</verbtemplate>
+  <verbtemplate name="enter">go in</verbtemplate>
+  <verbtemplate name="enter">go into</verbtemplate>
+  <verbtemplate name="enter">get in</verbtemplate>
+  <verbtemplate name="enter">get into</verbtemplate>
+  <dynamictemplate name="DefaultEnter">WriteVerb(game.pov, "can't") + " enter " + object.article + "."</dynamictemplate>
   
   
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -487,7 +487,6 @@
   
   
   <!-- Added by KV -->
-  <template templatetype="command" name="log_cmd">^log$|^view log$|^display log$</template>
   <template templatetype="command" name="transcript_on_cmd">^(transcript|script)( on|)$|^enable (script|transcript)$</template>
   <template templatetype="command" name="transcript_off_cmd">^(transcript|script) off$|^disable (script|transcript)$</template>
   <template templatetype="command" name="view_transcript_cmd">^(view|display|show) (the |)(script|transcript)$</template>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -542,15 +542,13 @@
   
   <template name="NoTranscriptFeature">This game has no transcript feature.</template>
   <template name="TranscriptAlreadyEnabled">The transcript is already enabled.</template>
-  <template name="TranscriptTryAgain">An error occurred while detecting the Quest player's platform. Please try again.</template>
-  <template name="TranscriptDesktopOnly">Sorry, but this feature is only available in the Quest desktop player.</template>
   <template name="TranscriptDisabled">End of transcript.</template>
   <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
-  <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  "-transcript.txt" will be appended to this filename.)<br/>  <i>(The file will be saved in "Documents\Quest Transcripts\".)</i></b>]]></template>
+  <template name="TranscriptEnterFilename"><![CDATA[Please enter a transcript name.]]></template>
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
   <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start of a transcript of:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + ""]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSCRIPT OFF</template>
-  <template name="TranscriptExcessiveRetries">transcript_on_cmd: Excessive retry attempts. The transcript feature has been disabled.</template>
+
   
   <template name="Noted">Noted.</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -489,10 +489,32 @@
   <!-- Added by KV -->
   <template templatetype="command" name="transcript_on_cmd">^(transcript|script)( on|)$|^enable (script|transcript)$</template>
   <template templatetype="command" name="transcript_off_cmd">^(transcript|script) off$|^disable (script|transcript)$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(view|display|show) (the |)(script|transcript)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|about)$</template>
   
+  
+  
   <!-- DevMode templates moved here by KV to avoid issues with gamebooks-->
+  <template name="EditorGameEnableDevMode">Show DevMode options</template>
+  <template name="EditorGameDevMode">DevMode</template>
+  <template name="EditorGameDevModeInfoRelease">Important: Before releasing the game DevMode must be deactivated!</template>
+  <template name="EditorGameDevModeInfoCommands">Enhanced commands are available in the current game. Enter '#?' to get more information.</template>
+  <template name="EditorGameDevModeOptions">Options</template>
+  <template name="EditorGameDevModeChangePov">Select another player</template>
+  <template name="EditorGameDevModeChangePovPos">Select another starting location for the player</template>
+  <template name="EditorGameDevModePov">Player</template>
+  <template name="EditorGameDevModePlace">Location</template>
+  <template name="EditorGameDevModeSetInitScript">Use an initialization script for DevMode</template>
+  <template name="EditorGameDevModeInitScript">Initialization script for DevMode</template>
+  <template name="EditorGameDevModeShowDebugTable">Show debugtable</template>
+  <template name="EditorGameDevModeSetVerbs">Add DevMode verbs to the verb list of objects</template>
+  <template name="EditorGameDevModeShowInfos">Display DevMode output</template>
+  <template name="EditorGameDevModeOwnFontColour">Use your own font color for DevMode output</template>
+  <template name="EditorGameDevModeFontColour">Font color for DevMode output</template>
+  <template name="EditorGameDevModeOn">Active</template>
+  <template name="EditorGameDevModeOff">Inactive</template>
+  <template name="EditorGameDevModeAttributes">Attributes</template>
+  <template name="EditorGameDevModeDescriptionAttribute"><![CDATA[Enter the object with the corresponding attribute in "Key" (e. g. game.showtitle or player.look). The assignment is entered in "Value". It is possible to create Strings ("Hello World!"), Boolean (true or false), Integer (15), Double (25.55), Listen (["Hello","World","!"]) and Dictionarys ({H:"Hello",W:"World"}.)]]></template>
+  
   <template name="DevModeErrorWrongFormat">That's the wrong format.</template>
   <template name="DevModeErrorObjectNotRecognised">The object was not found.</template>
   <template name="DevModeErrorWrongTyp">That's the wrong type.</template>
@@ -518,5 +540,17 @@
   <verbtemplate name="enter">get into</verbtemplate>
   <dynamictemplate name="DefaultEnter">WriteVerb(game.pov, "can't") + " enter " + object.article + "."</dynamictemplate>
   
+  <template name="NoTranscriptFeature">This game has no transcript feature.</template>
+  <template name="TranscriptAlreadyEnabled">The transcript is already enabled.</template>
+  <template name="TranscriptTryAgain">An error occurred while detecting the Quest player's platform. Please try again.</template>
+  <template name="TranscriptDesktopOnly">Sorry, but this feature is only available in the Quest desktop player.</template>
+  <template name="TranscriptDisabled">End of transcript.</template>
+  <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
+  <template name="TranscriptEnterFilename"><![CDATA[Please enter a filename.  (<b>  "-transcript.txt" will be appended to this filename.)<br/>  <i>(The file will be saved in "Documents\Quest Transcripts\".)</i></b>]]></template>
+  <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
+  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start of a transcript of:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + ""]]></dynamictemplate>
+  <template name="TranscriptOffAllCaps">TRANSCRIPT OFF</template>
+  <template name="TranscriptExcessiveRetries">transcript_on_cmd: Excessive retry attempts. The transcript feature has been disabled.</template>
   
+  <template name="Noted">Noted.</template>
 </library>

--- a/WorldModel/WorldModel/Core/Languages/English.aslx
+++ b/WorldModel/WorldModel/Core/Languages/English.aslx
@@ -544,7 +544,7 @@
   <template name="TranscriptAlreadyEnabled">The transcript is already enabled.</template>
   <template name="TranscriptDisabled">End of transcript.</template>
   <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
-  <template name="TranscriptEnterFilename"><![CDATA[Please enter a transcript name.]]></template>
+  <template name="TranscriptEnterFilename">Please enter a transcript name.</template>
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
   <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start of a transcript of:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid + ""]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSCRIPT OFF</template>

--- a/WorldModel/WorldModel/Core/Languages/Greek.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Greek.aslx
@@ -382,7 +382,6 @@
     <template templatetype="command" name="help">^βοήθεια$|^\?$</template>
     <template templatetype="command" name="save">^σώσε$|^αποθήκευσε$</template>
 
-    <template templatetype="command" name="log_cmd">^αρχείο$|^δες αρχείο$|^δείξε αρχείο$</template>
   <!-- Modified by KV -->
   <template templatetype="command" name="transcript_on_cmd">^ιστορικό$|^ιστορικό ενεργό$</template>
   <template templatetype="command" name="transcript_off_cmd">^ιστορικό ανενεργό$</template>

--- a/WorldModel/WorldModel/Core/Languages/Greek.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Greek.aslx
@@ -385,7 +385,8 @@
   <!-- Modified by KV -->
   <template templatetype="command" name="transcript_on_cmd">^ιστορικό$|^ιστορικό ενεργό$</template>
   <template templatetype="command" name="transcript_off_cmd">^ιστορικό ανενεργό$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(δες|δείξε) (το |)ιστορικό$</template>
+  
+  <template name="TranscriptOffAllCaps">ιστορικό ανενεργό</template>
   <!-- END of modification by KV -->
   <template templatetype="command" name="version_cmd">^(έκδοση|πληροφορίες|σχετικά)$</template>
 

--- a/WorldModel/WorldModel/Core/Languages/Italiano.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Italiano.aslx
@@ -415,8 +415,9 @@ Feel free to let comments and tips on http://www.textadventures.co.uk/forum/view
 
   <template templatetype="command" name="transcript_on_cmd">^trascrizione$</template>
   <template templatetype="command" name="transcript_off_cmd">^trascrizione off$|^spegni trascrizione$</template>
-  <template templatetype="command" name="view_transcript_cmd">^(vedi|mostra|visualizza|) (la |)trascrizione$</template>
   <template templatetype="command" name="version_cmd">^(versione|info)$</template>
+  
+  <template name="TranscriptOffAllCaps">TRASCRIZIONE OFF</template>
   
   <template name="DefaultHelp"><![CDATA[<u>Aiuto rapido</u><br/><br/>
 <b>- Oggetti:</b>  Prova a scrivere GUARDA (l'oggetto o la persona)..., PARLA CON..., PRENDI..., LASCIA..., APRI..., DAI (qualcosa) A (qualcuno)..., USA... (qualcosa) SU/CON (qualcuno)...<br/>

--- a/WorldModel/WorldModel/Core/Languages/Italiano.aslx
+++ b/WorldModel/WorldModel/Core/Languages/Italiano.aslx
@@ -413,7 +413,6 @@ Feel free to let comments and tips on http://www.textadventures.co.uk/forum/view
   <template templatetype="command" name="help">^aiuto$|^\?$</template>
   <template templatetype="command" name="save">^salva$</template>
 
-  <template templatetype="command" name="log_cmd">^(diario|vedi diario|mostra diario)$</template>
   <template templatetype="command" name="transcript_on_cmd">^trascrizione$</template>
   <template templatetype="command" name="transcript_off_cmd">^trascrizione off$|^spegni trascrizione$</template>
   <template templatetype="command" name="view_transcript_cmd">^(vedi|mostra|visualizza|) (la |)trascrizione$</template>

--- a/WorldModel/WorldModel/Core/Templates/Espanol.template
+++ b/WorldModel/WorldModel/Core/Templates/Espanol.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Español">
+﻿<asl version="580" template="Español">
 
   <include ref="Espanol.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Francais.template
+++ b/WorldModel/WorldModel/Core/Templates/Francais.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Français">
+﻿<asl version="580" template="Français">
 
   <include ref="Francais.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Gamebook.template
+++ b/WorldModel/WorldModel/Core/Templates/Gamebook.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" templatetype="gamebook">
+﻿<asl version="580" templatetype="gamebook">
 
   <include ref="GamebookCore.aslx"/>
 

--- a/WorldModel/WorldModel/Core/Templates/Greek.template
+++ b/WorldModel/WorldModel/Core/Templates/Greek.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Greek">
+﻿<asl version="580" template="Greek">
 
   <include ref="Greek.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Italiano.template
+++ b/WorldModel/WorldModel/Core/Templates/Italiano.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Italiano">
+﻿<asl version="580" template="Italiano">
 
   <include ref="Italiano.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Portugues-Portugal.template
+++ b/WorldModel/WorldModel/Core/Templates/Portugues-Portugal.template
@@ -1,4 +1,4 @@
-<asl version="550" template="Português (Portugal)">
+<asl version="580" template="Português (Portugal)">
 
   <include ref="Portugues-Portugal.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Portugues.template
+++ b/WorldModel/WorldModel/Core/Templates/Portugues.template
@@ -1,4 +1,4 @@
-<asl version="550" template="Português (Brasil)">
+<asl version="580" template="Português (Brasil)">
 
   <include ref="Portugues.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Romana.template
+++ b/WorldModel/WorldModel/Core/Templates/Romana.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Română">
+﻿<asl version="580" template="Română">
 
   <include ref="Romana.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Russian.template
+++ b/WorldModel/WorldModel/Core/Templates/Russian.template
@@ -1,4 +1,4 @@
-<asl version="550" template="Русский">
+<asl version="580" template="Русский">
 
   <include ref="Russian.aslx"/>
   <include ref="Core.aslx"/>

--- a/docs/transcript.md
+++ b/docs/transcript.md
@@ -3,7 +3,11 @@ layout: index
 title: Transcripts
 ---
 
-As of Quest 5.8 there is a fully functional transcript feature. A transcript is a recording of everything the player types and the game prints, and can be very useful when beta-testing, for example.
+As of Quest 5.8, if using the desktop player, there is a fully functional transcript feature.
+
+A transcript is a recording of everything the player types and the game prints, and can be very useful when beta-testing, for example.
+
+Transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the TXT format.
 
 To turn the transcript on, use any of these commands during play.
 
@@ -23,15 +27,6 @@ TRANSCRIPT OFF
 DISABLE SCRIPT
 DISABLE TRANSCRIPT
 
-You can view the transcript at any time, using one of these comnmands. The transcript will appear in a pop-up window. You can print the trascript too.
 
-SHOW SCRIPT
-VIEW SCRIPT
-SHOW TRANSCRIPT
-VIEW TRANSCRIPT
 
-If using the desktop player (as of the upcoming 5.8.0 release), transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the HTML format. When double-clicked, the transcript should open in the user's default browser.
-
-CSS is added to align everything to the left. The background is set to white and the color to black. Be aware that the transcript may have a few strange-looking areas, depending on what all HTML and CSS code you have in a game (we are fixing every issue we come across, but it is hard to foresee what code a Quest game may include!).
-
-Note that during play you can type a * and then some text, and Quest will ignore it. This is useful for when you want to comment on something, such as a bug you have found. The comment will appear in the transcript (and can be searched for as it starts with a *), but you will not confuse the game with your weird command.
+Note that during play you can type a \* and then some text, and Quest will ignore it. This is useful for when you want to comment on something, such as a bug you have found. The comment will appear in the transcript (and can be searched for as it starts with a \*), but you will not confuse the game with your weird command.

--- a/docs/transcript.md
+++ b/docs/transcript.md
@@ -3,11 +3,17 @@ layout: index
 title: Transcripts
 ---
 
-As of Quest 5.8, if using the desktop player, there is a fully functional transcript feature.
+As of Quest 5.8, there is a fully functional transcript feature.
 
 A transcript is a recording of everything the player types and the game prints, and can be very useful when beta-testing, for example.
 
-Transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the TXT format.
+When using the desktop player, transcripts will be saved to the directory "Documents\Quest Transcripts". This file will be in the TXT format.
+
+When playing online, transcripts will be saved to the user's browser in localStorage. Online users can visit this page to access online transcripts: https://play.textadventures.co.uk/Play.aspx?id=4wqdac8qd0sf7-ilff8mia
+
+
+IMPORTANT NOTE TO ONLINE USERS: If your cookies are deleted, your transcripts will all be deleted!!! If your browser settings have been changed to delete cookies when closed, your transcript files will be deleted!!! Make sure to view and/or print your transcript(s) before closing your browser if it is set to delete cookies when closed!
+
 
 To turn the transcript on, use any of these commands during play.
 


### PR DESCRIPTION
### How the transcript works now

There are four attributes on the `game` object in Quest which concern the transcript :

`game.savingtranscript` is `false` by default.

- When the player enters **TRANSCRIPT ON**, this will set `game.savingtranscript` to `true`, and the transcript will begin to write each bit of text which is output by `JS.addText()` to a transcript file.

- Entering **TRANSCRIPT OFF** will set `game.savingtranscript` to `false`, and the transcript will be "on standby" until **TRANSCRIPT ON** is entered again.

---
`game.notranscript` is `false` by default.

- If this is set to `true`, the player will not be allowed to record any transcripts during play.

---
`game.transcriptname` is self-explanatory. It will be the name the transcript is saved as.
- This is not setup in CoreTypes. It is created automatically and set as the game name at startup if it does not exist.
  - This is not really for the author, as the player is who confirms the transcript name when enabling it.

---
`game.transcript_forcecommands` is `false` by default.
- If `game.echocommand` is `false` and `game.transcript_forcecommands` is `true`, Quest will include the player's commands in the transcript.

---
That's all there is to it, really.

There are two commands now: **TRANSCRIPT ON** and **TRANSCRIPT OFF**.

If using the desktop player, the transcript will be written to **"Documents\Quest Transcripts\transcript_name-transcript.txt"**

If online, the transcript will be written to `localStorage` in the user's browser, with the key `"questtranscript-transcript_name"`.


For everyone to have access to their transcripts online, I currently have a Quest game posing as a website:
https://play.textadventures.co.uk/Play.aspx?id=4wqdac8qd0sf7-ilff8mia

Alex was kind enough to host my first attempt at this code on https://play.textadventures.co.uk/ (so it would be the same URL as the games to make the `localStorage` the same), but my code had errors (of course). So, I ended up publishing a Quest game to handle things for now; this way I can test it and update it without causing Alex extra work.

That "site" works for everyone who has tested it, but it sure could use a little Pixie CSS magic.

Also, here are two games designed to test the online transcript functionality, so you'll have transcripts to view on that site:
https://textadventures.co.uk/games/view/3r90vfn9su6mcpprpy4arg/online-transcript-tester-20240915
https://textadventures.co.uk/games/view/9mpiy36fr0yi_nufvfiaca/the-transcript-strikes-back

NOTE: Both of those games have a "Transcripts" button inserted by the "Save" button. That button works, but ignore that button and visit the website linked above instead, as I do not have code in Quest to add that (ugly) button to every Quest game!


---
### Changes

Before I list these changes, it is important to note that no one can really use the transcript feature in Quest 5.8 as it stands anyway, and most of these changes are removing bad code.

Online, the game immediately crashes if the player enables the transcript. This is because I added the `SaveTranscript()` function to **"Player\desktopplayer.js"** without adding its counterpart to **"WebPlayer\player.js"**. So that function is undefined online, and the game crashes.

In the desktop player, the turn scripts will not fire while the transcript is enabled. The game doesn't actually crash, like the web player does, but it might as well if it breaks the turn scripts.

- The transcript now saves to a plain TXT file when using the desktop player.

- The transcript now saves to `localStorage` in the user's browser when using the web player.

- Removed the ability to view the transcript from within the game. (Games run much more smoothly when not saving all that data)

- Removed the **VIEW TRANSCRIPT** command.

- JS function `SaveTranscript()` has been replaced by `writeTranscriptToFile()` in playercore.js. 
  - `writeTranscriptToFile()` then calls `WriteTranscriptToFile()`, which exists (with different scripts) in Player\desktopplayer.js as well as WebPlayer\player.js
  - `SaveTranscript()` is now included in playercore.js (as a fallback/fix), but it just forwards its args to `writeTranscriptToFile()`
  
  
- The JS variable `transcriptString` no longer exists, as it was negatively effecting game performance exponentially

- The JS function `replaceTranscriptString()` also no longer exists.

- The Quest attribute `game.transcriptstring` also no longer exists

- The Quest attribute `game.savetranscript` no longer exists, as this is now the only option.

- The Quest function `UpdateTranscriptString` has been deprecated. It is still in the code to avoid possible errors, but it does nothing.


- Added the ability to overwrite a transcript file, rather than appending to the file.
  - To do this, include `"@@@OVERWRITEFILE@@@"` in the string sent to (or from) `JS.writeToTranscript(text)` each time you would like to overwrite the file rather than append to it.


- Fixed error where transcript did not save to the filename entered by the player


- Quest will now retrieve any existing 'alt' properties from IMG elements output via `JS.addText()` for the transcript


- In Quest 5.8, `ShowMenu` creates a link for each option which calls `ASLEvent()` on click. This link now calls `JS.sendCommand()` on click rather than `ASLEvent()`.


- `HandleCommand` and `HandleMenuTextResponse` have been modified to write the player's command to the transcript when `game.echocommand` is `false` and `game.notranscript` is `false` and `game.savingtranscript` is `true` and `game.transcript_forcecommands` is `true`


- Changed the default value of the JS variable `saveClearedText` to `false`. (Saving the cleared text was slowing down games which print good amounts of text.)
  - The JS function `printScrollback()` still exists, and it currently works when tested in the desktop player, as well as Firefox and Chrome desktop and mobile version. If `saveClearedText` is set to `true`, this will include any cleared text.

- Removed all the jQuery-UI pop-up functions added to Quest 5.8 due to walkthrough and saved game issues


- The walkthrough will no longer record or run "event:WhereAmI"

- The walkthrough will also ignore any `ASLEvent` calling a function beginning with "NoEventFunc"

- Removed **"*.ogv"** from `game.publishfileextensions`. I added it to 5.8, but it seems like not including any video formats by default is a good idea, considering the site's maximum file size limit.


---
Passes all 87 tests:
![image](https://github.com/user-attachments/assets/4adfa9e6-f6f4-4148-a4b9-e678ee9440e1)

---
Saves games on desktop:
![image](https://github.com/user-attachments/assets/6ae6a1e6-0592-4591-9e59-190359f6b801)

---
No JS errors on desktop:
![image](https://github.com/user-attachments/assets/de067777-1c82-4727-a354-0d41ed8d1cf4)

---
The transcript file made by the desktop player:
https://github.com/KVonGit/quest5-stuff/blob/main/transcripts/Transcript%20Tester%2020240914-transcript.txt

---
Saves games in the web player (or it would, if I were logged in, but I am running the web player from VS):
![image](https://github.com/user-attachments/assets/9b36996c-0834-4c6b-849d-25c9d7dbf324)

---
Online Game - Your Transcripts
![image](https://github.com/user-attachments/assets/84574f41-5e8d-4c05-990e-2c5b2ef1bbbc)

---
Transcript from Online Game - Saved As a TXT File:
https://github.com/KVonGit/quest5-stuff/blob/main/online%20transcripts%20(saved%20as%20plain%20text)/Transcript%20Tester%2020240914%20-%20Transcript.txt

---
Thanks to Pertex and Raist for all the testing and feedback!

Thanks to Alex for creating Quest in the first place, for putting my test web page on the site, and for all the coding I've learned by using Quest!

Thanks to mrangel for providing copious amounts of invaluable wisdom over the years!

And special thanks to @ThePix, who has taught me a great many things over the years, but mostly because said notable is going to have to go through all my recent pull requests!