### PR TITLE
Add C# syntax highlighting to code view textboxes

### DIFF
--- a/EditorControls/ScriptEditorControl.xaml
+++ b/EditorControls/ScriptEditorControl.xaml
@@ -44,7 +44,8 @@
                     FontSize="10pt" Text=""
                     VerticalScrollBarVisibility="Auto"
                     HorizontalScrollBarVisibility="Auto"
-                    MaxHeight="500" />
+                    MaxHeight="500"
+                    SyntaxHighlighting="C#" />
                 </Border>
                 <ListBox Name="lstScripts" Grid.Row="1" SelectionMode="Extended" SelectionChanged="lstScripts_SelectionChanged" AlternationCount="2" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                     <ListBox.Resources>


### PR DESCRIPTION
Add C# syntax highlighting to code view textboxes

(TODO - Can we add word-wrap using ScriptEditorControl.xaml.cs, based on the current word-wrap settings?)