### PR TITLE
Quest 5.8 => 5.9

### DIFF
--- a/Editor/My Project/AssemblyInfo.vb
+++ b/Editor/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")> 
 <Assembly: AssemblyCompany("")> 
 <Assembly: AssemblyProduct("Editor")>
-<Assembly: AssemblyCopyright("Copyright © 2017/2018 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
+<Assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
 <Assembly: AssemblyTrademark("")> 
 
 <Assembly: ComVisible(False)>
@@ -30,4 +30,4 @@ Imports System.Runtime.InteropServices
 ' You can specify all the values or you can default the Build and Revision Numbers 
 ' by using the '*' as shown below:
 
-<Assembly: AssemblyVersion("5.8.*")>
+<Assembly: AssemblyVersion("5.9.*")>

--- a/EditorController/Properties/AssemblyInfo.cs
+++ b/EditorController/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("EditorController")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/EditorControllerTests/Properties/AssemblyInfo.cs
+++ b/EditorControllerTests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("EditorControllerTests")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/EditorControls/Properties/AssemblyInfo.cs
+++ b/EditorControls/Properties/AssemblyInfo.cs
@@ -51,4 +51,4 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.6.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/GameBrowser/My Project/AssemblyInfo.vb
+++ b/GameBrowser/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")>
 <Assembly: AssemblyCompany("Textadventures.co.uk")>
 <Assembly: AssemblyProduct("Quest")>
-<Assembly: AssemblyCopyright("Copyright © 2017/2018 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
+<Assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
 <Assembly: AssemblyTrademark("")> 
 
 <Assembly: ComVisible(False)>
@@ -30,4 +30,4 @@ Imports System.Runtime.InteropServices
 ' You can specify all the values or you can default the Build and Revision Numbers 
 ' by using the '*' as shown below:
 
-<Assembly: AssemblyVersion("5.8.*")>
+<Assembly: AssemblyVersion("5.9.*")>

--- a/IASL/Properties/AssemblyInfo.cs
+++ b/IASL/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Textadventures.co.uk")]
 [assembly: AssemblyProduct("Quest")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/JawsApi/Properties/AssemblyInfo.cs
+++ b/JawsApi/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("JawsApi")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/Legacy/AssemblyInfo.vb
+++ b/Legacy/AssemblyInfo.vb
@@ -28,7 +28,7 @@ Imports System.Runtime.InteropServices
 ' You can specify all the values or you can default the Build and Revision Numbers
 ' by using the '*' as shown below:
 
-<Assembly: AssemblyVersion("5.8.*")>
+<Assembly: AssemblyVersion("5.9.*")>
 
 
 

--- a/LegacyASLTests/Properties/AssemblyInfo.cs
+++ b/LegacyASLTests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("LegacyASLTests")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/Menus/My Project/AssemblyInfo.vb
+++ b/Menus/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")> 
 <Assembly: AssemblyCompany("Alex Warren")> 
 <Assembly: AssemblyProduct("Quest")>
-<Assembly: AssemblyCopyright("Copyright © 2017/2018 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
+<Assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
 <Assembly: AssemblyTrademark("")> 
 
 <Assembly: ComVisible(False)>
@@ -30,4 +30,4 @@ Imports System.Runtime.InteropServices
 ' You can specify all the values or you can default the Build and Revision Numbers 
 ' by using the '*' as shown below:
 
-<Assembly: AssemblyVersion("5.8.*")>
+<Assembly: AssemblyVersion("5.9.*")>

--- a/Player/My Project/AssemblyInfo.vb
+++ b/Player/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")>
 <Assembly: AssemblyCompany("Textadventures.co.uk")>
 <Assembly: AssemblyProduct("Quest")>
-<Assembly: AssemblyCopyright("Copyright © 2017/2018 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
+<Assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
 <Assembly: AssemblyTrademark("")> 
 
 <Assembly: ComVisible(True)> 
@@ -31,4 +31,4 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("5.8.*")>
+<Assembly: AssemblyVersion("5.9.*")>

--- a/PlayerController/Properties/AssemblyInfo.cs
+++ b/PlayerController/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("PlayerController")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/PlayerControllerTests/Properties/AssemblyInfo.cs
+++ b/PlayerControllerTests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PlayerControllerTests")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Quest/Constants.vb
+++ b/Quest/Constants.vb
@@ -1,6 +1,6 @@
 ﻿Public Class Constants
 
-    Public Const QuestVersion As String = "5.8.0"
+    Public Const QuestVersion As String = "5.9.0"
     Public Const MaxASLVersion As Integer = 580
 
 End Class

--- a/Quest/My Project/AssemblyInfo.vb
+++ b/Quest/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")>
 <Assembly: AssemblyCompany("Textadventures.co.uk")>
 <Assembly: AssemblyProduct("Quest")>
-<Assembly: AssemblyCopyright("Copyright © 2017/2018 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
+<Assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE. All Icons by https://de.icons8.com/ are licensed under CC BY-ND 3.0.")>
 <Assembly: AssemblyTrademark("")> 
 
 <Assembly: ComVisible(False)>
@@ -31,4 +31,4 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("5.8.*")>
+<Assembly: AssemblyVersion("5.9.*")>

--- a/Setup/setup.iss
+++ b/Setup/setup.iss
@@ -2,14 +2,14 @@
 ; github.com/stfx/innodependencyinstaller
 ; codeproject.com/Articles/20868/NET-Framework-1-1-2-0-3-5-Installer-for-InnoSetup
 
-#define QuestVersion '5.8.0'
-#define SetupVersion '580'
+#define QuestVersion '5.9.0'
+#define SetupVersion '590'
 
 [Setup]
 AppName=Quest
 AppVersion={#QuestVersion}
 AppVerName=Quest {#QuestVersion}
-AppCopyright=Copyright © 2017/2018 Andy Joel, 1998-2016 Alex Warren
+AppCopyright=Copyright © 2024 Alex Warren, Andy Joel and contributors
 VersionInfoVersion={#QuestVersion}
 AppPublisher=Andy Joel
 AppPublisherURL=https://textadventures.co.uk/

--- a/Utility/Properties/AssemblyInfo.cs
+++ b/Utility/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Utility")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]
 

--- a/WebEditor/WebEditor/Properties/AssemblyInfo.cs
+++ b/WebEditor/WebEditor/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("WebEditor")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/WebPlayer/Properties/AssemblyInfo.cs
+++ b/WebPlayer/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("WebPlayer")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]

--- a/WorldModel/WorldModel/Properties/AssemblyInfo.cs
+++ b/WorldModel/WorldModel/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Textadventures.co.uk")]
 [assembly: AssemblyProduct("Quest")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]
 
 [assembly: InternalsVisibleTo("WorldModelTests")]

--- a/WorldModelTests/Properties/AssemblyInfo.cs
+++ b/WorldModelTests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("WorldModelTests")]
-[assembly: AssemblyCopyright("Copyright © 2017 Andy Joel - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
+[assembly: AssemblyCopyright("Copyright © 2024 Alex Warren, Andy Joel and contributors - full copyright and license information at https://github.com/textadventures/quest/blob/master/LICENSE")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("5.8.*")]
+[assembly: AssemblyVersion("5.9.*")]


### PR DESCRIPTION
setup.iss
- I only changed the version number of Quest, nothing more.
- This still has the old dotnet stuff.
- I also did not change appPublisher from Andy Joel
  - it seems like there were issues when changing that last time; so I'll leave that part to the professionals ---
Both UtilityTests and PlayerControllerTests are still on v1.0.0.0; so I did not change those version numbers. ---
Updated copyright to 2024 Alex Warren, Andy Joel and contributors