### PR TITLE
Add CSharp SyntaxHighlighting to Script TextBoxes

### DIFF
--- a/EditorControls/ScriptEditorControl.xaml
+++ b/EditorControls/ScriptEditorControl.xaml
@@ -44,7 +44,8 @@
                     FontSize="10pt" Text=""
                     VerticalScrollBarVisibility="Auto"
                     HorizontalScrollBarVisibility="Auto"
-                    MaxHeight="500" />
+                    MaxHeight="500"
+                    SyntaxHighlighting="C#"/>
                 </Border>
                 <ListBox Name="lstScripts" Grid.Row="1" SelectionMode="Extended" SelectionChanged="lstScripts_SelectionChanged" AlternationCount="2" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                     <ListBox.Resources>


### PR DESCRIPTION
Would it also be possible to apply the word wrap settings from full code view to script text-boxes?