### PR TITLE
All ASL 550 to 580

### DIFF
--- a/WorldModel/WorldModel/Core/Templates/Espanol.template
+++ b/WorldModel/WorldModel/Core/Templates/Espanol.template
@@ -9,11 +9,11 @@
     <firstpublished>$YEAR$</firstpublished>
   </game>
 
-  <object name="lugar">
+  <object name="room">
     <inherit name="editor_room" />
     <isroom />
 
-    <object name="jugador">
+    <object name="player">
       <inherit name="editor_object" />
       <inherit name="editor_player" />
     </object>

--- a/WorldModel/WorldModel/Core/Templates/Espanol.template
+++ b/WorldModel/WorldModel/Core/Templates/Espanol.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Español">
+﻿<asl version="580" template="Español">
 
   <include ref="Espanol.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Francais.template
+++ b/WorldModel/WorldModel/Core/Templates/Francais.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Français">
+﻿<asl version="580" template="Français">
 
   <include ref="Francais.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Gamebook.template
+++ b/WorldModel/WorldModel/Core/Templates/Gamebook.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" templatetype="gamebook">
+﻿<asl version="580" templatetype="gamebook">
 
   <include ref="GamebookCore.aslx"/>
 

--- a/WorldModel/WorldModel/Core/Templates/Greek.template
+++ b/WorldModel/WorldModel/Core/Templates/Greek.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Greek">
+﻿<asl version="580" template="Greek">
 
   <include ref="Greek.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Italiano.template
+++ b/WorldModel/WorldModel/Core/Templates/Italiano.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Italiano">
+﻿<asl version="580" template="Italiano">
 
   <include ref="Italiano.aslx"/>
   <include ref="Core.aslx"/>
@@ -14,7 +14,8 @@
     <isroom />
 
     <object name="player">
-      <inherit name="defaultplayer" />
+      <inherit name="editor_object" />
+      <inherit name="editor_player" />
     </object>
   </object>
 

--- a/WorldModel/WorldModel/Core/Templates/Portugues-Portugal.template
+++ b/WorldModel/WorldModel/Core/Templates/Portugues-Portugal.template
@@ -1,4 +1,4 @@
-<asl version="550" template="Português (Portugal)">
+<asl version="580" template="Português (Portugal)">
 
   <include ref="Portugues-Portugal.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Portugues.template
+++ b/WorldModel/WorldModel/Core/Templates/Portugues.template
@@ -1,4 +1,4 @@
-<asl version="550" template="Português (Brasil)">
+<asl version="580" template="Português (Brasil)">
 
   <include ref="Portugues.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Romana.template
+++ b/WorldModel/WorldModel/Core/Templates/Romana.template
@@ -1,4 +1,4 @@
-﻿<asl version="550" template="Română">
+﻿<asl version="580" template="Română">
 
   <include ref="Romana.aslx"/>
   <include ref="Core.aslx"/>

--- a/WorldModel/WorldModel/Core/Templates/Russian.template
+++ b/WorldModel/WorldModel/Core/Templates/Russian.template
@@ -1,4 +1,4 @@
-<asl version="550" template="Русский">
+<asl version="580" template="Русский">
 
   <include ref="Russian.aslx"/>
   <include ref="Core.aslx"/>


### PR DESCRIPTION
These were left out during the last update.
Closes #1193 

---
Since **Espanol.template** is already modified here, I also changed its objects' names to match the other templates in this PR.

Closes #1285 

See Discussion #1283 