### PR TITLE
Pertex - Add delay option to walkthrough

### DIFF
--- a/Player/WalkthroughRunner.vb
+++ b/Player/WalkthroughRunner.vb
@@ -23,6 +23,7 @@ Friend Class WalkthroughRunner
     Public Sub Run()
         Dim delay As Integer = 0
         Dim dateStart = DateTime.Now
+        Dim showRuntime As Boolean = False
         For Each cmd As String In m_gameDebug.Walkthroughs.Walkthroughs(m_walkthrough).Steps
             If m_cancelled Then Exit For
             RaiseEvent MarkScrollPosition()
@@ -49,6 +50,8 @@ Friend Class WalkthroughRunner
                     Dim eventName As String = eventData(0)
                     Dim param As String = eventData(1)
                     m_game.SendEvent(eventName, param)
+                ElseIf cmd.StartsWith("runtime:") Then
+                    showRuntime = True
                 Else
                     m_game.SendCommand(cmd)
                 End If
@@ -70,9 +73,11 @@ Friend Class WalkthroughRunner
             Thread.Sleep(delay)
         Next
         Dim dateEnd = DateTime.Now
-        Dim diff = dateEnd.Subtract(dateStart)
-        Dim res = String.Format("{0}:{1}:{2}", diff.Hours, diff.Minutes, diff.Seconds)
-        WriteLine("Walkthrough Runtime: " + res)
+        If (showRuntime) Then
+            Dim diff = dateEnd.Subtract(dateStart)
+            Dim res = String.Format("{0}:{1}:{2}", diff.Hours, diff.Minutes, diff.Seconds)
+            WriteLine("Walkthrough Runtime: " + res)
+        End If
     End Sub
 
     Public Sub ShowMenu(menu As MenuData)

--- a/Player/WalkthroughRunner.vb
+++ b/Player/WalkthroughRunner.vb
@@ -22,9 +22,9 @@ Friend Class WalkthroughRunner
 
     Public Sub Run()
         Dim delay As Integer = 0
+        Dim dateStart = DateTime.Now
         For Each cmd As String In m_gameDebug.Walkthroughs.Walkthroughs(m_walkthrough).Steps
             If m_cancelled Then Exit For
-
             RaiseEvent MarkScrollPosition()
             If m_showingMenu Then
                 SetMenuResponse(cmd)
@@ -69,6 +69,10 @@ Friend Class WalkthroughRunner
             Loop Until (Not m_waiting And Not m_pausing) Or m_cancelled
             Thread.Sleep(delay)
         Next
+        Dim dateEnd = DateTime.Now
+        Dim diff = dateEnd.Subtract(dateStart)
+        Dim res = String.Format("{0}:{1}:{2}", diff.Hours, diff.Minutes, diff.Seconds)
+        WriteLine("Walkthrough Runtime: " + res)
     End Sub
 
     Public Sub ShowMenu(menu As MenuData)

--- a/Player/WalkthroughRunner.vb
+++ b/Player/WalkthroughRunner.vb
@@ -23,7 +23,6 @@ Friend Class WalkthroughRunner
     Public Sub Run()
         Dim delay As Integer = 0
         Dim dateStart = DateTime.Now
-        Dim showRuntime As Boolean = False
         For Each cmd As String In m_gameDebug.Walkthroughs.Walkthroughs(m_walkthrough).Steps
             If m_cancelled Then Exit For
             RaiseEvent MarkScrollPosition()
@@ -51,7 +50,10 @@ Friend Class WalkthroughRunner
                     Dim param As String = eventData(1)
                     m_game.SendEvent(eventName, param)
                 ElseIf cmd.StartsWith("runtime:") Then
-                    showRuntime = True
+                    Dim dateEnd = DateTime.Now
+                    Dim diff = dateEnd.Subtract(dateStart)
+                    Dim res = String.Format("{0}:{1}:{2}", diff.Hours, diff.Minutes, diff.Seconds)
+                    WriteLine("Walkthrough Runtime: " + res)
                 Else
                     m_game.SendCommand(cmd)
                 End If
@@ -72,12 +74,7 @@ Friend Class WalkthroughRunner
             Loop Until (Not m_waiting And Not m_pausing) Or m_cancelled
             Thread.Sleep(delay)
         Next
-        Dim dateEnd = DateTime.Now
-        If (showRuntime) Then
-            Dim diff = dateEnd.Subtract(dateStart)
-            Dim res = String.Format("{0}:{1}:{2}", diff.Hours, diff.Minutes, diff.Seconds)
-            WriteLine("Walkthrough Runtime: " + res)
-        End If
+
     End Sub
 
     Public Sub ShowMenu(menu As MenuData)

--- a/Player/WalkthroughRunner.vb
+++ b/Player/WalkthroughRunner.vb
@@ -1,4 +1,6 @@
-﻿Friend Class WalkthroughRunner
+﻿Imports System.Threading
+
+Friend Class WalkthroughRunner
     Private m_gameDebug As IASLDebug
     Private m_game As IASL
     Private m_walkthrough As String
@@ -19,6 +21,7 @@
     End Sub
 
     Public Sub Run()
+        Dim delay As Integer = 0
         For Each cmd As String In m_gameDebug.Walkthroughs.Walkthroughs(m_walkthrough).Steps
             If m_cancelled Then Exit For
 
@@ -39,6 +42,8 @@
                     End If
                 ElseIf cmd.StartsWith("label:") Then
                     ' ignore
+                ElseIf cmd.StartsWith("delay:") Then
+                    delay = Int32.Parse(cmd.Substring(6).Trim)
                 ElseIf cmd.StartsWith("event:") Then
                     Dim eventData As String() = cmd.Substring(6).Split(New Char() {";"c}, 2)
                     Dim eventName As String = eventData(0)
@@ -62,6 +67,7 @@
                     FinishPause()
                 End If
             Loop Until (Not m_waiting And Not m_pausing) Or m_cancelled
+            Thread.Sleep(delay * 1000)
         Next
     End Sub
 

--- a/Player/WalkthroughRunner.vb
+++ b/Player/WalkthroughRunner.vb
@@ -67,7 +67,7 @@ Friend Class WalkthroughRunner
                     FinishPause()
                 End If
             Loop Until (Not m_waiting And Not m_pausing) Or m_cancelled
-            Thread.Sleep(delay * 1000)
+            Thread.Sleep(delay)
         Next
     End Sub
 

--- a/docs/using_walkthroughs.md
+++ b/docs/using_walkthroughs.md
@@ -81,13 +81,12 @@ As of Quest 5.9 you can include the line
 
      runtime:
 
-anywhere in the walkthrough to display the total runtime of the walkthrough.
+anywhere in the walkthrough to display the total runtime of the walkthrough. The command can also be used several times in a walkthrough.
 
 Output speed
 ------------
 
 From Quest 5.9 you can influence the speed of the output with the line "delay:". The delay in milliseconds is specified behind it. The setting takes effect after the delay command line.
-
 
      <walkthrough name="main">
        <steps>
@@ -101,9 +100,7 @@ From Quest 5.9 you can influence the speed of the output with the line "delay:".
          examine horse
          use apple with horse
          runtime:
-
        <steps>
      <walkthrough>
-
 
 The command can also be used several times in a walkthrough if certain areas are to be displayed with their own speed.

--- a/docs/using_walkthroughs.md
+++ b/docs/using_walkthroughs.md
@@ -73,3 +73,37 @@ For example, in the walkthrough below, the assert expression checks that the "ta
      <walkthrough>
 
 If a walkthrough assert expression returns false, the walkthrough is immediately stopped.
+
+Displaying runtime
+------------------
+
+As of Quest 5.9 you can include the line
+
+     runtime:
+
+anywhere in the walkthrough to display the total runtime of the walkthrough.
+
+Output speed
+------------
+
+From Quest 5.9 you can influence the speed of the output with the line "delay:". The delay in milliseconds is specified behind it. The setting takes effect after the delay command line.
+
+
+     <walkthrough name="main">
+       <steps>
+         look 
+         get apple
+         delay:1000
+         examine apple
+         north
+         look
+         delay:200
+         examine horse
+         use apple with horse
+         runtime:
+
+       <steps>
+     <walkthrough>
+
+
+The command can also be used several times in a walkthrough if certain areas are to be displayed with their own speed.


### PR DESCRIPTION
Submitted by Pertex

New walkthrough step option:
`delay:`

Sets interval between steps in seconds

Example:
```
delay:3
```

After this step, each step will pause 3 seconds before calling the next step