### PR TITLE
Pertex - endWaitDiv

### DIFF
--- a/PlayerController/playercore.htm
+++ b/PlayerController/playercore.htm
@@ -157,6 +157,8 @@
             <span id="txtCommandPrompt"></span>
             <input type="text" x-webkit-speech id="txtCommand" onkeydown="return commandKey(event);" placeholder="Type here..."
                 autofocus />
+        </div>
+        <div id="endWaitDiv">
             <a id="endWaitLink" onclick="endWait();" class="cmdlink" style="display: none">Continue...</a>
         </div>
     </div>

--- a/WebPlayer/Mobile/Play.aspx
+++ b/WebPlayer/Mobile/Play.aspx
@@ -187,6 +187,8 @@
                         </td>
                     </tr>
                 </table>
+            </div>
+            <div id="endWaitDiv">       
                 <a id="endWaitLink" onclick="endWait();" class="cmdlink" style="display: none">Continue...</a>
             </div>
         </div>


### PR DESCRIPTION
Allows "continue" link during a `wait` script when there is no command bar.

Closes #1228 