### PR TITLE
Fix error message in DictionaryRemove

### DIFF
--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -586,7 +586,7 @@
 
   <function name="DictionaryRemove" parameters="dict, key">
     if (dict = null or TypeOf(dict)="object") {
-      error ("DictionaryAdd:  Dictionary does not exist!")
+      error ("DictionaryRemove:  Dictionary does not exist!")
     }
     if (DictionaryContains(dict, key)) {
       dictionary remove (dict, key)


### PR DESCRIPTION
It said "DictionaryAdd" in the `DictionaryRemove` error message. Copy & paste error corrected.