### PR TITLE
Throw error if ChangePOV object has no parent

### DIFF
--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -163,6 +163,9 @@
   
   <function name="ChangePOV" parameters="object">
     <![CDATA[
+    if (not HasObject(object, "parent")) {
+      error ("ChangePOV cannot change player to object with no parent.")
+    }
     if (game.pov <> object) {
       game.pov = object
       if (game.gridmap) {


### PR DESCRIPTION
Users occasionally use ChangePOV thinking it will move the player. This will now throw an error if the object has no parent object.

Closes #1298