### PR TITLE
Add MovePlayer function

### DIFF
--- a/WorldModel/WorldModel/Core/CoreEditorScriptsObjects.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorScriptsObjects.aslx
@@ -21,6 +21,24 @@
   </editor>
   
   <editor>
+    <appliesto>(function)MovePlayer</appliesto>
+    <display>[EditorScriptsObjectsMovePlayerto] #0</display>
+    <category>[EditorScriptsObjectsObjects]</category>
+    <create>MovePlayer ()</create>
+    <add>[EditorScriptsObjectsMovePlayer]</add>
+    <control>
+      <controltype>label</controltype>
+      <caption>[EditorScriptsObjectsMovePlayerto]</caption>
+    </control>
+    <control>
+      <controltype>expression</controltype>
+      <attribute>0</attribute>
+      <simple>object</simple>
+      <simpleeditor>objects</simpleeditor>
+    </control>
+  </editor>
+  
+  <editor>
     <appliesto>(function)MoveObject</appliesto>
     <display>Move #0 to #1</display>
     <category>[EditorScriptsObjectsObjects]</category>

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -39,6 +39,10 @@
     object.parent = parent
   </function>
 
+  <function name="MovePlayer" parameters="loc">
+    game.pov.parent = loc
+  </function>
+  
   <function name="MoveObjectHere" parameters="object">
     object.parent = game.pov.parent
   </function>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -557,6 +557,8 @@
   <template name="EditorScriptsObjectsto">to</template>
   <template name="EditorScriptsObjectsMoveobjectCurrentRoom">Move object to the current room</template>
   <template name="EditorScriptsObjectstothecurrent">to the current room</template>
+  <template name="EditorScriptsObjectsMovePlayer">Move player</template>
+  <template name="EditorScriptsObjectsMovePlayerto">Move player to</template>
   <template name="EditorScriptsObjectsMakeobject">Make object visible</template>  
   <template name="EditorScriptsObjectsMakeobjectinvisible">Make object invisible</template>
   <template name="EditorScriptsObjectsMakevisible">Make visible</template>


### PR DESCRIPTION
Closes #1297

> Currently to move the player you have to move game.pov, and this is commonly confused with the ChangePOV function. So let's add a "move player" function to live alongside "move object", which should be nice and easy to find.
- Alex