### PR TITLE
Set saveClearedText to false by default

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -765,7 +765,7 @@ function disableAllCommandLinks() {
 }
 
 // Modified by KV to handle the scrollback feature
-var saveClearedText = true;
+var saveClearedText = false;
 var clearedOnce = false;
 function clearScreen() {
     if (!saveClearedText) {
@@ -795,16 +795,12 @@ function clearScreen() {
 // Scrollback functions added by KV
 
 function showScrollback() {
-    var scrollbackDivString = "";
-    scrollbackDivString += "<div ";
-    scrollbackDivString += "id='scrollback-dialog' ";
-    scrollbackDivString += "style='display:none;'>";
-    scrollbackDivString += "<div id='scrollbackdata'></div></div>";
+    var scrollbackDivString = '<div id="scrollback-dialog" style="display:none;"><div id="scrollbackdata"></div></div>';
     addText(scrollbackDivString);
     var scrollbackDialog = $("#scrollback-dialog").dialog({
         autoOpen: false,
-        width: 600,
-        height: 500,
+        width: $(window).width(),
+        height: $(window).height(),
         title: "Scrollback",
         buttons: {
             Ok: function () {
@@ -825,8 +821,6 @@ function showScrollback() {
         $("#scrollbackdata a").addClass("disabled");
     }, 1);
 };
-
-
 
 function printScrollbackDiv() {
     var iframe = document.createElement('iframe');

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -765,7 +765,7 @@ function disableAllCommandLinks() {
 }
 
 // Modified by KV to handle the scrollback feature
-var saveClearedText = true;
+var saveClearedText = false;
 var clearedOnce = false;
 function clearScreen() {
     if (!saveClearedText) {
@@ -795,16 +795,12 @@ function clearScreen() {
 // Scrollback functions added by KV
 
 function showScrollback() {
-    var scrollbackDivString = "";
-    scrollbackDivString += "<div ";
-    scrollbackDivString += "id='scrollback-dialog' ";
-    scrollbackDivString += "style='display:none;'>";
-    scrollbackDivString += "<div id='scrollbackdata'></div></div>";
+    var scrollbackDivString = '<div id="scrollback-dialog" style="display:none;"><div id="scrollbackdata"></div></div>';
     addText(scrollbackDivString);
     var scrollbackDialog = $("#scrollback-dialog").dialog({
         autoOpen: false,
-        width: 600,
-        height: 500,
+        width: $(window).width(),
+        height: $(window).height(),
         title: "Scrollback",
         buttons: {
             Ok: function () {
@@ -825,8 +821,6 @@ function showScrollback() {
         $("#scrollbackdata a").addClass("disabled");
     }, 1);
 };
-
-
 
 function printScrollbackDiv() {
     var iframe = document.createElement('iframe');


### PR DESCRIPTION
`saveClearedText` (added in Quest 5.8) should have been `false` by default to begin with.

When false, `clearScreen` dumps all the data it clears from `#divOutput`. When true, a class is used to hide the data and preserve it to be displayed using `showScrollback`.

This also changes the display settings of the pop-up dialog displayed by `showScrollback` to fullscreen, so things will work properly regardless of screen dimensions.

NOTE: The change to `clearScreen` accidentally fixed an issue with `getCurrentDiv`. This will 're-introduce' that issue, but I will create an Issue to log that.

---
ALSO NOTE: This PR will, in fact, resolve an issue if merged, but we are also considering removing this functionality, in which case this PR merely illustrates the issue with `clearScreen`.