### PR TITLE
Pertex fixes all rooms

### DIFF
--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -426,10 +426,16 @@
     UpdateObjectLinks
   </function>  
 
-
-
   <function name="WhereAmI" parameters="s">
     game.questplatform = s
   </function>
 
+  <type name="editor_room">
+    <isroom />
+  </type>
+  
+  <type name="editor_object">
+    <isroom type="boolean">false</isroom>
+  </type>
+  
 </library>

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -426,16 +426,19 @@
     UpdateObjectLinks
   </function>  
 
+
+
   <function name="WhereAmI" parameters="s">
     game.questplatform = s
   </function>
 
-  <type name="editor_room">
-    <isroom />
-  </type>
-  
   <type name="editor_object">
     <isroom type="boolean">false</isroom>
   </type>
-  
+  <type name="editor_room">
+    <isroom />
+  </type>
+  <type name="editor_room_object">
+    <isroom />
+  </type>
 </library>

--- a/WorldModel/WorldModel/Core/CoreEditor.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditor.aslx
@@ -16,10 +16,6 @@
   <template name="EditorImageFormats">*.jpg;*.jpeg;*.png;*.gif</template>
   <template name="HTMLColorNames">AliceBlue;AntiqueWhite;Aqua;Aquamarine;Azure;Beige;Bisque;Black;BlanchedAlmond;Blue;BlueViolet;Brown;BurlyWood;CadetBlue;Chartreuse;Chocolate;Coral;CornflowerBlue;Cornsilk;Crimson;Cyan;DarkBlue;DarkCyan;DarkGoldenRod;DarkGray;DarkGrey;DarkGreen;DarkKhaki;DarkMagenta;DarkOliveGreen;Darkorange;DarkOrchid;DarkRed;DarkSalmon;DarkSeaGreen;DarkSlateBlue;DarkSlateGray;DarkSlateGrey;DarkTurquoise;DarkViolet;DeepPink;DeepSkyBlue;DimGray;DimGrey;DodgerBlue;FireBrick;FloralWhite;ForestGreen;Fuchsia;Gainsboro;GhostWhite;Gold;GoldenRod;Gray;Grey;Green;GreenYellow;HoneyDew;HotPink;IndianRed ;Indigo ;Ivory;Khaki;Lavender;LavenderBlush;LawnGreen;LemonChiffon;LightBlue;LightCoral;LightCyan;LightGoldenRodYellow;LightGray;LightGrey;LightGreen;LightPink;LightSalmon;LightSeaGreen;LightSkyBlue;LightSlateGray;LightSlateGrey;LightSteelBlue;LightYellow;Lime;LimeGreen;Linen;Magenta;Maroon;MediumAquaMarine;MediumBlue;MediumOrchid;MediumPurple;MediumSeaGreen;MediumSlateBlue;MediumSpringGreen;MediumTurquoise;MediumVioletRed;MidnightBlue;MintCream;MistyRose;Moccasin;NavajoWhite;Navy;OldLace;Olive;OliveDrab;Orange;OrangeRed;Orchid;PaleGoldenRod;PaleGreen;PaleTurquoise;PaleVioletRed;PapayaWhip;PeachPuff;Peru;Pink;Plum;PowderBlue;Purple;Red;RosyBrown;RoyalBlue;SaddleBrown;Salmon;SandyBrown;SeaGreen;SeaShell;Sienna;Silver;SkyBlue;SlateBlue;SlateGray;SlateGrey;Snow;SpringGreen;SteelBlue;Tan;Teal;Thistle;Tomato;Turquoise;Violet;Wheat;White;WhiteSmoke;Yellow;YellowGreen</template>
 
-  <type name="editor_room">
-    <isroom />
-  </type>
-  <type name="editor_object"/>
   <type name="editor_player">
     <feature_player />
   </type>

--- a/WorldModel/WorldModel/Core/CoreEditorObjectSetup.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectSetup.aslx
@@ -6,7 +6,7 @@
     <control>
       <caption>[EditorObjectSetupType]</caption>
       <controltype>dropdowntypes</controltype>
-      <types>editor_room=[TypeObjectRoom]; editor_object=[TypeObjectObject]; *=[TypeObjectAndOr]</types>
+      <types>editor_room=[TypeObjectRoom]; editor_object=[TypeObjectObject]; editor_room_object=[TypeObjectAndOr]; *=[TypeObjectUndefined]</types>
       <width>150</width>
       <advanced/>
     </control>

--- a/WorldModel/WorldModel/Core/CoreEditorObjectSetup.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectSetup.aslx
@@ -61,12 +61,6 @@
     </control>
 
     <control>
-      <controltype>checkbox</controltype>
-      <caption>[EditorObjectSetupIsRoom]</caption>
-      <attribute>isroom</attribute>
-    </control>
-
-    <control>
       <mustnotinherit>editor_room</mustnotinherit>
       <controltype>dropdowntypes</controltype>
       <caption>[EditorObjectSetupType]</caption>

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -323,7 +323,6 @@
     <hasbeenmoved type="boolean">false</hasbeenmoved>
     <timesexamined type="int">0</timesexamined>
     <not_all type="boolean">false</not_all>
-    <isroom/>
   </type>
 
   <type name="defaultexit">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -323,6 +323,7 @@
     <hasbeenmoved type="boolean">false</hasbeenmoved>
     <timesexamined type="int">0</timesexamined>
     <not_all type="boolean">false</not_all>
+    <isroom/>
   </type>
 
   <type name="defaultexit">

--- a/WorldModel/WorldModel/Core/Languages/EditorDeutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorDeutsch.aslx
@@ -446,7 +446,6 @@
   <template name="EditorObjectScriptsTurnscripts">Nach jedem Zug in diesem Raum</template>
   <template name="EditorObjectScriptsCommands">Kommandos in diesem Raum</template>
   <template name="EditorObjectSetupSetup">Konfiguration</template>
-  <template name="EditorObjectSetupIsRoom">Das Objekt ist ein Raum</template>
   <template name="EditorObjectSetupType">Typ</template>
   <template name="EditorObjectSetupName">Name</template>
   <template name="EditorObjectSetupAlias">Alias</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorDeutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorDeutsch.aslx
@@ -862,7 +862,7 @@
   <template name="TypeObjectRoom">Raum</template>
   <template name="TypeObjectObject">Objekt</template>
   <template name="TypeObjectAndOr">Objekt und Raum</template>
-  <template name="TypeObjectUndefined">Object ist undefiniert</template>
+  <template name="TypeObjectUndefined">Objekttyp ist nicht festgelegt</template>
   <template name="TypeInanimateObject">Neutrales Objekt</template>
   <template name="TypeMaleCharacter">Maskuline Person</template>
   <template name="TypeMaleCharacterNamed">Maskuline Person (Nullartikel)</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorDeutsch.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorDeutsch.aslx
@@ -861,7 +861,8 @@
   <template name="TypeCanPlayer">Kann der Spieler sein</template>
   <template name="TypeObjectRoom">Raum</template>
   <template name="TypeObjectObject">Objekt</template>
-  <template name="TypeObjectAndOr">Objekt und/oder Raum</template>
+  <template name="TypeObjectAndOr">Objekt und Raum</template>
+  <template name="TypeObjectUndefined">Object ist undefiniert</template>
   <template name="TypeInanimateObject">Neutrales Objekt</template>
   <template name="TypeMaleCharacter">Maskuline Person</template>
   <template name="TypeMaleCharacterNamed">Maskuline Person (Nullartikel)</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -444,7 +444,6 @@
   <template name="EditorObjectScriptsTurnscripts">Turn scripts - run after every turn the player takes in this room</template>
   <template name="EditorObjectScriptsCommands">Commands</template>
   <template name="EditorObjectSetupSetup">Setup</template>
-  <template name="EditorObjectSetupIsRoom">Object is a room</template>
   <template name="EditorObjectSetupType">Type</template>
   <template name="EditorObjectSetupName">Name</template>
   <template name="EditorObjectSetupAlias">Alias</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -860,7 +860,8 @@
   <template name="TypeCanPlayer">Can be a player</template>
   <template name="TypeObjectRoom">Room</template>
   <template name="TypeObjectObject">Object</template>
-  <template name="TypeObjectAndOr">Object and/or room</template>
+  <template name="TypeObjectAndOr">Object and room</template>
+  <template name="TypeObjectUndefined">Object is undefined</template>
   <template name="TypeInanimateObject">Inanimate object</template>
   <template name="TypeMaleCharacter">Male character</template>
   <template name="TypeMaleCharacterNamed">Male character (named)</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -861,7 +861,7 @@
   <template name="TypeObjectRoom">Room</template>
   <template name="TypeObjectObject">Object</template>
   <template name="TypeObjectAndOr">Object and room</template>
-  <template name="TypeObjectUndefined">Object is undefined</template>
+  <template name="TypeObjectUndefined">Object type not set</template>
   <template name="TypeInanimateObject">Inanimate object</template>
   <template name="TypeMaleCharacter">Male character</template>
   <template name="TypeMaleCharacterNamed">Male character (named)</template>

--- a/WorldModel/WorldModel/Core/Templates/Dansk.template
+++ b/WorldModel/WorldModel/Core/Templates/Dansk.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Deutsch.template
+++ b/WorldModel/WorldModel/Core/Templates/Deutsch.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/English.template
+++ b/WorldModel/WorldModel/Core/Templates/English.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Espanol.template
+++ b/WorldModel/WorldModel/Core/Templates/Espanol.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Esperanto.template
+++ b/WorldModel/WorldModel/Core/Templates/Esperanto.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Francais.template
+++ b/WorldModel/WorldModel/Core/Templates/Francais.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Greek.template
+++ b/WorldModel/WorldModel/Core/Templates/Greek.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Icelandic.template
+++ b/WorldModel/WorldModel/Core/Templates/Icelandic.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Italiano.template
+++ b/WorldModel/WorldModel/Core/Templates/Italiano.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Nederlands.template
+++ b/WorldModel/WorldModel/Core/Templates/Nederlands.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Norsk.template
+++ b/WorldModel/WorldModel/Core/Templates/Norsk.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Portugues-Portugal.template
+++ b/WorldModel/WorldModel/Core/Templates/Portugues-Portugal.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Portugues.template
+++ b/WorldModel/WorldModel/Core/Templates/Portugues.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Romana.template
+++ b/WorldModel/WorldModel/Core/Templates/Romana.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />

--- a/WorldModel/WorldModel/Core/Templates/Russian.template
+++ b/WorldModel/WorldModel/Core/Templates/Russian.template
@@ -11,7 +11,6 @@
 
   <object name="room">
     <inherit name="editor_room" />
-    <isroom />
 
     <object name="player">
       <inherit name="editor_object" />


### PR DESCRIPTION
Changes:
- Move `editor_object` and `editor_room` to **Core.aslx**
- Leave `isroom` set to `true` on `editor_room` type
- Set `isroom` to `false` on `editor_object` type
- Set `isroom` to `true` on `defaultobject` type
- Purge `isroom` checkbox control from object setup
- Purge `isroom` attribute from every template file
- Purge `EditorObjectSetupIsRoom` templates from language files

---
Now:
- An object's `isroom` attribute is `false`
- A room's `isroom` attribute is `true`
- "An object and/or a room" has its `isroom` set to `true`
- Even in a published game!

Closes #1202 

Authored-By: @Pertex 
Copied-and-Pasted-By: KVonGit (from #1316 )

---
### Published game
![image](https://github.com/user-attachments/assets/6050ea2b-2147-4b87-9d99-0e3ed13cef30)

---
Test game directory:
[Look at All the Rooms.zip](https://github.com/user-attachments/files/18278576/Look.at.All.the.Rooms.zip)
