### PR TITLE
clearScreen Repair Follow-Up - Remove element IDs on Dialog Close

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -799,13 +799,16 @@ function showScrollback() {
     addText(scrollbackDivString);
     var scrollbackDialog = $("#scrollback-dialog").dialog({
         autoOpen: false,
-        width: $(window).width(),
-        height: $(window).height(),
+        width: (window.innerWidth || document.documentElement.clientWidth || 
+document.body.clientWidth) - 100,
+        height: (window.innerHeight|| document.documentElement.clientHeight|| 
+document.body.clientHeight) - 100,
         title: "Scrollback",
         buttons: {
             Ok: function () {
                 $(this).dialog("close");
                 $(this).remove();
+                $("#scrollback-dialog,#scrollbackdata").remove();
             },
             Print: function () {
                 printScrollbackDiv();
@@ -820,7 +823,7 @@ function showScrollback() {
     setTimeout(function () {
         $("#scrollbackdata a").addClass("disabled");
     }, 1);
-};
+}
 
 function printScrollbackDiv() {
     var iframe = document.createElement('iframe');
@@ -830,7 +833,7 @@ function printScrollbackDiv() {
     document.body.removeChild(iframe);
     $("#scrollback-dialog").dialog("close");
     $("#scrollback-dialog").remove();
-};
+}
 
 function keyPressCode(e) {
     var keynum

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -799,13 +799,16 @@ function showScrollback() {
     addText(scrollbackDivString);
     var scrollbackDialog = $("#scrollback-dialog").dialog({
         autoOpen: false,
-        width: $(window).width(),
-        height: $(window).height(),
+        width: (window.innerWidth || document.documentElement.clientWidth || 
+document.body.clientWidth) - 100,
+        height: (window.innerHeight|| document.documentElement.clientHeight|| 
+document.body.clientHeight) - 100,
         title: "Scrollback",
         buttons: {
             Ok: function () {
                 $(this).dialog("close");
                 $(this).remove();
+                $("#scrollback-dialog,#scrollbackdata").remove();
             },
             Print: function () {
                 printScrollbackDiv();
@@ -820,7 +823,7 @@ function showScrollback() {
     setTimeout(function () {
         $("#scrollbackdata a").addClass("disabled");
     }, 1);
-};
+}
 
 function printScrollbackDiv() {
     var iframe = document.createElement('iframe');
@@ -830,7 +833,7 @@ function printScrollbackDiv() {
     document.body.removeChild(iframe);
     $("#scrollback-dialog").dialog("close");
     $("#scrollback-dialog").remove();
-};
+}
 
 function keyPressCode(e) {
     var keynum


### PR DESCRIPTION
- Remove the pop-up dialog's HTML elements on close, because they each have an ID (and they will likely be created more than once)
- Set width and height to fit properly when called via `JS.`
- Formatting

---
After further testing, I found we couldn't open the "scrollback" pop-up after closing it the first time. This was because two HTML elements that are created for this each have an ID. Removing those elements when closing the dialog window solved the issue.

---
Also: https://discord.com/channels/1278365322054996018/1314620834467545200/1323485436701573230

This is what led to changing the width and height settings of the dialog window to be sure it always fits within the visible window. (In case that link no longer works in the future, calling `JS.showScrollback()` from a Quest script resulted in a dialog window larger than the visible window dimensions, but calling `showScrollback()` directly from the HTML console fit properly.)