### PR TITLE
Save the outputData element when clearing the screen

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -768,6 +768,8 @@ function disableAllCommandLinks() {
 var saveClearedText = false;
 var clearedOnce = false;
 function clearScreen() {
+    // Move outputData out of divOutput
+    $("#outputData").appendTo($("body"));
     if (!saveClearedText) {
         $("#divOutput").css("min-height", 0);
         $("#divOutput").html("");
@@ -783,12 +785,15 @@ function clearScreen() {
         }
         clearedOnce = true;
         $('#divOutput').children().addClass('clearedScreen');
+        $('.clearedScreen').attr('id',null);
         $('#divOutput').css('min-height', 0);
         createNewDiv('left');
         beginningOfCurrentTurnScrollPosition = 0;
         setTimeout(function () {
             $('html,body').scrollTop(0);
         }, 100);
+    // Move outputData back to divOutput
+    $("#outputData").appendTo($("#divOutput"));
     }
 }
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -799,13 +799,16 @@ function showScrollback() {
     addText(scrollbackDivString);
     var scrollbackDialog = $("#scrollback-dialog").dialog({
         autoOpen: false,
-        width: $(window).width(),
-        height: $(window).height(),
+        width: (window.innerWidth || document.documentElement.clientWidth || 
+document.body.clientWidth) - 100,
+        height: (window.innerHeight|| document.documentElement.clientHeight|| 
+document.body.clientHeight) - 100,
         title: "Scrollback",
         buttons: {
             Ok: function () {
                 $(this).dialog("close");
                 $(this).remove();
+                $("#scrollback-dialog,#scrollbackdata").remove();
             },
             Print: function () {
                 printScrollbackDiv();
@@ -820,7 +823,7 @@ function showScrollback() {
     setTimeout(function () {
         $("#scrollbackdata a").addClass("disabled");
     }, 1);
-};
+}
 
 function printScrollbackDiv() {
     var iframe = document.createElement('iframe');
@@ -830,7 +833,7 @@ function printScrollbackDiv() {
     document.body.removeChild(iframe);
     $("#scrollback-dialog").dialog("close");
     $("#scrollback-dialog").remove();
-};
+}
 
 function keyPressCode(e) {
     var keynum

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -768,6 +768,8 @@ function disableAllCommandLinks() {
 var saveClearedText = false;
 var clearedOnce = false;
 function clearScreen() {
+    // Move outputData out of divOutput
+    $("#outputData").appendTo($("body"));
     if (!saveClearedText) {
         $("#divOutput").css("min-height", 0);
         $("#divOutput").html("");
@@ -783,12 +785,15 @@ function clearScreen() {
         }
         clearedOnce = true;
         $('#divOutput').children().addClass('clearedScreen');
+        $('.clearedScreen').attr('id',null);
         $('#divOutput').css('min-height', 0);
         createNewDiv('left');
         beginningOfCurrentTurnScrollPosition = 0;
         setTimeout(function () {
             $('html,body').scrollTop(0);
         }, 100);
+    // Move outputData back to divOutput
+    $("#outputData").appendTo($("#divOutput"));
     }
 }
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -799,13 +799,16 @@ function showScrollback() {
     addText(scrollbackDivString);
     var scrollbackDialog = $("#scrollback-dialog").dialog({
         autoOpen: false,
-        width: $(window).width(),
-        height: $(window).height(),
+        width: (window.innerWidth || document.documentElement.clientWidth || 
+document.body.clientWidth) - 100,
+        height: (window.innerHeight|| document.documentElement.clientHeight|| 
+document.body.clientHeight) - 100,
         title: "Scrollback",
         buttons: {
             Ok: function () {
                 $(this).dialog("close");
                 $(this).remove();
+                $("#scrollback-dialog,#scrollbackdata").remove();
             },
             Print: function () {
                 printScrollbackDiv();
@@ -820,7 +823,7 @@ function showScrollback() {
     setTimeout(function () {
         $("#scrollbackdata a").addClass("disabled");
     }, 1);
-};
+}
 
 function printScrollbackDiv() {
     var iframe = document.createElement('iframe');
@@ -830,7 +833,7 @@ function printScrollbackDiv() {
     document.body.removeChild(iframe);
     $("#scrollback-dialog").dialog("close");
     $("#scrollback-dialog").remove();
-};
+}
 
 function keyPressCode(e) {
     var keynum


### PR DESCRIPTION
- Remove "scrollback" HTML elements created for dialog when closing dialog to avoid errors, as they each have an ID
- Change "scrollback" width and height settings to be slightly smaller than the inner-dimensions of the window
- Move `#outputData` out of `#divOutput` before clearing the screen, then back again at the end of `clearScreen`. (To retain the data when saving/resuming online)

Related: #1323 

Note: I can split these up if that would be better.

Also note: this does not close issue 1200, and I can't edit that commit message. 1200 needs code modified in the save command's script -- or `sendCommand` in the WebPlayer needs to catch the save command and call `saveGame` from there (or both?)