### PR TITLE
Retain outputData during call to clearScreen

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -768,6 +768,8 @@ function disableAllCommandLinks() {
 var saveClearedText = false;
 var clearedOnce = false;
 function clearScreen() {
+    // Move outputData out of divOutput
+    $("#outputData").appendTo($("body"));
     if (!saveClearedText) {
         $("#divOutput").css("min-height", 0);
         $("#divOutput").html("");
@@ -783,12 +785,15 @@ function clearScreen() {
         }
         clearedOnce = true;
         $('#divOutput').children().addClass('clearedScreen');
+        $('.clearedScreen').attr('id',null);
         $('#divOutput').css('min-height', 0);
         createNewDiv('left');
         beginningOfCurrentTurnScrollPosition = 0;
         setTimeout(function () {
             $('html,body').scrollTop(0);
         }, 100);
+    // Move outputData back to divOutput
+    $("#outputData").appendTo($("#divOutput"));
     }
 }
 

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -792,9 +792,9 @@ function clearScreen() {
         setTimeout(function () {
             $('html,body').scrollTop(0);
         }, 100);
+    }
     // Move outputData back to divOutput
     $("#outputData").appendTo($("#divOutput"));
-    }
 }
 
 // Scrollback functions added by KV

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -768,6 +768,8 @@ function disableAllCommandLinks() {
 var saveClearedText = false;
 var clearedOnce = false;
 function clearScreen() {
+    // Move outputData out of divOutput
+    $("#outputData").appendTo($("body"));
     if (!saveClearedText) {
         $("#divOutput").css("min-height", 0);
         $("#divOutput").html("");
@@ -783,12 +785,15 @@ function clearScreen() {
         }
         clearedOnce = true;
         $('#divOutput').children().addClass('clearedScreen');
+        $('.clearedScreen').attr('id',null);
         $('#divOutput').css('min-height', 0);
         createNewDiv('left');
         beginningOfCurrentTurnScrollPosition = 0;
         setTimeout(function () {
             $('html,body').scrollTop(0);
         }, 100);
+    // Move outputData back to divOutput
+    $("#outputData").appendTo($("#divOutput"));
     }
 }
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -792,9 +792,9 @@ function clearScreen() {
         setTimeout(function () {
             $('html,body').scrollTop(0);
         }, 100);
+    }
     // Move outputData back to divOutput
     $("#outputData").appendTo($("#divOutput"));
-    }
 }
 
 // Scrollback functions added by KV


### PR DESCRIPTION
- Move the `#outputData` element out of the `#divOutput` element before dumping the data with `clearScreen`
- Set ID of all elements with the `.clearedScreen` class to `null`
  - Otherwise lines appear at the top of the page due to duplicate or *de facto* sequential IDs, and other shenanigans
- Return `#outputData` to `#divOutput` before exiting `clearScreen` script

Closes #1314