### PR TITLE
Use LCase to compare 'Again' templates in HandleSingleCommand

### DIFF
--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -123,7 +123,7 @@
   -->
   <function name="HandleSingleCommand" parameters="command">
     <![CDATA[
-    if (LCase(command) = "[Again1]" or LCase(command) = "[Again2]") {
+    if (LCase(command) = LCase(Template("Again1")) or LCase(command) = LCase(Template("Again2"))) {
       // First handle AGAIN
       if (not game.pov.currentcommand = null) {
         HandleSingleCommand(game.pov.currentcommand)


### PR DESCRIPTION
Submitted by Pertex

Not all template values are lower case. Make everything lower case when checking for the AGAIN command.

Closes #1284