### PR TITLE
Pertex - Add custom location bar background image option

### DIFF
--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -126,14 +126,13 @@
       else {
         JS.setCss ("#status", "border:none")
       }
-      // Pertex: this is new
       if (HasString(game, "locationbarimage")){
         url = game.locationbarimage
         if (not Trim(url) = ""){ 
-          if (not StartsWith(game.locationbarimage,  "http")){
-            url = GetFileURL(game.locationbarimage)
+          if (not StartsWith(url,  "http://") and not StartsWith(url, "https://")){
+            url = GetFileURL(url)
+            JS.eval ("$('.ui-widget-header').css('background-image','url(" + url + ")');")
           }
-          JS.eval ("$('.ui-widget-header').css('background-image','url(" + url + ")');")
         }
       }
     }

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -127,12 +127,9 @@
         JS.setCss ("#status", "border:none")
       }
       if (HasString(game, "locationbarimage")){
-        url = game.locationbarimage
-        if (not Trim(url) = ""){ 
-          if (not StartsWith(url,  "http://") and not StartsWith(url, "https://")){
-            url = GetFileURL(url)
-            JS.eval ("$('.ui-widget-header').css('background-image','url(" + url + ")');")
-          }
+        if (not Trim(game.locationbarimage) = ""){ 
+          url = GetFileURL(game.locationbarimage)
+          JS.eval ("$('.ui-widget-header').css('background-image','url(" + url + ")');")
         }
       }
     }

--- a/WorldModel/WorldModel/Core/Core.aslx
+++ b/WorldModel/WorldModel/Core/Core.aslx
@@ -126,6 +126,16 @@
       else {
         JS.setCss ("#status", "border:none")
       }
+      // Pertex: this is new
+      if (HasString(game, "locationbarimage")){
+        url = game.locationbarimage
+        if (not Trim(url) = ""){ 
+          if (not StartsWith(game.locationbarimage,  "http")){
+            url = GetFileURL(game.locationbarimage)
+          }
+          JS.eval ("$('.ui-widget-header').css('background-image','url(" + url + ")');")
+        }
+      }
     }
     //request (Show, "Location")
     if (game.showlocation) {

--- a/WorldModel/WorldModel/Core/CoreEditorGame.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorGame.aslx
@@ -589,6 +589,30 @@
         <attribute>showlocation</attribute>
       </control>
 
+
+     <control>
+        <controltype>file</controltype>
+        <caption>[EditorGameLocationBarBg]</caption>
+        <attribute>locationbarimage</attribute>
+        <source>[EditorImageFormats]</source>
+        <filefiltername>Picture Files</filefiltername>
+        <preview/>
+        <onlydisplayif>game.showlocation and not game.classiclocation and not game.locationbarimageisurl</onlydisplayif>
+      </control>
+       <control>
+        <controltype>checkbox</controltype>
+        <caption>[EditorGameLocationBarUseUrlInstead]</caption>
+        <attribute>locationbarimageisurl</attribute>
+        <onlydisplayif>game.showlocation and not game.classiclocation</onlydisplayif>
+        <breakbefore type="boolean">false</breakbefore>
+      </control>
+      <control>
+        <controltype>textbox</controltype>
+        <caption>[EditorGameURLforLocationBarImage]</caption>
+        <attribute>locationbarimage</attribute>
+        <onlydisplayif>game.showlocation and not game.classiclocation and game.locationbarimageisurl</onlydisplayif>
+      </control>
+
       <control>
         <controltype>checkbox</controltype>
         <caption>[EditorGameClassiclocation]</caption>

--- a/WorldModel/WorldModel/Core/CoreEditorGame.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorGame.aslx
@@ -590,27 +590,14 @@
       </control>
 
 
-     <control>
+      <control>
         <controltype>file</controltype>
         <caption>[EditorGameLocationBarBg]</caption>
         <attribute>locationbarimage</attribute>
         <source>[EditorImageFormats]</source>
         <filefiltername>Picture Files</filefiltername>
         <preview/>
-        <onlydisplayif>game.showlocation and not game.classiclocation and not game.locationbarimageisurl</onlydisplayif>
-      </control>
-       <control>
-        <controltype>checkbox</controltype>
-        <caption>[EditorGameLocationBarUseUrlInstead]</caption>
-        <attribute>locationbarimageisurl</attribute>
         <onlydisplayif>game.showlocation and not game.classiclocation</onlydisplayif>
-        <breakbefore type="boolean">false</breakbefore>
-      </control>
-      <control>
-        <controltype>textbox</controltype>
-        <caption>[EditorGameURLforLocationBarImage]</caption>
-        <attribute>locationbarimage</attribute>
-        <onlydisplayif>game.showlocation and not game.classiclocation and game.locationbarimageisurl</onlydisplayif>
       </control>
 
       <control>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -205,8 +205,6 @@
   <template name="EditorGameLocationCaption">Location bar</template>
   <template name="EditorGameCommandBarCaption">Command bar</template>
   <template name="EditorGameLocationBarBg">Location Bar Background Image</template>
-  <template name="EditorGameLocationBarUseUrlInstead">Use a URL for the Location Bar Background Image.</template>
-  <template name="EditorGameURLforLocationBarImage">URL for Location Bar Background Image</template>
   <template name="EditorGamePictureOptions">Picture frame</template>
   <template name="EditorGamePanesCaption">Game panes</template>
   <template name="EditorGameShowpanesInventory,">Show panes (Inventory, Places and Objects, Compass)</template>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -204,6 +204,9 @@
   <template name="EditorGameBorderCaption">Border</template>
   <template name="EditorGameLocationCaption">Location bar</template>
   <template name="EditorGameCommandBarCaption">Command bar</template>
+  <template name="EditorGameLocationBarBg">Location Bar Background Image</template>
+  <template name="EditorGameLocationBarUseUrlInstead">Use a URL for the Location Bar Background Image.</template>
+  <template name="EditorGameURLforLocationBarImage">URL for Location Bar Background Image</template>
   <template name="EditorGamePictureOptions">Picture frame</template>
   <template name="EditorGamePanesCaption">Game panes</template>
   <template name="EditorGameShowpanesInventory,">Show panes (Inventory, Places and Objects, Compass)</template>


### PR DESCRIPTION
Submitted by Pertex

Add option to use custom image in the location bar, complete with editor controls

Can use URL or local image

<details><summary> Screenshot </summary>

![image](https://github.com/user-attachments/assets/2984740a-b429-4b9f-a6a9-e8a6416de54d)

</details>

<details><summary> <b>PertexTester.aslx</b> </summary>

```xml
<!--Saved by Quest 5.9.9123.20989-->
<asl version="580">
  <include ref="English.aslx" />
  <include ref="Core.aslx" />
  <game name="pertex tester">
    <gameid>af60d15c-82de-4042-b14a-432ba7ac84e6</gameid>
    <version>1.0</version>
    <firstpublished>2024</firstpublished>
    <classiclocation type="boolean">false</classiclocation>
    <locationbarimage>https://secure.gravatar.com/avatar/4cc1e52f99452e841ecf4cbee9eadde9?d=retro</locationbarimage>
    <locationbarimageisurl />
    <showlocation />
    <customlocationtextcolour>Transparent</customlocationtextcolour>
  </game>
  <object name="room">
    <inherit name="editor_room" />
    <isroom />
    <object name="player">
      <inherit name="editor_object" />
      <inherit name="editor_player" />
    </object>
  </object>
</asl>
```

</details>