### PR TITLE
Retain outputData during call to clearScreen

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -765,10 +765,10 @@ function disableAllCommandLinks() {
     });
 }
 
-// Modified by KV to handle the scrollback feature
 var saveClearedText = false;
 var clearedOnce = false;
 function clearScreen() {
+    $("#outputData").appendTo($("body"));
     if (!saveClearedText) {
         $("#divOutput").css("min-height", 0);
         $("#divOutput").html("");
@@ -784,12 +784,14 @@ function clearScreen() {
         }
         clearedOnce = true;
         $('#divOutput').children().addClass('clearedScreen');
+        $('.clearedScreen').attr('id',null);
         $('#divOutput').css('min-height', 0);
         createNewDiv('left');
         beginningOfCurrentTurnScrollPosition = 0;
         setTimeout(function () {
             $('html,body').scrollTop(0);
         }, 100);
+    $("#outputData").appendTo($("#divOutput"));
     }
 }
 

--- a/WebPlayer/playercore.js
+++ b/WebPlayer/playercore.js
@@ -765,10 +765,10 @@ function disableAllCommandLinks() {
     });
 }
 
-// Modified by KV to handle the scrollback feature
 var saveClearedText = false;
 var clearedOnce = false;
 function clearScreen() {
+    $("#outputData").appendTo($("body"));
     if (!saveClearedText) {
         $("#divOutput").css("min-height", 0);
         $("#divOutput").html("");
@@ -784,12 +784,14 @@ function clearScreen() {
         }
         clearedOnce = true;
         $('#divOutput').children().addClass('clearedScreen');
+        $('.clearedScreen').attr('id',null);
         $('#divOutput').css('min-height', 0);
         createNewDiv('left');
         beginningOfCurrentTurnScrollPosition = 0;
         setTimeout(function () {
             $('html,body').scrollTop(0);
         }, 100);
+    $("#outputData").appendTo($("#divOutput"));
     }
 }
 


### PR DESCRIPTION
- Move the #outputData element out of the #divOutput element before dumping the data with clearScreen
- Set ID of all elements with the .clearedScreen class to null
    - Otherwise lines appear at the top of the page due to duplicate or de facto sequential IDs, and other shenanigans
- Return #outputData to #divOutput before exiting clearScreen script

Closes #1314