### PR TITLE
Revert GetListDisplayAlias to 5.7 behaviour

### DIFF
--- a/WorldModel/WorldModel/Core/CoreDescriptions.aslx
+++ b/WorldModel/WorldModel/Core/CoreDescriptions.aslx
@@ -369,8 +369,7 @@
   <function name="GetListDisplayAlias" type="string" parameters="obj">
     <![CDATA[
     if (HasString(obj, "listalias")) {
-      // Modified by KV
-      result = ProcessText(obj.listalias)
+      result = obj.listalias
     }
     else {
       result = GetDisplayAlias(obj)


### PR DESCRIPTION
- Remove text processor functionality from `GetListDisplayAlias`
  - This was added in 5.8, and it causes errors when images are used

Closes #1259