### PR TITLE
Save command will use JS.saveGame online

### DIFF
--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -923,7 +923,7 @@
   <command name="save">
     <pattern type="string">^save$</pattern>
     <script>
-      if (IsDesktop()){}
+      if (IsDesktop()){
         request(RequestSave, "")
       }
       else {

--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -913,7 +913,6 @@
   <command name="wait" pattern="[wait]">msg (Template("DefaultWait"))</command>
   <command name="xyzzy" pattern="[xyzzy]">msg (Template("DefaultXyzzy"))</command>
   
-  <!-- Modified to suppress turn scripts -->
   <command name="help" pattern="[help]">
     <script>
       msg (Template("DefaultHelp"))
@@ -921,27 +920,19 @@
     </script>
   </command>
 
-  <!-- Modified by KV to resolve issue with empty divOutput when saving online with this command. -->
   <command name="save">
     <pattern type="string">^save$</pattern>
     <script>
-      if (HasAttribute(game, "questplatform")) {
-        if (game.questplatform = "desktop") {
-           request(RequestSave, "")
-        }
-        else {
-          JS.saveGame ()
-        }
-      }
-      else {
+      if (IsDesktop()){}
         request(RequestSave, "")
       }
-      game.suppressturnscripts = true
+      else {
+        JS.saveGame ()
+      }
+      SuppressTurnscripts
     </script>
   </command>
   
-  <!-- added by KV -->
-
   <command name="version_cmd" pattern="[version_cmd]">
     <script><![CDATA[
       s = "<b>TITLE: </b>" + game.gamename + "<br/>"


### PR DESCRIPTION
When saving progress online, the text from `#divOutput` is not retained when calling the `request` script.

In 5.8, we changed it to use the game object attribute set by `JS.whereAmi()`, which ended up being unused (due to issues when run from the init script). This script initially included a call to whereAmI if the attribute was not set, which was also problematic, and it devolved into its current state -- which does not work on its own.

This will not use JS to check the platform and will still use JS to save when online.