### PR TITLE
Add HTML element text processor commands

### DIFF
--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -769,6 +769,16 @@
       }
     }
   ]]></function>
+
+  <function name="ProcessTextCommand_Element" parameters="section, data" type="string"><![CDATA[
+    if (IsRegexMatch(":?/?\\w+\\b((?<=\\s)\\w+\\b|(?<=\\s)\\w+=\\w+\\b|(?<=\\s)\\w+=\"[^\"]*\"|(?<=\\s)\\w+='[^']*')*/?\\s*", section)) {
+      if (StartsWith (section, ":")) section = LTrim (Mid (section, 2))
+      return("<" + section + ">")
+    }
+    else {
+      return ("@@@open@@@" + ProcessTextSection (section, data) + "@@@close@@@")
+    }
+  ]]></function>
   
   <function name="SetFramePicture" parameters="filename">
     <![CDATA[

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -202,6 +202,12 @@
       <item key="=">
         game.textprocessorcommandresult = ProcessTextCommand_Eval (section, data)
       </item>
+      <item key=":">
+        game.textprocessorcommandresult = ProcessTextCommand_Element (section, data)
+      </item>
+      <item key="/">
+        game.textprocessorcommandresult = ProcessTextCommand_Element (section, data)
+      </item>
     </textprocessorcommands>
     <feature_devmode type="boolean">false</feature_devmode>
   </type>


### PR DESCRIPTION
Closes #1337

Allows things like this (for the WebEditor users, who can't always use `<`):
```
{:div id="test-div"}{:span id="test-span"}I am the text in the SPAN.{/span}{/div}
```

`<div id="test-div"><span id="test-span">I am the text in the SPAN.</span></div>`