### PR TITLE
Correct typo in using_dictionaries.md

### DIFF
--- a/docs/using_dictionaries.md
+++ b/docs/using_dictionaries.md
@@ -120,7 +120,7 @@ dictionary add (options, "vomit", "Try to vomit the poison up")
 ShowMenu ("Choose", options, false) {
   do(player, result)
 }
-
+```
 
 ### Script parameters
 


### PR DESCRIPTION
Add missing backticks before the Script Parameters section