### PR TITLE
Fix link in objectlist.md

### DIFF
--- a/docs/types/objectlist.md
+++ b/docs/types/objectlist.md
@@ -3,10 +3,10 @@ layout: index
 title: Objectlist
 ---
 
-An objectlist is a [list](list.html) that can contain any number of elements, all of which have to be of type [object](object.html). see [Using Lists](../guides/using_lists.html) for more information.
+An objectlist is a [list](list.html) that can contain any number of elements, all of which have to be of type [object](object.html).
 
 The format in an ASLX file is:
 
      <mylist type="objectlist">player; object1; thing</mylist>
 
-There is more on lists [here](../using_lists.html).
+ See [Using Lists](../using_lists.html) for more information.


### PR DESCRIPTION
"Using lists" was linked in two places, and one was a bad link.

(I used `ListCombine` to tidy up.)