### PR TITLE
Remove checks for WebPlayer from save command

### DIFF
--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -921,22 +921,11 @@
     </script>
   </command>
 
-  <!-- Modified by KV to resolve issue with empty divOutput when saving online with this command. -->
   <command name="save">
     <pattern type="string">^save$</pattern>
     <script>
-      if (HasAttribute(game, "questplatform")) {
-        if (game.questplatform = "desktop") {
-           request(RequestSave, "")
-        }
-        else {
-          JS.saveGame ()
-        }
-      }
-      else {
-        request(RequestSave, "")
-      }
-      game.suppressturnscripts = true
+      request(RequestSave, "")
+      SuppressTurnscripts
     </script>
   </command>
   


### PR DESCRIPTION
- Save command will simply call `request (RequestSave, "")` and suppress turn scripts