### PR TITLE
Use object's display alias for ShowMenuResponse during disambiguation

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1469,6 +1469,9 @@ function loadTranscriptNameInputVal(){
 
 // ***********************************
 
+function disableCmdLink(el){
+  $('.' + el + ' .cmdlink').addClass('disabled').attr('onclick',null);
+}
 
 
 // GRID FUNCTIONS ***********************************************************************************************************************

--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -1469,7 +1469,7 @@ function loadTranscriptNameInputVal(){
 
 // ***********************************
 
-function disableCmdLink(el){
+function disableMenuOutputSection (el){
   $('.' + el + ' .cmdlink').addClass('disabled').attr('onclick',null);
 }
 

--- a/WorldModel/WorldModel/Core/CoreEditorGame.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorGame.aslx
@@ -355,6 +355,23 @@
         <attribute>deactivatecommandlinks</attribute>
         <onlydisplayif>game.enablehyperlinks</onlydisplayif>
       </control>
+      
+      <control>
+        <controltype>title</controltype>
+        <caption>[EditorGameShowMenuOptionsCaption]</caption>
+      </control>
+      
+      <control>
+        <controltype>checkbox</controltype>
+        <caption>[EditorGameDoNotClearMenus]</caption>
+        <attribute>donotclearmenus</attribute>
+      </control>
+      
+      <control>
+        <controltype>checkbox</controltype>
+        <caption>[EditorGameShowMenuResponses]</caption>
+        <attribute>showmenuresponses</attribute>
+      </control>
 
       <control>
         <controltype>title</controltype>

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -254,14 +254,14 @@
       if (not GetBoolean(game, "disambiguating")) {
         game.runturnscripts = true
       }
-      else {
-        if (GetBoolean (game, "showmenuresponses")) {
+      if (GetBoolean (game, "showmenuresponses")) {
+        if (GetBoolean (game, "disambiguating")){
           obj = GetObject (option)
           if (obj <> null){
             option = GetDisplayAlias(obj)
           }
-          msg (Template("ShowMenuResponsePrompt") + option)
         }
+        msg (Template("ShowMenuResponsePrompt") + option)
       }
       game.disambiguating = false
       invoke (script, parameters)

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -237,24 +237,47 @@
     game.menuoutputsection = outputsection
   ]]></function>
   
-  <function name="ShowMenuResponse" parameters="option">
+  <function name="ShowMenuResponse" parameters="option"><![CDATA[
     if (game.menucallback = null) {
       error ("Unexpected menu response")
     }
     else {
       parameters = NewStringDictionary()
       dictionary add (parameters, "result", UnescapeQuotes(option))
-      msg (Template("ShowMenuResponsePrompt") + option)
       script = game.menucallback
-      ClearMenu
-      // Added by KV to handle the new FinishTurn setup in 580
+      if (GetBoolean (game, "donotclearmenus")) {
+        DisableMenu
+      }
+      else {
+        ClearMenu
+      }
       if (not GetBoolean(game, "disambiguating")) {
         game.runturnscripts = true
+      }
+      else {
+        if (GetBoolean (game, "showmenuresponses")) {
+          obj = GetObject (option)
+          if (obj <> null){
+            option = GetDisplayAlias(obj)
+          }
+          msg (Template("ShowMenuResponsePrompt") + option)
+        }
       }
       game.disambiguating = false
       invoke (script, parameters)
       FinishTurn
     }
+  ]]></function>
+  
+  <function name="DisableMenu">
+    DisableOutputSection (game.menuoutputsection)
+    game.menuoutputsection = null
+    game.menuoptions = null
+    game.menucallback = null
+  </function>
+  
+  <function name="DisableOutputSection" parameters="section">
+    JS.disableCmdLink (section)
   </function>
   
   <function name="EscapeQuotes" parameters="s" type="string">

--- a/WorldModel/WorldModel/Core/CoreFunctions.aslx
+++ b/WorldModel/WorldModel/Core/CoreFunctions.aslx
@@ -270,14 +270,14 @@
   ]]></function>
   
   <function name="DisableMenu">
-    DisableOutputSection (game.menuoutputsection)
+    DisableMenuOutputSection (game.menuoutputsection)
     game.menuoutputsection = null
     game.menuoptions = null
     game.menucallback = null
   </function>
-  
-  <function name="DisableOutputSection" parameters="section">
-    JS.disableCmdLink (section)
+
+  <function name="DisableMenuOutputSection" parameters="section">
+    JS.disableMenuOutputSection (section)
   </function>
   
   <function name="EscapeQuotes" parameters="s" type="string">

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -90,6 +90,8 @@
     <feature_advancedwearables type="boolean">false</feature_advancedwearables>
     <feature_advancedscripts type="boolean">false</feature_advancedscripts>
     <deactivatecommandlinks type="boolean">false</deactivatecommandlinks>
+    <donotclearmenus type="boolean">false</donotclearmenus>
+    <showmenuresponses type="boolean">false</showmenuresponses>
     <multiplecommands type="boolean">false</multiplecommands>
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
     <writelogtofile type="boolean">false</writelogtofile>

--- a/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
+++ b/WorldModel/WorldModel/Core/Languages/EditorEnglish.aslx
@@ -193,6 +193,9 @@
   <template name="EditorGameBackground">Background</template>
   <template name="EditorGameHoverbackground">Hover background</template>
   <template name="EditorGameHoverforeground">Hover foreground</template>
+  <template name="EditorGameShowMenuOptionsCaption">Menus</template>
+  <template name="EditorGameDoNotClearMenus">Do not clear menus after selections are made.</template>
+  <template name="EditorGameShowMenuResponses">Print reponses after making menu selections.</template>
   <template name="EditorGameInterface">Interface</template>
   <template name="EditorGameMap">Map</template>
   <template name="EditorGameScale">Scale</template>


### PR DESCRIPTION
- Use `GetDisplayAlias` to print selection made in `ShowMenuResponse`
- Add "donotclearmenus" boolean attribute to game object, default `false`
- Add "showmenuresponses" boolean attribute to game object, default `false`
- Add `DisableMenu` function
- Add `DisableMenuOutputSection` function
- Add JS `disableMenuOutputSection` function
- Add editor controls for new game object attributes

---
<details><summary>  Screenshot (Editor Controls) </summary>

![404703720-cb2af34b-dbd8-41b3-99c1-600741e899ed](https://github.com/user-attachments/assets/35ddc4d6-dfec-4492-aa41-e01676f70fc2)

</details>

---
<details><summary>  Animated GIF 1 </summary>

![quest-pertex-showmenuresponse-mod](https://github.com/user-attachments/assets/ce6fff64-def9-4140-99dc-da21a10a8be4)

</details>

---
<details><summary>  Animated GIF 2 </summary>

![quest-pertex-showmenuresponse-mod-normal-settings](https://github.com/user-attachments/assets/d91d2486-83d1-4e60-a85e-e1618e7b34a9)

</details>

---
Test game:

[Testing GetDisplayAlias in ShowMenuResponse.zip](https://github.com/user-attachments/files/18471051/Testing.GetDisplayAlias.in.ShowMenuResponse.zip)