### PR TITLE
Fix link in hs_baddy2.md

### DIFF
--- a/docs/helpsheets/hs_baddy2.md
+++ b/docs/helpsheets/hs_baddy2.md
@@ -35,7 +35,7 @@ title: Baddies behind a Door who want to kill you (but if you close the door you
 
 10. I then click on **Add new script** and choose the from the *Timers* section, choose “**Run a script after a number of seconds**”.
 
-     ![](Hsbaddy26.jpg)
+     ![](Hsbaddy13.jpg)
 
 11. I can choose how many seconds to wait before something else happens. In this case, 10 seconds.
 


### PR DESCRIPTION
Found the old page using the Wayback Machine

https://web.archive.org/web/20130308034144/http://quest5.net/wiki/Hs-baddy2

![image](https://github.com/user-attachments/assets/f4f20e79-af4e-41c2-8f8a-59a7d33a07a6)
