### PR TITLE
Show `usedefaultprefix` checkbox when object is scenery

### DIFF
--- a/WorldModel/WorldModel/Core/CoreEditorObjectSetup.aslx
+++ b/WorldModel/WorldModel/Core/CoreEditorObjectSetup.aslx
@@ -43,14 +43,13 @@
       <controltype>checkbox</controltype>
       <caption>[EditorObjectSetupUsedefault]</caption>
       <attribute>usedefaultprefix</attribute>
-      <onlydisplayif>not this.scenery</onlydisplayif>
     </control>
 
     <control>
       <caption>[EditorObjectSetupPrefix]</caption>
       <controltype>textbox</controltype>
       <attribute>prefix</attribute>
-      <onlydisplayif>not this.usedefaultprefix and not this.scenery</onlydisplayif>
+      <onlydisplayif>not this.usedefaultprefix</onlydisplayif>
     </control>
 
     <control>


### PR DESCRIPTION
Do not hide the `usedefaultprefix` checkbox when the object is scenery, because scenery still uses the prefix when printing the object display name/alias.

Closes #1359 