### PR TITLE
Fix `outputoff` in LegacyGame

### DIFF
--- a/Legacy/LegacyGame.vb
+++ b/Legacy/LegacyGame.vb
@@ -10922,6 +10922,10 @@ Public Class LegacyGame
     End Sub
 
     Friend Sub Print(txt As String, ctx As Context)
+        If Not _outPutOn Then 
+            LogASLError(Date.Now.ToString() & " - PRINT: Text not printed because outputoff is true:" & vbCrLf & "'" & txt & "'")
+            Exit Sub
+        End If
         Dim printString = ""
 
         If txt = "" Then

--- a/Legacy/LegacyGame.vb
+++ b/Legacy/LegacyGame.vb
@@ -10922,8 +10922,7 @@ Public Class LegacyGame
     End Sub
 
     Friend Sub Print(txt As String, ctx As Context)
-        If Not _outPutOn Then 
-            LogASLError(Date.Now.ToString() & " - PRINT: Text not printed because outputoff is true:" & vbCrLf & "'" & txt & "'")
+        If Not _outPutOn Then
             Exit Sub
         End If
         Dim printString = ""


### PR DESCRIPTION
Modify `Print` to log the text and exit the sub when `Not _outPutOn`

Closes #1401

---
```
define game <ASL LegacyGame Tester>
	asl-version <210>
	game version <1.0>
	game author <KV>
	game copyright <© 2025 KV>
	game info <Just testing the LegacyGame code.>
	start <Quest Testing>
  command <test> do <testproc>
end define

define room <Quest Testing>
	look <Try entering “TEST”>
end define

define text <intro>
  This is only a test game. All you can do is TEST.
end define

define text <win>
  You win, but you gain nothing.
end define

define text <lose>
  You lose, but you gain experience.
end define

define procedure <testproc>
    msg <message 1>
    msg <message 2>
    outputoff
    msg <message 3 (should not print!)>
    outputon
    msg <message 4>
end define
```

![image](https://github.com/user-attachments/assets/f7c6080a-10b3-49e6-9159-7c474b69ee83)
