### PR TITLE
Correct DevMode controltypes (for WebEditor)

### DIFF
--- a/WorldModel/WorldModel/Core/CoreDevMode.aslx
+++ b/WorldModel/WorldModel/Core/CoreDevMode.aslx
@@ -850,9 +850,8 @@
     </control>
 
     <control>
-      <controltype>expression</controltype>
-      <simple>[EditorGameDevModePov]</simple>
-      <simpleeditor>objects</simpleeditor>
+      <controltype>objects</controltype>
+      <caption>[EditorGameDevModePov]</caption>
       <attribute>devmode_pov</attribute>
       <onlydisplayif>game.devmode_changepov</onlydisplayif>
       <mustinherit>devmode</mustinherit>
@@ -866,9 +865,8 @@
     </control>
 
     <control>
-      <controltype>expression</controltype>
-      <simple>[EditorGameDevModePlace]</simple>
-      <simpleeditor>objects</simpleeditor>
+      <controltype>objects</controltype>
+      <caption>[EditorGameDevModePlace]</caption>
       <attribute>devmode_povpos</attribute>
       <onlydisplayif>game.devmode_changepovpos</onlydisplayif>
       <mustinherit>devmode</mustinherit>


### PR DESCRIPTION
- Change `controltype` of editor controls using dropdowns for objects to `objects`

Closes #1431

Also see Discussion #1430 

When using DevMode to change starting POV or starting room, the controltype of the object dropdowns crashes the WebEditor and renders the file uneditable online.

---
After changing the `controltype` to `objects`:

![image](https://github.com/user-attachments/assets/83992650-f898-4c31-b5e8-62df9a10de34)