### PR TITLE
Remove calls to `GetWindowsSafeName`

### DIFF
--- a/src/Engine/Core/CoreCommands.aslx
+++ b/src/Engine/Core/CoreCommands.aslx
@@ -971,7 +971,7 @@
             }
           }
           else {
-            filename = GetWindowsSafeName(game.gamename)
+            filename = game.gamename
             InitiateTranscript(filename)
           }
         }

--- a/src/Engine/Core/CoreTypes.aslx
+++ b/src/Engine/Core/CoreTypes.aslx
@@ -103,7 +103,7 @@
       }
       else if (game.savetranscript){
         if (not HasAttribute (game, "transcriptname")){
-          game.transcriptname = GetWindowsSafeName(game.gamename)
+          game.transcriptname = game.gamename
         }
         JS.enableTranscript(game.transcriptname)
       }


### PR DESCRIPTION
`GetWindowsSafeName` was added in the early 5.9 development stages, then removed. There were two bits of code that were not cleaned up.

Closes #1438