### PR TITLE
Purge GetWindowsSafeName V5

### DIFF
--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -971,7 +971,7 @@
             }
           }
           else {
-            filename = GetWindowsSafeName(game.gamename)
+            filename = game.gamename
             InitiateTranscript(filename)
           }
         }

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -103,7 +103,7 @@
       }
       else if (game.savetranscript){
         if (not HasAttribute (game, "transcriptname")){
-          game.transcriptname = GetWindowsSafeName(game.gamename)
+          game.transcriptname = game.gamename
         }
         JS.enableTranscript(game.transcriptname)
       }


### PR DESCRIPTION
- Remove all calls to `GetWindowsSafeName` v5
  - This was a function created and then deleted during early development stages)