### PR TITLE
Add debugging and walkthrough support for legacy games

### DIFF
--- a/examples/test.asl
+++ b/examples/test.asl
@@ -88,3 +88,11 @@ define selection <test menu>
 	choice <one> msg <Option 1>
 	choice <two> msg <Option 2>
 end define
+
+define text <walkthrough test>
+	x thing
+	x book
+	menu:1
+	take it
+	e
+end define

--- a/examples/test.asl
+++ b/examples/test.asl
@@ -6,6 +6,9 @@ define game <>
 	asl-version <410>
 	start <room>
 	game info <Created with QDK 4.1.5>
+	command <ifp> {
+		if property <kitchen; visited> then msg <Visited kitchen> else msg <Not visited kitchen>
+	}
 	command <test> {
 		msg <Enter some words...>
 		enter <input>
@@ -95,4 +98,5 @@ define text <walkthrough test>
 	menu:1
 	take it
 	e
+	assert:property <kitchen; visited>
 end define

--- a/src/Common/IGameDebug.cs
+++ b/src/Common/IGameDebug.cs
@@ -66,6 +66,8 @@ namespace QuestViva.Common
 
     public class DebugData
     {
+        public static readonly DebugData Empty = new DebugData();
+        
         private Dictionary<string, DebugDataItem> m_data = new Dictionary<string, DebugDataItem>();
         public Dictionary<string, DebugDataItem> Data
         {

--- a/src/Common/IGameDebug.cs
+++ b/src/Common/IGameDebug.cs
@@ -14,7 +14,7 @@ namespace QuestViva.Common
         bool DebugEnabled { get; }
         event EventHandler<ObjectsUpdatedEventArgs>? ObjectsUpdated;
         List<string> GetObjects(string type);
-        DebugData GetDebugData(string obj);
+        DebugData GetDebugData(string tab, string obj);
         List<string> DebuggerObjectTypes { get; }
         IWalkthroughs Walkthroughs { get; }
         bool Assert(string expression);

--- a/src/Common/IGameDebug.cs
+++ b/src/Common/IGameDebug.cs
@@ -83,6 +83,6 @@ namespace QuestViva.Common
 
     public interface IWalkthrough
     {
-        List<string> Steps { get; }
+        string[] Steps { get; }
     }
 }

--- a/src/Engine/Walkthrough.cs
+++ b/src/Engine/Walkthrough.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using QuestViva.Common;
 
 namespace QuestViva.Engine

--- a/src/Engine/Walkthrough.cs
+++ b/src/Engine/Walkthrough.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using QuestViva.Common;
 
 namespace QuestViva.Engine
@@ -32,7 +33,7 @@ namespace QuestViva.Engine
             m_walkthroughs = walkthroughs;
         }
 
-        public List<string> Steps
+        public string[] Steps
         {
             get {
                 if (m_element.Parent == null)
@@ -44,12 +45,12 @@ namespace QuestViva.Engine
                     List<string> result = new List<string>();
                     result.AddRange(m_walkthroughs.Walkthroughs[m_element.Parent.Name].Steps);
                     result.AddRange(ThisSteps());
-                    return result;
+                    return result.ToArray();
                 }
             }
         }
 
-        private List<string> ThisSteps()
+        private string[] ThisSteps()
         {
             List<string> result = new List<string>();
             IEnumerable<string> steps = m_element.Fields[FieldDefinitions.Steps];
@@ -57,7 +58,7 @@ namespace QuestViva.Engine
             {
                 result.AddRange(steps);
             }
-            return result;
+            return result.ToArray();
         }
     }
 }

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -888,6 +888,11 @@ namespace QuestViva.Engine
             return result;
         }
 
+        public DebugData GetDebugData(string _, string el)
+        {
+            return m_elements.Get(el).GetDebugData();
+        }
+        
         public DebugData GetDebugData(string el)
         {
             return m_elements.Get(el).GetDebugData();

--- a/src/Legacy/V4Game.Debug.cs
+++ b/src/Legacy/V4Game.Debug.cs
@@ -18,6 +18,14 @@ public partial class V4Game
         {
             case "Variables":
                 return ["Strings", "Numerics"];
+            case "Game":
+                return [_objs[1].ObjectName];
+            case "Rooms":
+                return _objs.Skip(2).Where(o => o.IsRoom).Select(r => r.ObjectName).ToList();
+            case "Objects":
+                return _objs.Skip(2).Where(o => !o.IsRoom && !o.IsExit).Select(r => r.ObjectName).ToList();
+            case "Exits":
+                return _objs.Skip(2).Where(o => o.IsExit).Select(r => r.ObjectName).ToList();
             default:
                 throw new NotImplementedException();
         }
@@ -62,6 +70,7 @@ public partial class V4Game
 
     public List<string> DebuggerObjectTypes => [
         "Variables",
+        "Game",
         "Rooms",
         "Objects",
         "Exits",

--- a/src/Legacy/V4Game.Debug.cs
+++ b/src/Legacy/V4Game.Debug.cs
@@ -152,6 +152,6 @@ public partial class V4Game
 
     public bool Assert(string expression)
     {
-        throw new NotImplementedException();
+        return ExecuteConditions(expression, _nullContext);
     }
 }

--- a/src/Legacy/V4Game.Debug.cs
+++ b/src/Legacy/V4Game.Debug.cs
@@ -1,0 +1,77 @@
+using QuestViva.Common;
+
+namespace QuestViva.Legacy;
+
+public partial class V4Game
+{
+    private class WalkthroughList : IWalkthroughs
+    {
+        public IDictionary<string, IWalkthrough> Walkthroughs => new Dictionary<string, IWalkthrough>();
+    }
+    
+    public bool DebugEnabled => true;
+    public event EventHandler<ObjectsUpdatedEventArgs> ObjectsUpdated;
+    
+    public List<string> GetObjects(string type)
+    {
+        switch (type)
+        {
+            case "Variables":
+                return ["Strings", "Numerics"];
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    public DebugData GetDebugData(string tab, string obj)
+    {
+        switch (tab)
+        {
+            case "Variables":
+                return obj switch
+                {
+                    "Strings" => GetVariableDebugData(_stringVariable),
+                    "Numerics" => GetVariableDebugData(_numericVariable),
+                    _ => throw new NotImplementedException()
+                };
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    private DebugData GetVariableDebugData(VariableType[] variable)
+    {
+        if (variable == null || variable.Length == 0)
+        {
+            return new DebugData
+            {
+                Data = new Dictionary<string, DebugDataItem>()
+            };
+        }
+        
+        var data = variable
+            .Skip(1)
+            .Select(v => new KeyValuePair<string, DebugDataItem>(v.VariableName,
+                new DebugDataItem(string.Join(", ", v.VariableContents))));
+
+        return new DebugData
+        {
+            Data = data.ToDictionary()
+        };
+    }
+
+    public List<string> DebuggerObjectTypes => [
+        "Variables",
+        "Rooms",
+        "Objects",
+        "Exits",
+        "Timers"
+    ];
+
+    public IWalkthroughs Walkthroughs => new WalkthroughList();
+    
+    public bool Assert(string expression)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Legacy/V4Game.Debug.cs
+++ b/src/Legacy/V4Game.Debug.cs
@@ -42,7 +42,9 @@ public partial class V4Game
     }
     
     public bool DebugEnabled => true;
+    #pragma warning disable CS0067
     public event EventHandler<ObjectsUpdatedEventArgs> ObjectsUpdated;
+    #pragma warning restore CS0067
     
     public List<string> GetObjects(string type)
     {

--- a/src/Legacy/V4Game.Debug.cs
+++ b/src/Legacy/V4Game.Debug.cs
@@ -26,6 +26,8 @@ public partial class V4Game
                 return _objs.Skip(2).Where(o => !o.IsRoom && !o.IsExit).Select(r => r.ObjectName).ToList();
             case "Exits":
                 return _objs.Skip(2).Where(o => o.IsExit).Select(r => r.ObjectName).ToList();
+            case "Timers":
+                return _timers.Skip(1).Select(t => t.TimerName).ToList();
             default:
                 throw new NotImplementedException();
         }
@@ -42,6 +44,13 @@ public partial class V4Game
                     "Numerics" => GetVariableDebugData(_numericVariable),
                     _ => throw new NotImplementedException()
                 };
+            case "Game":
+            case "Rooms":
+            case "Objects":
+            case "Exits":
+                return GetObjectDebugData(_objs.Skip(1).First(o => o.ObjectName == obj));
+            case "Timers":
+                return GetTimerDebugData(_timers.Skip(1).First(t => t.TimerName == obj));
             default:
                 throw new NotImplementedException();
         }
@@ -51,10 +60,7 @@ public partial class V4Game
     {
         if (variable == null || variable.Length == 0)
         {
-            return new DebugData
-            {
-                Data = new Dictionary<string, DebugDataItem>()
-            };
+            return DebugData.Empty;
         }
         
         var data = variable
@@ -65,6 +71,38 @@ public partial class V4Game
         return new DebugData
         {
             Data = data.ToDictionary()
+        };
+    }
+
+    private DebugData GetObjectDebugData(ObjectType obj)
+    {
+        if (obj.Properties == null)
+        {
+            return DebugData.Empty;
+        }
+        
+        var data = obj
+            .Properties
+            .Skip(1)
+            .Select(p => new KeyValuePair<string, DebugDataItem>(p.PropertyName,
+                new DebugDataItem(p.PropertyValue)));
+
+        return new DebugData
+        {
+            Data = data.ToDictionary()
+        };
+    }
+
+    private DebugData GetTimerDebugData(TimerType timer)
+    {
+        return new DebugData
+        {
+            Data = new Dictionary<string, DebugDataItem>
+            {
+                ["Ticks"] = new(timer.TimerTicks.ToString()),
+                ["Interval"] = new(timer.TimerInterval.ToString()),
+                ["Active"] = new(timer.TimerActive ? "true" : "false")
+            }
         };
     }
 

--- a/src/Legacy/V4Game.cs
+++ b/src/Legacy/V4Game.cs
@@ -6,7 +6,7 @@ using Constants = Microsoft.VisualBasic.Constants;
 
 namespace QuestViva.Legacy;
 
-public partial class V4Game : IGame, IGameTimer
+public partial class V4Game : IGameDebug, IGameTimer
 {
     public enum State
     {

--- a/src/PlayerCore/WalkthroughRunner.cs
+++ b/src/PlayerCore/WalkthroughRunner.cs
@@ -196,7 +196,7 @@ internal class WalkthroughRunner(IGameDebug game, string walkthrough)
         Output?.Invoke(text);
     }
 
-    public int Steps => game.Walkthroughs.Walkthroughs[walkthrough].Steps.Count;
+    public int Steps => game.Walkthroughs.Walkthroughs[walkthrough].Steps.Length;
 
     public void Cancel()
     {

--- a/src/WebPlayer/Components/Debugger/Attributes.razor
+++ b/src/WebPlayer/Components/Debugger/Attributes.razor
@@ -8,7 +8,7 @@
     }
 </style>
 
-<List Items="Game.GetObjects(ActiveTab)" OnItemSelected="OnObjectSelected"></List>
+<List Items="Game.GetObjects(ActiveTab)" OnItemSelected="OnObjectSelected" SelectedItem="@selectedObject"></List>
 
 <div class="right-pane">
     <table class="table table-sm">

--- a/src/WebPlayer/Components/Debugger/Attributes.razor
+++ b/src/WebPlayer/Components/Debugger/Attributes.razor
@@ -28,7 +28,7 @@
         }
         else
         {
-            foreach (var attr in Game.GetDebugData(selectedObject).Data)
+            foreach (var attr in Game.GetDebugData(ActiveTab, selectedObject).Data)
             {
                 <tr class="@(attr.Value.IsInherited ? "table-secondary" : "")">
                     <td>@attr.Key</td>

--- a/src/WebPlayer/Components/Debugger/List.razor
+++ b/src/WebPlayer/Components/Debugger/List.razor
@@ -38,7 +38,7 @@
         {
             <li>
                 <button
-                    class="list-item-button @(item == selectedItem ? "selected" : "")"
+                    class="list-item-button @(item == SelectedItem ? "selected" : "")"
                     @onclick="() => ItemSelected(item)">
                     @item
                 </button>
@@ -50,15 +50,15 @@
 @code {
     [Parameter] public IEnumerable<string> Items { get; set; } = [];
     [Parameter] public EventCallback<string> OnItemSelected { get; set; }
-    private string? selectedItem;
+    [Parameter] public string? SelectedItem { get; set; }
     
     private void ItemSelected(string item)
     {
-        if (item == selectedItem)
+        if (item == SelectedItem)
         {
             return;
         }
-        selectedItem = item;
+        SelectedItem = item;
         OnItemSelected.InvokeAsync(item);
     }
 }


### PR DESCRIPTION
This adds Debug support for games written for Quest 1-4, including walkthrough support - which was something that only came along originally in Quest 5.

To support walkthroughs in games for Quest 1-4, we can add a `text` block with a name starting with `walkthrough`. You can even use assertions, set the delay etc. just as when using walkthroughs in Quest 5.

The Debugger lets you see string and numeric variables, plus properties of objects, rooms and exits, just like in the Quest 4 Object Debugger. Fun fact, the Timers tab on Quest 4.1.5's Object Debugger looks like it didn't work - not sure how many versions that was broken for.

Now, I doubt anybody _needs_ a Quest 1-4 debugger, so this is partially a bit of fun, but it will also be handy to verify things are still working after doing any refactoring in the legacy game code.