### PR TITLE
Insert #endWaitDiv before #txtCommandDiv

### DIFF
--- a/src/PlayerCore/Resources/playercore.htm
+++ b/src/PlayerCore/Resources/playercore.htm
@@ -156,15 +156,15 @@
                 Loading...</h1>
         </div>
         <div id="txtCommandSpacer"></div>
+        <div id="endWaitDiv">
+            <a id="endWaitLink" onclick="endWait();" class="cmdlink" style="display: none">Continue...</a>
+        </div>
         <div id="txtCommandDiv">
             <div id="txtCommandContainer">
                 <span id="txtCommandPrompt"></span>
                 <input type="text" x-webkit-speech id="txtCommand" onkeydown="return commandKey(event);" placeholder="Type here..."
                        autofocus />
             </div>
-        </div>
-        <div id="endWaitDiv">
-            <a id="endWaitLink" onclick="endWait();" class="cmdlink" style="display: none">Continue...</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
#1559 

- Move the Continue link to avoid whitespace issues