### PR TITLE
Fix NullReferenceException when adding script to empty block

### DIFF
--- a/EditorControls/ScriptEditorControl.xaml.cs
+++ b/EditorControls/ScriptEditorControl.xaml.cs
@@ -80,11 +80,11 @@ namespace TextAdventures.Quest.EditorControls
             {
                 if (m_parentScript != null)
                 {
-                    m_scripts = m_controller.CreateNewEditableScriptsChild(m_parentScript, m_helper.ControlDefinition.Attribute, script, true);
+                    m_scripts = m_controller.CreateNewEditableScriptsChild(m_parentScript, m_helper.ControlDefinition?.Attribute, script, true);
                 }
                 else
                 {
-                    m_scripts = m_controller.CreateNewEditableScripts(ElementName, m_helper.ControlDefinition.Attribute, script, true, true);
+                    m_scripts = m_controller.CreateNewEditableScripts(ElementName, m_helper.ControlDefinition?.Attribute, script, true, true);
                 }
             }
             else


### PR DESCRIPTION
ControlDefinition can be null when DoInitialise is called with a null definition (e.g. IfEditorChild, PopupEditors.EditScript). Guard both accesses in AddNewScriptCommand with the null-conditional operator.

Fixes #1568