### PR TITLE
Fix IndexOutOfRangeException when undoing more times than actions taken

### DIFF
--- a/WorldModel/WorldModel/UndoLogger.cs
+++ b/WorldModel/WorldModel/UndoLogger.cs
@@ -125,7 +125,7 @@ namespace TextAdventures.Quest
 
         public void RollbackTransaction()
         {
-            if (m_currentTransaction != null) EndTransaction();
+            if (m_logging) EndTransaction();
             Undo();
             if (m_currentTransaction != null)
             {


### PR DESCRIPTION
The undo command skips `start transaction` (via the isundo flag), so m_logging is false when RollbackTransaction is called. The old guard `if (m_currentTransaction != null)` incorrectly called EndTransaction on an already-committed transaction, re-pushing it onto the undo stack. This phantom duplicate caused a stale transaction to be undone twice, crashing with IndexOutOfRangeException on the second replay.

Fixes #1582.