### PR TITLE
Lazily initialise AvalonEdit in ScriptEditorControl (#1583)

### DIFF
--- a/EditorControls/ScriptEditorControl.xaml
+++ b/EditorControls/ScriptEditorControl.xaml
@@ -36,17 +36,7 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <this:ScriptToolbar x:Name="ctlToolbar" IsTabStop="False"/>
-                <Border BorderThickness="1" Padding="4,2,4,4" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Grid.Row="1" Name="textEditorBorder" Visibility="Collapsed" Background="White">
-                    <avalonEdit:TextEditor
-                    xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
-                    Name="textEditor"
-                    FontFamily="Consolas, Courier New"
-                    FontSize="10pt" Text=""
-                    VerticalScrollBarVisibility="Auto"
-                    HorizontalScrollBarVisibility="Auto"
-                    MaxHeight="500"
-                    SyntaxHighlighting="C#"/>
-                </Border>
+                <Border BorderThickness="1" Padding="4,2,4,4" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Grid.Row="1" Name="textEditorBorder" Visibility="Collapsed" Background="White"/>
                 <ListBox Name="lstScripts" Grid.Row="1" SelectionMode="Extended" SelectionChanged="lstScripts_SelectionChanged" AlternationCount="2" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                     <ListBox.Resources>
                         <LinearGradientBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" StartPoint="0,0" EndPoint="0,0.5" SpreadMethod="Reflect">

--- a/EditorControls/ScriptEditorControl.xaml.cs
+++ b/EditorControls/ScriptEditorControl.xaml.cs
@@ -5,7 +5,10 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Threading;
+using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Highlighting;
 using TextAdventures.Utility.Language;
 
 namespace TextAdventures.Quest.EditorControls
@@ -23,6 +26,7 @@ namespace TextAdventures.Quest.EditorControls
         private bool m_saving;
         private bool m_populating;
         private bool m_initialised;
+        private TextEditor textEditor;
 
         internal event Action Initialise;
 
@@ -167,8 +171,6 @@ namespace TextAdventures.Quest.EditorControls
             bool fromInheritedType = IsScriptFromInheritedType();
             if (fromInheritedType) m_readOnly = true;
             ctlToolbar.CanMakeEditable = fromInheritedType;
-
-            textEditor.IsReadOnly = m_readOnly;
 
             m_populating = true;
             CodeView = false;
@@ -718,6 +720,7 @@ namespace TextAdventures.Quest.EditorControls
                         }
                     }
 
+                    EnsureTextEditor();
                     PopulateCodeView();
                     SetCodeViewEditButtonsEnabled();
                 }
@@ -730,6 +733,22 @@ namespace TextAdventures.Quest.EditorControls
                 cmdAddScript.Visibility = value ? Visibility.Collapsed : Visibility.Visible;
                 ctlToolbar.IsCodeView = value;
             }
+        }
+
+        private void EnsureTextEditor()
+        {
+            if (textEditor != null) return;
+            textEditor = new TextEditor
+            {
+                FontFamily = new FontFamily("Consolas, Courier New"),
+                FontSize = 10.0 * 96.0 / 72.0,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                MaxHeight = 500,
+                SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("C#"),
+                IsReadOnly = m_readOnly
+            };
+            textEditorBorder.Child = textEditor;
         }
 
         private void PopulateCodeView()


### PR DESCRIPTION
Previously the TextEditor was declared in XAML, so every ScriptEditorControl (including those nested inside ScriptExpander for if/else and loop bodies) would instantiate an AvalonEdit instance and load the C# highlighting definition at parse time, even though the code view is collapsed by default and may never be used.

EnsureTextEditor() now creates the TextEditor on demand the first time code view is enabled, eliminating the overhead for functions that are only ever edited in block view.