### PR TITLE
Remove DotNetZip

### DIFF
--- a/PlayerController/GameLauncher.cs
+++ b/PlayerController/GameLauncher.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TextAdventures.Quest;
-using Ionic.Zip;
 using System.IO;
+using System.IO.Compression;
 using TextAdventures.Quest.LegacyASL;
 
 namespace TextAdventures.Quest
@@ -70,8 +70,7 @@ namespace TextAdventures.Quest
 
             tempDir = Path.Combine(Path.GetTempPath(), "Quest", Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempDir);
-            ZipFile zip = ZipFile.Read(zipFile);
-            zip.ExtractAll(tempDir);
+            ZipFile.ExtractToDirectory(zipFile, tempDir);
 
             return SearchForGameFile(tempDir, "aslx", "asl", "cas");
         }

--- a/PlayerController/PlayerController.csproj
+++ b/PlayerController/PlayerController.csproj
@@ -35,10 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip, Version=1.9.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.9.3\lib\net20\Ionic.Zip.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/PlayerController/packages.config
+++ b/PlayerController/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.9.3" targetFramework="net40-client" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
 </packages>

--- a/WebEditor/WebEditor/Controllers/EditController.cs
+++ b/WebEditor/WebEditor/Controllers/EditController.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Web;
 using System.Web.Mvc;
 using System.Configuration;
-using Ionic.Zip;
+using System.IO.Compression;
 using TextAdventures.Quest;
 using System.IO;
 using Azure.Storage.Blobs;
@@ -528,29 +528,22 @@ namespace WebEditor.Controllers
                 return HttpNotFound();
             }
 
-            var zip = new ZipFile();
-            var blobStreams = new List<MemoryStream>();
-
             var container = GetAzureBlobContainer("editorgames");
             var blobs = container.GetBlobs(prefix: uploadPath + "/");
-            foreach (var blobItem in blobs)
-            {
-                var blobClient = container.GetBlobClient(blobItem.Name);
-                var ms = new MemoryStream();
-                blobStreams.Add(ms);
-                blobClient.DownloadTo(ms);
-                ms.Position = 0;
-
-                zip.AddEntry(Path.GetFileName(blobItem.Name), ms);
-            }
 
             return new FileGeneratingResult("game.zip", "application/zip", stream =>
             {
-                using (zip)
+                using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
                 {
-                    zip.Save(stream);
+                    foreach (var blobItem in blobs)
+                    {
+                        var blobClient = container.GetBlobClient(blobItem.Name);
+                        using (var entryStream = archive.CreateEntry(Path.GetFileName(blobItem.Name)).Open())
+                        {
+                            blobClient.DownloadTo(entryStream);
+                        }
+                    }
                 }
-                foreach (var ms in blobStreams) ms.Dispose();
             });
         }
     }

--- a/WebEditor/WebEditor/WebEditor.csproj
+++ b/WebEditor/WebEditor/WebEditor.csproj
@@ -50,10 +50,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip, Version=1.9.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetZip.1.9.3\lib\net20\Ionic.Zip.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>

--- a/WebEditor/WebEditor/packages.config
+++ b/WebEditor/WebEditor/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.9.3" targetFramework="net45" />
   <package id="jQuery" version="2.1.4" targetFramework="net45" />
   <package id="jQuery.UI.Combined" version="1.8.11" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.14.0" targetFramework="net45" />

--- a/WorldModel/WorldModel/GameLoader/PackageReader.cs
+++ b/WorldModel/WorldModel/GameLoader/PackageReader.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
-using Ionic.Zip;
+using System.IO.Compression;
 
 namespace TextAdventures.Quest
 {
@@ -20,8 +20,7 @@ namespace TextAdventures.Quest
             ReadResult result = new ReadResult();
             string tempDir = Path.Combine(Path.GetTempPath(), "Quest", Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempDir);
-            ZipFile zip = ZipFile.Read(filename);
-            zip.ExtractAll(tempDir);
+            ZipFile.ExtractToDirectory(filename, tempDir);
 
             result.Folder = tempDir;
             result.GameFile = Path.Combine(tempDir, "game.aslx");

--- a/WorldModel/WorldModel/GameLoader/Packager.cs
+++ b/WorldModel/WorldModel/GameLoader/Packager.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Ionic.Zip;
 using System.IO;
+using System.IO.Compression;
 
 namespace TextAdventures.Quest
 {
@@ -25,9 +25,13 @@ namespace TextAdventures.Quest
                 string data = m_worldModel.Save(SaveMode.Package, includeWalkthrough);
                 string baseFolder = Path.GetDirectoryName(m_worldModel.Filename);
 
-                using (ZipFile zip = new ZipFile(Encoding.UTF8))
+                Stream zipStream = filename != null
+                    ? new FileStream(filename, FileMode.Create, FileAccess.Write)
+                    : outputStream;
+
+                using (var zip = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: filename == null))
                 {
-                    zip.AddEntry("game.aslx", data, Encoding.UTF8);
+                    AddStringEntry(zip, "game.aslx", data, Encoding.UTF8);
 
                     if (includeFiles == null)
                     {
@@ -36,28 +40,19 @@ namespace TextAdventures.Quest
 
                         foreach (var file in m_worldModel.GetAvailableExternalFiles(fileTypesToInclude))
                         {
-                            zip.AddFile(Path.Combine(baseFolder, file), "");
+                            zip.CreateEntryFromFile(Path.Combine(baseFolder, file), Path.GetFileName(file));
                         }
                     }
                     else
                     {
                         foreach (var file in includeFiles)
                         {
-                            zip.AddEntry(file.Filename, file.Content);
+                            AddStreamEntry(zip, file.Filename, file.Content);
                         }
                     }
-                    
+
                     AddLibraryResources(zip, baseFolder, ElementType.Javascript);
                     AddLibraryResources(zip, baseFolder, ElementType.Resource);
-
-                    if (filename != null)
-                    {
-                        zip.Save(filename);
-                    }
-                    else if (outputStream != null)
-                    {
-                        zip.Save(outputStream);
-                    }
                 }
             }
             catch (Exception ex)
@@ -69,7 +64,23 @@ namespace TextAdventures.Quest
             return true;
         }
 
-        private void AddLibraryResources(ZipFile zip, string baseFolder, ElementType elementType)
+        private static void AddStringEntry(ZipArchive zip, string name, string content, Encoding encoding)
+        {
+            using (var writer = new StreamWriter(zip.CreateEntry(name).Open(), encoding))
+            {
+                writer.Write(content);
+            }
+        }
+
+        private static void AddStreamEntry(ZipArchive zip, string name, Stream content)
+        {
+            using (var entryStream = zip.CreateEntry(name).Open())
+            {
+                content.CopyTo(entryStream);
+            }
+        }
+
+        private void AddLibraryResources(ZipArchive zip, string baseFolder, ElementType elementType)
         {
             foreach (Element e in m_worldModel.Elements.GetElements(elementType))
             {
@@ -79,7 +90,8 @@ namespace TextAdventures.Quest
                     libFolder = TextAdventures.Utility.Utility.RemoveFileColonPrefix(libFolder);
                     if (libFolder != baseFolder)
                     {
-                        zip.AddFile(Path.Combine(libFolder, e.Fields[FieldDefinitions.Src]), "");
+                        string src = e.Fields[FieldDefinitions.Src];
+                        zip.CreateEntryFromFile(Path.Combine(libFolder, src), Path.GetFileName(src));
                     }
                 }
             }

--- a/WorldModel/WorldModel/WorldModel.csproj
+++ b/WorldModel/WorldModel/WorldModel.csproj
@@ -69,10 +69,8 @@
     <Reference Include="Ciloci.Flee">
       <HintPath>..\..\Dependencies\Ciloci.Flee.dll</HintPath>
     </Reference>
-    <Reference Include="Ionic.Zip, Version=1.9.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetZip.1.9.3\lib\net20\Ionic.Zip.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/WorldModel/WorldModel/packages.config
+++ b/WorldModel/WorldModel/packages.config
@@ -1,4 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.9.3" targetFramework="net40-client" />
 </packages>


### PR DESCRIPTION
We were previously using DotNetZip, which is deprecated and has security vulnerabilities. Replace it with System.IO.Compression.