### PR TITLE
Fix inventory maxobjects limit not being enforced (#1614)

### DIFF
--- a/WorldModel/WorldModel/Core/CoreCommands.aslx
+++ b/WorldModel/WorldModel/Core/CoreCommands.aslx
@@ -186,6 +186,7 @@
           else {
             msg (prefix + DynamicTemplate("MaxObjectsInInventory", object))
           }
+          return (false)
         }
       }
     }


### PR DESCRIPTION
CheckLimits was printing the "max objects" message but missing return (false), causing the take action to succeed despite the limit being reached.

Thanks to @KVonGit for identifying the fix.