### PR TITLE
Fix NotImplementedException when editing SetTimeout/GetInput scripts …

### DIFF
--- a/EditorController/EditableScript.cs
+++ b/EditorController/EditableScript.cs
@@ -136,7 +136,9 @@ namespace TextAdventures.Quest
             {
                 if (index == "script")
                 {
-                    throw new NotImplementedException();
+                    FunctionCallScript.SetFunctionCallParameterScript(valueToSet as IScript);
+                    RaiseUpdated(new EditableScriptUpdatedEventArgs { IsNestedScriptUpdate = true });
+                    return;
                 }
                 FunctionCallScript.SetFunctionCallParameter(int.Parse(index), valueToSet);
                 return;

--- a/WorldModel/WorldModel/Scripts/FunctionCallScript.cs
+++ b/WorldModel/WorldModel/Scripts/FunctionCallScript.cs
@@ -278,5 +278,10 @@ namespace TextAdventures.Quest.Scripts
         {
             return m_paramFunction;
         }
+
+        public void SetFunctionCallParameterScript(IScript script)
+        {
+            m_paramFunction = script;
+        }
     }
 }

--- a/WorldModel/WorldModel/Scripts/IScript.cs
+++ b/WorldModel/WorldModel/Scripts/IScript.cs
@@ -72,6 +72,7 @@ namespace TextAdventures.Quest.Scripts
         object GetFunctionCallParameter(int index);
         void SetFunctionCallParameter(int index, object value);
         IScript GetFunctionCallParameterScript();
+        void SetFunctionCallParameterScript(IScript script);
         event EventHandler<ScriptUpdatedEventArgs> FunctionCallParametersUpdated;
     }
 


### PR DESCRIPTION
…with no body (#1578)

When a game file contained a function call like SetTimeout without braces, the editor would throw NotImplementedException attempting to set the script body via SetParameter. Implement SetFunctionCallParameterScript on FunctionCallScript and wire it up in EditableScript.SetParameter, raising an IsNestedScriptUpdate event to mark dirty without triggering a re-entrant RefreshScriptsList.