### PR TITLE
Fix race condition in ClearBuffer causing walkthrough crash (#1564)

### DIFF
--- a/Player/PlayerHTML.vb
+++ b/Player/PlayerHTML.vb
@@ -271,6 +271,7 @@ Public Class PlayerHTML
         If Not Me.IsHandleCreated Then Return
         ' copy m_buffer to a new list, in case invoking scripts cause new scripts to be added
         ' to the buffer.
+        Dim hasItems As Boolean
         Do
             Dim bufferCopy As List(Of Action)
             SyncLock m_buffer
@@ -280,7 +281,10 @@ Public Class PlayerHTML
             For Each script In bufferCopy
                 script.Invoke()
             Next
-        Loop Until Not m_buffer.Any()
+            SyncLock m_buffer
+                hasItems = m_buffer.Any()
+            End SyncLock
+        Loop Until Not hasItems
     End Sub
 
     Private Const k_scriptsPlaceholder As String = "<!-- EXTERNAL_SCRIPTS_PLACEHOLDER -->"


### PR DESCRIPTION
m_buffer.Any() was called outside SyncLock, allowing another thread to modify the collection mid-enumeration and throw InvalidOperationException.