### PR TITLE
Fix verb code view losing edits and not updating display on verb switch

### DIFF
--- a/EditorControls/ScriptEditorControl.xaml.cs
+++ b/EditorControls/ScriptEditorControl.xaml.cs
@@ -158,6 +158,12 @@ namespace TextAdventures.Quest.EditorControls
 
         public void Populate(IEditableScripts script)
         {
+            if (CodeView && textEditor != null && textEditor.IsModified && m_scripts != null)
+            {
+                m_scripts.Code = textEditor.Text;
+                textEditor.IsModified = false;
+            }
+
             if (m_scripts != null)
             {
                 m_scripts.Updated -= m_scripts_Updated;
@@ -184,6 +190,7 @@ namespace TextAdventures.Quest.EditorControls
             if (CodeView && textEditor.IsModified)
             {
                 m_scripts.Code = textEditor.Text;
+                textEditor.IsModified = false;
             }
 
             m_saving = true;

--- a/EditorControls/WFAttributesControl.cs
+++ b/EditorControls/WFAttributesControl.cs
@@ -357,6 +357,19 @@ namespace TextAdventures.Quest.EditorControls
 
         private void EditItem(string attribute)
         {
+            if (m_data != null)
+            {
+                ctlMultiControl.Save();
+                foreach (ListViewItem item in lstAttributes.Items)
+                {
+                    object value = m_data.GetAttribute(item.Name);
+                    if (value != null)
+                    {
+                        item.SubItems[1].Text = GetDisplayString(value);
+                    }
+                }
+            }
+
             if ((string.IsNullOrEmpty(attribute)))
             {
                 ctlMultiControl.Visible = false;


### PR DESCRIPTION
When switching verbs while in code view, unsaved script edits were discarded because Populate() replaced m_scripts before saving. The verb table also failed to refresh the edited verb's display string due to ctlMultiControl_Dirty using the newly selected verb's attribute instead of the one being saved.