### PR TITLE
Fix OutputTextRaw overriding custom command bar style settings (#1345)

### DIFF
--- a/PlayerController/playercore.js
+++ b/PlayerController/playercore.js
@@ -620,8 +620,14 @@ function disableInterface() {
 
 function setCommandBarStyle(style) {
     var width = $("#txtCommand").width();
+    var hidden = $("#txtCommand").is(":hidden") && $("#txtCommand").parent().is(":visible");
     $("#txtCommand").attr("style", style);
     $("#txtCommand").width(width);
+    if (hidden) {
+        $("#txtCommand").hide();
+    } else {
+        $("#txtCommand").show();
+    }
 }
 
 function addTextAndScroll(text) {

--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -23,11 +23,7 @@
   </function>
 
   <function name="GetCommandBarFormat" type="string">
-    format = GetCurrentTextFormat("") + ";background:" + game.defaultbackground
-    if (HasString(game, "overridecommandbarformat")) {
-      format = format + ";" + game.overridecommandbarformat
-    }
-    return (format)
+    return (GetCurrentTextFormat("") + ";background:" + game.defaultbackground)
   </function>
 
   <function name="OutputTextNoBr" parameters="text">

--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -9,17 +9,25 @@
     <![CDATA[
     format = GetCurrentTextFormat("")
     JS.addText("<span style=\"" + format + "\">" + text + "</span><br/>")
-    if (GetString(game, "commandbarformat") <> format) {
-      ResetCommandBarFormat
-    }
+    ResetCommandBarFormat
     RequestSpeak (text)
     ]]>
   </function>
 
   <function name="ResetCommandBarFormat">
+    format = GetCommandBarFormat()
+    if (GetString(game, "commandbarformat") <> format) {
+      game.commandbarformat = format
+      JS.setCommandBarStyle(format)
+    }
+  </function>
+
+  <function name="GetCommandBarFormat" type="string">
     format = GetCurrentTextFormat("") + ";background:" + game.defaultbackground
-    game.commandbarformat = format
-    JS.setCommandBarStyle(format)
+    if (HasString(game, "overridecommandbarformat")) {
+      format = format + ";" + game.overridecommandbarformat
+    }
+    return (format)
   </function>
 
   <function name="OutputTextNoBr" parameters="text">


### PR DESCRIPTION
## Summary
- `OutputTextRaw` was unconditionally resetting the command bar style via `ResetCommandBarFormat`, ignoring any custom styles applied to the command bar
- Extracted `GetCommandBarFormat` to centralise the format string calculation
- `ResetCommandBarFormat` now only calls into JS when the format has actually changed, avoiding unnecessary DOM updates
- `setCommandBarStyle` in JS now preserves the hidden/visible state of `#txtCommand`, preventing a style update from accidentally showing the input during a `wait`

## Test plan
- [ ] Verify command bar style updates correctly when game font/colour changes mid-game
- [ ] Verify command bar remains hidden during `wait` after text is output
- [ ] Verify custom CSS applied directly to `#txtCommand` is not wiped on next output

Closes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)