### PR TITLE
Fix Canvas2D willReadFrequently warning in paper.js (#1269)

### DIFF
--- a/PlayerController/paper.js
+++ b/PlayerController/paper.js
@@ -10668,7 +10668,7 @@ var CanvasProvider = {
 		} else {
 			canvas = document.createElement('canvas');
 		}
-		var ctx = canvas.getContext('2d');
+		var ctx = canvas.getContext('2d', {willReadFrequently: true});
 		if (canvas.width === width && canvas.height === height) {
 			if (init)
 				ctx.clearRect(0, 0, width + 1, height + 1);


### PR DESCRIPTION
## Summary

- Passes `willReadFrequently: true` when creating the 2D canvas context in `CanvasProvider.getCanvas` (`PlayerController/paper.js:10671`)
- Suppresses the browser dev-tools warning: *"Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true"*
- Identified and tested by @KVonGit in #1269 — map and all other functionality confirmed working after the change

## Test plan

- [ ] Load a game that uses the map feature and verify the Canvas2D warning no longer appears in browser dev tools
- [ ] Confirm map renders and behaves correctly
- [ ] Confirm no regressions in other canvas-based features

Closes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)