### PR TITLE
Fix GetScope using "object" instead of var when allow_all is true

### DIFF
--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -271,7 +271,7 @@
           if (result = null) {
             if (StartsWith(var, "object")) {
               if (GetBoolean(game.pov.currentcommandpattern, "allow_all")) {
-                scope = FilterByAttribute(GetScope("object", "", "object"), "scenery", false)
+                scope = FilterByAttribute(GetScope(var, "", "object"), "scenery", false)
                 game.pov.currentcommandpendingobjectscope = ListExclude(scope, FilterByAttribute(scope, "not_all", true))
                 game.pov.currentcommandpendingvariable = var
                 ResolveNameList (value, "object")


### PR DESCRIPTION
## Summary

Fixes #1641.

When a command uses `allow_all` with per-variable scoping (e.g. `<scope>object1=inventory|object2=notheld</scope>`), the `allow_all` code path in `ResolveNextName` was calling `GetScope("object", "", "object")` with the hard-coded string `"object"` rather than the actual variable name (`object1`, `object2`, etc.).

This meant `GetScoping` could never find a matching `object=` entry in the scope string and always fell back to `"all"`, ignoring the per-variable scoping entirely.

The fix is a one-character change: pass `var` (which already holds the correct variable name) instead of the literal `"object"`.

## Test plan

- [ ] Create a command with pattern `foo #object1# at #object2#`, `scope` set to `object1=inventory|object2=notheld`, and `allow_all` enabled
- [ ] Pick up an object; type `FOO ALL AT <room object>` — ALL should expand to inventory items only, not everything visible
- [ ] Verify `object2` also respects its own scope independently

🤖 Generated with [Claude Code](https://claude.ai/claude-code)