### PR TITLE
Update dependencies

### DIFF
--- a/src/WebPlayer/WebPlayer.csproj
+++ b/src/WebPlayer/WebPlayer.csproj
@@ -11,7 +11,8 @@
   </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.0.0" />
+      <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
+      <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes a vulnerability warning about `OpenTelemetry.Api`, which is a dependency of `Microsoft.ApplicationInsights.AspNetCore`.