### PR TITLE
WebEditor Phase 3: typed property editors with tab navigation

### DIFF
--- a/docs/webeditor-wasm-svelte.md
+++ b/docs/webeditor-wasm-svelte.md
@@ -174,7 +174,7 @@ The browser cannot read files from the local filesystem directly. Currently impl
 4. Tab navigation: tabs from the EditorDefinition are rendered as a tab bar; clicking a tab switches the visible controls
 5. `editor-store.ts` now exports `selectedData` (replacing `selectedAttributes`) and `setAttribute`
 
-Known limitations for this phase: control visibility conditions (`onlydisplayif`) are not evaluated — all controls are shown regardless of visibility. Live C#→JS events not yet implemented.
+Known limitations for this phase: live C#→JS events not yet implemented.
 
 ### Phase 4 — Script editor
 - Integrate Monaco or CodeMirror 6 for script attribute editing

--- a/docs/webeditor-wasm-svelte.md
+++ b/docs/webeditor-wasm-svelte.md
@@ -28,17 +28,38 @@ All data crossing the JS/WASM boundary is JSON. The Svelte layer calls `[JSExpor
 ```csharp
 [JSExport] Task<bool> Initialise(byte[] gameFileBytes, string filename)
 [JSExport] string     GetTreeNodes()           // JSON: List<{key, text, parent}>
-[JSExport] string?    GetEditorData(string key) // JSON: Dictionary<string, string?>
+[JSExport] string?    GetEditorData(string key) // JSON: EditorDataResponse (see below)
+[JSExport] string     SetAttribute(string elementKey, string attribute, string controlType, string value)
 [JSExport] string     Save()                   // returns XML
 [JSExport] void       Undo()
 [JSExport] void       Redo()
 ```
 
-Tree nodes are collected during `Initialise` by subscribing to `EditorController.AddedNode`, then returned as a flat list via `GetTreeNodes()`. `GetEditorData` uses `IEditorDataExtendedAttributeInfo` to enumerate attributes for a given element key.
+`GetEditorData` returns an `EditorDataResponse`:
+```json
+{
+  "attributes": { "name": "My Room", "alias": null, ... },
+  "tabs": [
+    {
+      "caption": "Setup",
+      "controls": [
+        { "attribute": "name", "controlType": "textbox", "caption": "Name", "options": null },
+        { "attribute": "enabled", "controlType": "checkbox", "caption": "Enabled", "options": null },
+        { "attribute": "direction", "controlType": "dropdown", "caption": "Direction",
+          "options": [{ "value": "north", "label": "north" }, ...] }
+      ]
+    }
+  ],
+  "controls": []
+}
+```
+
+`SetAttribute` converts `value` (always a string) to the correct .NET type based on `controlType` (`checkbox` → `bool`, `number` → `int`, `numberdouble` → `double`, otherwise `string`), wraps in a transaction for undo support, and returns `"ok"` or an error message.
+
+Tree nodes are collected during `Initialise` by subscribing to `EditorController.AddedNode`, then returned as a flat list via `GetTreeNodes()`.
 
 ### Not yet implemented
 
-- `SetAttribute` — needed for any editing; blocked on Phase 3
 - Live JS callbacks (JSImport) — events currently captured into C# state at init time rather than pushed to JS as they occur
 
 ### Supporting types
@@ -80,11 +101,11 @@ src/WebEditor/
 │   ├── lib/
 │   │   ├── wasm.ts         # loads dotnet.js, exposes WasmBridge
 │   │   ├── editor-store.ts # Svelte stores + wrappers for all WASM calls
-│   │   └── types.ts        # TreeNode, ElementAttributes
+│   │   └── types.ts        # TreeNode, ControlInfo, TabInfo, EditorDataResponse
 │   ├── components/
 │   │   ├── Toolbar.svelte         # AppBar: title, filename, undo/redo/save
 │   │   ├── TreePanel.svelte       # Skeleton TreeView (flat→hierarchy conversion)
-│   │   └── PropertyEditor.svelte  # Raw attribute grid (placeholder)
+│   │   └── PropertyEditor.svelte  # Typed controls with tab navigation
 │   └── routes/
 │       ├── +layout.svelte  # imports app.css
 │       ├── +layout.ts      # prerendering config
@@ -143,15 +164,17 @@ The browser cannot read files from the local filesystem directly. Currently impl
 - Toolbar: save (file download), undo, redo
 - Skeleton UI v4 + Tailwind CSS 4 + ESLint configured
 
-### Phase 3 — Property editors (next)
+### Phase 3 — Property editors ✅
 
-The current `PropertyEditor` is a raw key/value dump. Phase 3 replaces it with proper typed controls.
+`PropertyEditor` replaced with typed controls and tab navigation:
 
-Steps:
-1. Implement `SetAttribute(string element, string attribute, string jsonValue)` in `WasmEditorBridge`
-2. Extend `GetEditorData` response to include the EditorCore control type for each attribute (dropdown, textbox, checkbox, script, etc.)
-3. Map each control type to a Svelte component in `PropertyEditor`
-4. Two-way binding: editing a control → `SetAttribute` → refresh affected state
+1. `SetAttribute(elementKey, attribute, controlType, value)` added to `WasmEditorBridge` — type-converts `value` based on `controlType`, wraps in undo transaction
+2. `GetEditorData` extended to return `EditorDataResponse` with `attributes`, `tabs`, and `controls` — each control carries `controlType`, `caption`, and `options` (for dropdowns)
+3. `PropertyEditor.svelte` maps `controlType` to inputs: `textbox`/`richtext` → text input, `checkbox` → checkbox, `number`/`numberdouble` → number input, `dropdown` → select with options, `script` → Phase 4 placeholder, others → read-only display
+4. Tab navigation: tabs from the EditorDefinition are rendered as a tab bar; clicking a tab switches the visible controls
+5. `editor-store.ts` now exports `selectedData` (replacing `selectedAttributes`) and `setAttribute`
+
+Known limitations for this phase: control visibility conditions (`onlydisplayif`) are not evaluated — all controls are shown regardless of visibility. Live C#→JS events not yet implemented.
 
 ### Phase 4 — Script editor
 - Integrate Monaco or CodeMirror 6 for script attribute editing

--- a/docs/webeditor-wasm-svelte.md
+++ b/docs/webeditor-wasm-svelte.md
@@ -140,10 +140,38 @@ The browser cannot read files from the local filesystem directly. Currently impl
 - JS reads it as `ArrayBuffer`, converts to `Uint8Array`, passes to `Initialise`
 - Save triggers a download via a temporary `<a>` with an object URL
 
-**Option B (future)** — OPFS (Origin Private File System)
-- Game files live in the browser's private storage
-- Read/write without prompts after initial import
-- Enables auto-save
+**Option B (future)** — File System Access API + OPFS
+- Chrome/Edge: use `showOpenFilePicker` / `showSaveFilePicker` for direct read/write to the user's real files without a download prompt; store recent file handles in IndexedDB for "recent files"
+- Safari/Firefox: fall back to `<input type="file">` open + download save (no persistent handle)
+- Consider using [`browser-fs-access`](https://github.com/GoogleChromeLabs/browser-fs-access) (Google Chrome Labs, ~5KB) rather than hand-rolling the feature detection — the Squiffy editor has already done this (see [squiffy#215](https://github.com/textadventures/squiffy/issues/215))
+- OPFS (Origin Private File System) for auto-save: supported on Chrome, Safari 15.2+, Firefox 111+; game files live in browser private storage with no prompts after initial import
+
+**Option C (future)** — Asset storage for images
+- Images referenced in game files need to survive across sessions and be resolvable during preview
+- Store blobs in OPFS (preferred over raw IndexedDB for binary assets)
+- A Service Worker intercepts requests for asset URLs during preview and serves from OPFS
+- This avoids needing a server round-trip for user-uploaded images
+
+**Option D (future)** — Electron wrapper
+- Electron exposes Node.js `fs` to the renderer via `contextBridge`
+- A thin adapter (~20 lines) behind a common `FileAdapter` interface would allow the same Svelte code to work in both browser PWA and Electron
+- See shared adapter design below
+
+**Shared filesystem adapter** (future, coordinate with Squiffy)
+
+Both Quest WebEditor and Squiffy face the same three-tier file system problem (File System Access API → OPFS → Electron `fs`). The intent is to extract a shared TypeScript package rather than duplicate the pattern. Proposed interface:
+
+```typescript
+interface FileAdapter {
+  openFile(opts?: OpenOptions): Promise<FileContent | null>
+  saveFile(data: Uint8Array | string): Promise<boolean>
+  saveFileAs(data: Uint8Array | string, suggestedName?: string): Promise<boolean>
+  putAsset(key: string, data: Blob): Promise<void>
+  getAsset(key: string): Promise<Blob | null>
+}
+```
+
+Factory functions: `createBrowserAdapter()`, `createOPFSAdapter()`, `createElectronAdapter()`.
 
 ---
 
@@ -183,7 +211,8 @@ Known limitations for this phase: live C#→JS events not yet implemented.
 ### Phase 5 — Full feature parity
 - New game (from templates)
 - Publish/export
-- OPFS persistence
+- File System Access API + OPFS persistence (see File handling section)
+- Asset storage for images via OPFS + Service Worker
 - Test suite for the WASM bridge
 
 ---
@@ -194,3 +223,5 @@ Known limitations for this phase: live C#→JS events not yet implemented.
 - **Live C# → JS events**: Currently tree state is snapshot-based (collected at init). As editing adds/removes/renames nodes, the bridge will need to push updates to JS rather than relying on a full re-fetch.
 - **Build integration**: Should `WasmEditor` output be served by `WebPlayer` (embedded SPA) or deployed separately?
 - **Auth / server-side storage**: Is cloud save in scope? Affects whether the editor stays purely client-side.
+- **Shared filesystem adapter**: Extract a common `FileAdapter` TypeScript package shared with Squiffy (see File handling section and [squiffy#215](https://github.com/textadventures/squiffy/issues/215)).
+- **Electron wrapper**: Both Quest and Squiffy editors are candidates for an Electron app. The `FileAdapter` interface is the seam; `createElectronAdapter()` would be a thin IPC shim. Decide whether to build one Electron shell that hosts both, or separate apps.

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -963,6 +963,11 @@ namespace QuestViva.EditorCore
             return m_worldModel.UndoLogger.UndoList();
         }
 
+        public IEnumerable<string> GetRedoItems()
+        {
+            return m_worldModel.UndoLogger.RedoList();
+        }
+
         internal EditableScriptFactory ScriptFactory
         {
             get { return m_editableScriptFactory; }

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -206,7 +206,7 @@ public partial class WorldModel : IGame, IGameDebug
 
     public void Print(string text, bool linebreak = true)
     {
-        if (Version >= WorldModelVersion.v540 && Elements.ContainsKey(ElementType.Function, "OutputText"))
+        if (!EditMode && Version >= WorldModelVersion.v540 && Elements.ContainsKey(ElementType.Function, "OutputText"))
         {
             try
             {
@@ -217,7 +217,7 @@ public partial class WorldModel : IGame, IGameDebug
                 LogException(ex);
             }
         }
-        else
+        else if (!EditMode)
         {
             if (PrintText != null)
             {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -10,10 +11,14 @@ using QuestViva.EditorCore;
 namespace QuestViva.WasmEditor;
 
 internal record TreeNodeData(string Key, string Text, string? Parent);
+internal record ControlOption(string Value, string Label);
+internal record ControlInfo(string? Attribute, string ControlType, string? Caption, List<ControlOption>? Options);
+internal record TabInfo(string? Caption, List<ControlInfo> Controls);
+internal record EditorDataResponse(Dictionary<string, string?> Attributes, List<TabInfo> Tabs, List<ControlInfo> Controls);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
-[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(EditorDataResponse))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext { }
 
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
@@ -47,7 +52,8 @@ public partial class WasmEditorBridge
     [JSExport]
     public static string? GetEditorData(string key)
     {
-        var data = _controller?.GetEditorData(key);
+        if (_controller == null) return null;
+        var data = _controller.GetEditorData(key);
         if (data is not IEditorDataExtendedAttributeInfo extended) return null;
 
         var attrs = new Dictionary<string, string?>();
@@ -55,7 +61,47 @@ public partial class WasmEditorBridge
         {
             attrs[attr.AttributeName] = data.GetAttribute(attr.AttributeName)?.ToString();
         }
-        return JsonSerializer.Serialize(attrs, WasmEditorJsonContext.Default.DictionaryStringString);
+
+        var tabs = new List<TabInfo>();
+        var topControls = new List<ControlInfo>();
+
+        var editorName = _controller.GetElementEditorName(key);
+        if (editorName != null)
+        {
+            var def = _controller.GetEditorDefinition(editorName);
+            foreach (var tab in def.Tabs.Values)
+            {
+                tabs.Add(new TabInfo(tab.Caption, tab.Controls.Select(ToControlInfo).ToList()));
+            }
+            topControls.AddRange(def.Controls.Select(ToControlInfo));
+        }
+
+        return JsonSerializer.Serialize(
+            new EditorDataResponse(attrs, tabs, topControls),
+            WasmEditorJsonContext.Default.EditorDataResponse);
+    }
+
+    [JSExport]
+    public static string SetAttribute(string elementKey, string attribute, string controlType, string value)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        object typedValue = controlType switch
+        {
+            "checkbox" => bool.Parse(value),
+            "number" => int.TryParse(value, out var i) ? (object)i : value,
+            "numberdouble" => double.TryParse(value, System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture, out var d) ? (object)d : value,
+            _ => value
+        };
+
+        _controller.StartTransaction($"Set {attribute}");
+        var result = data.SetAttribute(attribute, typedValue);
+        _controller.EndTransaction();
+
+        return result.Valid ? "ok" : result.Message.ToString();
     }
 
     [JSExport]
@@ -70,5 +116,27 @@ public partial class WasmEditorBridge
     private static void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e)
     {
         TreeNodes.Add(new TreeNodeData(e.Key, e.Text, e.Parent));
+    }
+
+    private static ControlInfo ToControlInfo(IEditorControl ctrl)
+    {
+        List<ControlOption>? options = null;
+        if (ctrl.ControlType == "dropdown")
+        {
+            var list = ctrl.GetListString("validvalues");
+            if (list != null)
+            {
+                options = list.Select(v => new ControlOption(v, v)).ToList();
+            }
+            else
+            {
+                var dict = ctrl.GetDictionary("validvalues");
+                if (dict != null)
+                {
+                    options = dict.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
+                }
+            }
+        }
+        return new ControlInfo(ctrl.Attribute, ctrl.ControlType, ctrl.Caption, options);
     }
 }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -76,9 +76,14 @@ public partial class WasmEditorBridge
             var def = _controller.GetEditorDefinition(editorName);
             foreach (var tab in def.Tabs.Values)
             {
-                tabs.Add(new TabInfo(tab.Caption, tab.Controls.Select(ToControlInfo).ToList()));
+                if (!tab.IsTabVisible(data)) continue;
+                var visibleControls = tab.Controls.Where(c => c.IsControlVisible(data)).ToList();
+                AddDropdownTypeValues(attrs, visibleControls, key);
+                tabs.Add(new TabInfo(tab.Caption, visibleControls.Select(ToControlInfo).ToList()));
             }
-            topControls.AddRange(def.Controls.Select(ToControlInfo));
+            var visibleTopControls = def.Controls.Where(c => c.IsControlVisible(data)).ToList();
+            AddDropdownTypeValues(attrs, visibleTopControls, key);
+            topControls.AddRange(visibleTopControls.Select(ToControlInfo));
         }
 
         return JsonSerializer.Serialize(
@@ -137,6 +142,49 @@ public partial class WasmEditorBridge
         _controller.Redo();
     }
 
+    [JSExport]
+    public static string SetDropdownType(string elementKey, string controlId, string selectedType)
+    {
+        if (_controller == null) return "error";
+        var editorName = _controller.GetElementEditorName(elementKey);
+        if (editorName == null) return "error";
+        var def = _controller.GetEditorDefinition(editorName);
+
+        var ctrl = def.Tabs.Values.SelectMany(t => t.Controls)
+            .Concat(def.Controls)
+            .FirstOrDefault(c => c.Id == controlId);
+        if (ctrl == null) return "error";
+
+        var types = ctrl.GetDictionary("types");
+        if (types == null) return "error";
+
+        _controller.StartTransaction($"Set type");
+        try
+        {
+            foreach (var typeName in types.Keys.Where(k => k != "*"))
+            {
+                if (_controller.DoesElementInheritType(elementKey, typeName))
+                    _controller.RemoveInheritedTypeFromElement(elementKey, typeName, false);
+            }
+            if (selectedType != "*")
+            {
+                var result = _controller.AddInheritedTypeToElement(elementKey, selectedType, false);
+                if (!result.Valid) return result.Message.ToString();
+            }
+            return "ok";
+        }
+        finally
+        {
+            _controller.EndTransaction();
+        }
+    }
+
+    private static void AddDropdownTypeValues(Dictionary<string, string?> attrs, List<IEditorControl> controls, string elementKey)
+    {
+        foreach (var ctrl in controls.Where(c => c.ControlType == "dropdowntypes"))
+            attrs[ctrl.Id] = _controller!.GetSelectedDropDownType(ctrl, elementKey);
+    }
+
     private static void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e)
     {
         TreeNodes.Add(new TreeNodeData(e.Key, e.Text, e.Parent));
@@ -145,6 +193,8 @@ public partial class WasmEditorBridge
     private static ControlInfo ToControlInfo(IEditorControl ctrl)
     {
         List<ControlOption>? options = null;
+        string? attribute = ctrl.Attribute;
+
         if (ctrl.ControlType == "dropdown")
         {
             var list = ctrl.GetListString("validvalues");
@@ -161,6 +211,14 @@ public partial class WasmEditorBridge
                 }
             }
         }
-        return new ControlInfo(ctrl.Attribute, ctrl.ControlType, ctrl.Caption, options);
+        else if (ctrl.ControlType == "dropdowntypes")
+        {
+            var dict = ctrl.GetDictionary("types");
+            if (dict != null)
+                options = dict.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
+            attribute = ctrl.Id;
+        }
+
+        return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption, options);
     }
 }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -38,6 +38,11 @@ public partial class WasmEditorBridge
         _controller.BeginTreeUpdate += (_, _) => { };
         _controller.EndTreeUpdate += (_, _) => { };
         _controller.AddedNode += OnAddedNode;
+        // RetitledNode and RemovedNode are called without null guards in EditorController,
+        // so they must be subscribed even if we don't act on them yet.
+        _controller.RetitledNode += (_, _) => { };
+        _controller.RemovedNode += (_, _) => { };
+        _controller.RenamedNode += (_, _) => { };
 
         var provider = new ByteArrayGameDataProvider(gameFileBytes, filename);
         var ok = await _controller.Initialise(new WasmConfig(), provider);
@@ -98,20 +103,39 @@ public partial class WasmEditorBridge
         };
 
         _controller.StartTransaction($"Set {attribute}");
-        var result = data.SetAttribute(attribute, typedValue);
-        _controller.EndTransaction();
-
-        return result.Valid ? "ok" : result.Message.ToString();
+        try
+        {
+            var result = data.SetAttribute(attribute, typedValue);
+            return result.Valid ? "ok" : result.Message.ToString();
+        }
+        finally
+        {
+            _controller.EndTransaction();
+        }
     }
 
     [JSExport]
     public static string Save() => _controller?.Save() ?? string.Empty;
 
     [JSExport]
-    public static void Undo() => _controller?.Undo();
+    public static bool CanUndo() => _controller?.GetUndoItems().Any() ?? false;
 
     [JSExport]
-    public static void Redo() => _controller?.Redo();
+    public static bool CanRedo() => _controller?.GetRedoItems().Any() ?? false;
+
+    [JSExport]
+    public static void Undo()
+    {
+        if (_controller == null || !_controller.GetUndoItems().Any()) return;
+        _controller.Undo();
+    }
+
+    [JSExport]
+    public static void Redo()
+    {
+        if (_controller == null || !_controller.GetRedoItems().Any()) return;
+        _controller.Redo();
+    }
 
     private static void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e)
     {

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectedKey, selectedData, setAttribute } from "$lib/editor-store";
+    import { selectedKey, selectedData, setAttribute, setDropdownType } from "$lib/editor-store";
     import type { ControlInfo } from "$lib/types";
 
     let activeTab = $state<string | null>(null);
@@ -135,6 +135,16 @@
                     class="select text-xs py-0.5 px-1.5 w-full"
                     value={attrValue(ctrl.attribute) ?? ""}
                     onchange={(e) => onDropdownChange(ctrl.attribute!, (e.target as HTMLSelectElement).value)}
+                >
+                    {#each ctrl.options as opt, oi (oi)}
+                        <option value={opt.value}>{opt.label}</option>
+                    {/each}
+                </select>
+            {:else if ctrl.controlType === "dropdowntypes" && ctrl.options && ctrl.attribute}
+                <select
+                    class="select text-xs py-0.5 px-1.5 w-full"
+                    value={attrValue(ctrl.attribute) ?? "*"}
+                    onchange={(e) => $selectedKey && setDropdownType($selectedKey, ctrl.attribute!, (e.target as HTMLSelectElement).value)}
                 >
                     {#each ctrl.options as opt, oi (oi)}
                         <option value={opt.value}>{opt.label}</option>

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -3,13 +3,20 @@
     import type { ControlInfo } from "$lib/types";
 
     let activeTab = $state<string | null>(null);
+    let lastKey = $state<string | null>(null);
 
     $effect(() => {
+        const key = $selectedKey;
         const data = $selectedData;
-        if (data && data.tabs.length > 0) {
-            activeTab = data.tabs[0].caption;
+        if (key !== lastKey) {
+            lastKey = key;
+            activeTab = (data && data.tabs.length > 0) ? data.tabs[0].caption : null;
+        } else if (activeTab !== null) {
+            // Keep activeTab valid after a data refresh (tab list is stable for the same node)
+            const stillExists = data?.tabs.some(t => t.caption === activeTab);
+            if (!stillExists) activeTab = (data && data.tabs.length > 0) ? data.tabs[0].caption : null;
         } else {
-            activeTab = null;
+            activeTab = (data && data.tabs.length > 0) ? data.tabs[0].caption : null;
         }
     });
 

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -1,5 +1,57 @@
 <script lang="ts">
-    import { selectedKey, selectedAttributes } from "$lib/editor-store";
+    import { selectedKey, selectedData, setAttribute } from "$lib/editor-store";
+    import type { ControlInfo } from "$lib/types";
+
+    let activeTab = $state<string | null>(null);
+
+    $effect(() => {
+        const data = $selectedData;
+        if (data && data.tabs.length > 0) {
+            activeTab = data.tabs[0].caption;
+        } else {
+            activeTab = null;
+        }
+    });
+
+    function onTextChange(attribute: string, controlType: string, value: string) {
+        if ($selectedKey) setAttribute($selectedKey, attribute, controlType, value);
+    }
+
+    function onCheckboxChange(attribute: string, checked: boolean) {
+        if ($selectedKey) setAttribute($selectedKey, attribute, "checkbox", checked.toString());
+    }
+
+    function onNumberChange(attribute: string, controlType: string, value: string) {
+        if ($selectedKey) setAttribute($selectedKey, attribute, controlType, value);
+    }
+
+    function onDropdownChange(attribute: string, value: string) {
+        if ($selectedKey) setAttribute($selectedKey, attribute, "dropdown", value);
+    }
+
+    function getControlsForView(): ControlInfo[] {
+        const data = $selectedData;
+        if (!data) return [];
+        if (data.tabs.length > 0) {
+            return data.tabs.find(t => t.caption === activeTab)?.controls ?? [];
+        }
+        return data.controls;
+    }
+
+    function attrValue(attribute: string): string | null {
+        return $selectedData?.attributes[attribute] ?? null;
+    }
+
+    function boolValue(attribute: string): boolean {
+        const v = attrValue(attribute);
+        return v === "True" || v === "true";
+    }
+
+    function tabClass(caption: string | null): string {
+        return activeTab === caption
+            ? "px-3 py-1.5 text-xs whitespace-nowrap transition-colors text-primary-600-400 border-b-2 border-primary-500 font-medium"
+            : "px-3 py-1.5 text-xs whitespace-nowrap transition-colors text-surface-500-400 hover:text-surface-900-100";
+    }
 </script>
 
 <div class="flex flex-col flex-1 bg-surface-50-950 overflow-hidden">
@@ -9,24 +61,98 @@
 
     {#if $selectedKey === null}
         <p class="px-3 py-4 text-sm text-surface-400-500">Select an object to view its properties.</p>
-    {:else if $selectedAttributes === null}
+    {:else if $selectedData === null}
         <p class="px-3 py-4 text-sm text-surface-400-500">No properties available.</p>
     {:else}
-        <div class="grid grid-cols-2 px-3 py-1 text-xs font-semibold text-surface-500-400 bg-surface-100-900 border-b border-surface-200-800">
-            <span>Attribute</span>
-            <span>Value</span>
-        </div>
+        {#if $selectedData.tabs.length > 0}
+            <div class="flex border-b border-surface-200-800 bg-surface-100-900 overflow-x-auto flex-shrink-0">
+                {#each $selectedData.tabs as tab, ti (ti)}
+                    <button
+                        type="button"
+                        class={tabClass(tab.caption)}
+                        onclick={() => { activeTab = tab.caption; }}
+                    >
+                        {tab.caption ?? "Tab"}
+                    </button>
+                {/each}
+            </div>
+        {/if}
+
         <div class="flex-1 overflow-y-auto">
-            {#each Object.entries($selectedAttributes) as [attr, value] (attr)}
-                <div class="grid grid-cols-2 px-3 py-1 text-sm border-b border-surface-100-900 hover:bg-surface-100-900">
-                    <span class="text-surface-600-400 overflow-hidden text-ellipsis whitespace-nowrap" title={attr}>{attr}</span>
-                    {#if value !== null}
-                        <span class="overflow-hidden text-ellipsis whitespace-nowrap" title={value}>{value}</span>
-                    {:else}
-                        <em class="text-surface-400-500">null</em>
-                    {/if}
-                </div>
+            {#each getControlsForView() as ctrl, i (i)}
+                {@render controlRow(ctrl)}
             {/each}
         </div>
     {/if}
 </div>
+
+{#snippet controlRow(ctrl: ControlInfo)}
+    {#if ctrl.controlType === "title"}
+        <div class="px-3 pt-3 pb-1 text-xs font-semibold text-surface-500-400 uppercase tracking-wide">
+            {ctrl.caption ?? ""}
+        </div>
+    {:else if ctrl.controlType === "label"}
+        <div class="px-3 py-1 text-xs text-surface-500-400 italic">
+            {ctrl.caption ?? ""}
+        </div>
+    {:else if ctrl.attribute !== null}
+        <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900 hover:bg-surface-100-900 min-h-8">
+            <span class="text-xs text-surface-600-400 w-32 flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap" title={ctrl.caption ?? ctrl.attribute}>
+                {ctrl.caption ?? ctrl.attribute}
+            </span>
+
+            {#if ctrl.controlType === "checkbox"}
+                <input
+                    type="checkbox"
+                    class="checkbox"
+                    checked={boolValue(ctrl.attribute)}
+                    onchange={(e) => onCheckboxChange(ctrl.attribute!, (e.target as HTMLInputElement).checked)}
+                />
+            {:else if ctrl.controlType === "number"}
+                <input
+                    type="number"
+                    class="input text-xs py-0.5 px-1.5 w-full"
+                    value={attrValue(ctrl.attribute) ?? ""}
+                    onchange={(e) => onNumberChange(ctrl.attribute!, "number", (e.target as HTMLInputElement).value)}
+                />
+            {:else if ctrl.controlType === "numberdouble"}
+                <input
+                    type="number"
+                    step="any"
+                    class="input text-xs py-0.5 px-1.5 w-full"
+                    value={attrValue(ctrl.attribute) ?? ""}
+                    onchange={(e) => onNumberChange(ctrl.attribute!, "numberdouble", (e.target as HTMLInputElement).value)}
+                />
+            {:else if ctrl.controlType === "dropdown" && ctrl.options}
+                <select
+                    class="select text-xs py-0.5 px-1.5 w-full"
+                    value={attrValue(ctrl.attribute) ?? ""}
+                    onchange={(e) => onDropdownChange(ctrl.attribute!, (e.target as HTMLSelectElement).value)}
+                >
+                    {#each ctrl.options as opt, oi (oi)}
+                        <option value={opt.value}>{opt.label}</option>
+                    {/each}
+                </select>
+            {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
+                <input
+                    type="text"
+                    class="input text-xs py-0.5 px-1.5 w-full"
+                    value={attrValue(ctrl.attribute) ?? ""}
+                    onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value)}
+                />
+            {:else if ctrl.controlType === "script"}
+                <button type="button" class="btn btn-sm preset-outlined text-xs py-0.5" disabled>
+                    Script editor (Phase 4)
+                </button>
+            {:else}
+                {#if attrValue(ctrl.attribute) !== null}
+                    <span class="text-xs overflow-hidden text-ellipsis whitespace-nowrap" title={attrValue(ctrl.attribute) ?? ""}>
+                        {attrValue(ctrl.attribute)}
+                    </span>
+                {:else}
+                    <em class="text-xs text-surface-400-500">null</em>
+                {/if}
+            {/if}
+        </div>
+    {/if}
+{/snippet}

--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { AppBar } from "@skeletonlabs/skeleton-svelte";
-    import { gameFilename, saveGame, undo, redo } from "$lib/editor-store";
+    import { gameFilename, saveGame, undo, redo, canUndo, canRedo } from "$lib/editor-store";
 
     function handleSave() {
         const xml = saveGame();
@@ -24,8 +24,8 @@
         </AppBar.Lead>
         <AppBar.Trail>
             <div class="flex gap-2">
-                <button type="button" class="btn btn-sm preset-outlined" onclick={undo} title="Undo">↩ Undo</button>
-                <button type="button" class="btn btn-sm preset-outlined" onclick={redo} title="Redo">↪ Redo</button>
+                <button type="button" class="btn btn-sm preset-outlined" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
+                <button type="button" class="btn btn-sm preset-outlined" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
                 <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleSave} title="Save">💾 Save</button>
             </div>
         </AppBar.Trail>

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -46,6 +46,14 @@ export function setAttribute(elementKey: string, attribute: string, controlType:
     return result;
 }
 
+export function setDropdownType(elementKey: string, controlId: string, selectedType: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetDropdownType(elementKey, controlId, selectedType);
+    refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
 export function saveGame(): string {
     return _bridge?.Save() ?? "";
 }

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -1,7 +1,7 @@
 import { writable } from "svelte/store";
 import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
-import type { TreeNode, ElementAttributes } from "./types";
+import type { TreeNode, EditorDataResponse } from "./types";
 
 let _bridge: WasmBridge | null = null;
 
@@ -9,7 +9,7 @@ export const isLoaded = writable(false);
 export const gameFilename = writable<string | null>(null);
 export const treeNodes = writable<TreeNode[]>([]);
 export const selectedKey = writable<string | null>(null);
-export const selectedAttributes = writable<ElementAttributes | null>(null);
+export const selectedData = writable<EditorDataResponse | null>(null);
 
 export async function openGame(file: File): Promise<boolean> {
     const bytes = new Uint8Array(await file.arrayBuffer());
@@ -27,7 +27,12 @@ export function selectNode(key: string) {
     if (!_bridge) return;
     selectedKey.set(key);
     const json = _bridge.GetEditorData(key);
-    selectedAttributes.set(json ? JSON.parse(json) : null);
+    selectedData.set(json ? JSON.parse(json) : null);
+}
+
+export function setAttribute(elementKey: string, attribute: string, controlType: string, value: string): string {
+    if (!_bridge) return "error";
+    return _bridge.SetAttribute(elementKey, attribute, controlType, value);
 }
 
 export function saveGame(): string {

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -41,6 +41,7 @@ export function selectNode(key: string) {
 export function setAttribute(elementKey: string, attribute: string, controlType: string, value: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SetAttribute(elementKey, attribute, controlType, value);
+    refreshSelectedData();
     refreshUndoRedo();
     return result;
 }

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -1,4 +1,4 @@
-import { writable } from "svelte/store";
+import { writable, get } from "svelte/store";
 import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
 import type { TreeNode, EditorDataResponse } from "./types";
@@ -10,6 +10,13 @@ export const gameFilename = writable<string | null>(null);
 export const treeNodes = writable<TreeNode[]>([]);
 export const selectedKey = writable<string | null>(null);
 export const selectedData = writable<EditorDataResponse | null>(null);
+export const canUndo = writable(false);
+export const canRedo = writable(false);
+
+function refreshUndoRedo() {
+    canUndo.set(_bridge?.CanUndo() ?? false);
+    canRedo.set(_bridge?.CanRedo() ?? false);
+}
 
 export async function openGame(file: File): Promise<boolean> {
     const bytes = new Uint8Array(await file.arrayBuffer());
@@ -19,6 +26,7 @@ export async function openGame(file: File): Promise<boolean> {
         treeNodes.set(JSON.parse(_bridge.GetTreeNodes()));
         isLoaded.set(true);
         gameFilename.set(file.name);
+        refreshUndoRedo();
     }
     return ok;
 }
@@ -32,7 +40,9 @@ export function selectNode(key: string) {
 
 export function setAttribute(elementKey: string, attribute: string, controlType: string, value: string): string {
     if (!_bridge) return "error";
-    return _bridge.SetAttribute(elementKey, attribute, controlType, value);
+    const result = _bridge.SetAttribute(elementKey, attribute, controlType, value);
+    refreshUndoRedo();
+    return result;
 }
 
 export function saveGame(): string {
@@ -41,8 +51,19 @@ export function saveGame(): string {
 
 export function undo() {
     _bridge?.Undo();
+    refreshSelectedData();
+    refreshUndoRedo();
 }
 
 export function redo() {
     _bridge?.Redo();
+    refreshSelectedData();
+    refreshUndoRedo();
+}
+
+function refreshSelectedData() {
+    const key = get(selectedKey);
+    if (!_bridge || !key) return;
+    const json = _bridge.GetEditorData(key);
+    selectedData.set(json ? JSON.parse(json) : null);
 }

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -4,4 +4,25 @@ export interface TreeNode {
   parent: string | null
 }
 
-export type ElementAttributes = Record<string, string | null>
+export interface ControlOption {
+  value: string
+  label: string
+}
+
+export interface ControlInfo {
+  attribute: string | null
+  controlType: string
+  caption: string | null
+  options: ControlOption[] | null
+}
+
+export interface TabInfo {
+  caption: string | null
+  controls: ControlInfo[]
+}
+
+export interface EditorDataResponse {
+  attributes: Record<string, string | null>
+  tabs: TabInfo[]
+  controls: ControlInfo[]
+}

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -2,6 +2,7 @@ export interface WasmBridge {
   Initialise(bytes: Uint8Array, filename: string): Promise<boolean>
   GetTreeNodes(): string
   GetEditorData(key: string): string | null
+  SetAttribute(elementKey: string, attribute: string, controlType: string, value: string): string
   Save(): string
   Undo(): void
   Redo(): void

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -3,6 +3,7 @@ export interface WasmBridge {
   GetTreeNodes(): string
   GetEditorData(key: string): string | null
   SetAttribute(elementKey: string, attribute: string, controlType: string, value: string): string
+  SetDropdownType(elementKey: string, controlId: string, selectedType: string): string
   Save(): string
   CanUndo(): boolean
   CanRedo(): boolean

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -4,6 +4,8 @@ export interface WasmBridge {
   GetEditorData(key: string): string | null
   SetAttribute(elementKey: string, attribute: string, controlType: string, value: string): string
   Save(): string
+  CanUndo(): boolean
+  CanRedo(): boolean
   Undo(): void
   Redo(): void
 }


### PR DESCRIPTION
## Summary

- Adds `SetAttribute` to `WasmEditorBridge` — converts the string value to the correct .NET type based on `controlType` (checkbox → bool, number → int, numberdouble → double, otherwise string), wraps each edit in an undo transaction
- Extends `GetEditorData` to return an `EditorDataResponse` with `attributes`, `tabs`, and per-control metadata (`controlType`, `caption`, `options`) so the UI can render typed inputs
- Replaces the raw attribute grid in `PropertyEditor.svelte` with typed controls (text input, checkbox, number input, dropdown with options) and tab navigation driven by the EditorDefinition
- Adds `GetRedoItems()` to `EditorController` (symmetric with existing `GetUndoItems()`)
- Fixes `WorldModel.Print` skipping its `EditMode` guard, which caused NCalc errors when editing
- Fixes undo not visually reverting the most recent change, and empty tabs for feature-gated controls
- Updates docs to mark Phase 3 complete and expands the file-handling section with File System Access API, OPFS, asset storage, Electron adapter, and shared `FileAdapter` interface design (for future coordination with Squiffy)

Known limitation carried into Phase 4: live C# → JS events not yet implemented (tree state is still snapshot-based).

## Test plan

- [ ] Load a game file in the WebEditor and select an element — verify typed controls render in tabs
- [ ] Edit a textbox, checkbox, number, and dropdown field — verify changes are saved
- [ ] Undo/redo a change — verify the UI reverts/re-applies correctly
- [ ] Undo button is disabled when there is nothing to undo

🤖 Generated with [Claude Code](https://claude.com/claude-code)