### PR TITLE
WebEditor Phase 4: visual script editor

### DIFF
--- a/src/EditorCore/EditableScriptFactory.cs
+++ b/src/EditorCore/EditableScriptFactory.cs
@@ -10,8 +10,9 @@ namespace QuestViva.EditorCore
     {
         private Expression<bool> m_visibilityExpression;
 
-        public EditableScriptData(Element editor, WorldModel worldModel)
+        public EditableScriptData(Element editor, WorldModel worldModel, int order)
         {
+            Order = order;
             DisplayString = editor.Fields.GetString("display");
             Category = editor.Fields.GetString("category");
             CreateString = editor.Fields.GetString("create");
@@ -38,6 +39,7 @@ namespace QuestViva.EditorCore
         public bool IsVisibleInSimpleMode { get; private set; }
         public bool IsDesktopOnly { get; private set; }
         public string CommonButton { get; private set; }
+        public int Order { get; private set; }
     }
 
     internal class EditableScriptFactory
@@ -54,10 +56,11 @@ namespace QuestViva.EditorCore
             m_scriptFactory = factory;
             m_worldModel = worldModel;
 
+            int order = 0;
             foreach (Element editor in worldModel.Elements.GetElements(ElementType.Editor).Where(IsScriptEditor))
             {
                 string appliesTo = editor.Fields.GetString("appliesto");
-                m_scriptData.Add(appliesTo, new EditableScriptData(editor, worldModel));
+                m_scriptData.Add(appliesTo, new EditableScriptData(editor, worldModel, order++));
             }
         }
 

--- a/src/EditorCore/IEditorDefinition.cs
+++ b/src/EditorCore/IEditorDefinition.cs
@@ -7,5 +7,7 @@ namespace QuestViva.EditorCore
         IDictionary<string, IEditorTab> Tabs { get; }
         IEnumerable<IEditorControl> Controls { get; }
         string GetDefaultFilterName(string filterGroupName, IEditorData data);
+        string Description { get; }
+        string OriginalPattern { get; }
     }
 }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -16,9 +17,36 @@ internal record ControlInfo(string? Attribute, string ControlType, string? Capti
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 internal record EditorDataResponse(Dictionary<string, string?> Attributes, List<TabInfo> Tabs, List<ControlInfo> Controls);
 
+internal record ScriptControlData(
+    string ControlType,
+    string? Caption,
+    string? Attribute,
+    string? Value,
+    string? SimpleEditor,
+    List<ControlOption>? Options,
+    List<ScriptNodeData>? Scripts
+);
+internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
+internal record ScriptNodeData(
+    string Id,
+    string Type,
+    string? DisplayString,
+    List<ScriptControlData>? Controls,
+    string? Expression,
+    List<ScriptNodeData>? ThenScripts,
+    List<ElseIfClauseData>? ElseIfClauses,
+    List<ScriptNodeData>? ElseScripts
+);
+internal record ScriptBlockData(List<ScriptNodeData> Scripts);
+internal record ScriptCommandInfo(string Keyword, string Display, string Add, string CreateString);
+internal record ScriptCategoryInfo(string Name, List<ScriptCommandInfo> Commands);
+internal record ScriptCommandCategoriesData(List<ScriptCategoryInfo> Categories);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
 [JsonSerializable(typeof(EditorDataResponse))]
+[JsonSerializable(typeof(ScriptBlockData))]
+[JsonSerializable(typeof(ScriptCommandCategoriesData))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext { }
 
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
@@ -183,6 +211,428 @@ public partial class WasmEditorBridge
     {
         foreach (var ctrl in controls.Where(c => c.ControlType == "dropdowntypes"))
             attrs[ctrl.Id] = _controller!.GetSelectedDropDownType(ctrl, elementKey);
+    }
+
+    // ── Script editor API ──────────────────────────────────────────────────────
+
+    [JSExport]
+    public static string? GetScriptData(string elementKey, string attribute)
+    {
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return null;
+        return JsonSerializer.Serialize(BuildScriptBlockData(scripts), WasmEditorJsonContext.Default.ScriptBlockData);
+    }
+
+    [JSExport]
+    public static string SetScriptParameter(string elementKey, string attribute, string containerPath, int scriptIndex, string paramName, string value)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count) return "error";
+        var script = container[scriptIndex];
+
+        _controller.StartTransaction($"Set script parameter");
+        try
+        {
+            script.SetParameter(paramName, value);
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+        finally
+        {
+            _controller.EndTransaction();
+        }
+    }
+
+    [JSExport]
+    public static string SetIfExpression(string elementKey, string attribute, string containerPath, int scriptIndex, string expression)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count) return "error";
+        var script = container[scriptIndex];
+        if (script is not EditableIfScript ifScript) return "not an if script";
+
+        _controller.StartTransaction("Set if expression");
+        try
+        {
+            ifScript.SetAttribute("expression", expression);
+            return "ok";
+        }
+        finally
+        {
+            _controller.EndTransaction();
+        }
+    }
+
+    [JSExport]
+    public static string SetElseIfExpression(string elementKey, string attribute, string containerPath, int scriptIndex, int elseIfIndex, string expression)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count) return "error";
+        var script = container[scriptIndex];
+        if (script is not EditableIfScript ifScript) return "not an if script";
+        var elseIf = ifScript.ElseIfScripts.ElementAtOrDefault(elseIfIndex);
+        if (elseIf == null) return "error";
+
+        _controller.StartTransaction("Set else-if expression");
+        try
+        {
+            elseIf.SetAttribute("expression", expression);
+            return "ok";
+        }
+        finally
+        {
+            _controller.EndTransaction();
+        }
+    }
+
+    [JSExport]
+    public static string AddScript(string elementKey, string attribute, string containerPath, string keyword)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+
+        // Attribute not yet set — create a new script container directly on the element
+        if (scripts == null && string.IsNullOrEmpty(containerPath))
+        {
+            try
+            {
+                _controller.CreateNewEditableScripts(elementKey, attribute, keyword, true);
+                return "ok";
+            }
+            catch (Exception ex)
+            {
+                return ex.Message;
+            }
+        }
+
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null) return "error";
+
+        try
+        {
+            container.AddNew(keyword, elementKey);
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    [JSExport]
+    public static string DeleteScript(string elementKey, string attribute, string containerPath, int scriptIndex)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count) return "error";
+
+        container.Remove([scriptIndex]);
+        return "ok";
+    }
+
+    [JSExport]
+    public static string MoveScript(string elementKey, string attribute, string containerPath, int index1, int index2)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null) return "error";
+        if (index1 < 0 || index1 >= container.Count || index2 < 0 || index2 >= container.Count) return "error";
+
+        _controller.StartTransaction("Move script");
+        try
+        {
+            container.Swap(index1, index2);
+            return "ok";
+        }
+        finally
+        {
+            _controller.EndTransaction();
+        }
+    }
+
+    [JSExport]
+    public static string AddElse(string elementKey, string attribute, string containerPath, int scriptIndex)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count) return "error";
+        if (container[scriptIndex] is not EditableIfScript ifScript) return "not an if script";
+
+        try
+        {
+            ifScript.AddElse();
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string AddElseIf(string elementKey, string attribute, string containerPath, int scriptIndex)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count) return "error";
+        if (container[scriptIndex] is not EditableIfScript ifScript) return "not an if script";
+
+        try
+        {
+            ifScript.AddElseIf();
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string RemoveElse(string elementKey, string attribute, string containerPath, int scriptIndex)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count) return "error";
+        if (container[scriptIndex] is not EditableIfScript ifScript) return "not an if script";
+
+        try
+        {
+            ifScript.RemoveElse();
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string RemoveElseIf(string elementKey, string attribute, string containerPath, int scriptIndex, int elseIfIndex)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count) return "error";
+        if (container[scriptIndex] is not EditableIfScript ifScript) return "not an if script";
+        var elseIf = ifScript.ElseIfScripts.ElementAtOrDefault(elseIfIndex);
+        if (elseIf == null) return "error";
+
+        try
+        {
+            ifScript.RemoveElseIf(elseIf);
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string GetScriptCommandCategories()
+    {
+        if (_controller == null) return "null";
+        var scriptData = _controller.GetScriptEditorData();
+        var grouped = scriptData
+            .Where(kv => !string.IsNullOrEmpty(kv.Value.Category)
+                      && !kv.Value.IsDesktopOnly
+                      && kv.Value.IsVisible()
+                      && !string.IsNullOrEmpty(kv.Value.CreateString))
+            .GroupBy(kv => kv.Value.Category)
+            .Select(g => new ScriptCategoryInfo(
+                g.Key,
+                g.Select(kv => new ScriptCommandInfo(
+                    kv.Key,
+                    kv.Value.DisplayString ?? kv.Key,
+                    kv.Value.AdderDisplayString ?? kv.Key,
+                    kv.Value.CreateString!
+                )).OrderBy(c => c.Add).ToList()
+            ))
+            .ToList();
+        var data = new ScriptCommandCategoriesData(grouped);
+        return JsonSerializer.Serialize(data, WasmEditorJsonContext.Default.ScriptCommandCategoriesData);
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
+
+    private static IEditableScripts? GetScripts(string elementKey, string attribute)
+    {
+        if (_controller == null) return null;
+        var data = _controller.GetEditorData(elementKey);
+        return data?.GetAttribute(attribute) as IEditableScripts;
+    }
+
+    private static IEditableScripts? ResolveContainer(IEditableScripts root, string containerPath)
+    {
+        if (string.IsNullOrEmpty(containerPath)) return root;
+
+        var parts = containerPath.Split('/');
+        var current = root;
+        int i = 0;
+
+        while (i < parts.Length)
+        {
+            if (!int.TryParse(parts[i], out int scriptIndex)) return null;
+            i++;
+
+            if (i >= parts.Length) return null; // path ends at a script index, not a container
+
+            if (scriptIndex < 0 || scriptIndex >= current.Count) return null;
+            var script = current[scriptIndex];
+            var segment = parts[i];
+            i++;
+
+            if (script.Type == ScriptType.If)
+            {
+                var ifScript = (EditableIfScript)script;
+                if (segment == "then")
+                {
+                    current = ifScript.ThenScript;
+                }
+                else if (segment == "else")
+                {
+                    if (ifScript.ElseScript == null) return null;
+                    current = ifScript.ElseScript;
+                }
+                else if (segment == "elseif")
+                {
+                    if (i >= parts.Length || !int.TryParse(parts[i], out int elseIfIndex)) return null;
+                    i++;
+                    var elseIf = ifScript.ElseIfScripts.ElementAtOrDefault(elseIfIndex);
+                    if (elseIf == null) return null;
+                    current = elseIf.EditableScripts;
+                }
+                else return null;
+            }
+            else
+            {
+                if (segment == "param")
+                {
+                    if (i >= parts.Length) return null;
+                    var paramAttr = parts[i++];
+                    var scriptEditorData = _controller!.GetScriptEditorData(script);
+                    if (scriptEditorData.GetAttribute(paramAttr) is not IEditableScripts nestedScripts) return null;
+                    current = nestedScripts;
+                }
+                else return null;
+            }
+        }
+
+        return current;
+    }
+
+    private static ScriptBlockData BuildScriptBlockData(IEditableScripts scripts) =>
+        new(scripts.Scripts.Select(BuildScriptNodeData).ToList());
+
+    private static ScriptNodeData BuildScriptNodeData(IEditableScript script)
+    {
+        if (script.Type == ScriptType.If)
+        {
+            var ifScript = (EditableIfScript)script;
+            var elseIfClauses = ifScript.ElseIfScripts
+                .Select(ei => new ElseIfClauseData(ei.Id, ei.Expression, BuildScriptBlockData(ei.EditableScripts).Scripts))
+                .ToList();
+
+            return new ScriptNodeData(
+                Id: script.Id,
+                Type: "if",
+                DisplayString: null,
+                Controls: null,
+                Expression: ifScript.IfExpression,
+                ThenScripts: BuildScriptBlockData(ifScript.ThenScript).Scripts,
+                ElseIfClauses: elseIfClauses,
+                ElseScripts: ifScript.ElseScript != null ? BuildScriptBlockData(ifScript.ElseScript).Scripts : null
+            );
+        }
+
+        string? displayString = null;
+        List<ScriptControlData>? controls = null;
+
+        try
+        {
+            var def = _controller!.GetEditorDefinition(script);
+            var editorData = _controller.GetScriptEditorData(script);
+            displayString = script.DisplayString();
+            controls = def.Controls.Select(c => BuildScriptControlData(c, editorData)).ToList();
+        }
+        catch
+        {
+            displayString = script.DisplayString();
+            controls = [];
+        }
+
+        return new ScriptNodeData(
+            Id: script.Id,
+            Type: "normal",
+            DisplayString: displayString,
+            Controls: controls,
+            Expression: null,
+            ThenScripts: null,
+            ElseIfClauses: null,
+            ElseScripts: null
+        );
+    }
+
+    private static ScriptControlData BuildScriptControlData(IEditorControl ctrl, IEditorData editorData)
+    {
+        string? value = null;
+        string? simpleEditor = null;
+        List<ControlOption>? options = null;
+        List<ScriptNodeData>? nestedScripts = null;
+
+        if (ctrl.Attribute != null)
+        {
+            if (ctrl.ControlType == "script")
+            {
+                var attrValue = editorData.GetAttribute(ctrl.Attribute);
+                if (attrValue is IEditableScripts nested)
+                    nestedScripts = BuildScriptBlockData(nested).Scripts;
+            }
+            else
+            {
+                value = editorData.GetAttribute(ctrl.Attribute)?.ToString();
+            }
+        }
+
+        if (ctrl.ControlType == "expression")
+        {
+            simpleEditor = ctrl.GetString("simpleeditor");
+        }
+        else if (ctrl.ControlType == "dropdown")
+        {
+            var list = ctrl.GetListString("validvalues");
+            if (list != null)
+                options = list.Select(v => new ControlOption(v, v)).ToList();
+            else
+            {
+                var dict = ctrl.GetDictionary("validvalues");
+                if (dict != null)
+                    options = dict.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
+            }
+        }
+
+        return new ScriptControlData(
+            ControlType: ctrl.ControlType,
+            Caption: ctrl.Caption,
+            Attribute: ctrl.Attribute,
+            Value: value,
+            SimpleEditor: simpleEditor,
+            Options: options,
+            Scripts: nestedScripts
+        );
     }
 
     private static void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -23,6 +23,7 @@ internal record ScriptControlData(
     string? Attribute,
     string? Value,
     string? SimpleEditor,
+    string? SimpleLabel,
     List<ControlOption>? Options,
     List<ScriptNodeData>? Scripts
 );
@@ -42,11 +43,28 @@ internal record ScriptCommandInfo(string Keyword, string Display, string Add, st
 internal record ScriptCategoryInfo(string Name, List<ScriptCommandInfo> Commands);
 internal record ScriptCommandCategoriesData(List<ScriptCategoryInfo> Categories);
 
+internal record ExpressionTemplateControlData(
+    string Name,
+    string? Value,
+    string? SimpleEditor,
+    string? SimpleLabel,
+    List<ControlOption>? Options
+);
+internal record IfExpressionTemplateData(
+    string TemplateName,
+    string OriginalPattern,
+    List<ExpressionTemplateControlData> Controls
+);
+internal record IfExpressionTemplate(string Name, string CreateExpression);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
 [JsonSerializable(typeof(EditorDataResponse))]
 [JsonSerializable(typeof(ScriptBlockData))]
 [JsonSerializable(typeof(ScriptCommandCategoriesData))]
+[JsonSerializable(typeof(List<string>))]
+[JsonSerializable(typeof(List<IfExpressionTemplate>))]
+[JsonSerializable(typeof(IfExpressionTemplateData))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext { }
 
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
@@ -466,6 +484,81 @@ public partial class WasmEditorBridge
         return JsonSerializer.Serialize(data, WasmEditorJsonContext.Default.ScriptCommandCategoriesData);
     }
 
+    [JSExport]
+    public static string GetObjectNames()
+    {
+        if (_controller == null) return "[]";
+        var names = _controller.GetObjectNames("object", includeLibraryObjects: false).ToList();
+        return JsonSerializer.Serialize(names, WasmEditorJsonContext.Default.ListString);
+    }
+
+    [JSExport]
+    public static string GetIfExpressionTemplates()
+    {
+        if (_controller == null) return "[]";
+        var templates = _controller.GetExpressionEditorNames("if")
+            .Select(name => new IfExpressionTemplate(Name: name, CreateExpression: _controller.GetNewExpression(name)))
+            .ToList();
+        return JsonSerializer.Serialize(templates, WasmEditorJsonContext.Default.ListIfExpressionTemplate);
+    }
+
+    [JSExport]
+    public static string? GetIfExpressionTemplateData(string expression)
+    {
+        if (_controller == null || string.IsNullOrEmpty(expression)) return null;
+        var definition = _controller.GetExpressionEditorDefinition(expression, "if");
+        if (definition == null) return null;
+
+        IEditorData templateData;
+        try { templateData = _controller.GetExpressionEditorData(expression, "if", null!); }
+        catch { return null; }
+
+        var controls = definition.Controls
+            .Where(ctrl => ctrl.Attribute != null)
+            .Select(ctrl =>
+            {
+                var simpleLabel = ctrl.GetString("simple");
+                var simpleEditorTag = ctrl.GetString("simpleeditor");
+                var simpleEditor = simpleEditorTag ?? (simpleLabel != null ? "textbox" : null);
+
+                List<ControlOption>? options = null;
+                if (simpleEditor == "dropdown")
+                {
+                    var list = ctrl.GetListString("validvalues");
+                    if (list != null)
+                        options = list.Select(v => new ControlOption(v, v)).ToList();
+                    else
+                    {
+                        var dict = ctrl.GetDictionary("validvalues");
+                        if (dict != null)
+                            options = dict.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
+                    }
+                }
+
+                string? paramValue = null;
+                try { paramValue = (string?)templateData.GetAttribute(ctrl.Attribute!); }
+                catch { /* parameter not present in expression */ }
+
+                return new ExpressionTemplateControlData(
+                    Name: ctrl.Attribute!,
+                    Value: paramValue,
+                    SimpleEditor: simpleEditor,
+                    SimpleLabel: simpleLabel,
+                    Options: options
+                );
+            })
+            .ToList();
+
+        return JsonSerializer.Serialize(
+            new IfExpressionTemplateData(
+                TemplateName: definition.Description,
+                OriginalPattern: definition.OriginalPattern,
+                Controls: controls
+            ),
+            WasmEditorJsonContext.Default.IfExpressionTemplateData
+        );
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     private static IEditableScripts? GetScripts(string elementKey, string attribute)
@@ -607,9 +700,27 @@ public partial class WasmEditorBridge
             }
         }
 
+        string? simpleLabel = null;
+
         if (ctrl.ControlType == "expression")
         {
-            simpleEditor = ctrl.GetString("simpleeditor");
+            simpleLabel = ctrl.GetString("simple");
+            var simpleEditorTag = ctrl.GetString("simpleeditor");
+            // If <simpleeditor> is absent but <simple> is set, default simple editor is a textbox
+            simpleEditor = simpleEditorTag ?? (simpleLabel != null ? "textbox" : null);
+
+            if (simpleEditor == "dropdown")
+            {
+                var list = ctrl.GetListString("validvalues");
+                if (list != null)
+                    options = list.Select(v => new ControlOption(v, v)).ToList();
+                else
+                {
+                    var dict = ctrl.GetDictionary("validvalues");
+                    if (dict != null)
+                        options = dict.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
+                }
+            }
         }
         else if (ctrl.ControlType == "dropdown")
         {
@@ -630,6 +741,7 @@ public partial class WasmEditorBridge
             Attribute: ctrl.Attribute,
             Value: value,
             SimpleEditor: simpleEditor,
+            SimpleLabel: simpleLabel,
             Options: options,
             Scripts: nestedScripts
         );

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -472,12 +472,12 @@ public partial class WasmEditorBridge
             .GroupBy(kv => kv.Value.Category)
             .Select(g => new ScriptCategoryInfo(
                 g.Key,
-                g.Select(kv => new ScriptCommandInfo(
+                g.OrderBy(kv => kv.Value.Order).Select(kv => new ScriptCommandInfo(
                     kv.Key,
                     kv.Value.DisplayString ?? kv.Key,
                     kv.Value.AdderDisplayString ?? kv.Key,
                     kv.Value.CreateString!
-                )).OrderBy(c => c.Add).ToList()
+                )).ToList()
             ))
             .ToList();
         var data = new ScriptCommandCategoriesData(grouped);

--- a/src/WebEditor/src/components/AddScriptModal.svelte
+++ b/src/WebEditor/src/components/AddScriptModal.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+    import type { ScriptCategoryInfo, ScriptCommandInfo } from "$lib/types";
+
+    interface Props {
+        categories: ScriptCategoryInfo[];
+        onAdd: (createString: string) => void;
+        onClose: () => void;
+    }
+
+    let { categories, onAdd, onClose }: Props = $props();
+
+    const SHORTCUT_KEYWORDS: string[] = [
+        "msg",
+        "(function)AddToInventory",
+        "(function)MoveObject",
+        "(function)MakeObjectVisible",
+        "(function)MakeObjectInvisible",
+        "if",
+    ];
+    const SHORTCUT_LABELS: Record<string, string> = {
+        "msg": "Print",
+        "(function)AddToInventory": "Inventory",
+        "(function)MoveObject": "Move",
+        "(function)MakeObjectVisible": "Show",
+        "(function)MakeObjectInvisible": "Hide",
+        "if": "If",
+    };
+
+    const shortcuts = $derived(
+        SHORTCUT_KEYWORDS.flatMap((keyword) => {
+            for (const cat of categories) {
+                const cmd = cat.commands.find((c) => c.keyword === keyword);
+                if (cmd) return [{ label: SHORTCUT_LABELS[keyword] ?? cmd.add, createString: cmd.createString }];
+            }
+            return [];
+        })
+    );
+
+    let selectedCategoryIndex = $state(0);
+    let selectedCommand = $state<ScriptCommandInfo | null>(null);
+
+    const selectedCategory = $derived(categories[selectedCategoryIndex] ?? null);
+
+    // Auto-select first command when category changes
+    $effect(() => {
+        const cat = selectedCategory;
+        selectedCommand = cat && cat.commands.length > 0 ? cat.commands[0] : null;
+    });
+
+    function onShortcutClick(createString: string) {
+        onAdd(createString);
+        onClose();
+    }
+
+    function onOk() {
+        if (selectedCommand) {
+            onAdd(selectedCommand.createString);
+            onClose();
+        }
+    }
+
+    function onKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") onClose();
+        if (e.key === "Enter" && selectedCommand) onOk();
+    }
+
+    function onBackdropClick(e: MouseEvent) {
+        if (e.target === e.currentTarget) onClose();
+    }
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50"
+    onclick={onBackdropClick}
+    onkeydown={onKeydown}
+>
+    <div class="bg-surface-50-950 rounded-xl shadow-2xl w-[600px] h-[520px] flex flex-col overflow-hidden ring-1 ring-surface-200-800">
+
+        <!-- Header -->
+        <div class="preset-filled-primary-500 px-5 py-3 flex items-center justify-between flex-shrink-0">
+            <h2 class="font-semibold text-base tracking-wide">Add Script Command</h2>
+            <button
+                type="button"
+                onclick={onClose}
+                class="opacity-80 hover:opacity-100 text-xl leading-none px-1 transition-opacity"
+                aria-label="Close"
+            >×</button>
+        </div>
+
+        <!-- Shortcut buttons -->
+        {#if shortcuts.length > 0}
+            <div class="px-5 py-3 border-b border-surface-200-800 flex gap-2 flex-wrap flex-shrink-0 bg-surface-100-900">
+                <span class="text-xs font-medium text-surface-500-400 self-center mr-1">Quick add:</span>
+                {#each shortcuts as shortcut (shortcut.createString)}
+                    <button
+                        type="button"
+                        onclick={() => onShortcutClick(shortcut.createString)}
+                        class="btn btn-sm preset-tonal-primary rounded-full px-4 py-1 text-sm font-medium"
+                    >{shortcut.label}</button>
+                {/each}
+            </div>
+        {/if}
+
+        <!-- Body: categories + commands -->
+        <div class="flex flex-1 min-h-0">
+            <!-- Category sidebar -->
+            <div class="w-40 bg-surface-100-900 border-r border-surface-200-800 overflow-y-auto flex-shrink-0">
+                {#each categories as cat, ci (ci)}
+                    <button
+                        type="button"
+                        onclick={() => { selectedCategoryIndex = ci; }}
+                        class="w-full text-left px-4 py-2.5 text-sm font-medium transition-colors {
+                            selectedCategoryIndex === ci
+                                ? 'preset-filled-primary-500'
+                                : 'text-surface-700-300 hover:bg-surface-200-800 hover:text-surface-900-100'
+                        }"
+                    >{cat.name}</button>
+                {/each}
+            </div>
+
+            <!-- Commands list -->
+            <div class="flex-1 overflow-y-auto py-2">
+                {#if selectedCategory}
+                    {#each selectedCategory.commands as cmd (cmd.createString)}
+                        {@const isSelected = selectedCommand?.createString === cmd.createString}
+                        <button
+                            type="button"
+                            onclick={() => (selectedCommand = cmd)}
+                            ondblclick={() => { selectedCommand = cmd; onOk(); }}
+                            class="w-full text-left px-5 py-2 text-sm flex items-center gap-3 transition-colors {
+                                isSelected
+                                    ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300 font-medium'
+                                    : 'text-surface-700-300 hover:bg-surface-100-900'
+                            }"
+                        >
+                            <span class="w-4 flex-shrink-0 text-primary-500 {isSelected ? 'opacity-100' : 'opacity-0'}">●</span>
+                            {cmd.add}
+                        </button>
+                    {/each}
+                {/if}
+            </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="px-5 py-3 border-t border-surface-200-800 flex justify-end gap-3 flex-shrink-0 bg-surface-100-900">
+            <button type="button" onclick={onClose} class="btn preset-outlined">Cancel</button>
+            <button
+                type="button"
+                onclick={onOk}
+                class="btn preset-filled-primary-500"
+                disabled={!selectedCommand}
+            >OK</button>
+        </div>
+    </div>
+</div>

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { selectedKey, selectedData, setAttribute, setDropdownType } from "$lib/editor-store";
     import type { ControlInfo } from "$lib/types";
+    import ScriptEditor from "./ScriptEditor.svelte";
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
@@ -157,10 +158,10 @@
                     value={attrValue(ctrl.attribute) ?? ""}
                     onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value)}
                 />
-            {:else if ctrl.controlType === "script"}
-                <button type="button" class="btn btn-sm preset-outlined text-xs py-0.5" disabled>
-                    Script editor (Phase 4)
-                </button>
+            {:else if ctrl.controlType === "script" && ctrl.attribute !== null && $selectedKey !== null}
+                <div class="flex-1 min-w-0 overflow-hidden">
+                    <ScriptEditor elementKey={$selectedKey} attribute={ctrl.attribute} />
+                </div>
             {:else}
                 {#if attrValue(ctrl.attribute) !== null}
                     <span class="text-xs overflow-hidden text-ellipsis whitespace-nowrap" title={attrValue(ctrl.attribute) ?? ""}>

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -1,0 +1,365 @@
+<script lang="ts">
+    import ScriptEditor from "./ScriptEditor.svelte";
+    import {
+        scriptVersion,
+        getScriptData,
+        setScriptParameter,
+        setIfExpression,
+        setElseIfExpression,
+        addScript,
+        deleteScript,
+        moveScript,
+        addElse,
+        addElseIf,
+        removeElse,
+        removeElseIf,
+        getScriptCommandCategories,
+    } from "$lib/editor-store";
+    import type {
+        ScriptBlockData,
+        ScriptNodeData,
+        ScriptControlData,
+        ScriptCategoryInfo,
+    } from "$lib/types";
+
+    interface Props {
+        elementKey: string;
+        attribute: string;
+        containerPath?: string;
+        // Pre-loaded data for nested blocks (avoids extra WASM round-trips)
+        initialData?: ScriptNodeData[] | null;
+        depth?: number;
+    }
+
+    let {
+        elementKey,
+        attribute,
+        containerPath = "",
+        initialData = null,
+        depth = 0,
+    }: Props = $props();
+
+    let scriptData = $state<ScriptBlockData | null>(null);
+    let categories = $state<ScriptCategoryInfo[]>([]);
+    let addKeyword = $state("");
+    let isRoot = $derived(initialData === null);
+
+    // Load on mount and whenever scriptVersion bumps (undo/redo)
+    $effect(() => {
+        const version = $scriptVersion; // track for reactivity on undo/redo
+        if (isRoot) {
+            scriptData = version >= 0 ? getScriptData(elementKey, attribute) : null;
+        }
+        if (categories.length === 0) {
+            const cats = getScriptCommandCategories();
+            if (cats) {
+                categories = cats.categories;
+                if (cats.categories.length > 0 && cats.categories[0].commands.length > 0) {
+                    addKeyword = cats.categories[0].commands[0].createString;
+                }
+            }
+        }
+    });
+
+    function scripts(): ScriptNodeData[] {
+        if (!isRoot && initialData !== null) return initialData;
+        return scriptData?.scripts ?? [];
+    }
+
+    function refresh() {
+        if (isRoot) {
+            scriptData = getScriptData(elementKey, attribute);
+        }
+    }
+
+    function mutate(fn: () => string): boolean {
+        const result = fn();
+        if (result === "ok") {
+            refresh();
+            return true;
+        }
+        return false;
+    }
+
+    function onAddScript() {
+        if (!addKeyword) return;
+        mutate(() => addScript(elementKey, attribute, containerPath, addKeyword));
+    }
+
+    function onDelete(index: number) {
+        mutate(() => deleteScript(elementKey, attribute, containerPath, index));
+    }
+
+    function onMoveUp(index: number) {
+        if (index === 0) return;
+        mutate(() => moveScript(elementKey, attribute, containerPath, index, index - 1));
+    }
+
+    function onMoveDown(index: number) {
+        const list = scripts();
+        if (index >= list.length - 1) return;
+        mutate(() => moveScript(elementKey, attribute, containerPath, index, index + 1));
+    }
+
+    function onSetParam(scriptIndex: number, paramName: string, value: string) {
+        mutate(() => setScriptParameter(elementKey, attribute, containerPath, scriptIndex, paramName, value));
+    }
+
+    function onSetIfExpr(scriptIndex: number, expression: string) {
+        mutate(() => setIfExpression(elementKey, attribute, containerPath, scriptIndex, expression));
+    }
+
+    function onSetElseIfExpr(scriptIndex: number, elseIfIndex: number, expression: string) {
+        mutate(() => setElseIfExpression(elementKey, attribute, containerPath, scriptIndex, elseIfIndex, expression));
+    }
+
+    function onAddElse(scriptIndex: number) {
+        mutate(() => addElse(elementKey, attribute, containerPath, scriptIndex));
+    }
+
+    function onAddElseIf(scriptIndex: number) {
+        mutate(() => addElseIf(elementKey, attribute, containerPath, scriptIndex));
+    }
+
+    function onRemoveElse(scriptIndex: number) {
+        mutate(() => removeElse(elementKey, attribute, containerPath, scriptIndex));
+    }
+
+    function onRemoveElseIf(scriptIndex: number, elseIfIndex: number) {
+        mutate(() => removeElseIf(elementKey, attribute, containerPath, scriptIndex, elseIfIndex));
+    }
+
+    // Nested container path helpers
+    function thenPath(scriptIndex: number): string {
+        return containerPath ? `${containerPath}/${scriptIndex}/then` : `${scriptIndex}/then`;
+    }
+    function elsePath(scriptIndex: number): string {
+        return containerPath ? `${containerPath}/${scriptIndex}/else` : `${scriptIndex}/else`;
+    }
+    function elseIfPath(scriptIndex: number, elseIfIndex: number): string {
+        const base = containerPath ? `${containerPath}/${scriptIndex}` : `${scriptIndex}`;
+        return `${base}/elseif/${elseIfIndex}`;
+    }
+    function paramPath(scriptIndex: number, paramAttr: string): string {
+        const base = containerPath ? `${containerPath}/${scriptIndex}` : `${scriptIndex}`;
+        return `${base}/param/${paramAttr}`;
+    }
+
+    const indentClass = $derived(depth > 0 ? "ml-4 border-l border-surface-300-700 pl-2" : "");
+</script>
+
+<div class={indentClass}>
+    {#each scripts() as script, i (script.id)}
+        <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950">
+            <!-- Script row actions -->
+            <div class="absolute right-1 top-1 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10">
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined px-1 py-0 text-xs leading-none"
+                    title="Move up"
+                    disabled={i === 0}
+                    onclick={() => onMoveUp(i)}
+                >↑</button>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined px-1 py-0 text-xs leading-none"
+                    title="Move down"
+                    disabled={i === scripts().length - 1}
+                    onclick={() => onMoveDown(i)}
+                >↓</button>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
+                    title="Delete"
+                    onclick={() => onDelete(i)}
+                >×</button>
+            </div>
+
+            {#if script.type === "if"}
+                {@render ifBlock(script, i)}
+            {:else}
+                {@render normalBlock(script, i)}
+            {/if}
+        </div>
+    {/each}
+
+    <!-- Add script row -->
+    <div class="flex items-center gap-1 mt-1">
+        {#if categories.length > 0}
+            <select
+                class="select text-xs py-0.5 px-1 flex-1 min-w-0"
+                bind:value={addKeyword}
+            >
+                {#each categories as cat, ci (ci)}
+                    <optgroup label={cat.name}>
+                        {#each cat.commands as cmd, cmi (cmi)}
+                            <option value={cmd.createString}>{cmd.add}</option>
+                        {/each}
+                    </optgroup>
+                {/each}
+            </select>
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined text-xs py-0.5 whitespace-nowrap"
+                onclick={onAddScript}
+            >Add script</button>
+        {:else if isRoot}
+            <span class="text-xs text-surface-400-500 italic">Loading commands…</span>
+        {/if}
+    </div>
+</div>
+
+{#snippet normalBlock(script: ScriptNodeData, i: number)}
+    <div class="px-2 py-1 pr-16 flex flex-wrap items-center gap-x-1 gap-y-0.5 text-xs">
+        {#each script.controls ?? [] as ctrl, ci (ci)}
+            {@render inlineControl(ctrl, i)}
+        {/each}
+    </div>
+{/snippet}
+
+{#snippet inlineControl(ctrl: ScriptControlData, scriptIndex: number)}
+    {#if ctrl.controlType === "label"}
+        <span class="text-surface-600-400 select-none">{ctrl.caption ?? ""}</span>
+    {:else if ctrl.controlType === "script" && ctrl.attribute !== null}
+        <!-- Nested script block for commands like for/while/foreach/firsttime -->
+        <div class="w-full mt-0.5">
+            {#if ctrl.caption}
+                <span class="text-surface-500-400 text-xs italic">{ctrl.caption}:</span>
+            {/if}
+            <ScriptEditor
+                {elementKey}
+                {attribute}
+                containerPath={paramPath(scriptIndex, ctrl.attribute)}
+                initialData={ctrl.scripts ?? []}
+                depth={depth + 1}
+            />
+        </div>
+    {:else if ctrl.attribute !== null}
+        {@render valueControl(ctrl, scriptIndex)}
+    {/if}
+{/snippet}
+
+{#snippet valueControl(ctrl: ScriptControlData, scriptIndex: number)}
+    {#if ctrl.controlType === "expression" || ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
+        <input
+            type="text"
+            class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+            value={ctrl.value ?? ""}
+            onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
+        />
+    {:else if ctrl.controlType === "checkbox"}
+        <input
+            type="checkbox"
+            class="checkbox"
+            checked={ctrl.value === "True" || ctrl.value === "true"}
+            onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).checked.toString())}
+        />
+        {#if ctrl.caption}<span class="text-surface-600-400">{ctrl.caption}</span>{/if}
+    {:else if ctrl.controlType === "dropdown" && ctrl.options}
+        <select
+            class="select text-xs py-0 px-1 max-w-32"
+            value={ctrl.value ?? ""}
+            onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLSelectElement).value)}
+        >
+            {#each ctrl.options as opt, oi (oi)}
+                <option value={opt.value}>{opt.label}</option>
+            {/each}
+        </select>
+    {:else}
+        <span class="text-surface-400-500 italic text-xs">[{ctrl.controlType}]</span>
+    {/if}
+{/snippet}
+
+{#snippet ifBlock(script: ScriptNodeData, i: number)}
+    <div class="px-2 py-1 pr-16 text-xs">
+        <!-- If condition -->
+        <div class="flex items-center gap-1 flex-wrap">
+            <span class="text-surface-600-400 font-medium select-none">if</span>
+            <input
+                type="text"
+                class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
+                value={script.expression ?? ""}
+                onchange={(e) => onSetIfExpr(i, (e.target as HTMLInputElement).value)}
+            />
+            <span class="text-surface-600-400 select-none">then</span>
+        </div>
+
+        <!-- Then block -->
+        <div class="mt-1">
+            <ScriptEditor
+                {elementKey}
+                {attribute}
+                containerPath={thenPath(i)}
+                initialData={script.thenScripts ?? []}
+                depth={depth + 1}
+            />
+        </div>
+
+        <!-- Else-if blocks -->
+        {#each script.elseIfClauses ?? [] as elseIf, ei (elseIf.id)}
+            <div class="mt-1 flex items-center gap-1 flex-wrap">
+                <span class="text-surface-600-400 font-medium select-none">else if</span>
+                <input
+                    type="text"
+                    class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
+                    value={elseIf.expression}
+                    onchange={(e) => onSetElseIfExpr(i, ei, (e.target as HTMLInputElement).value)}
+                />
+                <span class="text-surface-600-400 select-none">then</span>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none ml-auto"
+                    title="Remove else if"
+                    onclick={() => onRemoveElseIf(i, ei)}
+                >×</button>
+            </div>
+            <div class="mt-1">
+                <ScriptEditor
+                    {elementKey}
+                    {attribute}
+                    containerPath={elseIfPath(i, ei)}
+                    initialData={elseIf.scripts}
+                    depth={depth + 1}
+                />
+            </div>
+        {/each}
+
+        <!-- Else block -->
+        {#if script.elseScripts !== null && script.elseScripts !== undefined}
+            <div class="mt-1 flex items-center gap-1">
+                <span class="text-surface-600-400 font-medium select-none">else</span>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none ml-auto"
+                    title="Remove else"
+                    onclick={() => onRemoveElse(i)}
+                >×</button>
+            </div>
+            <div class="mt-1">
+                <ScriptEditor
+                    {elementKey}
+                    {attribute}
+                    containerPath={elsePath(i)}
+                    initialData={script.elseScripts}
+                    depth={depth + 1}
+                />
+            </div>
+        {/if}
+
+        <!-- Add else if / Add else buttons -->
+        <div class="flex gap-1 mt-1">
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined text-xs py-0.5"
+                onclick={() => onAddElseIf(i)}
+            >+ else if</button>
+            {#if script.elseScripts === null || script.elseScripts === undefined}
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined text-xs py-0.5"
+                    onclick={() => onAddElse(i)}
+                >+ else</button>
+            {/if}
+        </div>
+    </div>
+{/snippet}

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -14,12 +14,17 @@
         removeElse,
         removeElseIf,
         getScriptCommandCategories,
+        getObjectNames,
+        getIfExpressionTemplates,
+        getIfExpressionTemplateData,
     } from "$lib/editor-store";
     import type {
         ScriptBlockData,
         ScriptNodeData,
         ScriptControlData,
         ScriptCategoryInfo,
+        IfExpressionTemplateData,
+        IfExpressionTemplate,
     } from "$lib/types";
 
     interface Props {
@@ -43,6 +48,11 @@
     let categories = $state<ScriptCategoryInfo[]>([]);
     let addKeyword = $state("");
     let isRoot = $derived(initialData === null);
+    // Tracks which expression controls the user has explicitly forced into expression mode,
+    // overriding the default simple-mode detection based on value shape.
+    let expressionOverrides = $state(new Set<string>());
+    let objectNames = $state<string[]>([]);
+    let ifTemplates = $state<IfExpressionTemplate[]>([]);
 
     // Load on mount and whenever scriptVersion bumps (undo/redo)
     $effect(() => {
@@ -59,6 +69,14 @@
                 }
             }
         }
+        if (objectNames.length === 0) {
+            const names = getObjectNames();
+            if (names && names.length > 0) objectNames = names;
+        }
+        if (ifTemplates.length === 0) {
+            const templates = getIfExpressionTemplates();
+            if (templates && templates.length > 0) ifTemplates = templates;
+        }
     });
 
     function scripts(): ScriptNodeData[] {
@@ -70,6 +88,7 @@
         if (isRoot) {
             scriptData = getScriptData(elementKey, attribute);
         }
+        expressionOverrides = new Set();
     }
 
     function mutate(fn: () => string): boolean {
@@ -79,6 +98,110 @@
             return true;
         }
         return false;
+    }
+
+    // Expression / simple-mode helpers
+
+    function exprKey(scriptIndex: number, attr: string): string {
+        return `${containerPath}/${scriptIndex}/${attr}`;
+    }
+
+    function isSimpleValue(ctrl: ScriptControlData): boolean {
+        const v = ctrl.value ?? '';
+        switch (ctrl.simpleEditor) {
+            case 'boolean':
+                return v === 'true' || v === 'false';
+            case 'number':
+            case 'numberdouble':
+                return v !== '' && Number.isFinite(Number(v));
+            case 'objects':
+                // Bare identifier (object name) or empty — not a complex expression
+                return v === '' || /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(v);
+            default:
+                // textbox, dropdown, file: simple when value is a quoted string literal
+                return v.length >= 2 && v.startsWith('"') && v.endsWith('"');
+        }
+    }
+
+    function inSimpleMode(ctrl: ScriptControlData, scriptIndex: number): boolean {
+        if (!ctrl.simpleEditor) return false;
+        const key = exprKey(scriptIndex, ctrl.attribute!);
+        if (expressionOverrides.has(key)) return false;
+        return isSimpleValue(ctrl);
+    }
+
+    function toSimpleDisplay(ctrl: ScriptControlData): string {
+        const v = ctrl.value ?? '';
+        switch (ctrl.simpleEditor) {
+            case 'boolean':
+            case 'number':
+            case 'numberdouble':
+            case 'objects':
+                return v;
+            default: {
+                if (v.length < 2) return '';
+                return v.slice(1, -1).replace(/<br\/>/g, '\n').replace(/\\"/g, '"');
+            }
+        }
+    }
+
+    function fromSimpleToExpression(simpleValue: string, simpleEditor: string): string {
+        switch (simpleEditor) {
+            case 'boolean':
+            case 'number':
+            case 'numberdouble':
+            case 'objects':
+                return simpleValue;
+            default: {
+                const escaped = simpleValue.replace(/"/g, '\\"').replace(/\n/g, '<br/>');
+                return `"${escaped}"`;
+            }
+        }
+    }
+
+    function setExpressionOverride(scriptIndex: number, attr: string) {
+        expressionOverrides = new Set(expressionOverrides).add(exprKey(scriptIndex, attr));
+    }
+
+    function clearExpressionOverride(scriptIndex: number, attr: string) {
+        const next = new Set(expressionOverrides);
+        next.delete(exprKey(scriptIndex, attr));
+        expressionOverrides = next;
+    }
+
+    function onSwitchToExpression(scriptIndex: number, ctrl: ScriptControlData) {
+        setExpressionOverride(scriptIndex, ctrl.attribute!);
+    }
+
+    function onSwitchToSimple(scriptIndex: number, ctrl: ScriptControlData) {
+        clearExpressionOverride(scriptIndex, ctrl.attribute!);
+        // If the current value is not a valid simple value, reset to a default simple value
+        if (!isSimpleValue(ctrl)) {
+            switch (ctrl.simpleEditor) {
+                case 'boolean':
+                    onSetParam(scriptIndex, ctrl.attribute!, 'true');
+                    break;
+                case 'number':
+                case 'numberdouble':
+                    onSetParam(scriptIndex, ctrl.attribute!, '0');
+                    break;
+                default:
+                    onSetParam(scriptIndex, ctrl.attribute!, '""');
+            }
+        }
+    }
+
+    function onSimpleValueChange(scriptIndex: number, ctrl: ScriptControlData, simpleValue: string) {
+        onSetParam(scriptIndex, ctrl.attribute!, fromSimpleToExpression(simpleValue, ctrl.simpleEditor!));
+    }
+
+    function buildTemplateExpression(tmpl: IfExpressionTemplateData, changedName: string, changedValue: string): string {
+        let result = tmpl.originalPattern;
+        for (const ctrl of tmpl.controls) {
+            const value = ctrl.name === changedName ? changedValue : (ctrl.value ?? '');
+            result = result.replace(`#${ctrl.name}#`, value);
+        }
+        return result;
     }
 
     function onAddScript() {
@@ -240,7 +363,101 @@
 {/snippet}
 
 {#snippet valueControl(ctrl: ScriptControlData, scriptIndex: number)}
-    {#if ctrl.controlType === "expression" || ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
+    {#if ctrl.controlType === "expression" && ctrl.simpleEditor !== null}
+        {@const simple = inSimpleMode(ctrl, scriptIndex)}
+        {#if ctrl.simpleEditor === "boolean"}
+            <!-- Boolean: yes / no / expression dropdown (no separate widget) -->
+            <select
+                class="select text-xs py-0 px-1 max-w-32"
+                value={simple ? ctrl.value : "expression"}
+                onchange={(e) => {
+                    const v = (e.target as HTMLSelectElement).value;
+                    if (v === "expression") {
+                        onSwitchToExpression(scriptIndex, ctrl);
+                    } else {
+                        clearExpressionOverride(scriptIndex, ctrl.attribute!);
+                        onSetParam(scriptIndex, ctrl.attribute!, v === "yes" ? "true" : "false");
+                    }
+                }}
+            >
+                <option value="true">yes</option>
+                <option value="false">no</option>
+                <option value="expression">expression</option>
+            </select>
+            {#if !simple}
+                <input
+                    type="text"
+                    class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+                    value={ctrl.value ?? ""}
+                    onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
+                />
+            {/if}
+        {:else}
+            <!-- Textbox / dropdown / number: labelled mode toggle + widget -->
+            <select
+                class="select text-xs py-0 px-1 max-w-28"
+                value={simple ? (ctrl.simpleLabel ?? "simple") : "expression"}
+                onchange={(e) => {
+                    const v = (e.target as HTMLSelectElement).value;
+                    if (v === "expression") {
+                        onSwitchToExpression(scriptIndex, ctrl);
+                    } else {
+                        onSwitchToSimple(scriptIndex, ctrl);
+                    }
+                }}
+            >
+                <option value={ctrl.simpleLabel ?? "simple"}>{ctrl.simpleLabel ?? "simple"}</option>
+                <option value="expression">expression</option>
+            </select>
+            {#if simple}
+                {#if ctrl.simpleEditor === "objects"}
+                    <select
+                        class="select text-xs py-0 px-1 max-w-40"
+                        value={ctrl.value ?? ""}
+                        onchange={(e) => onSimpleValueChange(scriptIndex, ctrl, (e.target as HTMLSelectElement).value)}
+                    >
+                        <option value=""></option>
+                        {#each objectNames as name (name)}
+                            <option value={name}>{name}</option>
+                        {/each}
+                    </select>
+                {:else if ctrl.simpleEditor === "dropdown" && ctrl.options}
+                    <select
+                        class="select text-xs py-0 px-1 max-w-32"
+                        value={toSimpleDisplay(ctrl)}
+                        onchange={(e) => onSimpleValueChange(scriptIndex, ctrl, (e.target as HTMLSelectElement).value)}
+                    >
+                        {#each ctrl.options as opt, oi (oi)}
+                            <option value={opt.value}>{opt.label}</option>
+                        {/each}
+                    </select>
+                {:else if ctrl.simpleEditor === "number" || ctrl.simpleEditor === "numberdouble"}
+                    <input
+                        type="number"
+                        class="input text-xs py-0 px-1 min-w-12 max-w-24"
+                        value={ctrl.value ?? "0"}
+                        onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
+                    />
+                {:else}
+                    <!-- textbox (default for message, text, colour, etc.) -->
+                    <input
+                        type="text"
+                        class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+                        value={toSimpleDisplay(ctrl)}
+                        onchange={(e) => onSimpleValueChange(scriptIndex, ctrl, (e.target as HTMLInputElement).value)}
+                    />
+                {/if}
+            {:else}
+                <!-- Expression mode: raw expression text input -->
+                <input
+                    type="text"
+                    class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+                    value={ctrl.value ?? ""}
+                    onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
+                />
+            {/if}
+        {/if}
+    {:else if ctrl.controlType === "expression" || ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
         <input
             type="text"
             class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
@@ -271,16 +488,75 @@
 {/snippet}
 
 {#snippet ifBlock(script: ScriptNodeData, i: number)}
+    {@const tmplData = getIfExpressionTemplateData(script.expression ?? "")}
+    {@const exprKey = `if/${i}`}
+    {@const inTemplateMode = tmplData !== null && !expressionOverrides.has(exprKey)}
     <div class="px-2 py-1 pr-16 text-xs">
         <!-- If condition -->
         <div class="flex items-center gap-1 flex-wrap">
             <span class="text-surface-600-400 font-medium select-none">if</span>
-            <input
-                type="text"
-                class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
-                value={script.expression ?? ""}
-                onchange={(e) => onSetIfExpr(i, (e.target as HTMLInputElement).value)}
-            />
+            {#if ifTemplates.length > 0}
+                <!-- Template / expression mode toggle -->
+                <select
+                    class="select text-xs py-0 px-1 max-w-40"
+                    value={inTemplateMode ? tmplData!.templateName : "expression"}
+                    onchange={(e) => {
+                        const v = (e.target as HTMLSelectElement).value;
+                        if (v === "expression") {
+                            expressionOverrides = new Set(expressionOverrides).add(exprKey);
+                        } else {
+                            const next = new Set(expressionOverrides);
+                            next.delete(exprKey);
+                            expressionOverrides = next;
+                            const tpl = ifTemplates.find(t => t.name === v);
+                            if (tpl) onSetIfExpr(i, tpl.createExpression);
+                        }
+                    }}
+                >
+                    <option value="expression">expression</option>
+                    {#each ifTemplates as tpl (tpl.name)}
+                        <option value={tpl.name}>{tpl.name}</option>
+                    {/each}
+                </select>
+            {/if}
+            {#if inTemplateMode && tmplData}
+                <!-- Template controls (e.g. object picker for Got(#object#)) -->
+                {#each tmplData.controls as ctrl (ctrl.name)}
+                    {#if ctrl.simpleEditor === "objects"}
+                        <select
+                            class="select text-xs py-0 px-1 max-w-40"
+                            value={ctrl.value ?? ""}
+                            onchange={(e) => {
+                                const newVal = (e.target as HTMLSelectElement).value;
+                                onSetIfExpr(i, buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                            }}
+                        >
+                            <option value=""></option>
+                            {#each objectNames as name (name)}
+                                <option value={name}>{name}</option>
+                            {/each}
+                        </select>
+                    {:else}
+                        <input
+                            type="text"
+                            class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
+                            placeholder={ctrl.simpleLabel ?? ctrl.name}
+                            value={ctrl.value ?? ""}
+                            onchange={(e) => {
+                                const newVal = (e.target as HTMLInputElement).value;
+                                onSetIfExpr(i, buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                            }}
+                        />
+                    {/if}
+                {/each}
+            {:else}
+                <input
+                    type="text"
+                    class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
+                    value={script.expression ?? ""}
+                    onchange={(e) => onSetIfExpr(i, (e.target as HTMLInputElement).value)}
+                />
+            {/if}
             <span class="text-surface-600-400 select-none">then</span>
         </div>
 
@@ -297,14 +573,71 @@
 
         <!-- Else-if blocks -->
         {#each script.elseIfClauses ?? [] as elseIf, ei (elseIf.id)}
+            {@const eiTmplData = getIfExpressionTemplateData(elseIf.expression ?? "")}
+            {@const eiExprKey = `elseif/${i}/${ei}`}
+            {@const eiInTemplateMode = eiTmplData !== null && !expressionOverrides.has(eiExprKey)}
             <div class="mt-1 flex items-center gap-1 flex-wrap">
                 <span class="text-surface-600-400 font-medium select-none">else if</span>
-                <input
-                    type="text"
-                    class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
-                    value={elseIf.expression}
-                    onchange={(e) => onSetElseIfExpr(i, ei, (e.target as HTMLInputElement).value)}
-                />
+                {#if ifTemplates.length > 0}
+                    <select
+                        class="select text-xs py-0 px-1 max-w-40"
+                        value={eiInTemplateMode ? eiTmplData!.templateName : "expression"}
+                        onchange={(e) => {
+                            const v = (e.target as HTMLSelectElement).value;
+                            if (v === "expression") {
+                                expressionOverrides = new Set(expressionOverrides).add(eiExprKey);
+                            } else {
+                                const next = new Set(expressionOverrides);
+                                next.delete(eiExprKey);
+                                expressionOverrides = next;
+                                const tpl = ifTemplates.find(t => t.name === v);
+                                if (tpl) onSetElseIfExpr(i, ei, tpl.createExpression);
+                            }
+                        }}
+                    >
+                        <option value="expression">expression</option>
+                        {#each ifTemplates as tpl (tpl.name)}
+                            <option value={tpl.name}>{tpl.name}</option>
+                        {/each}
+                    </select>
+                {/if}
+                {#if eiInTemplateMode && eiTmplData}
+                    {#each eiTmplData.controls as ctrl (ctrl.name)}
+                        {#if ctrl.simpleEditor === "objects"}
+                            <select
+                                class="select text-xs py-0 px-1 max-w-40"
+                                value={ctrl.value ?? ""}
+                                onchange={(e) => {
+                                    const newVal = (e.target as HTMLSelectElement).value;
+                                    onSetElseIfExpr(i, ei, buildTemplateExpression(eiTmplData!, ctrl.name, newVal));
+                                }}
+                            >
+                                <option value=""></option>
+                                {#each objectNames as name (name)}
+                                    <option value={name}>{name}</option>
+                                {/each}
+                            </select>
+                        {:else}
+                            <input
+                                type="text"
+                                class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
+                                placeholder={ctrl.simpleLabel ?? ctrl.name}
+                                value={ctrl.value ?? ""}
+                                onchange={(e) => {
+                                    const newVal = (e.target as HTMLInputElement).value;
+                                    onSetElseIfExpr(i, ei, buildTemplateExpression(eiTmplData!, ctrl.name, newVal));
+                                }}
+                            />
+                        {/if}
+                    {/each}
+                {:else}
+                    <input
+                        type="text"
+                        class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
+                        value={elseIf.expression}
+                        onchange={(e) => onSetElseIfExpr(i, ei, (e.target as HTMLInputElement).value)}
+                    />
+                {/if}
                 <span class="text-surface-600-400 select-none">then</span>
                 <button
                     type="button"

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import ScriptEditor from "./ScriptEditor.svelte";
+    import AddScriptModal from "./AddScriptModal.svelte";
     import {
         scriptVersion,
         getScriptData,
@@ -46,7 +47,7 @@
 
     let scriptData = $state<ScriptBlockData | null>(null);
     let categories = $state<ScriptCategoryInfo[]>([]);
-    let addKeyword = $state("");
+    let showAddModal = $state(false);
     let isRoot = $derived(initialData === null);
     // Tracks which expression controls the user has explicitly forced into expression mode,
     // overriding the default simple-mode detection based on value shape.
@@ -64,9 +65,6 @@
             const cats = getScriptCommandCategories();
             if (cats) {
                 categories = cats.categories;
-                if (cats.categories.length > 0 && cats.categories[0].commands.length > 0) {
-                    addKeyword = cats.categories[0].commands[0].createString;
-                }
             }
         }
         if (objectNames.length === 0) {
@@ -204,9 +202,8 @@
         return result;
     }
 
-    function onAddScript() {
-        if (!addKeyword) return;
-        mutate(() => addScript(elementKey, attribute, containerPath, addKeyword));
+    function onAddScript(createString: string) {
+        mutate(() => addScript(elementKey, attribute, containerPath, createString));
     }
 
     function onDelete(index: number) {
@@ -309,27 +306,23 @@
     <!-- Add script row -->
     <div class="flex items-center gap-1 mt-1">
         {#if categories.length > 0}
-            <select
-                class="select text-xs py-0.5 px-1 flex-1 min-w-0"
-                bind:value={addKeyword}
-            >
-                {#each categories as cat, ci (ci)}
-                    <optgroup label={cat.name}>
-                        {#each cat.commands as cmd, cmi (cmi)}
-                            <option value={cmd.createString}>{cmd.add}</option>
-                        {/each}
-                    </optgroup>
-                {/each}
-            </select>
             <button
                 type="button"
-                class="btn btn-sm preset-outlined text-xs py-0.5 whitespace-nowrap"
-                onclick={onAddScript}
-            >Add script</button>
+                class="btn btn-sm preset-outlined text-xs py-0.5"
+                onclick={() => (showAddModal = true)}
+            >+ Add script</button>
         {:else if isRoot}
             <span class="text-xs text-surface-400-500 italic">Loading commands…</span>
         {/if}
     </div>
+
+    {#if showAddModal}
+        <AddScriptModal
+            {categories}
+            onAdd={onAddScript}
+            onClose={() => (showAddModal = false)}
+        />
+    {/if}
 </div>
 
 {#snippet normalBlock(script: ScriptNodeData, i: number)}

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -1,7 +1,7 @@
 import { writable, get } from "svelte/store";
 import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
-import type { TreeNode, EditorDataResponse } from "./types";
+import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData } from "./types";
 
 let _bridge: WasmBridge | null = null;
 
@@ -12,6 +12,7 @@ export const selectedKey = writable<string | null>(null);
 export const selectedData = writable<EditorDataResponse | null>(null);
 export const canUndo = writable(false);
 export const canRedo = writable(false);
+export const scriptVersion = writable(0);
 
 function refreshUndoRedo() {
     canUndo.set(_bridge?.CanUndo() ?? false);
@@ -62,12 +63,112 @@ export function undo() {
     _bridge?.Undo();
     refreshSelectedData();
     refreshUndoRedo();
+    scriptVersion.update(n => n + 1);
 }
 
 export function redo() {
     _bridge?.Redo();
     refreshSelectedData();
     refreshUndoRedo();
+    scriptVersion.update(n => n + 1);
+}
+
+// ── Script editor functions ─────────────────────────────────────────────────
+
+export function getScriptData(elementKey: string, attribute: string): ScriptBlockData | null {
+    if (!_bridge) return null;
+    const json = _bridge.GetScriptData(elementKey, attribute);
+    return json ? JSON.parse(json) : null;
+}
+
+function bumpScriptVersion() {
+    scriptVersion.update(n => n + 1);
+}
+
+export function setScriptParameter(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramName: string, value: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetScriptParameter(elementKey, attribute, containerPath, scriptIndex, paramName, value);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function setIfExpression(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, expression: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetIfExpression(elementKey, attribute, containerPath, scriptIndex, expression);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function setElseIfExpression(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, elseIfIndex: number, expression: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetElseIfExpression(elementKey, attribute, containerPath, scriptIndex, elseIfIndex, expression);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function addScript(elementKey: string, attribute: string, containerPath: string, keyword: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.AddScript(elementKey, attribute, containerPath, keyword);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function deleteScript(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string {
+    if (!_bridge) return "error";
+    const result = _bridge.DeleteScript(elementKey, attribute, containerPath, scriptIndex);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function moveScript(elementKey: string, attribute: string, containerPath: string, index1: number, index2: number): string {
+    if (!_bridge) return "error";
+    const result = _bridge.MoveScript(elementKey, attribute, containerPath, index1, index2);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function addElse(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string {
+    if (!_bridge) return "error";
+    const result = _bridge.AddElse(elementKey, attribute, containerPath, scriptIndex);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function addElseIf(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string {
+    if (!_bridge) return "error";
+    const result = _bridge.AddElseIf(elementKey, attribute, containerPath, scriptIndex);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function removeElse(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string {
+    if (!_bridge) return "error";
+    const result = _bridge.RemoveElse(elementKey, attribute, containerPath, scriptIndex);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function removeElseIf(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, elseIfIndex: number): string {
+    if (!_bridge) return "error";
+    const result = _bridge.RemoveElseIf(elementKey, attribute, containerPath, scriptIndex, elseIfIndex);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function getScriptCommandCategories(): ScriptCommandCategoriesData | null {
+    if (!_bridge) return null;
+    const json = _bridge.GetScriptCommandCategories();
+    return json ? JSON.parse(json) : null;
 }
 
 function refreshSelectedData() {

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -1,7 +1,7 @@
 import { writable, get } from "svelte/store";
 import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
-import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData } from "./types";
+import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate } from "./types";
 
 let _bridge: WasmBridge | null = null;
 
@@ -169,6 +169,28 @@ export function getScriptCommandCategories(): ScriptCommandCategoriesData | null
     if (!_bridge) return null;
     const json = _bridge.GetScriptCommandCategories();
     return json ? JSON.parse(json) : null;
+}
+
+export function getObjectNames(): string[] | null {
+    if (!_bridge) return null;
+    try {
+        return JSON.parse(_bridge.GetObjectNames());
+    } catch { return null; }
+}
+
+export function getIfExpressionTemplates(): IfExpressionTemplate[] | null {
+    if (!_bridge) return null;
+    try {
+        return JSON.parse(_bridge.GetIfExpressionTemplates());
+    } catch { return null; }
+}
+
+export function getIfExpressionTemplateData(expression: string): IfExpressionTemplateData | null {
+    if (!_bridge) return null;
+    try {
+        const json = _bridge.GetIfExpressionTemplateData(expression);
+        return json ? JSON.parse(json) : null;
+    } catch { return null; }
 }
 
 function refreshSelectedData() {

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -33,6 +33,7 @@ export interface ScriptControlData {
   attribute: string | null
   value: string | null
   simpleEditor: string | null
+  simpleLabel: string | null
   options: ControlOption[] | null
   scripts: ScriptNodeData[] | null
 }
@@ -72,4 +73,23 @@ export interface ScriptCategoryInfo {
 
 export interface ScriptCommandCategoriesData {
   categories: ScriptCategoryInfo[]
+}
+
+export interface ExpressionTemplateControlData {
+  name: string
+  value: string | null
+  simpleEditor: string | null
+  simpleLabel: string | null
+  options: ControlOption[] | null
+}
+
+export interface IfExpressionTemplateData {
+  templateName: string
+  originalPattern: string
+  controls: ExpressionTemplateControlData[]
+}
+
+export interface IfExpressionTemplate {
+  name: string
+  createExpression: string
 }

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -26,3 +26,50 @@ export interface EditorDataResponse {
   tabs: TabInfo[]
   controls: ControlInfo[]
 }
+
+export interface ScriptControlData {
+  controlType: string
+  caption: string | null
+  attribute: string | null
+  value: string | null
+  simpleEditor: string | null
+  options: ControlOption[] | null
+  scripts: ScriptNodeData[] | null
+}
+
+export interface ElseIfClauseData {
+  id: string
+  expression: string
+  scripts: ScriptNodeData[]
+}
+
+export interface ScriptNodeData {
+  id: string
+  type: "normal" | "if"
+  displayString?: string
+  controls?: ScriptControlData[]
+  expression?: string
+  thenScripts?: ScriptNodeData[]
+  elseIfClauses?: ElseIfClauseData[]
+  elseScripts?: ScriptNodeData[] | null
+}
+
+export interface ScriptBlockData {
+  scripts: ScriptNodeData[]
+}
+
+export interface ScriptCommandInfo {
+  keyword: string
+  display: string
+  add: string
+  createString: string
+}
+
+export interface ScriptCategoryInfo {
+  name: string
+  commands: ScriptCommandInfo[]
+}
+
+export interface ScriptCommandCategoriesData {
+  categories: ScriptCategoryInfo[]
+}

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -22,6 +22,9 @@ export interface WasmBridge {
   RemoveElse(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string
   RemoveElseIf(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, elseIfIndex: number): string
   GetScriptCommandCategories(): string
+  GetObjectNames(): string
+  GetIfExpressionTemplates(): string
+  GetIfExpressionTemplateData(expression: string): string | null
 }
 
 let _bridge: WasmBridge | null = null;

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -9,6 +9,19 @@ export interface WasmBridge {
   CanRedo(): boolean
   Undo(): void
   Redo(): void
+  // Script editor API
+  GetScriptData(elementKey: string, attribute: string): string | null
+  SetScriptParameter(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramName: string, value: string): string
+  SetIfExpression(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, expression: string): string
+  SetElseIfExpression(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, elseIfIndex: number, expression: string): string
+  AddScript(elementKey: string, attribute: string, containerPath: string, keyword: string): string
+  DeleteScript(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string
+  MoveScript(elementKey: string, attribute: string, containerPath: string, index1: number, index2: number): string
+  AddElse(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string
+  AddElseIf(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string
+  RemoveElse(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string
+  RemoveElseIf(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, elseIfIndex: number): string
+  GetScriptCommandCategories(): string
 }
 
 let _bridge: WasmBridge | null = null;


### PR DESCRIPTION
## Summary

- Adds a full visual script editor to the web-based game editor, allowing users to view, edit, and reorder scripts attached to game elements
- Replaces the flat script-adder dropdown with a modal picker that browses commands by category
- Adds expression/simple-mode toggle and an object picker for script parameters, so users can switch between typing a raw expression and selecting a game object from a dropdown

## New components & files

- `ScriptEditor.svelte` — renders a script block as a tree of nodes; supports if/else-if/else, nested blocks, inline parameter editing, drag-to-reorder, add/delete
- `AddScriptModal.svelte` — categorised command browser modal replacing the old dropdown
- `WasmEditorBridge.cs` — new script-editor API surface (`GetScriptData`, `SetScriptParameter`, `AddScript`, `DeleteScript`, `MoveScript`, `SwapScripts`, `GetIfExpressionTemplates`, `SetIfExpression`, `AddElseIf`, `DeleteElseIf`, `GetScriptCommandCategories`, `GetObjectNames`)

## Test plan

- [ ] Open a game with scripted elements and confirm scripts render correctly in the editor
- [ ] Edit a script parameter (simple mode and expression mode) and confirm the change persists
- [ ] Add a new script via the modal picker and confirm it appears in the correct position
- [ ] Delete a script node and confirm it is removed
- [ ] Move a script node up/down and confirm the new order is preserved
- [ ] Test if/else-if/else branching: add else-if clause, edit expression, delete clause
- [ ] Verify object picker populates with current game objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)