### PR TITLE
WebEditor: script code view and copy/paste

### DIFF
--- a/docs/webeditor-wasm-svelte.md
+++ b/docs/webeditor-wasm-svelte.md
@@ -6,9 +6,10 @@
 Browser
 ├── SvelteKit frontend  (src/WebEditor/)
 │   ├── TreePanel       — game object hierarchy (Skeleton TreeView)
-│   ├── PropertyEditor  — attribute display (placeholder; full editors in Phase 3)
-│   ├── Toolbar         — save, undo/redo (Skeleton AppBar)
-│   └── [future] ScriptEditor, StatusBar
+│   ├── PropertyEditor  — attribute display with typed controls and tab navigation
+│   ├── ScriptEditor    — visual script editor with code view and copy/paste
+│   ├── AddScriptModal  — categorised command picker
+│   └── Toolbar         — save, undo/redo (Skeleton AppBar)
 │
 └── .NET WASM module  (src/WasmEditor/)
     ├── WasmEditorBridge  — thin JSExport interop layer
@@ -101,11 +102,13 @@ src/WebEditor/
 │   ├── lib/
 │   │   ├── wasm.ts         # loads dotnet.js, exposes WasmBridge
 │   │   ├── editor-store.ts # Svelte stores + wrappers for all WASM calls
-│   │   └── types.ts        # TreeNode, ControlInfo, TabInfo, EditorDataResponse
+│   │   └── types.ts        # TreeNode, ControlInfo, TabInfo, EditorDataResponse, ScriptNodeData, …
 │   ├── components/
 │   │   ├── Toolbar.svelte         # AppBar: title, filename, undo/redo/save
 │   │   ├── TreePanel.svelte       # Skeleton TreeView (flat→hierarchy conversion)
-│   │   └── PropertyEditor.svelte  # Typed controls with tab navigation
+│   │   ├── PropertyEditor.svelte  # Typed controls with tab navigation
+│   │   ├── ScriptEditor.svelte    # Visual script editor (recursive); code view; copy/paste
+│   │   └── AddScriptModal.svelte  # Categorised command picker modal
 │   └── routes/
 │       ├── +layout.svelte  # imports app.css
 │       ├── +layout.ts      # prerendering config
@@ -204,26 +207,34 @@ Factory functions: `createBrowserAdapter()`, `createOPFSAdapter()`, `createElect
 
 Known limitations for this phase: live C#→JS events not yet implemented.
 
-### Phase 4 — Script editor
+### Phase 4 — Script editor ✅
 
-Implement a v5-style visual script editor (see `WebEditor/WebEditor/Views/Edit/ScriptEditor.cshtml` on the `v5` branch for the reference implementation).
+Visual script editor, code view, and copy/paste — full feature parity with the v5 web editor for script editing.
 
-Design:
-- Script commands render as inline rows: labels + textboxes/dropdowns/expression inputs interleaved in a sentence-like layout (e.g. `Print [textbox]`, `Set [dropdown] of [dropdown] to [expression]`)
-- Nested scripts (if/then/else, for, foreach) recurse into child script blocks with their own Add/Delete buttons
-- `if` blocks are special-cased: condition + Then block, with Add Else If / Add Else buttons
-- Expression parameters offer a simple/expression toggle: friendly widget (dropdown, number, object picker) when the value matches a simple pattern; raw text input for arbitrary expressions
-- An "Add script" button opens a categorised command picker
+**Visual editor** (`ScriptEditor.svelte`)
+- Script commands render as inline rows: labels + textboxes/dropdowns/expression inputs interleaved in a sentence-like layout (`Print [textbox]`, `Set [dropdown] of [dropdown] to [expression]`)
+- Nested scripts (if/then/else, for, foreach) recurse into child `ScriptEditor` instances with their own Add/Delete buttons
+- `if` blocks special-cased: condition + Then block, with Add Else If / Add Else buttons
+- Expression parameters offer a simple/expression toggle: friendly widget (dropdown, number, object picker) when the value matches a simple form; raw text input for arbitrary expressions
+- `if` condition additionally offers a template picker (36 predefined patterns from `usetemplates="if"`) for the most common conditions
+- Move up/down and delete via hover action buttons on each row
 
-The underlying `IEditableScript` tree (via `GetParameter`/`SetParameter` on the WASM bridge) is view-agnostic; the script editor is purely a rendering layer over it.
+**Add script** (`AddScriptModal.svelte`)
+- Categorised command picker with quick-add shortcuts for common commands
+- Keyboard: Escape cancels, Enter confirms, double-click adds immediately
 
-Steps:
-1. Extend `WasmEditorBridge` with script-specific API: `GetScriptEditorData`, `SetScriptParameter`, `AddScript`, `DeleteScript`, `MoveScript`
-2. Expose editor definitions (`IEditorDefinition`, control types) from EditorCore so the Svelte layer knows how to render each script command's parameters
-3. Implement the `ScriptEditor` Svelte component, recursing for nested scripts
-4. Wire `ScriptEditor` into `PropertyEditor` when a script-type attribute is selected
+**Code view**
+- Toggle button switches the block between the visual editor and a monospace textarea showing the raw Quest script text
+- Round-trips through `EditableScripts.Code` (`Save()` / `LoadCode()`); works correctly on empty attributes by auto-creating the container
 
-A plain text code view (Monaco or CodeMirror) is also worth adding alongside the visual editor — each script already has a `Save()` / `Code` representation, so the round-trip exists.
+**Copy / cut / paste**
+- Checkbox on each root-level row; checking any shows a selection toolbar with Cut, Copy, Delete, and (single selection) Move Up / Move Down
+- Cut/Copy use `IEditableScripts.Cut/Copy` — clipboard lives in `EditorController.m_clipboardScripts`
+- Paste appends clipboard scripts at the end of the container; handles empty (unset) attributes by creating the container first
+- `scriptClipboardHasContent` Svelte store controls Paste button visibility
+
+**Bridge additions** (all `[JSExport]` on `WasmEditorBridge`):
+`GetScriptData`, `SetScriptParameter`, `SetIfExpression`, `SetElseIfExpression`, `AddScript`, `DeleteScript`, `DeleteScripts`, `MoveScript`, `AddElse`, `AddElseIf`, `RemoveElse`, `RemoveElseIf`, `GetScriptCommandCategories`, `GetObjectNames`, `GetIfExpressionTemplates`, `GetIfExpressionTemplateData`, `GetScriptCode`, `SetScriptCode`, `CopyScripts`, `CutScripts`, `PasteScripts`, `CanPasteScript`
 
 ### Phase 5 — Full feature parity
 - New game (from templates)
@@ -242,9 +253,9 @@ Three rendering modes over the same `IEditableScript` model, toggleable per-scri
 
 | Mode | Description |
 |---|---|
-| **Visual (v5-style)** | Inline form rows with typed controls per parameter — the Phase 4 target |
+| **Visual (v5-style)** | Inline form rows with typed controls per parameter ✅ |
+| **Code view** | Raw Quest script text — round-trips through `EditableScripts.Code` / `Save()` ✅ |
 | **Blockly** | Block-based drag-and-drop — future, see below |
-| **Code view** | Raw Quest script text via Monaco/CodeMirror — round-trips through `Save()` |
 
 All three modes read/write the same underlying script tree. Switching mode is a pure UI concern.
 

--- a/docs/webeditor-wasm-svelte.md
+++ b/docs/webeditor-wasm-svelte.md
@@ -243,6 +243,15 @@ Visual script editor, code view, and copy/paste — full feature parity with the
 - Asset storage for images via OPFS + Service Worker
 - Test suite for the WASM bridge
 
+### Phase 6 — Raw ASLX editor
+
+The desktop editor (to be replaced by this WebEditor wrapped in Electron) includes a full raw-file code view. Required for parity.
+
+- A CodeMirror 6 XML editor surfaced as a top-level toggle (whole-file view, not per-script)
+- XML syntax highlighting is built into CM6 — no custom grammar needed
+- Round-trips through save/reload; needs a clear "you are editing raw XML" warning since changes bypass all validation
+- Natural fit for CodeMirror 6 given bundle size and the availability of the XML language package; Monaco is an alternative if a more VS Code–like experience is wanted at the cost of a much larger bundle
+
 ---
 
 ## Script editor design

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -65,6 +65,7 @@ internal record IfExpressionTemplate(string Name, string CreateExpression);
 [JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(List<IfExpressionTemplate>))]
 [JsonSerializable(typeof(IfExpressionTemplateData))]
+[JsonSerializable(typeof(int[]))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext { }
 
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
@@ -232,6 +233,106 @@ public partial class WasmEditorBridge
     }
 
     // ── Script editor API ──────────────────────────────────────────────────────
+
+    [JSExport]
+    public static string GetScriptCode(string elementKey, string attribute)
+    {
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts is not EditableScripts editableScripts) return string.Empty;
+        return editableScripts.Code;
+    }
+
+    [JSExport]
+    public static string SetScriptCode(string elementKey, string attribute, string code)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts is not EditableScripts editableScripts) return "error";
+        try
+        {
+            editableScripts.Code = code;
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    [JSExport]
+    public static string CopyScripts(string elementKey, string attribute, string containerPath, string indicesJson)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null) return "error";
+        var indices = JsonSerializer.Deserialize(indicesJson, WasmEditorJsonContext.Default.Int32Array);
+        if (indices == null || indices.Length == 0) return "error";
+        container.Copy(indices);
+        return "ok";
+    }
+
+    [JSExport]
+    public static string CutScripts(string elementKey, string attribute, string containerPath, string indicesJson)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null) return "error";
+        var indices = JsonSerializer.Deserialize(indicesJson, WasmEditorJsonContext.Default.Int32Array);
+        if (indices == null || indices.Length == 0) return "error";
+        try { container.Cut(indices); return "ok"; }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string DeleteScripts(string elementKey, string attribute, string containerPath, string indicesJson)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null) return "error";
+        var indices = JsonSerializer.Deserialize(indicesJson, WasmEditorJsonContext.Default.Int32Array);
+        if (indices == null || indices.Length == 0) return "ok";
+        container.Remove(indices);
+        return "ok";
+    }
+
+    [JSExport]
+    public static string PasteScripts(string elementKey, string attribute, string containerPath)
+    {
+        if (_controller == null) return "error";
+        if (!_controller.CanPasteScript()) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+
+        // No scripts container yet (attribute never set) — create an empty one then paste
+        if (scripts == null && string.IsNullOrEmpty(containerPath))
+        {
+            _controller.StartTransaction("Paste script");
+            try
+            {
+                _controller.CreateNewEditableScripts(elementKey, attribute, null!, false);
+                scripts = GetScripts(elementKey, attribute);
+                if (scripts == null) return "error";
+                scripts.Paste(0, false);
+                return "ok";
+            }
+            catch (Exception ex) { return ex.Message; }
+            finally { _controller.EndTransaction(); }
+        }
+
+        if (scripts == null) return "error";
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null) return "error";
+        container.Paste(container.Count, true);
+        return "ok";
+    }
+
+    [JSExport]
+    public static bool CanPasteScript() => _controller?.CanPasteScript() ?? false;
 
     [JSExport]
     public static string? GetScriptData(string elementKey, string attribute)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -247,7 +247,17 @@ public partial class WasmEditorBridge
     {
         if (_controller == null) return "error";
         var scripts = GetScripts(elementKey, attribute);
-        if (scripts is not EditableScripts editableScripts) return "error";
+
+        if (scripts is not EditableScripts editableScripts)
+        {
+            if (string.IsNullOrWhiteSpace(code)) return "ok";
+            // Attribute not yet set — create an empty container then fall through to set Code
+            _controller.CreateNewEditableScripts(elementKey, attribute, null!, false);
+            scripts = GetScripts(elementKey, attribute);
+            if (scripts is not EditableScripts newScripts) return "error";
+            editableScripts = newScripts;
+        }
+
         try
         {
             editableScripts.Code = code;

--- a/src/WebEditor/src/components/AddScriptModal.svelte
+++ b/src/WebEditor/src/components/AddScriptModal.svelte
@@ -9,6 +9,9 @@
 
     let { categories, onAdd, onClose }: Props = $props();
 
+    let dialogEl: HTMLDivElement;
+    $effect(() => { dialogEl?.focus(); });
+
     const SHORTCUT_KEYWORDS: string[] = [
         "msg",
         "(function)AddToInventory",
@@ -71,6 +74,7 @@
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
+    bind:this={dialogEl}
     role="dialog"
     aria-modal="true"
     tabindex="-1"

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -104,7 +104,7 @@
             {ctrl.caption ?? ""}
         </div>
     {:else if ctrl.attribute !== null}
-        <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900 hover:bg-surface-100-900 min-h-8">
+        <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900 min-h-8">
             <span class="text-xs text-surface-600-400 w-32 flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap" title={ctrl.caption ?? ctrl.attribute}>
                 {ctrl.caption ?? ctrl.attribute}
             </span>

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -3,7 +3,14 @@
     import AddScriptModal from "./AddScriptModal.svelte";
     import {
         scriptVersion,
+        scriptClipboardHasContent,
         getScriptData,
+        getScriptCode,
+        setScriptCode,
+        copyScripts,
+        cutScripts,
+        deleteScripts,
+        pasteScripts,
         setScriptParameter,
         setIfExpression,
         setElseIfExpression,
@@ -49,6 +56,11 @@
     let categories = $state<ScriptCategoryInfo[]>([]);
     let showAddModal = $state(false);
     let isRoot = $derived(initialData === null);
+    let codeViewMode = $state(false);
+    let scriptCode = $state("");
+    let selectedIndices = $state(new Set<number>());
+    // Set before a move mutation so the $effect restores it instead of clearing
+    let nextSelection: Set<number> | null = null;
     // Tracks which expression controls the user has explicitly forced into expression mode,
     // overriding the default simple-mode detection based on value shape.
     let expressionOverrides = $state(new Set<string>());
@@ -60,6 +72,8 @@
         const version = $scriptVersion; // track for reactivity on undo/redo
         if (isRoot) {
             scriptData = version >= 0 ? getScriptData(elementKey, attribute) : null;
+            selectedIndices = nextSelection ?? new Set();
+            nextSelection = null;
         }
         if (categories.length === 0) {
             const cats = getScriptCommandCategories();
@@ -202,6 +216,64 @@
         return result;
     }
 
+    function onToggleCodeView() {
+        codeViewMode = !codeViewMode;
+        if (codeViewMode) {
+            scriptCode = getScriptCode(elementKey, attribute);
+        } else {
+            refresh();
+        }
+    }
+
+    function onCodeViewSave(value: string) {
+        const result = setScriptCode(elementKey, attribute, value);
+        if (result === "ok") {
+            scriptCode = value;
+        }
+    }
+
+    function sortedSelection(): number[] {
+        return [...selectedIndices].sort((a, b) => a - b);
+    }
+
+    function toggleSelection(i: number, checked: boolean) {
+        const next = new Set(selectedIndices);
+        if (checked) next.add(i); else next.delete(i);
+        selectedIndices = next;
+    }
+
+    function onCopySelected() {
+        copyScripts(elementKey, attribute, containerPath, sortedSelection());
+        // no scriptVersion bump — selection intentionally preserved after copy
+    }
+
+    function onCutSelected() {
+        cutScripts(elementKey, attribute, containerPath, sortedSelection());
+        // selectedIndices cleared by $effect when scriptVersion bumps
+    }
+
+    function onDeleteSelected() {
+        deleteScripts(elementKey, attribute, containerPath, sortedSelection());
+    }
+
+    function onPaste() {
+        pasteScripts(elementKey, attribute, containerPath);
+    }
+
+    function onMoveUpSelected() {
+        const [idx] = sortedSelection();
+        if (idx <= 0) return;
+        nextSelection = new Set([idx - 1]);
+        mutate(() => moveScript(elementKey, attribute, containerPath, idx, idx - 1));
+    }
+
+    function onMoveDownSelected() {
+        const [idx] = sortedSelection();
+        if (idx >= scripts().length - 1) return;
+        nextSelection = new Set([idx + 1]);
+        mutate(() => moveScript(elementKey, attribute, containerPath, idx, idx + 1));
+    }
+
     function onAddScript(createString: string) {
         mutate(() => addScript(elementKey, attribute, containerPath, createString));
     }
@@ -269,50 +341,123 @@
 </script>
 
 <div class={indentClass}>
-    {#each scripts() as script, i (script.id)}
-        <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950">
-            <!-- Script row actions -->
-            <div class="absolute right-1 top-1 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10">
-                <button
-                    type="button"
-                    class="btn btn-sm preset-outlined px-1 py-0 text-xs leading-none"
-                    title="Move up"
-                    disabled={i === 0}
-                    onclick={() => onMoveUp(i)}
-                >↑</button>
-                <button
-                    type="button"
-                    class="btn btn-sm preset-outlined px-1 py-0 text-xs leading-none"
-                    title="Move down"
-                    disabled={i === scripts().length - 1}
-                    onclick={() => onMoveDown(i)}
-                >↓</button>
-                <button
-                    type="button"
-                    class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
-                    title="Delete"
-                    onclick={() => onDelete(i)}
-                >×</button>
-            </div>
+    {#if codeViewMode}
+        <textarea
+            class="textarea text-xs font-mono w-full"
+            rows={10}
+            value={scriptCode}
+            onchange={(e) => onCodeViewSave((e.target as HTMLTextAreaElement).value)}
+        ></textarea>
+    {:else}
+        {#each scripts() as script, i (script.id)}
+            <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-start">
+                {#if isRoot}
+                    <label class="flex items-start pt-1.5 pl-1.5 pr-0.5 cursor-pointer flex-shrink-0">
+                        <input
+                            type="checkbox"
+                            class="checkbox size-3.5"
+                            checked={selectedIndices.has(i)}
+                            onchange={(e) => toggleSelection(i, (e.target as HTMLInputElement).checked)}
+                        />
+                    </label>
+                {/if}
+                <div class="flex-1 min-w-0">
+                    <!-- Script row actions (hover) -->
+                    <div class="absolute right-1 top-1 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10">
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined px-1 py-0 text-xs leading-none"
+                            title="Move up"
+                            disabled={i === 0}
+                            onclick={() => onMoveUp(i)}
+                        >↑</button>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined px-1 py-0 text-xs leading-none"
+                            title="Move down"
+                            disabled={i === scripts().length - 1}
+                            onclick={() => onMoveDown(i)}
+                        >↓</button>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
+                            title="Delete"
+                            onclick={() => onDelete(i)}
+                        >×</button>
+                    </div>
 
-            {#if script.type === "if"}
-                {@render ifBlock(script, i)}
-            {:else}
-                {@render normalBlock(script, i)}
-            {/if}
-        </div>
-    {/each}
+                    {#if script.type === "if"}
+                        {@render ifBlock(script, i)}
+                    {:else}
+                        {@render normalBlock(script, i)}
+                    {/if}
+                </div>
+            </div>
+        {/each}
+
+        <!-- Selection toolbar -->
+        {#if isRoot && selectedIndices.size > 0}
+            {@const sel = sortedSelection()}
+            <div class="flex items-center gap-1 mb-1 px-1 py-1 bg-surface-100-900 rounded border border-surface-200-800 text-xs">
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined text-xs py-0.5"
+                    onclick={onCutSelected}
+                >Cut</button>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined text-xs py-0.5"
+                    onclick={onCopySelected}
+                >Copy</button>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-tonal-error text-xs py-0.5"
+                    onclick={onDeleteSelected}
+                >Delete</button>
+                {#if sel.length === 1}
+                    <span class="w-px h-4 bg-surface-300-700 mx-0.5"></span>
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined text-xs py-0.5"
+                        disabled={sel[0] === 0}
+                        onclick={onMoveUpSelected}
+                    >↑ Move up</button>
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined text-xs py-0.5"
+                        disabled={sel[0] === scripts().length - 1}
+                        onclick={onMoveDownSelected}
+                    >↓ Move down</button>
+                {/if}
+                <span class="ml-auto text-surface-400-500">{sel.length} selected</span>
+            </div>
+        {/if}
+    {/if}
 
     <!-- Add script row -->
-    <div class="flex items-center gap-1 mt-1">
-        {#if categories.length > 0}
+    <div class="flex items-center gap-1 mt-1 flex-wrap">
+        {#if !codeViewMode && categories.length > 0}
             <button
                 type="button"
                 class="btn btn-sm preset-outlined text-xs py-0.5"
                 onclick={() => (showAddModal = true)}
             >+ Add script</button>
-        {:else if isRoot}
+        {:else if !codeViewMode && isRoot}
             <span class="text-xs text-surface-400-500 italic">Loading commands…</span>
+        {/if}
+        {#if isRoot && $scriptClipboardHasContent && !codeViewMode}
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined text-xs py-0.5"
+                onclick={onPaste}
+            >Paste</button>
+        {/if}
+        {#if isRoot}
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined text-xs py-0.5"
+                onclick={onToggleCodeView}
+            >{codeViewMode ? "Visual editor" : "Code view"}</button>
         {/if}
     </div>
 

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -13,6 +13,7 @@ export const selectedData = writable<EditorDataResponse | null>(null);
 export const canUndo = writable(false);
 export const canRedo = writable(false);
 export const scriptVersion = writable(0);
+export const scriptClipboardHasContent = writable(false);
 
 function refreshUndoRedo() {
     canUndo.set(_bridge?.CanUndo() ?? false);
@@ -28,6 +29,7 @@ export async function openGame(file: File): Promise<boolean> {
         isLoaded.set(true);
         gameFilename.set(file.name);
         refreshUndoRedo();
+        scriptClipboardHasContent.set(false);
     }
     return ok;
 }
@@ -74,6 +76,49 @@ export function redo() {
 }
 
 // ── Script editor functions ─────────────────────────────────────────────────
+
+export function getScriptCode(elementKey: string, attribute: string): string {
+    return _bridge?.GetScriptCode(elementKey, attribute) ?? "";
+}
+
+export function setScriptCode(elementKey: string, attribute: string, code: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetScriptCode(elementKey, attribute, code);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function copyScripts(elementKey: string, attribute: string, containerPath: string, indices: number[]): string {
+    if (!_bridge) return "error";
+    const result = _bridge.CopyScripts(elementKey, attribute, containerPath, JSON.stringify(indices));
+    if (result === "ok") scriptClipboardHasContent.set(true);
+    return result;
+}
+
+export function cutScripts(elementKey: string, attribute: string, containerPath: string, indices: number[]): string {
+    if (!_bridge) return "error";
+    const result = _bridge.CutScripts(elementKey, attribute, containerPath, JSON.stringify(indices));
+    if (result === "ok") { bumpScriptVersion(); scriptClipboardHasContent.set(true); }
+    refreshUndoRedo();
+    return result;
+}
+
+export function deleteScripts(elementKey: string, attribute: string, containerPath: string, indices: number[]): string {
+    if (!_bridge) return "error";
+    const result = _bridge.DeleteScripts(elementKey, attribute, containerPath, JSON.stringify(indices));
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function pasteScripts(elementKey: string, attribute: string, containerPath: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.PasteScripts(elementKey, attribute, containerPath);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
 
 export function getScriptData(elementKey: string, attribute: string): ScriptBlockData | null {
     if (!_bridge) return null;

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -10,6 +10,13 @@ export interface WasmBridge {
   Undo(): void
   Redo(): void
   // Script editor API
+  GetScriptCode(elementKey: string, attribute: string): string
+  SetScriptCode(elementKey: string, attribute: string, code: string): string
+  CopyScripts(elementKey: string, attribute: string, containerPath: string, indicesJson: string): string
+  CutScripts(elementKey: string, attribute: string, containerPath: string, indicesJson: string): string
+  DeleteScripts(elementKey: string, attribute: string, containerPath: string, indicesJson: string): string
+  PasteScripts(elementKey: string, attribute: string, containerPath: string): string
+  CanPasteScript(): boolean
   GetScriptData(elementKey: string, attribute: string): string | null
   SetScriptParameter(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramName: string, value: string): string
   SetIfExpression(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, expression: string): string


### PR DESCRIPTION
## Summary

- **Code view** — toggle button next to _Add script_ switches the script editor between the visual editor and a raw text view backed by the existing `EditableScripts.Code` round-trip (`Save()` / `LoadCode()`); works correctly on empty script attributes by auto-creating the container when needed
- **Copy / cut / paste** — checkboxes on each root-level script row; checking any shows a toolbar with Cut, Copy, Delete, and (single selection) Move Up / Move Down as accessible alternatives to the hover-only action buttons; a Paste button appears next to _Add script_ whenever the clipboard has content; paste into an empty (unset) attribute is handled by creating the container first
- **Escape closes the Add Script modal** — auto-focuses the modal backdrop on open so the existing keydown handler fires correctly
- **Removed row hover highlight** from PropertyEditor to prevent the grey wash bleeding through the code-view textarea background

## Test plan

- [ ] Open a game, navigate to a script attribute with existing scripts
- [ ] Toggle Code view — raw Quest script text should appear; edits should round-trip back to the visual editor
- [ ] Toggle Code view on an empty script attribute, type a script (e.g. `msg ("hi")`), exit — scripts should appear in the visual editor
- [ ] Check one or more script rows — toolbar appears with Cut / Copy / Delete / Move Up / Move Down
- [ ] Cut scripts, navigate to another element, use Paste to insert them
- [ ] Paste into an element with no scripts yet — should work
- [ ] Escape key closes the Add Script modal

🤖 Generated with [Claude Code](https://claude.ai/claude-code)