### PR TITLE
WebEditor: add/delete elements, tree fixes, and UI polish

### DIFF
--- a/docs/webeditor-wasm-svelte.md
+++ b/docs/webeditor-wasm-svelte.md
@@ -34,6 +34,18 @@ All data crossing the JS/WASM boundary is JSON. The Svelte layer calls `[JSExpor
 [JSExport] string     Save()                   // returns XML
 [JSExport] void       Undo()
 [JSExport] void       Redo()
+// Element creation — returns new element key on success, "error:..." on failure
+[JSExport] string     ValidateName(string name)
+[JSExport] string     GetUniqueName(string baseName)
+[JSExport] string     CreateRoom(string name, string? parent)    // parent="" means top-level
+[JSExport] string     CreateObject(string name, string? parent)
+[JSExport] string     CreateFunction(string name)
+[JSExport] string     CreateTimer(string name)
+[JSExport] string     CreateExit(string parent)       // anonymous; navigate to it to edit destination
+[JSExport] string     CreateTurnScript(string parent) // anonymous
+[JSExport] string     CreateCommand(string? parent)   // anonymous; parent="" means global
+[JSExport] string     CreateVerb(string? parent)      // anonymous; parent="" means global
+[JSExport] void       DeleteElement(string key)
 ```
 
 `GetEditorData` returns an `EditorDataResponse`:
@@ -236,7 +248,20 @@ Visual script editor, code view, and copy/paste — full feature parity with the
 **Bridge additions** (all `[JSExport]` on `WasmEditorBridge`):
 `GetScriptData`, `SetScriptParameter`, `SetIfExpression`, `SetElseIfExpression`, `AddScript`, `DeleteScript`, `DeleteScripts`, `MoveScript`, `AddElse`, `AddElseIf`, `RemoveElse`, `RemoveElseIf`, `GetScriptCommandCategories`, `GetObjectNames`, `GetIfExpressionTemplates`, `GetIfExpressionTemplateData`, `GetScriptCode`, `SetScriptCode`, `CopyScripts`, `CutScripts`, `PasteScripts`, `CanPasteScript`
 
-### Phase 5 — Full feature parity
+### Phase 5 — Add / delete elements ✅
+
+Tree panel and WASM bridge support creating and deleting all element types:
+
+- **Rooms and Objects** — named, via `AddElementModal` (live name validation, unique-name suggestion)
+- **Functions and Timers** — named, same modal flow
+- **Exits, Commands, Verbs, Turn Scripts** — anonymous (auto-named), created immediately and selected for editing
+- **Delete** — any non-header element; confirm dialog; tree and undo/redo update immediately
+- Tree nodes now carry `nodeIcon` so the UI knows element type without a round-trip
+- `RemovedNode`, `RenamedNode`, `RetitledNode` events now kept live in C# so `GetTreeNodes()` always returns current state
+
+UX: hovering a tree node reveals "+" (add child) and "×" (delete) action buttons. Header nodes get a single-click "+". The Rooms exits tab with a richer exit dialog is a separate future phase.
+
+### Phase 6 — Remaining full feature parity
 - New game (from templates)
 - Publish/export
 - File System Access API + OPFS persistence (see File handling section)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -73,6 +73,7 @@ public partial class WasmEditorBridge
 {
     private static EditorController? _controller;
     private static readonly List<TreeNodeData> TreeNodes = [];
+    private static bool _isRebuilding;
 
     [JSExport]
     public static async Task<bool> Initialise(byte[] gameFileBytes, string filename)
@@ -81,9 +82,9 @@ public partial class WasmEditorBridge
         TreeNodes.Clear();
 
         _controller = new EditorController();
-        _controller.ClearTree += (_, _) => { };
+        _controller.ClearTree += (_, _) => { TreeNodes.Clear(); _isRebuilding = true; };
         _controller.BeginTreeUpdate += (_, _) => { };
-        _controller.EndTreeUpdate += (_, _) => { };
+        _controller.EndTreeUpdate += (_, _) => { _isRebuilding = false; };
         _controller.AddedNode += OnAddedNode;
         _controller.RemovedNode += (_, e) => TreeNodes.RemoveAll(n => n.Key == e.Key);
         _controller.RenamedNode += (_, e) =>
@@ -982,15 +983,22 @@ public partial class WasmEditorBridge
 
     private static void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e)
     {
-        // AddedNode can fire multiple times for the same key (e.g. k_commands fires on every
-        // AddElementToTree("game") call, and field-update paths can re-fire for existing nodes).
-        // Treat this as an upsert: update text/parent if present, add if absent.
-        var idx = TreeNodes.FindIndex(n => n.Key == e.Key);
         var node = new TreeNodeData(e.Key, e.Text, e.Parent, e.NodeIcon, GetNodeType(e.Key, e.NodeIcon));
-        if (idx >= 0)
-            TreeNodes[idx] = node;
-        else
+        if (_isRebuilding)
+        {
+            // ClearTree already emptied the list; all keys are unique in a fresh rebuild.
             TreeNodes.Add(node);
+        }
+        else
+        {
+            // Outside a full rebuild, AddedNode can fire for an existing key
+            // (e.g. field-update paths re-fire for nodes that move between parents).
+            var idx = TreeNodes.FindIndex(n => n.Key == e.Key);
+            if (idx >= 0)
+                TreeNodes[idx] = node;
+            else
+                TreeNodes.Add(node);
+        }
     }
 
     private static ControlInfo ToControlInfo(IEditorControl ctrl)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -94,7 +94,7 @@ public partial class WasmEditorBridge
             for (int i = 0; i < TreeNodes.Count; i++)
             {
                 if (TreeNodes[i].Key == e.OldName)
-                    TreeNodes[i] = TreeNodes[i] with { Key = e.NewName, NodeType = GetNodeType(e.NewName, TreeNodes[i].NodeIcon) };
+                    TreeNodes[i] = TreeNodes[i] with { Key = e.NewName, Text = e.NewName, NodeType = GetNodeType(e.NewName, TreeNodes[i].NodeIcon) };
                 else if (TreeNodes[i].Parent == e.OldName)
                     TreeNodes[i] = TreeNodes[i] with { Parent = e.NewName };
             }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -74,6 +74,7 @@ public partial class WasmEditorBridge
     private static EditorController? _controller;
     private static readonly List<TreeNodeData> TreeNodes = [];
     private static bool _isRebuilding;
+    private static string? _pendingRenameNewKey;
 
     [JSExport]
     public static async Task<bool> Initialise(byte[] gameFileBytes, string filename)
@@ -89,6 +90,7 @@ public partial class WasmEditorBridge
         _controller.RemovedNode += (_, e) => TreeNodes.RemoveAll(n => n.Key == e.Key);
         _controller.RenamedNode += (_, e) =>
         {
+            _pendingRenameNewKey = e.NewName;
             for (int i = 0; i < TreeNodes.Count; i++)
             {
                 if (TreeNodes[i].Key == e.OldName)
@@ -166,11 +168,13 @@ public partial class WasmEditorBridge
             _ => value
         };
 
+        _pendingRenameNewKey = null;
         _controller.StartTransaction($"Set {attribute}");
         try
         {
             var result = data.SetAttribute(attribute, typedValue);
-            return result.Valid ? "ok" : result.Message.ToString();
+            if (!result.Valid) return result.Message.ToString();
+            return _pendingRenameNewKey != null ? $"renamed:{_pendingRenameNewKey}" : "ok";
         }
         finally
         {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -11,7 +11,7 @@ using QuestViva.EditorCore;
 
 namespace QuestViva.WasmEditor;
 
-internal record TreeNodeData(string Key, string Text, string? Parent);
+internal record TreeNodeData(string Key, string Text, string? Parent, string? NodeIcon, string NodeType);
 internal record ControlOption(string Value, string Label);
 internal record ControlInfo(string? Attribute, string ControlType, string? Caption, List<ControlOption>? Options);
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
@@ -85,11 +85,22 @@ public partial class WasmEditorBridge
         _controller.BeginTreeUpdate += (_, _) => { };
         _controller.EndTreeUpdate += (_, _) => { };
         _controller.AddedNode += OnAddedNode;
-        // RetitledNode and RemovedNode are called without null guards in EditorController,
-        // so they must be subscribed even if we don't act on them yet.
-        _controller.RetitledNode += (_, _) => { };
-        _controller.RemovedNode += (_, _) => { };
-        _controller.RenamedNode += (_, _) => { };
+        _controller.RemovedNode += (_, e) => TreeNodes.RemoveAll(n => n.Key == e.Key);
+        _controller.RenamedNode += (_, e) =>
+        {
+            for (int i = 0; i < TreeNodes.Count; i++)
+            {
+                if (TreeNodes[i].Key == e.OldName)
+                    TreeNodes[i] = TreeNodes[i] with { Key = e.NewName, NodeType = GetNodeType(e.NewName, TreeNodes[i].NodeIcon) };
+                else if (TreeNodes[i].Parent == e.OldName)
+                    TreeNodes[i] = TreeNodes[i] with { Parent = e.NewName };
+            }
+        };
+        _controller.RetitledNode += (_, e) =>
+        {
+            var idx = TreeNodes.FindIndex(n => n.Key == e.Key);
+            if (idx >= 0) TreeNodes[idx] = TreeNodes[idx] with { Text = e.NewTitle };
+        };
 
         var provider = new ByteArrayGameDataProvider(gameFileBytes, filename);
         var ok = await _controller.Initialise(new WasmConfig(), provider);
@@ -670,6 +681,101 @@ public partial class WasmEditorBridge
         );
     }
 
+    // ── Element creation / deletion ───────────────────────────────────────────
+
+    [JSExport]
+    public static string ValidateName(string name)
+    {
+        if (_controller == null) return "Not initialised";
+        var result = _controller.CanAdd(name);
+        return result.Valid ? "ok" : EditorController.GetValidationError(result, name);
+    }
+
+    [JSExport]
+    public static string GetUniqueName(string baseName)
+    {
+        if (_controller == null) return baseName;
+        return _controller.GetUniqueElementName(baseName);
+    }
+
+    [JSExport]
+    public static string CreateRoom(string name, string? parent)
+    {
+        if (_controller == null) return "error:Not initialised";
+        var validation = _controller.CanAdd(name);
+        if (!validation.Valid) return $"error:{EditorController.GetValidationError(validation, name)}";
+        try { _controller.CreateNewRoom(name, string.IsNullOrEmpty(parent) ? null : parent, null); return name; }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateObject(string name, string? parent)
+    {
+        if (_controller == null) return "error:Not initialised";
+        var validation = _controller.CanAdd(name);
+        if (!validation.Valid) return $"error:{EditorController.GetValidationError(validation, name)}";
+        try { _controller.CreateNewObject(name, string.IsNullOrEmpty(parent) ? null : parent, null); return name; }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateFunction(string name)
+    {
+        if (_controller == null) return "error:Not initialised";
+        var validation = _controller.CanAdd(name);
+        if (!validation.Valid) return $"error:{EditorController.GetValidationError(validation, name)}";
+        try { _controller.CreateNewFunction(name); return name; }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateTimer(string name)
+    {
+        if (_controller == null) return "error:Not initialised";
+        var validation = _controller.CanAdd(name);
+        if (!validation.Valid) return $"error:{EditorController.GetValidationError(validation, name)}";
+        try { _controller.CreateNewTimer(name); return name; }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateExit(string parent)
+    {
+        if (_controller == null) return "error:Not initialised";
+        try { return _controller.CreateNewExit(parent); }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateTurnScript(string parent)
+    {
+        if (_controller == null) return "error:Not initialised";
+        try { return _controller.CreateNewTurnScript(parent); }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateCommand(string? parent)
+    {
+        if (_controller == null) return "error:Not initialised";
+        try { return _controller.CreateNewCommand(string.IsNullOrEmpty(parent) ? null : parent); }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateVerb(string? parent)
+    {
+        if (_controller == null) return "error:Not initialised";
+        try { return _controller.CreateNewVerb(string.IsNullOrEmpty(parent) ? null : parent, true); }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static void DeleteElement(string key)
+    {
+        _controller?.DeleteElement(key, true);
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     private static IEditableScripts? GetScripts(string elementKey, string attribute)
@@ -858,9 +964,33 @@ public partial class WasmEditorBridge
         );
     }
 
+    private static string GetNodeType(string key, string? nodeIcon) => key.StartsWith("_")
+        ? "header"
+        : nodeIcon switch
+        {
+            "s_room" => "room",
+            "s_object" => "object",
+            "s_exit" => "exit",
+            "s_verb" => "verb",
+            "s_command" => "command",
+            "s_turn" => "turnscript",
+            "s_function" => "function",
+            "s_timer" => "timer",
+            "s_game" => "game",
+            _ => "other"
+        };
+
     private static void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e)
     {
-        TreeNodes.Add(new TreeNodeData(e.Key, e.Text, e.Parent));
+        // AddedNode can fire multiple times for the same key (e.g. k_commands fires on every
+        // AddElementToTree("game") call, and field-update paths can re-fire for existing nodes).
+        // Treat this as an upsert: update text/parent if present, add if absent.
+        var idx = TreeNodes.FindIndex(n => n.Key == e.Key);
+        var node = new TreeNodeData(e.Key, e.Text, e.Parent, e.NodeIcon, GetNodeType(e.Key, e.NodeIcon));
+        if (idx >= 0)
+            TreeNodes[idx] = node;
+        else
+            TreeNodes.Add(node);
     }
 
     private static ControlInfo ToControlInfo(IEditorControl ctrl)

--- a/src/WebEditor/src/app.css
+++ b/src/WebEditor/src/app.css
@@ -1,4 +1,8 @@
 @import 'tailwindcss';
 @import '@skeletonlabs/skeleton';
 @import '@skeletonlabs/skeleton-svelte';
-@import '@skeletonlabs/skeleton/themes/cerberus';
+@import '@skeletonlabs/skeleton/themes/wintry';
+
+[data-scope='app-bar'] {
+    background: light-dark(white, var(--color-surface-800));
+}

--- a/src/WebEditor/src/app.css
+++ b/src/WebEditor/src/app.css
@@ -6,3 +6,30 @@
 [data-scope='app-bar'] {
     background: light-dark(white, var(--color-surface-800));
 }
+
+/* Override flex-start so branches/items stretch to the full panel width */
+[data-scope='tree-view'][data-part='root'] {
+    align-items: stretch;
+}
+
+/* Reduce right padding so the ⋯ button sits close to the edge */
+/* Pointer cursor on all nodes; tighter vertical padding for compactness */
+[data-scope='tree-view'][data-part='item'],
+[data-scope='tree-view'][data-part='branch-control'] {
+    padding-inline-end: 0;
+    padding-block: calc(var(--spacing) * 1);
+    cursor: pointer;
+}
+
+/* Ensure indent guides paint above item backgrounds */
+[data-scope='tree-view'][data-part='branch-indent-guide'] {
+    z-index: 1;
+    pointer-events: none;
+}
+
+/* Subtle neutral selection highlight instead of the stark preset-filled black/white */
+[data-scope='tree-view'][data-part='item'][data-selected],
+[data-scope='tree-view'][data-part='branch-control'][data-selected] {
+    background-color: var(--color-surface-200-800);
+    color: inherit;
+}

--- a/src/WebEditor/src/app.html
+++ b/src/WebEditor/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="cerberus">
+<html lang="en" data-theme="wintry">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/WebEditor/src/components/AddElementModal.svelte
+++ b/src/WebEditor/src/components/AddElementModal.svelte
@@ -49,13 +49,13 @@
     role="dialog"
     aria-modal="true"
     tabindex="-1"
-    class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50"
+    class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
 >
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
-        class="card bg-surface-100-900 rounded-xl shadow-2xl w-80 p-6 flex flex-col gap-4"
+        class="card bg-white rounded-xl shadow-xl w-80 p-6 flex flex-col gap-4"
         onclick={(e) => e.stopPropagation()}
     >
         <h2 class="text-base font-semibold">
@@ -68,7 +68,7 @@
             <input
                 id="element-name"
                 type="text"
-                class={"input px-2 py-1 text-sm" + (error ? " !border-error-500" : "")}
+                class={"input bg-white px-2 py-1 text-sm" + (error ? " !border-error-500" : "")}
                 bind:value={name}
                 autofocus
                 placeholder="Enter a name..."

--- a/src/WebEditor/src/components/AddElementModal.svelte
+++ b/src/WebEditor/src/components/AddElementModal.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+    import { validateName } from "$lib/editor-store";
+
+    interface Props {
+        elementType: "room" | "object" | "function" | "timer";
+        parent?: string | null;
+        onconfirm: (name: string) => void;
+        oncancel: () => void;
+    }
+
+    const { elementType, parent = null, onconfirm, oncancel }: Props = $props();
+
+    const labels: Record<string, string> = {
+        room: "Room",
+        object: "Object",
+        function: "Function",
+        timer: "Timer",
+    };
+
+    let dialogEl: HTMLDivElement;
+    $effect(() => { dialogEl?.focus(); });
+
+    let name = $state("");
+    let error = $state("");
+
+    $effect(() => {
+        const result = name ? validateName(name) : "";
+        error = result === "ok" ? "" : result;
+    });
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter" && name && !error) confirm();
+        if (e.key === "Escape") oncancel();
+    }
+
+    function onBackdropClick(e: MouseEvent) {
+        if (e.target === e.currentTarget) oncancel();
+    }
+
+    function confirm() {
+        if (!name || error) return;
+        const result = validateName(name);
+        if (result !== "ok") { error = result; return; }
+        onconfirm(name);
+    }
+</script>
+
+<div
+    bind:this={dialogEl}
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50"
+    onclick={onBackdropClick}
+    onkeydown={handleKeydown}
+>
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+        class="card bg-surface-100-900 rounded-xl shadow-2xl w-80 p-6 flex flex-col gap-4"
+        onclick={(e) => e.stopPropagation()}
+    >
+        <h2 class="text-base font-semibold">
+            Add {labels[elementType]}{parent ? ` in "${parent}"` : ""}
+        </h2>
+
+        <div class="flex flex-col gap-1">
+            <label for="element-name" class="text-xs text-surface-500-400">Name</label>
+            <!-- svelte-ignore a11y_autofocus -->
+            <input
+                id="element-name"
+                type="text"
+                class={"input px-2 py-1 text-sm" + (error ? " !border-error-500" : "")}
+                bind:value={name}
+                autofocus
+                placeholder="Enter a name..."
+            />
+            {#if error}
+                <p class="text-xs text-error-500">{error}</p>
+            {/if}
+        </div>
+
+        <div class="flex justify-end gap-2">
+            <button class="btn btn-sm preset-tonal" onclick={oncancel}>Cancel</button>
+            <button
+                class="btn btn-sm preset-filled-primary-500"
+                onclick={confirm}
+                disabled={!name || !!error}
+            >
+                Add {labels[elementType]}
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/WebEditor/src/components/AddElementModal.svelte
+++ b/src/WebEditor/src/components/AddElementModal.svelte
@@ -18,7 +18,6 @@
     };
 
     let dialogEl: HTMLDivElement;
-    $effect(() => { dialogEl?.focus(); });
 
     let name = $state("");
     let error = $state("");

--- a/src/WebEditor/src/components/AddScriptModal.svelte
+++ b/src/WebEditor/src/components/AddScriptModal.svelte
@@ -78,11 +78,11 @@
     role="dialog"
     aria-modal="true"
     tabindex="-1"
-    class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50"
+    class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
     onclick={onBackdropClick}
     onkeydown={onKeydown}
 >
-    <div class="bg-surface-50-950 rounded-xl shadow-2xl w-[600px] h-[520px] flex flex-col overflow-hidden ring-1 ring-surface-200-800">
+    <div class="bg-white rounded-xl shadow-xl w-[600px] h-[520px] flex flex-col overflow-hidden ring-1 ring-surface-200-800">
 
         <!-- Header -->
         <div class="px-5 py-3 flex items-center justify-between flex-shrink-0 border-b border-surface-200-800">

--- a/src/WebEditor/src/components/AddScriptModal.svelte
+++ b/src/WebEditor/src/components/AddScriptModal.svelte
@@ -85,25 +85,25 @@
     <div class="bg-surface-50-950 rounded-xl shadow-2xl w-[600px] h-[520px] flex flex-col overflow-hidden ring-1 ring-surface-200-800">
 
         <!-- Header -->
-        <div class="preset-filled-primary-500 px-5 py-3 flex items-center justify-between flex-shrink-0">
-            <h2 class="font-semibold text-base tracking-wide">Add Script Command</h2>
+        <div class="px-5 py-3 flex items-center justify-between flex-shrink-0 border-b border-surface-200-800">
+            <h2 class="font-semibold text-base">Add Script Command</h2>
             <button
                 type="button"
                 onclick={onClose}
-                class="opacity-80 hover:opacity-100 text-xl leading-none px-1 transition-opacity"
+                class="text-surface-400-500 hover:text-surface-900-50 text-xl leading-none px-1 transition-colors"
                 aria-label="Close"
             >×</button>
         </div>
 
         <!-- Shortcut buttons -->
         {#if shortcuts.length > 0}
-            <div class="px-5 py-3 border-b border-surface-200-800 flex gap-2 flex-wrap flex-shrink-0 bg-surface-100-900">
+            <div class="px-5 py-3 border-b border-surface-200-800 flex gap-2 flex-wrap flex-shrink-0">
                 <span class="text-xs font-medium text-surface-500-400 self-center mr-1">Quick add:</span>
                 {#each shortcuts as shortcut (shortcut.createString)}
                     <button
                         type="button"
                         onclick={() => onShortcutClick(shortcut.createString)}
-                        class="btn btn-sm preset-tonal-primary rounded-full px-4 py-1 text-sm font-medium"
+                        class="btn btn-sm preset-outlined-primary-500 rounded-full px-4 py-1 text-sm font-medium"
                     >{shortcut.label}</button>
                 {/each}
             </div>
@@ -112,22 +112,22 @@
         <!-- Body: categories + commands -->
         <div class="flex flex-1 min-h-0">
             <!-- Category sidebar -->
-            <div class="w-40 bg-surface-100-900 border-r border-surface-200-800 overflow-y-auto flex-shrink-0">
+            <div class="w-40 border-r border-surface-200-800 overflow-y-auto flex-shrink-0">
                 {#each categories as cat, ci (ci)}
                     <button
                         type="button"
                         onclick={() => { selectedCategoryIndex = ci; }}
-                        class="w-full text-left px-4 py-2.5 text-sm font-medium transition-colors {
+                        class="w-full text-left px-4 py-2.5 text-sm transition-colors {
                             selectedCategoryIndex === ci
-                                ? 'preset-filled-primary-500'
-                                : 'text-surface-700-300 hover:bg-surface-200-800 hover:text-surface-900-100'
+                                ? 'font-semibold text-primary-600-400 bg-primary-100 dark:bg-primary-900/40'
+                                : 'text-surface-700-300 hover:bg-surface-100-900'
                         }"
                     >{cat.name}</button>
                 {/each}
             </div>
 
             <!-- Commands list -->
-            <div class="flex-1 overflow-y-auto py-2">
+            <div class="flex-1 overflow-y-auto pb-2">
                 {#if selectedCategory}
                     {#each selectedCategory.commands as cmd (cmd.createString)}
                         {@const isSelected = selectedCommand?.createString === cmd.createString}
@@ -150,8 +150,8 @@
         </div>
 
         <!-- Footer -->
-        <div class="px-5 py-3 border-t border-surface-200-800 flex justify-end gap-3 flex-shrink-0 bg-surface-100-900">
-            <button type="button" onclick={onClose} class="btn preset-outlined">Cancel</button>
+        <div class="px-5 py-3 border-t border-surface-200-800 flex justify-end gap-3 flex-shrink-0">
+            <button type="button" onclick={onClose} class="btn preset-tonal">Cancel</button>
             <button
                 type="button"
                 onclick={onOk}

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -63,7 +63,7 @@
 </script>
 
 <div class="flex flex-col flex-1 bg-surface-50-950 overflow-hidden">
-    <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800 bg-surface-100-900">
+    <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800">
         Properties
     </div>
 
@@ -73,7 +73,7 @@
         <p class="px-3 py-4 text-sm text-surface-400-500">No properties available.</p>
     {:else}
         {#if $selectedData.tabs.length > 0}
-            <div class="flex border-b border-surface-200-800 bg-surface-100-900 overflow-x-auto flex-shrink-0">
+            <div class="flex border-b border-surface-200-800 overflow-x-auto flex-shrink-0">
                 {#each $selectedData.tabs as tab, ti (ti)}
                     <button
                         type="button"

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -366,14 +366,14 @@
                     <div class="absolute right-1 top-1 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10">
                         <button
                             type="button"
-                            class="btn btn-sm preset-outlined px-1 py-0 text-xs leading-none"
+                            class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
                             title="Move up"
                             disabled={i === 0}
                             onclick={() => onMoveUp(i)}
                         >↑</button>
                         <button
                             type="button"
-                            class="btn btn-sm preset-outlined px-1 py-0 text-xs leading-none"
+                            class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
                             title="Move down"
                             disabled={i === scripts().length - 1}
                             onclick={() => onMoveDown(i)}
@@ -401,12 +401,12 @@
             <div class="flex items-center gap-1 mb-1 px-1 py-1 bg-surface-100-900 rounded border border-surface-200-800 text-xs">
                 <button
                     type="button"
-                    class="btn btn-sm preset-outlined text-xs py-0.5"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                     onclick={onCutSelected}
                 >Cut</button>
                 <button
                     type="button"
-                    class="btn btn-sm preset-outlined text-xs py-0.5"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                     onclick={onCopySelected}
                 >Copy</button>
                 <button
@@ -418,13 +418,13 @@
                     <span class="w-px h-4 bg-surface-300-700 mx-0.5"></span>
                     <button
                         type="button"
-                        class="btn btn-sm preset-outlined text-xs py-0.5"
+                        class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                         disabled={sel[0] === 0}
                         onclick={onMoveUpSelected}
                     >↑ Move up</button>
                     <button
                         type="button"
-                        class="btn btn-sm preset-outlined text-xs py-0.5"
+                        class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                         disabled={sel[0] === scripts().length - 1}
                         onclick={onMoveDownSelected}
                     >↓ Move down</button>
@@ -439,7 +439,7 @@
         {#if !codeViewMode && categories.length > 0}
             <button
                 type="button"
-                class="btn btn-sm preset-outlined text-xs py-0.5"
+                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                 onclick={() => (showAddModal = true)}
             >+ Add script</button>
         {:else if !codeViewMode && isRoot}
@@ -448,14 +448,14 @@
         {#if isRoot && $scriptClipboardHasContent && !codeViewMode}
             <button
                 type="button"
-                class="btn btn-sm preset-outlined text-xs py-0.5"
+                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                 onclick={onPaste}
             >Paste</button>
         {/if}
         {#if isRoot}
             <button
                 type="button"
-                class="btn btn-sm preset-outlined text-xs py-0.5"
+                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                 onclick={onToggleCodeView}
             >{codeViewMode ? "Visual editor" : "Code view"}</button>
         {/if}
@@ -821,13 +821,13 @@
         <div class="flex gap-1 mt-1">
             <button
                 type="button"
-                class="btn btn-sm preset-outlined text-xs py-0.5"
+                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                 onclick={() => onAddElseIf(i)}
             >+ else if</button>
             {#if script.elseScripts === null || script.elseScripts === undefined}
                 <button
                     type="button"
-                    class="btn btn-sm preset-outlined text-xs py-0.5"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
                     onclick={() => onAddElse(i)}
                 >+ else</button>
             {/if}

--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -56,11 +56,18 @@
     function closeAdd() { addOpen = false; }
     function toggleAdd(e: MouseEvent) { e.stopPropagation(); addOpen = !addOpen; }
     function doAdd(action: () => void) { action(); addOpen = false; }
+
+    $effect(() => {
+        if (!addOpen) return;
+        function onOutside(e: MouseEvent) {
+            if (!(e.target as HTMLElement).closest(".add-dropdown")) closeAdd();
+        }
+        document.addEventListener("mousedown", onOutside);
+        return () => document.removeEventListener("mousedown", onOutside);
+    });
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div onmousedown={(e) => { if (!(e.target as HTMLElement).closest(".add-dropdown")) closeAdd(); }}>
-    <AppBar>
+<AppBar>
         <AppBar.Toolbar class="grid-cols-[auto_1fr_auto]">
             <AppBar.Lead>
                 <span class="font-semibold">Quest Viva Editor</span>
@@ -105,4 +112,3 @@
             </AppBar.Trail>
         </AppBar.Toolbar>
     </AppBar>
-</div>

--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -74,12 +74,12 @@
                     <div class="add-dropdown relative">
                         <button
                             type="button"
-                            class="btn btn-sm preset-outlined"
+                            class="btn btn-sm preset-outlined-primary-500"
                             onclick={toggleAdd}
                             title="Add element"
                         >+ Add ▾</button>
                         {#if addOpen}
-                            <div class="absolute right-0 top-full z-[999] mt-1 w-56 bg-surface-100-900 border border-surface-200-800 rounded shadow-lg py-1">
+                            <div class="absolute right-0 top-full z-[999] mt-1 w-56 bg-surface-50-950 border border-surface-200-800 rounded shadow-lg py-1">
                                 {#each addOptions as opt (opt.label)}
                                     <button
                                         class="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-200-800"
@@ -98,8 +98,8 @@
                             title={"Delete " + (selectedNode?.text ?? "")}
                         >Delete</button>
                     {/if}
-                    <button type="button" class="btn btn-sm preset-outlined" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
-                    <button type="button" class="btn btn-sm preset-outlined" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
                     <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleSave} title="Save">💾 Save</button>
                 </div>
             </AppBar.Trail>

--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
     import { AppBar } from "@skeletonlabs/skeleton-svelte";
-    import { gameFilename, saveGame, undo, redo, canUndo, canRedo } from "$lib/editor-store";
+    import {
+        gameFilename, saveGame, undo, redo, canUndo, canRedo,
+        treeNodes, selectedKey, openAddModal,
+        createExit, createTurnScript, createCommand, createVerb,
+        deleteElement,
+    } from "$lib/editor-store";
+    import type { TreeNode } from "$lib/types";
 
     function handleSave() {
         const xml = saveGame();
@@ -12,22 +18,91 @@
         a.click();
         URL.revokeObjectURL(url);
     }
+
+    // Derive the currently selected tree node
+    let selectedNode = $derived<TreeNode | null>(
+        $treeNodes.find(n => n.key === $selectedKey) ?? null
+    );
+
+    let nt = $derived(selectedNode?.nodeType ?? "");
+    let canDelete = $derived(
+        nt !== "" && nt !== "header" && nt !== "game" && nt !== "other"
+    );
+
+    // Context-sensitive add options
+    type AddOption = { label: string; action: () => void };
+    let addOptions = $derived<AddOption[]>([
+        // Always available
+        { label: "Add Room", action: () => openAddModal("room", null) },
+        { label: "Add Function", action: () => openAddModal("function", null) },
+        { label: "Add Timer", action: () => openAddModal("timer", null) },
+        // Context-sensitive: when a room or object is selected
+        ...(nt === "room" || nt === "object" ? [
+            { label: `Add Object in "${selectedNode!.text}"`, action: () => openAddModal("object", selectedNode!.key) },
+        ] : []),
+        ...(nt === "room" ? [
+            { label: `Add Room in "${selectedNode!.text}"`, action: () => openAddModal("room", selectedNode!.key) },
+            { label: `Add Exit from "${selectedNode!.text}"`, action: () => createExit(selectedNode!.key) },
+        ] : []),
+        ...(nt === "room" || nt === "object" ? [
+            { label: `Add Command to "${selectedNode!.text}"`, action: () => createCommand(selectedNode!.key) },
+            { label: `Add Verb to "${selectedNode!.text}"`, action: () => createVerb(selectedNode!.key) },
+            { label: `Add Turn Script to "${selectedNode!.text}"`, action: () => createTurnScript(selectedNode!.key) },
+        ] : []),
+    ]);
+
+    let addOpen = $state(false);
+
+    function closeAdd() { addOpen = false; }
+    function toggleAdd(e: MouseEvent) { e.stopPropagation(); addOpen = !addOpen; }
+    function doAdd(action: () => void) { action(); addOpen = false; }
 </script>
 
-<AppBar>
-    <AppBar.Toolbar class="grid-cols-[auto_1fr_auto]">
-        <AppBar.Lead>
-            <span class="font-semibold">Quest Viva Editor</span>
-            {#if $gameFilename}
-                <span class="ml-3 text-sm text-surface-500-400">{$gameFilename}</span>
-            {/if}
-        </AppBar.Lead>
-        <AppBar.Trail>
-            <div class="flex gap-2">
-                <button type="button" class="btn btn-sm preset-outlined" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
-                <button type="button" class="btn btn-sm preset-outlined" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
-                <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleSave} title="Save">💾 Save</button>
-            </div>
-        </AppBar.Trail>
-    </AppBar.Toolbar>
-</AppBar>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div onmousedown={(e) => { if (!(e.target as HTMLElement).closest(".add-dropdown")) closeAdd(); }}>
+    <AppBar>
+        <AppBar.Toolbar class="grid-cols-[auto_1fr_auto]">
+            <AppBar.Lead>
+                <span class="font-semibold">Quest Viva Editor</span>
+                {#if $gameFilename}
+                    <span class="ml-3 text-sm text-surface-500-400">{$gameFilename}</span>
+                {/if}
+            </AppBar.Lead>
+            <AppBar.Trail>
+                <div class="flex gap-2 items-center">
+                    <!-- Add dropdown -->
+                    <div class="add-dropdown relative">
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined"
+                            onclick={toggleAdd}
+                            title="Add element"
+                        >+ Add ▾</button>
+                        {#if addOpen}
+                            <div class="absolute right-0 top-full z-[999] mt-1 w-56 bg-surface-100-900 border border-surface-200-800 rounded shadow-lg py-1">
+                                {#each addOptions as opt (opt.label)}
+                                    <button
+                                        class="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-200-800"
+                                        onclick={() => doAdd(opt.action)}
+                                    >{opt.label}</button>
+                                {/each}
+                            </div>
+                        {/if}
+                    </div>
+                    <!-- Delete button -->
+                    {#if canDelete}
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined-error-500"
+                            onclick={() => deleteElement(selectedNode!.key)}
+                            title={"Delete " + (selectedNode?.text ?? "")}
+                        >Delete</button>
+                    {/if}
+                    <button type="button" class="btn btn-sm preset-outlined" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
+                    <button type="button" class="btn btn-sm preset-outlined" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
+                    <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleSave} title="Save">💾 Save</button>
+                </div>
+            </AppBar.Trail>
+        </AppBar.Toolbar>
+    </AppBar>
+</div>

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -14,14 +14,6 @@
         children?: HierNode[]
     }
 
-    // Header keys that support a simple one-click "add" action
-    const HEADER_ADD: Record<string, () => void> = {
-        "_objects": () => openAddModal("room", null),
-        "_functions": () => openAddModal("function", null),
-        "_timers": () => openAddModal("timer", null),
-        "_gameVerbs": () => createVerb(null),
-        "_gameCommands": () => createCommand(null),
-    };
 
     // Build HierNode tree from flat list
     function buildHierTree(nodes: TreeNode[]): HierNode[] {
@@ -105,26 +97,42 @@
         deleteElement(id);
     }
 
-    // Returns child-add menu options for a given element node
-    function childAddOptions(id: string, nt: string): Array<{ label: string; action: () => void }> {
-        if (nt === "room") return [
-            { label: "Add Object here", action: () => openAddModal("object", id) },
-            { label: "Add Room here", action: () => openAddModal("room", id) },
-            { label: "Add Exit", action: () => createExit(id) },
-            { label: "Add Command", action: () => createCommand(id) },
-            { label: "Add Verb", action: () => createVerb(id) },
-            { label: "Add Turn Script", action: () => createTurnScript(id) },
-        ];
-        if (nt === "object") return [
-            { label: "Add Command", action: () => createCommand(id) },
-            { label: "Add Verb", action: () => createVerb(id) },
-            { label: "Add Turn Script", action: () => createTurnScript(id) },
-        ];
-        return [];
-    }
-
     function isDeletable(nt: string): boolean {
         return nt !== "header" && nt !== "game" && nt !== "other";
+    }
+
+    function nodeMenuOptions(node: HierNode): Array<{ label: string; action: () => void }> {
+        const opts: Array<{ label: string; action: () => void }> = [];
+        const { id, text, nodeType: nt } = node;
+
+        if (nt === "header") {
+            if (id === "_objects") opts.push({ label: "Add Room", action: () => openAddModal("room", null) });
+            else if (id === "_functions") opts.push({ label: "Add Function", action: () => openAddModal("function", null) });
+            else if (id === "_timers") opts.push({ label: "Add Timer", action: () => openAddModal("timer", null) });
+            else if (id === "_gameVerbs") opts.push({ label: "Add Verb", action: () => createVerb(null) });
+            else if (id === "_gameCommands") opts.push({ label: "Add Command", action: () => createCommand(null) });
+        } else if (nt === "room") {
+            opts.push(
+                { label: "Add Object here", action: () => openAddModal("object", id) },
+                { label: "Add Room here", action: () => openAddModal("room", id) },
+                { label: "Add Exit", action: () => createExit(id) },
+                { label: "Add Command", action: () => createCommand(id) },
+                { label: "Add Verb", action: () => createVerb(id) },
+                { label: "Add Turn Script", action: () => createTurnScript(id) },
+            );
+        } else if (nt === "object") {
+            opts.push(
+                { label: "Add Command", action: () => createCommand(id) },
+                { label: "Add Verb", action: () => createVerb(id) },
+                { label: "Add Turn Script", action: () => createTurnScript(id) },
+            );
+        }
+
+        if (isDeletable(nt)) {
+            opts.push({ label: `Delete "${text}"`, action: () => handleDelete(id) });
+        }
+
+        return opts;
     }
 </script>
 
@@ -136,7 +144,7 @@
         if (!t.closest(".node-actions") && !t.closest(".tree-dropdown")) closeDropdown();
     }}
 >
-    <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800 bg-surface-100-900">
+    <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800">
         Game Objects
     </div>
     <div class="flex-1 overflow-y-auto p-1">
@@ -155,7 +163,7 @@
     </div>
     {#if dropdownKey && dropdownPos}
         <div
-            class="tree-dropdown fixed z-[999] w-44 bg-surface-100-900 border border-surface-200-800 rounded shadow-lg py-1"
+            class="tree-dropdown fixed z-[999] w-44 bg-surface-50-950 border border-surface-200-800 rounded shadow-lg py-1"
             style="left: {dropdownPos.x}px; top: {dropdownPos.y}px"
         >
             {#each dropdownOpts as opt (opt.label)}
@@ -169,31 +177,14 @@
 </div>
 
 {#snippet nodeActions(node: HierNode)}
-    {@const headerAddFn = node.nodeType === "header" ? (HEADER_ADD[node.id] ?? null) : null}
-    {@const opts = node.nodeType !== "header" ? childAddOptions(node.id, node.nodeType) : []}
-    {@const deletable = isDeletable(node.nodeType)}
-    {#if headerAddFn || opts.length > 0 || deletable}
-        <span class="node-actions flex items-center gap-0.5 ml-auto pr-1">
-            {#if headerAddFn}
-                <button
-                    class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-primary-500 hover:bg-surface-200-800 text-sm leading-none"
-                    onclick={(e) => { e.stopPropagation(); headerAddFn(); }}
-                    title="Add"
-                >+</button>
-            {:else if opts.length > 0}
-                <button
-                    class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-primary-500 hover:bg-surface-200-800 text-sm leading-none"
-                    onclick={(e) => toggleDropdown(node.id + ":add", opts, e)}
-                    title="Add child"
-                >+</button>
-            {/if}
-            {#if deletable}
-                <button
-                    class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-error-500 hover:bg-surface-200-800 text-xs leading-none"
-                    onclick={(e) => { e.stopPropagation(); handleDelete(node.id); }}
-                    title="Delete"
-                >×</button>
-            {/if}
+    {@const opts = nodeMenuOptions(node)}
+    {#if opts.length > 0}
+        <span class="node-actions flex items-center ml-auto pr-1">
+            <button
+                class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-primary-500 hover:bg-surface-200-800 text-sm leading-none"
+                onclick={(e) => toggleDropdown(node.id + ":menu", opts, e)}
+                title="Options"
+            >⋯</button>
         </span>
     {/if}
 {/snippet}

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from "svelte";
     import { TreeView, createTreeViewCollection } from "@skeletonlabs/skeleton-svelte";
     import {
         treeNodes, selectedKey, selectNode,
@@ -43,8 +44,33 @@
 
     // ── Expansion state ────────────────────────────────────────────────────────
 
-    // Start with the main category headers open
-    let expandedIds = $state<string[]>(["_objects", "_functions", "_timers", "game"]);
+    let expandedIds = $state<string[]>([]);
+    let loadedGameKey = $state<string | null>(null);
+
+    // On game load, expand all nodes except _advanced
+    $effect(() => {
+        const nodes = $treeNodes;
+        if (nodes.length === 0) { loadedGameKey = null; return; }
+        const gameKey = nodes.find(n => n.nodeType === "game")?.key ?? null;
+        if (gameKey === loadedGameKey) return;
+        loadedGameKey = gameKey;
+        expandedIds = nodes.filter(n => n.key !== "_advanced").map(n => n.key);
+    });
+
+    function toggleExpand(id: string) {
+        if (expandedIds.includes(id)) {
+            // If the selected node is inside this branch, select the branch itself first
+            const nodeMap = new Map($treeNodes.map(n => [n.key, n]));
+            let cur = nodeMap.get($selectedKey ?? "");
+            while (cur?.parent) {
+                if (cur.parent === id) { selectNode(id); break; }
+                cur = nodeMap.get(cur.parent);
+            }
+            expandedIds = expandedIds.filter(x => x !== id);
+        } else {
+            expandedIds = [...expandedIds, id];
+        }
+    }
 
     // Auto-expand the ancestor chain whenever the selected node changes
     $effect(() => {
@@ -58,8 +84,11 @@
             toExpand.push(cur.parent);
             cur = nodeMap.get(cur.parent);
         }
-        if (toExpand.some(id => !expandedIds.includes(id))) {
-            expandedIds = [...new Set([...expandedIds, ...toExpand])];
+        // Use untrack so reading expandedIds doesn't make this effect re-run when
+        // the user manually collapses a branch (which would immediately re-expand it).
+        const current = untrack(() => expandedIds);
+        if (toExpand.some(id => !current.includes(id))) {
+            expandedIds = [...new Set([...current, ...toExpand])];
         }
     });
 
@@ -154,8 +183,8 @@
         <TreeView
             {collection}
             selectionMode="single"
+            expandOnClick={false}
             expandedValue={expandedIds}
-            onExpandedChange={(e) => { expandedIds = e.expandedValue; }}
             selectedValue={$selectedKey ? [$selectedKey] : []}
             onSelectionChange={(e) => { if (e.selectedValue[0]) selectNode(e.selectedValue[0]); }}
         >
@@ -196,8 +225,16 @@
     <TreeView.NodeProvider value={{ node, indexPath }}>
         {#if node.children}
             <TreeView.Branch>
-                <TreeView.BranchControl class="group">
-                    <TreeView.BranchIndicator />
+                <TreeView.BranchControl class="group" ondblclick={() => toggleExpand(node.id)}>
+                    <button
+                        type="button"
+                        tabindex="-1"
+                        class="flex-shrink-0 size-4 flex items-center justify-center transition-transform duration-150 {expandedIds.includes(node.id) ? 'rotate-90' : ''}"
+                        onclick={(e) => { e.stopPropagation(); toggleExpand(node.id); }}
+                        aria-label={expandedIds.includes(node.id) ? 'Collapse' : 'Expand'}
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="size-4"><polyline points="9 18 15 12 9 6" /></svg>
+                    </button>
                     <TreeView.BranchText class="flex-1 min-w-0 truncate">{node.text}</TreeView.BranchText>
                     <span class="opacity-0 group-hover:opacity-100">
                         {@render nodeActions(node)}

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -169,7 +169,7 @@
                         <div class="fixed z-[999] mt-0.5 w-44 bg-surface-100-900 border border-surface-200-800 rounded shadow-lg py-1">
                             {#each opts as opt (opt.label)}
                                 <button
-                                    class="w-full text-left px-3 py-1 text-xs hover:bg-surface-200-800"
+                                    class="w-full text-left px-3 py-1 text-xs text-surface-900-50 hover:bg-surface-200-800"
                                     onclick={() => dropdownAction(opt.action)}
                                 >{opt.label}</button>
                             {/each}

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -79,6 +79,16 @@
 
     function closeDropdown() { dropdownKey = null; dropdownPos = null; }
 
+    $effect(() => {
+        if (!dropdownKey) return;
+        function onOutside(e: MouseEvent) {
+            const t = e.target as HTMLElement;
+            if (!t.closest(".node-actions") && !t.closest(".tree-dropdown")) closeDropdown();
+        }
+        document.addEventListener("mousedown", onOutside);
+        return () => document.removeEventListener("mousedown", onOutside);
+    });
+
     function toggleDropdown(key: string, opts: Array<{ label: string; action: () => void }>, e: MouseEvent) {
         e.stopPropagation();
         if (dropdownKey === key) { closeDropdown(); return; }
@@ -136,14 +146,7 @@
     }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
-    class="flex flex-col w-60 min-w-[180px] border-r border-surface-200-800 bg-surface-50-950"
-    onmousedown={(e) => {
-        const t = e.target as HTMLElement;
-        if (!t.closest(".node-actions") && !t.closest(".tree-dropdown")) closeDropdown();
-    }}
->
+<div class="flex flex-col w-60 min-w-[180px] border-r border-surface-200-800 bg-surface-50-950">
     <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800">
         Game Objects
     </div>

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -82,17 +82,23 @@
     // ── Add / delete ───────────────────────────────────────────────────────────
 
     let dropdownKey = $state<string | null>(null);
+    let dropdownPos = $state<{ x: number; y: number } | null>(null);
+    let dropdownOpts = $state<Array<{ label: string; action: () => void }>>([]);
 
-    function closeDropdown() { dropdownKey = null; }
+    function closeDropdown() { dropdownKey = null; dropdownPos = null; }
 
-    function toggleDropdown(key: string, e: MouseEvent) {
+    function toggleDropdown(key: string, opts: Array<{ label: string; action: () => void }>, e: MouseEvent) {
         e.stopPropagation();
-        dropdownKey = dropdownKey === key ? null : key;
+        if (dropdownKey === key) { closeDropdown(); return; }
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        dropdownKey = key;
+        dropdownPos = { x: rect.left, y: rect.bottom + 2 };
+        dropdownOpts = opts;
     }
 
     function dropdownAction(fn: () => void) {
         fn();
-        dropdownKey = null;
+        closeDropdown();
     }
 
     function handleDelete(id: string) {
@@ -125,7 +131,10 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
     class="flex flex-col w-60 min-w-[180px] border-r border-surface-200-800 bg-surface-50-950"
-    onmousedown={(e) => { if (!(e.target as HTMLElement).closest(".node-actions")) closeDropdown(); }}
+    onmousedown={(e) => {
+        const t = e.target as HTMLElement;
+        if (!t.closest(".node-actions") && !t.closest(".tree-dropdown")) closeDropdown();
+    }}
 >
     <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800 bg-surface-100-900">
         Game Objects
@@ -144,6 +153,19 @@
             {/each}
         </TreeView>
     </div>
+    {#if dropdownKey && dropdownPos}
+        <div
+            class="tree-dropdown fixed z-[999] w-44 bg-surface-100-900 border border-surface-200-800 rounded shadow-lg py-1"
+            style="left: {dropdownPos.x}px; top: {dropdownPos.y}px"
+        >
+            {#each dropdownOpts as opt (opt.label)}
+                <button
+                    class="w-full text-left px-3 py-1 text-xs text-surface-900-50 hover:bg-surface-200-800"
+                    onclick={() => dropdownAction(opt.action)}
+                >{opt.label}</button>
+            {/each}
+        </div>
+    {/if}
 </div>
 
 {#snippet nodeActions(node: HierNode)}
@@ -159,23 +181,11 @@
                     title="Add"
                 >+</button>
             {:else if opts.length > 0}
-                <div class="relative">
-                    <button
-                        class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-primary-500 hover:bg-surface-200-800 text-sm leading-none"
-                        onclick={(e) => toggleDropdown(node.id + ":add", e)}
-                        title="Add child"
-                    >+</button>
-                    {#if dropdownKey === node.id + ":add"}
-                        <div class="fixed z-[999] mt-0.5 w-44 bg-surface-100-900 border border-surface-200-800 rounded shadow-lg py-1">
-                            {#each opts as opt (opt.label)}
-                                <button
-                                    class="w-full text-left px-3 py-1 text-xs text-surface-900-50 hover:bg-surface-200-800"
-                                    onclick={() => dropdownAction(opt.action)}
-                                >{opt.label}</button>
-                            {/each}
-                        </div>
-                    {/if}
-                </div>
+                <button
+                    class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-primary-500 hover:bg-surface-200-800 text-sm leading-none"
+                    onclick={(e) => toggleDropdown(node.id + ":add", opts, e)}
+                    title="Add child"
+                >+</button>
             {/if}
             {#if deletable}
                 <button

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -147,7 +147,7 @@
     <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800">
         Game Objects
     </div>
-    <div class="flex-1 overflow-y-auto p-1">
+    <div class="flex-1 overflow-y-auto p-1 text-xs">
         <TreeView
             {collection}
             selectionMode="single"

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -1,39 +1,132 @@
 <script lang="ts">
     import { TreeView, createTreeViewCollection } from "@skeletonlabs/skeleton-svelte";
-    import { treeNodes, selectedKey, selectNode } from "$lib/editor-store";
+    import {
+        treeNodes, selectedKey, selectNode,
+        openAddModal, createExit, createTurnScript, createCommand, createVerb,
+        deleteElement,
+    } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
 
     interface HierNode {
         id: string
         text: string
+        nodeType: string
         children?: HierNode[]
     }
 
+    // Header keys that support a simple one-click "add" action
+    const HEADER_ADD: Record<string, () => void> = {
+        "_objects": () => openAddModal("room", null),
+        "_functions": () => openAddModal("function", null),
+        "_timers": () => openAddModal("timer", null),
+        "_gameVerbs": () => createVerb(null),
+        "_gameCommands": () => createCommand(null),
+    };
+
+    // Build HierNode tree from flat list
     function buildHierTree(nodes: TreeNode[]): HierNode[] {
+        // Deduplicate by key (last write wins, matching C# upsert behaviour in OnAddedNode)
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity
+        const byKey = new Map<string, TreeNode>();
+        for (const n of nodes) byKey.set(n.key, n);
+
         // eslint-disable-next-line svelte/prefer-svelte-reactivity
         const byParent = new Map<string | null, TreeNode[]>();
-        for (const n of nodes) {
+        for (const n of byKey.values()) {
             const p = n.parent ?? null;
             if (!byParent.has(p)) byParent.set(p, []);
             byParent.get(p)!.push(n);
         }
-        function build(node: TreeNode): HierNode {
+        const build = (node: TreeNode): HierNode => {
             const children = byParent.get(node.key);
-            return { id: node.key, text: node.text, ...(children ? { children: children.map(build) } : {}) };
-        }
+            return {
+                id: node.key,
+                text: node.text,
+                nodeType: node.nodeType,
+                ...(children ? { children: children.map(build) } : {}),
+            };
+        };
         return (byParent.get(null) ?? []).map(build);
     }
+
+    // ── Expansion state ────────────────────────────────────────────────────────
+
+    // Start with the main category headers open
+    let expandedIds = $state<string[]>(["_objects", "_functions", "_timers", "game"]);
+
+    // Auto-expand the ancestor chain whenever the selected node changes
+    $effect(() => {
+        const key = $selectedKey;
+        const nodes = $treeNodes;
+        if (!key || !nodes.length) return;
+        const nodeMap = new Map(nodes.map(n => [n.key, n]));
+        const toExpand: string[] = [];
+        let cur: TreeNode | undefined = nodeMap.get(key);
+        while (cur?.parent) {
+            toExpand.push(cur.parent);
+            cur = nodeMap.get(cur.parent);
+        }
+        if (toExpand.some(id => !expandedIds.includes(id))) {
+            expandedIds = [...new Set([...expandedIds, ...toExpand])];
+        }
+    });
 
     let collection = $derived(
         createTreeViewCollection<HierNode>({
             nodeToValue: (n) => n.id,
             nodeToString: (n) => n.text,
-            rootNode: { id: "__root__", text: "", children: buildHierTree($treeNodes) }
+            rootNode: { id: "__root__", text: "", nodeType: "header", children: buildHierTree($treeNodes) },
         })
     );
+
+    // ── Add / delete ───────────────────────────────────────────────────────────
+
+    let dropdownKey = $state<string | null>(null);
+
+    function closeDropdown() { dropdownKey = null; }
+
+    function toggleDropdown(key: string, e: MouseEvent) {
+        e.stopPropagation();
+        dropdownKey = dropdownKey === key ? null : key;
+    }
+
+    function dropdownAction(fn: () => void) {
+        fn();
+        dropdownKey = null;
+    }
+
+    function handleDelete(id: string) {
+        deleteElement(id);
+    }
+
+    // Returns child-add menu options for a given element node
+    function childAddOptions(id: string, nt: string): Array<{ label: string; action: () => void }> {
+        if (nt === "room") return [
+            { label: "Add Object here", action: () => openAddModal("object", id) },
+            { label: "Add Room here", action: () => openAddModal("room", id) },
+            { label: "Add Exit", action: () => createExit(id) },
+            { label: "Add Command", action: () => createCommand(id) },
+            { label: "Add Verb", action: () => createVerb(id) },
+            { label: "Add Turn Script", action: () => createTurnScript(id) },
+        ];
+        if (nt === "object") return [
+            { label: "Add Command", action: () => createCommand(id) },
+            { label: "Add Verb", action: () => createVerb(id) },
+            { label: "Add Turn Script", action: () => createTurnScript(id) },
+        ];
+        return [];
+    }
+
+    function isDeletable(nt: string): boolean {
+        return nt !== "header" && nt !== "game" && nt !== "other";
+    }
 </script>
 
-<div class="flex flex-col w-60 min-w-[180px] border-r border-surface-200-800 bg-surface-50-950 overflow-hidden">
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    class="flex flex-col w-60 min-w-[180px] border-r border-surface-200-800 bg-surface-50-950"
+    onmousedown={(e) => { if (!(e.target as HTMLElement).closest(".node-actions")) closeDropdown(); }}
+>
     <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800 bg-surface-100-900">
         Game Objects
     </div>
@@ -41,6 +134,8 @@
         <TreeView
             {collection}
             selectionMode="single"
+            expandedValue={expandedIds}
+            onExpandedChange={(e) => { expandedIds = e.expandedValue; }}
             selectedValue={$selectedKey ? [$selectedKey] : []}
             onSelectionChange={(e) => { if (e.selectedValue[0]) selectNode(e.selectedValue[0]); }}
         >
@@ -51,13 +146,58 @@
     </div>
 </div>
 
+{#snippet nodeActions(node: HierNode)}
+    {@const headerAddFn = node.nodeType === "header" ? (HEADER_ADD[node.id] ?? null) : null}
+    {@const opts = node.nodeType !== "header" ? childAddOptions(node.id, node.nodeType) : []}
+    {@const deletable = isDeletable(node.nodeType)}
+    {#if headerAddFn || opts.length > 0 || deletable}
+        <span class="node-actions flex items-center gap-0.5 ml-auto pr-1">
+            {#if headerAddFn}
+                <button
+                    class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-primary-500 hover:bg-surface-200-800 text-sm leading-none"
+                    onclick={(e) => { e.stopPropagation(); headerAddFn(); }}
+                    title="Add"
+                >+</button>
+            {:else if opts.length > 0}
+                <div class="relative">
+                    <button
+                        class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-primary-500 hover:bg-surface-200-800 text-sm leading-none"
+                        onclick={(e) => toggleDropdown(node.id + ":add", e)}
+                        title="Add child"
+                    >+</button>
+                    {#if dropdownKey === node.id + ":add"}
+                        <div class="fixed z-[999] mt-0.5 w-44 bg-surface-100-900 border border-surface-200-800 rounded shadow-lg py-1">
+                            {#each opts as opt (opt.label)}
+                                <button
+                                    class="w-full text-left px-3 py-1 text-xs hover:bg-surface-200-800"
+                                    onclick={() => dropdownAction(opt.action)}
+                                >{opt.label}</button>
+                            {/each}
+                        </div>
+                    {/if}
+                </div>
+            {/if}
+            {#if deletable}
+                <button
+                    class="size-5 flex items-center justify-center rounded text-surface-400 hover:text-error-500 hover:bg-surface-200-800 text-xs leading-none"
+                    onclick={(e) => { e.stopPropagation(); handleDelete(node.id); }}
+                    title="Delete"
+                >×</button>
+            {/if}
+        </span>
+    {/if}
+{/snippet}
+
 {#snippet treeNode(node: HierNode, indexPath: number[])}
     <TreeView.NodeProvider value={{ node, indexPath }}>
         {#if node.children}
             <TreeView.Branch>
-                <TreeView.BranchControl>
+                <TreeView.BranchControl class="group">
                     <TreeView.BranchIndicator />
-                    <TreeView.BranchText>{node.text}</TreeView.BranchText>
+                    <TreeView.BranchText class="flex-1 min-w-0 truncate">{node.text}</TreeView.BranchText>
+                    <span class="opacity-0 group-hover:opacity-100">
+                        {@render nodeActions(node)}
+                    </span>
                 </TreeView.BranchControl>
                 <TreeView.BranchContent>
                     <TreeView.BranchIndentGuide />
@@ -67,7 +207,12 @@
                 </TreeView.BranchContent>
             </TreeView.Branch>
         {:else}
-            <TreeView.Item>{node.text}</TreeView.Item>
+            <TreeView.Item class="group flex items-center">
+                <span class="flex-1 min-w-0 truncate">{node.text}</span>
+                <span class="opacity-0 group-hover:opacity-100">
+                    {@render nodeActions(node)}
+                </span>
+            </TreeView.Item>
         {/if}
     </TreeView.NodeProvider>
 {/snippet}

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -51,6 +51,14 @@ export function selectNode(key: string) {
 export function setAttribute(elementKey: string, attribute: string, controlType: string, value: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SetAttribute(elementKey, attribute, controlType, value);
+    if (result.startsWith("renamed:")) {
+        const newKey = result.slice("renamed:".length);
+        selectedKey.set(newKey);
+        refreshTree();
+        refreshSelectedData();
+        refreshUndoRedo();
+        return "ok";
+    }
     refreshSelectedData();
     refreshUndoRedo();
     return result;

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -3,9 +3,16 @@ import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
 import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate } from "./types";
 
+export type AddElementModalState = { type: "room" | "object" | "function" | "timer"; parent: string | null } | null;
+
 let _bridge: WasmBridge | null = null;
 
 export const isLoaded = writable(false);
+export const addElementModal = writable<AddElementModalState>(null);
+
+export function openAddModal(type: "room" | "object" | "function" | "timer", parent: string | null) {
+    addElementModal.set({ type, parent });
+}
 export const gameFilename = writable<string | null>(null);
 export const treeNodes = writable<TreeNode[]>([]);
 export const selectedKey = writable<string | null>(null);
@@ -243,4 +250,76 @@ function refreshSelectedData() {
     if (!_bridge || !key) return;
     const json = _bridge.GetEditorData(key);
     selectedData.set(json ? JSON.parse(json) : null);
+}
+
+function refreshTree() {
+    if (!_bridge) return;
+    treeNodes.set(JSON.parse(_bridge.GetTreeNodes()));
+}
+
+// ── Element creation / deletion ─────────────────────────────────────────────
+
+export function validateName(name: string): string {
+    return _bridge?.ValidateName(name) ?? "error";
+}
+
+export function getUniqueName(baseName: string): string {
+    return _bridge?.GetUniqueName(baseName) ?? baseName;
+}
+
+function afterCreate(result: string): string {
+    if (result.startsWith("error:")) return result;
+    refreshTree();
+    selectNode(result);
+    refreshUndoRedo();
+    return result;
+}
+
+export function createRoom(name: string, parent: string | null): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateRoom(name, parent ?? ""));
+}
+
+export function createObject(name: string, parent: string | null): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateObject(name, parent ?? ""));
+}
+
+export function createFunction(name: string): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateFunction(name));
+}
+
+export function createTimer(name: string): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateTimer(name));
+}
+
+export function createExit(parent: string): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateExit(parent));
+}
+
+export function createTurnScript(parent: string): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateTurnScript(parent));
+}
+
+export function createCommand(parent: string | null): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateCommand(parent ?? ""));
+}
+
+export function createVerb(parent: string | null): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateVerb(parent ?? ""));
+}
+
+export function deleteElement(key: string) {
+    if (!_bridge) return;
+    _bridge.DeleteElement(key);
+    selectedKey.set(null);
+    selectedData.set(null);
+    refreshTree();
+    refreshUndoRedo();
 }

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -78,6 +78,7 @@ export function saveGame(): string {
 
 export function undo() {
     _bridge?.Undo();
+    refreshTree();
     refreshSelectedData();
     refreshUndoRedo();
     scriptVersion.update(n => n + 1);
@@ -85,6 +86,7 @@ export function undo() {
 
 export function redo() {
     _bridge?.Redo();
+    refreshTree();
     refreshSelectedData();
     refreshUndoRedo();
     scriptVersion.update(n => n + 1);

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -2,6 +2,8 @@ export interface TreeNode {
   key: string
   text: string
   parent: string | null
+  nodeIcon: string | null
+  nodeType: string
 }
 
 export interface ControlOption {

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -32,6 +32,18 @@ export interface WasmBridge {
   GetObjectNames(): string
   GetIfExpressionTemplates(): string
   GetIfExpressionTemplateData(expression: string): string | null
+  // Element creation / deletion
+  ValidateName(name: string): string
+  GetUniqueName(baseName: string): string
+  CreateRoom(name: string, parent: string): string
+  CreateObject(name: string, parent: string): string
+  CreateFunction(name: string): string
+  CreateTimer(name: string): string
+  CreateExit(parent: string): string
+  CreateTurnScript(parent: string): string
+  CreateCommand(parent: string): string
+  CreateVerb(parent: string): string
+  DeleteElement(key: string): void
 }
 
 let _bridge: WasmBridge | null = null;

--- a/src/WebEditor/src/routes/editor/+page.svelte
+++ b/src/WebEditor/src/routes/editor/+page.svelte
@@ -1,17 +1,30 @@
 <script lang="ts">
     import { onMount } from "svelte";
+    import { tick } from "svelte";
     import { goto } from "$app/navigation";
     import { get } from "svelte/store";
-    import { isLoaded } from "$lib/editor-store";
+    import { isLoaded, addElementModal, createRoom, createObject, createFunction, createTimer } from "$lib/editor-store";
     import Toolbar from "$components/Toolbar.svelte";
     import TreePanel from "$components/TreePanel.svelte";
     import PropertyEditor from "$components/PropertyEditor.svelte";
+    import AddElementModal from "$components/AddElementModal.svelte";
 
     onMount(() => {
         if (!get(isLoaded)) {
             goto("/");
         }
     });
+
+    async function handleAddConfirm(name: string) {
+        const mode = get(addElementModal);
+        addElementModal.set(null);
+        await tick();
+        if (!mode) return;
+        if (mode.type === "room") createRoom(name, mode.parent);
+        else if (mode.type === "object") createObject(name, mode.parent);
+        else if (mode.type === "function") createFunction(name);
+        else if (mode.type === "timer") createTimer(name);
+    }
 </script>
 
 <div class="flex flex-col h-svh overflow-hidden">
@@ -21,3 +34,12 @@
         <PropertyEditor />
     </div>
 </div>
+
+{#if $addElementModal}
+    <AddElementModal
+        elementType={$addElementModal.type}
+        parent={$addElementModal.parent}
+        onconfirm={handleAddConfirm}
+        oncancel={() => addElementModal.set(null)}
+    />
+{/if}


### PR DESCRIPTION
## Summary

- **Add/delete elements**: toolbar buttons to add objects/rooms/functions, a modal to name new elements, and delete via the ⋯ menu; backed by new `AddElement`/`DeleteElement` bridge methods
- **Tree fixes**: rename correctly updates tree and property viewer (including `selectedKey` update when element key changes after rename), undo/redo now refreshes the tree, O(n²) tree rebuild replaced with a keyed diff, `ClearTree` no-op fixed
- **UI polish**: switched theme to `wintry`, consistent `preset-outlined-primary-500` buttons throughout, de-greyed panel headers and tab strip, white modal dialogs with lighter backdrop, tighter/more compact tree view (text-xs, full-width items, subtler selection highlight, indent guides above selection background), ⋯ options menu replaces split +/× buttons on tree nodes
- **Dropdown fixes**: lifted dropdown out of tree-node DOM to break Skeleton's white-text inheritance on selected items; added explicit text colour for light/dark contrast
- **Tree UX**: chevron-only or double-click to expand/collapse (single click selects only); expand all non-`_advanced` nodes on load; correct parent selection when collapsing a branch containing the selected node; document-level listener closes Add menus on outside click

## Test plan

- [ ] Add a new object/room/function via toolbar; verify it appears in tree and is selected
- [ ] Delete an element via its ⋯ menu; verify it disappears
- [ ] Rename an element; verify tree label and property viewer title update immediately
- [ ] Undo/redo an add or delete; verify tree reflects the change
- [ ] Click a tree chevron to collapse; verify the node collapses without changing selection
- [ ] Double-click a node to expand; verify single click only selects
- [ ] Open an Add menu and click outside; verify it closes
- [ ] Open a modal dialog; verify white background and autofocus on Name input
- [ ] Check dropdown text colour on both selected and unselected tree items in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)