### PR TITLE
WebEditor: property editor controls and layout improvements

### DIFF
--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -13,7 +13,7 @@ namespace QuestViva.WasmEditor;
 
 internal record TreeNodeData(string Key, string Text, string? Parent, string? NodeIcon, string NodeType);
 internal record ControlOption(string Value, string Label);
-internal record ControlInfo(string? Attribute, string ControlType, string? Caption, List<ControlOption>? Options);
+internal record ControlInfo(string? Attribute, string ControlType, string? Caption, List<ControlOption>? Options, List<ControlOption>? SubEditors = null, string? SubAttribute = null);
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 internal record EditorDataResponse(Dictionary<string, string?> Attributes, List<TabInfo> Tabs, List<ControlInfo> Controls);
 
@@ -140,11 +140,11 @@ public partial class WasmEditorBridge
             {
                 if (!tab.IsTabVisible(data)) continue;
                 var visibleControls = tab.Controls.Where(c => c.IsControlVisible(data)).ToList();
-                AddDropdownTypeValues(attrs, visibleControls, key);
+                AddDropdownTypeValues(attrs, visibleControls, key, data);
                 tabs.Add(new TabInfo(tab.Caption, visibleControls.Select(ToControlInfo).ToList()));
             }
             var visibleTopControls = def.Controls.Where(c => c.IsControlVisible(data)).ToList();
-            AddDropdownTypeValues(attrs, visibleTopControls, key);
+            AddDropdownTypeValues(attrs, visibleTopControls, key, data);
             topControls.AddRange(visibleTopControls.Select(ToControlInfo));
         }
 
@@ -181,6 +181,36 @@ public partial class WasmEditorBridge
         {
             _controller.EndTransaction();
         }
+    }
+
+    [JSExport]
+    public static string SetMultiType(string elementKey, string attribute, string newType)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        _controller.StartTransaction($"Set type of {attribute}");
+        try
+        {
+            switch (newType)
+            {
+                case "null":
+                    data.SetAttribute(attribute, null!);
+                    break;
+                case "string":
+                    data.SetAttribute(attribute, "");
+                    break;
+                case "script":
+                    _controller.CreateNewEditableScripts(elementKey, attribute, null!, false);
+                    break;
+                default:
+                    return $"Unknown type: {newType}";
+            }
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+        finally { _controller.EndTransaction(); }
     }
 
     [JSExport]
@@ -262,10 +292,23 @@ public partial class WasmEditorBridge
         }
     }
 
-    private static void AddDropdownTypeValues(Dictionary<string, string?> attrs, List<IEditorControl> controls, string elementKey)
+    private static void AddDropdownTypeValues(Dictionary<string, string?> attrs, List<IEditorControl> controls, string elementKey, IEditorData data)
     {
         foreach (var ctrl in controls.Where(c => c.ControlType == "dropdowntypes"))
             attrs[ctrl.Id] = _controller!.GetSelectedDropDownType(ctrl, elementKey);
+
+        foreach (var ctrl in controls.Where(c => c.ControlType == "multi" && c.Attribute != null))
+        {
+            var val = data.GetAttribute(ctrl.Attribute!);
+            attrs[ctrl.Id] = val switch
+            {
+                null => "null",
+                string => "string",
+                IEditableScripts => "script",
+                IEditableObjectReference => "object",
+                _ => "null"
+            };
+        }
     }
 
     // ── Script editor API ──────────────────────────────────────────────────────
@@ -1058,7 +1101,19 @@ public partial class WasmEditorBridge
             var names = _controller!.GetObjectNames("object", includeLibraryObjects: false);
             options = names.Select(n => new ControlOption(n, n)).ToList();
         }
+        else if (ctrl.ControlType == "multi")
+        {
+            var typesDict = ctrl.GetDictionary("types");
+            if (typesDict != null)
+                options = typesDict.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
 
-        return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption, options);
+            var editorsDict = ctrl.GetDictionary("editors");
+            List<ControlOption>? subEditors = editorsDict?.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
+
+            var caption = ctrl.Caption ?? ctrl.GetString("selfcaption");
+            return new ControlInfo(ctrl.Id, ctrl.ControlType, caption, options, subEditors, ctrl.Attribute);
+        }
+
+        return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options);
     }
 }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -125,7 +125,8 @@ public partial class WasmEditorBridge
         var attrs = new Dictionary<string, string?>();
         foreach (var attr in extended.GetAttributeData())
         {
-            attrs[attr.AttributeName] = data.GetAttribute(attr.AttributeName)?.ToString();
+            var val = data.GetAttribute(attr.AttributeName);
+            attrs[attr.AttributeName] = val is IEditableObjectReference objRef ? objRef.Reference : val?.ToString();
         }
 
         var tabs = new List<TabInfo>();
@@ -180,6 +181,25 @@ public partial class WasmEditorBridge
         {
             _controller.EndTransaction();
         }
+    }
+
+    [JSExport]
+    public static string SetObjectReference(string elementKey, string attribute, string objectName)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        _controller.StartTransaction($"Set {attribute}");
+        try
+        {
+            var objRef = data.GetAttribute(attribute) as IEditableObjectReference
+                ?? _controller.CreateNewEditableObjectReference(elementKey, attribute, false);
+            objRef.Reference = objectName;
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+        finally { _controller.EndTransaction(); }
     }
 
     [JSExport]
@@ -1032,6 +1052,11 @@ public partial class WasmEditorBridge
             if (dict != null)
                 options = dict.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
             attribute = ctrl.Id;
+        }
+        else if (ctrl.ControlType == "objects")
+        {
+            var names = _controller!.GetObjectNames("object", includeLibraryObjects: false);
+            options = names.Select(n => new ControlOption(n, n)).ToList();
         }
 
         return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption, options);

--- a/src/WebEditor/src/components/AddElementModal.svelte
+++ b/src/WebEditor/src/components/AddElementModal.svelte
@@ -53,11 +53,7 @@
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
 >
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <div
-        class="card bg-white rounded-xl shadow-xl w-80 p-6 flex flex-col gap-4"
-        onclick={(e) => e.stopPropagation()}
-    >
+    <div class="card bg-white rounded-xl shadow-xl w-80 p-6 flex flex-col gap-4">
         <h2 class="text-base font-semibold">
             Add {labels[elementType]}{parent ? ` in "${parent}"` : ""}
         </h2>

--- a/src/WebEditor/src/components/Combobox.svelte
+++ b/src/WebEditor/src/components/Combobox.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+    import type { ControlOption } from "$lib/types";
+
+    let { value, options, onchange, class: className = "" }: {
+        value: string;
+        options: ControlOption[];
+        onchange: (value: string) => void;
+        class?: string;
+    } = $props();
+
+    // Unique ID prefix for ARIA references
+    let uid = Math.random().toString(36).slice(2, 7);
+
+    let open = $state(false);
+    let inputValue = $state("");
+    let activeIndex = $state(-1);
+    let listboxEl = $state<HTMLDivElement | null>(null);
+
+    $effect(() => {
+        if (!open) inputValue = value;
+    });
+
+    // Reset highlight when filtered list changes
+    $effect(() => {
+        filtered; // track
+        activeIndex = -1;
+    });
+
+    // Scroll active option into view
+    $effect(() => {
+        if (activeIndex >= 0 && listboxEl) {
+            const el = listboxEl.querySelector<HTMLElement>(`[data-idx="${activeIndex}"]`);
+            el?.scrollIntoView({ block: "nearest" });
+        }
+    });
+
+    let filtered = $derived(
+        inputValue === ""
+            ? options
+            : options.filter(o =>
+                o.label.toLowerCase().includes(inputValue.toLowerCase()) ||
+                o.value.toLowerCase().includes(inputValue.toLowerCase())
+            )
+    );
+
+    let activeDescendant = $derived(
+        open && activeIndex >= 0 ? `${uid}-opt-${activeIndex}` : undefined
+    );
+
+    function select(optValue: string) {
+        inputValue = optValue;
+        open = false;
+        activeIndex = -1;
+        onchange(optValue);
+    }
+
+    function handleFocus() {
+        inputValue = "";
+        open = true;
+    }
+
+    function handleBlur() {
+        open = false;
+        activeIndex = -1;
+        if (inputValue === "") {
+            inputValue = value;
+        } else {
+            onchange(inputValue);
+        }
+    }
+
+    function handleInput(e: Event) {
+        inputValue = (e.target as HTMLInputElement).value;
+        open = true;
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            if (!open) { open = true; activeIndex = 0; return; }
+            activeIndex = Math.min(activeIndex + 1, filtered.length - 1);
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            if (!open) return;
+            activeIndex = Math.max(activeIndex - 1, 0);
+        } else if (e.key === "Enter") {
+            if (open && activeIndex >= 0) {
+                e.preventDefault();
+                select(filtered[activeIndex].value);
+            } else if (open && filtered.length === 1) {
+                e.preventDefault();
+                select(filtered[0].value);
+            } else if (open) {
+                open = false;
+                onchange(inputValue);
+            }
+        } else if (e.key === "Escape") {
+            open = false;
+            inputValue = value;
+            activeIndex = -1;
+        }
+    }
+</script>
+
+<div class="relative">
+    <input
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+        aria-activedescendant={activeDescendant}
+        aria-controls="{uid}-listbox"
+        class={className}
+        value={inputValue}
+        onfocus={handleFocus}
+        onblur={handleBlur}
+        oninput={handleInput}
+        onkeydown={handleKeydown}
+    />
+    {#if open && filtered.length > 0}
+        <div
+            bind:this={listboxEl}
+            id="{uid}-listbox"
+            role="listbox"
+            class="absolute z-50 top-full left-0 mt-0.5 min-w-full max-h-48 overflow-y-auto rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-md"
+        >
+            {#each filtered as opt, i (opt.value)}
+                <div
+                    id="{uid}-opt-{i}"
+                    data-idx={i}
+                    role="option"
+                    tabindex="-1"
+                    aria-selected={opt.value === value}
+                    class="px-2 py-1 text-xs cursor-pointer {i === activeIndex ? 'bg-primary-100 dark:bg-primary-900' : 'hover:bg-surface-100-900'} {opt.value === value ? 'font-medium' : ''}"
+                    onmousedown={(e) => { e.preventDefault(); select(opt.value); }}
+                    onmouseenter={() => { activeIndex = i; }}
+                >
+                    {opt.label || opt.value}
+                </div>
+            {/each}
+        </div>
+    {/if}
+</div>

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -188,14 +188,15 @@
         {:else}
             {@const label = ctrl.caption ?? ctrl.attribute}
             {@const isLong = label.length > 20}
+            {@const isMultiline = ctrl.controlType === "richtext" || ctrl.controlType === "script"}
             {#if isLong}
                 <div class="flex flex-col gap-1 px-3 py-1.5">
                     <span class="text-xs text-surface-600-400">{label}:</span>
                     {@render controlOnly(ctrl)}
                 </div>
             {:else}
-                <div class="flex items-center gap-2 px-3 py-1.5 min-h-8">
-                    <span class="text-xs text-surface-600-400 w-32 flex-shrink-0">{label}:</span>
+                <div class="flex {isMultiline ? 'items-start' : 'items-center'} gap-2 px-3 py-1.5 min-h-8">
+                    <span class="text-xs text-surface-600-400 w-32 flex-shrink-0 {isMultiline ? 'pt-0.5' : ''}">{label}:</span>
                     {@render controlOnly(ctrl)}
                 </div>
             {/if}

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectedKey, selectedData, setAttribute, setDropdownType } from "$lib/editor-store";
+    import { selectedKey, selectedData, setAttribute, setDropdownType, setObjectReference } from "$lib/editor-store";
     import type { ControlInfo } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
     import Combobox from "./Combobox.svelte";
@@ -128,12 +128,25 @@
                 <option value={opt.value}>{opt.label}</option>
             {/each}
         </select>
-    {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
+    {:else if ctrl.controlType === "richtext"}
+        <textarea
+            class="input text-xs py-0.5 px-1.5 w-full min-h-24 resize-y"
+            value={attrValue(ctrl.attribute!) ?? ""}
+            onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLTextAreaElement).value)}
+        ></textarea>
+    {:else if ctrl.controlType === "textbox"}
         <input
             type="text"
             class="input text-xs py-0.5 px-1.5 w-full"
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value)}
+        />
+    {:else if ctrl.controlType === "objects" && ctrl.options}
+        <Combobox
+            value={attrValue(ctrl.attribute!) ?? ""}
+            options={ctrl.options}
+            onchange={(v) => $selectedKey && setObjectReference($selectedKey, ctrl.attribute!, v)}
+            class="input text-xs py-0.5 px-1.5 w-auto min-w-24"
         />
     {:else if ctrl.controlType === "script" && ctrl.attribute !== null && $selectedKey !== null}
         <div class="flex-1 min-w-0 overflow-hidden">

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -99,7 +99,7 @@
     {#if ctrl.controlType === "number"}
         <input
             type="number"
-            class="input text-xs py-0.5 px-1.5 w-full"
+            class="input text-xs py-0.5 px-1.5 w-auto"
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onNumberChange(ctrl.attribute!, "number", (e.target as HTMLInputElement).value)}
         />
@@ -107,7 +107,7 @@
         <input
             type="number"
             step="any"
-            class="input text-xs py-0.5 px-1.5 w-full"
+            class="input text-xs py-0.5 px-1.5 w-auto"
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onNumberChange(ctrl.attribute!, "numberdouble", (e.target as HTMLInputElement).value)}
         />
@@ -177,12 +177,12 @@
             {@const isLong = label.length > 20}
             {#if isLong}
                 <div class="flex flex-col gap-1 px-3 py-1.5">
-                    <span class="text-xs text-surface-600-400">{label}</span>
+                    <span class="text-xs text-surface-600-400">{label}:</span>
                     {@render controlOnly(ctrl)}
                 </div>
             {:else}
                 <div class="flex items-center gap-2 px-3 py-1.5 min-h-8">
-                    <span class="text-xs text-surface-600-400 w-32 flex-shrink-0">{label}</span>
+                    <span class="text-xs text-surface-600-400 w-32 flex-shrink-0">{label}:</span>
                     {@render controlOnly(ctrl)}
                 </div>
             {/if}

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -161,7 +161,7 @@
         </div>
     {:else if ctrl.attribute !== null}
         {#if ctrl.controlType === "checkbox"}
-            <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900 min-h-8">
+            <label class="flex items-center gap-2 px-3 py-1.5 min-h-8 cursor-pointer">
                 <input
                     type="checkbox"
                     class="checkbox flex-shrink-0"
@@ -171,17 +171,17 @@
                 <span class="text-xs text-surface-600-400">
                     {ctrl.caption ?? ctrl.attribute}
                 </span>
-            </div>
+            </label>
         {:else}
             {@const label = ctrl.caption ?? ctrl.attribute}
             {@const isLong = label.length > 20}
             {#if isLong}
-                <div class="flex flex-col gap-1 px-3 py-1.5 border-b border-surface-100-900">
+                <div class="flex flex-col gap-1 px-3 py-1.5">
                     <span class="text-xs text-surface-600-400">{label}</span>
                     {@render controlOnly(ctrl)}
                 </div>
             {:else}
-                <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900 min-h-8">
+                <div class="flex items-center gap-2 px-3 py-1.5 min-h-8">
                     <span class="text-xs text-surface-600-400 w-32 flex-shrink-0">{label}</span>
                     {@render controlOnly(ctrl)}
                 </div>

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectedKey, selectedData, setAttribute, setDropdownType, setObjectReference } from "$lib/editor-store";
+    import { selectedKey, selectedData, setAttribute, setDropdownType, setMultiType, setObjectReference } from "$lib/editor-store";
     import type { ControlInfo } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
     import Combobox from "./Combobox.svelte";
@@ -148,6 +148,36 @@
             onchange={(v) => $selectedKey && setObjectReference($selectedKey, ctrl.attribute!, v)}
             class="input text-xs py-0.5 px-1.5 w-auto min-w-24"
         />
+    {:else if ctrl.controlType === "multi" && ctrl.options}
+        {@const selectedType = attrValue(ctrl.attribute!) ?? "null"}
+        {@const subEditorType = ctrl.subEditors?.find(e => e.value === selectedType)?.label ?? selectedType}
+        <div class="flex flex-col gap-1 w-full">
+            <select
+                class="select text-xs py-0.5 px-1.5 w-auto self-start"
+                value={selectedType}
+                onchange={(e) => $selectedKey && setMultiType($selectedKey, ctrl.subAttribute!, (e.target as HTMLSelectElement).value)}
+            >
+                {#each ctrl.options as opt (opt.value)}
+                    <option value={opt.value}>{opt.label}</option>
+                {/each}
+            </select>
+            {#if subEditorType === "richtext" && ctrl.subAttribute !== null}
+                <textarea
+                    class="input text-xs py-0.5 px-1.5 w-full min-h-24 resize-y"
+                    value={attrValue(ctrl.subAttribute) ?? ""}
+                    onchange={(e) => onTextChange(ctrl.subAttribute!, "richtext", (e.target as HTMLTextAreaElement).value)}
+                ></textarea>
+            {:else if subEditorType === "textbox" && ctrl.subAttribute !== null}
+                <input
+                    type="text"
+                    class="input text-xs py-0.5 px-1.5 w-full"
+                    value={attrValue(ctrl.subAttribute) ?? ""}
+                    onchange={(e) => onTextChange(ctrl.subAttribute!, "textbox", (e.target as HTMLInputElement).value)}
+                />
+            {:else if subEditorType === "script" && ctrl.subAttribute !== null && $selectedKey !== null}
+                <ScriptEditor elementKey={$selectedKey} attribute={ctrl.subAttribute} />
+            {/if}
+        </div>
     {:else if ctrl.controlType === "script" && ctrl.attribute !== null && $selectedKey !== null}
         <div class="flex-1 min-w-0 overflow-hidden">
             <ScriptEditor elementKey={$selectedKey} attribute={ctrl.attribute} />
@@ -185,6 +215,40 @@
                     {ctrl.caption ?? ctrl.attribute}
                 </span>
             </label>
+        {:else if ctrl.controlType === "multi" && ctrl.options}
+            {@const label = ctrl.caption ?? ctrl.attribute}
+            {@const selectedType = attrValue(ctrl.attribute!) ?? "null"}
+            {@const subEditorType = ctrl.subEditors?.find(e => e.value === selectedType)?.label ?? selectedType}
+            <div class="flex flex-col gap-1 px-3 py-1.5">
+                <div class="flex items-center gap-2">
+                    <span class="text-xs text-surface-600-400 whitespace-nowrap">{label}:</span>
+                    <select
+                        class="select text-xs py-0.5 px-1.5 w-auto"
+                        value={selectedType}
+                        onchange={(e) => $selectedKey && setMultiType($selectedKey, ctrl.subAttribute!, (e.target as HTMLSelectElement).value)}
+                    >
+                        {#each ctrl.options as opt (opt.value)}
+                            <option value={opt.value}>{opt.label}</option>
+                        {/each}
+                    </select>
+                </div>
+                {#if subEditorType === "richtext" && ctrl.subAttribute !== null}
+                    <textarea
+                        class="input text-xs py-0.5 px-1.5 w-full min-h-24 resize-y"
+                        value={attrValue(ctrl.subAttribute) ?? ""}
+                        onchange={(e) => onTextChange(ctrl.subAttribute!, "richtext", (e.target as HTMLTextAreaElement).value)}
+                    ></textarea>
+                {:else if subEditorType === "textbox" && ctrl.subAttribute !== null}
+                    <input
+                        type="text"
+                        class="input text-xs py-0.5 px-1.5 w-full"
+                        value={attrValue(ctrl.subAttribute) ?? ""}
+                        onchange={(e) => onTextChange(ctrl.subAttribute!, "textbox", (e.target as HTMLInputElement).value)}
+                    />
+                {:else if subEditorType === "script" && ctrl.subAttribute !== null && $selectedKey !== null}
+                    <ScriptEditor elementKey={$selectedKey} attribute={ctrl.subAttribute} />
+                {/if}
+            </div>
         {:else}
             {@const label = ctrl.caption ?? ctrl.attribute}
             {@const isLong = label.length > 20}

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -2,6 +2,7 @@
     import { selectedKey, selectedData, setAttribute, setDropdownType } from "$lib/editor-store";
     import type { ControlInfo } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
+    import Combobox from "./Combobox.svelte";
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
@@ -94,6 +95,61 @@
     {/if}
 </div>
 
+{#snippet controlOnly(ctrl: ControlInfo)}
+    {#if ctrl.controlType === "number"}
+        <input
+            type="number"
+            class="input text-xs py-0.5 px-1.5 w-full"
+            value={attrValue(ctrl.attribute!) ?? ""}
+            onchange={(e) => onNumberChange(ctrl.attribute!, "number", (e.target as HTMLInputElement).value)}
+        />
+    {:else if ctrl.controlType === "numberdouble"}
+        <input
+            type="number"
+            step="any"
+            class="input text-xs py-0.5 px-1.5 w-full"
+            value={attrValue(ctrl.attribute!) ?? ""}
+            onchange={(e) => onNumberChange(ctrl.attribute!, "numberdouble", (e.target as HTMLInputElement).value)}
+        />
+    {:else if ctrl.controlType === "dropdown" && ctrl.options}
+        <Combobox
+            value={attrValue(ctrl.attribute!) ?? ""}
+            options={ctrl.options}
+            onchange={(v) => onDropdownChange(ctrl.attribute!, v)}
+            class="input text-xs py-0.5 px-1.5 w-auto min-w-24"
+        />
+    {:else if ctrl.controlType === "dropdowntypes" && ctrl.options && ctrl.attribute}
+        <select
+            class="select text-xs py-0.5 px-1.5 w-auto"
+            value={attrValue(ctrl.attribute) ?? "*"}
+            onchange={(e) => $selectedKey && setDropdownType($selectedKey, ctrl.attribute!, (e.target as HTMLSelectElement).value)}
+        >
+            {#each ctrl.options as opt, oi (oi)}
+                <option value={opt.value}>{opt.label}</option>
+            {/each}
+        </select>
+    {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
+        <input
+            type="text"
+            class="input text-xs py-0.5 px-1.5 w-full"
+            value={attrValue(ctrl.attribute!) ?? ""}
+            onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value)}
+        />
+    {:else if ctrl.controlType === "script" && ctrl.attribute !== null && $selectedKey !== null}
+        <div class="flex-1 min-w-0 overflow-hidden">
+            <ScriptEditor elementKey={$selectedKey} attribute={ctrl.attribute} />
+        </div>
+    {:else}
+        {#if attrValue(ctrl.attribute!) !== null}
+            <span class="text-xs overflow-hidden text-ellipsis whitespace-nowrap" title={attrValue(ctrl.attribute!) ?? ""}>
+                {attrValue(ctrl.attribute!)}
+            </span>
+        {:else}
+            <em class="text-xs text-surface-400-500">null</em>
+        {/if}
+    {/if}
+{/snippet}
+
 {#snippet controlRow(ctrl: ControlInfo)}
     {#if ctrl.controlType === "title"}
         <div class="px-3 pt-3 pb-1 text-xs font-semibold text-surface-500-400 uppercase tracking-wide">
@@ -104,73 +160,32 @@
             {ctrl.caption ?? ""}
         </div>
     {:else if ctrl.attribute !== null}
-        <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900 min-h-8">
-            <span class="text-xs text-surface-600-400 w-32 flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap" title={ctrl.caption ?? ctrl.attribute}>
-                {ctrl.caption ?? ctrl.attribute}
-            </span>
-
-            {#if ctrl.controlType === "checkbox"}
+        {#if ctrl.controlType === "checkbox"}
+            <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900 min-h-8">
                 <input
                     type="checkbox"
-                    class="checkbox"
+                    class="checkbox flex-shrink-0"
                     checked={boolValue(ctrl.attribute)}
                     onchange={(e) => onCheckboxChange(ctrl.attribute!, (e.target as HTMLInputElement).checked)}
                 />
-            {:else if ctrl.controlType === "number"}
-                <input
-                    type="number"
-                    class="input text-xs py-0.5 px-1.5 w-full"
-                    value={attrValue(ctrl.attribute) ?? ""}
-                    onchange={(e) => onNumberChange(ctrl.attribute!, "number", (e.target as HTMLInputElement).value)}
-                />
-            {:else if ctrl.controlType === "numberdouble"}
-                <input
-                    type="number"
-                    step="any"
-                    class="input text-xs py-0.5 px-1.5 w-full"
-                    value={attrValue(ctrl.attribute) ?? ""}
-                    onchange={(e) => onNumberChange(ctrl.attribute!, "numberdouble", (e.target as HTMLInputElement).value)}
-                />
-            {:else if ctrl.controlType === "dropdown" && ctrl.options}
-                <select
-                    class="select text-xs py-0.5 px-1.5 w-full"
-                    value={attrValue(ctrl.attribute) ?? ""}
-                    onchange={(e) => onDropdownChange(ctrl.attribute!, (e.target as HTMLSelectElement).value)}
-                >
-                    {#each ctrl.options as opt, oi (oi)}
-                        <option value={opt.value}>{opt.label}</option>
-                    {/each}
-                </select>
-            {:else if ctrl.controlType === "dropdowntypes" && ctrl.options && ctrl.attribute}
-                <select
-                    class="select text-xs py-0.5 px-1.5 w-full"
-                    value={attrValue(ctrl.attribute) ?? "*"}
-                    onchange={(e) => $selectedKey && setDropdownType($selectedKey, ctrl.attribute!, (e.target as HTMLSelectElement).value)}
-                >
-                    {#each ctrl.options as opt, oi (oi)}
-                        <option value={opt.value}>{opt.label}</option>
-                    {/each}
-                </select>
-            {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
-                <input
-                    type="text"
-                    class="input text-xs py-0.5 px-1.5 w-full"
-                    value={attrValue(ctrl.attribute) ?? ""}
-                    onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value)}
-                />
-            {:else if ctrl.controlType === "script" && ctrl.attribute !== null && $selectedKey !== null}
-                <div class="flex-1 min-w-0 overflow-hidden">
-                    <ScriptEditor elementKey={$selectedKey} attribute={ctrl.attribute} />
+                <span class="text-xs text-surface-600-400">
+                    {ctrl.caption ?? ctrl.attribute}
+                </span>
+            </div>
+        {:else}
+            {@const label = ctrl.caption ?? ctrl.attribute}
+            {@const isLong = label.length > 20}
+            {#if isLong}
+                <div class="flex flex-col gap-1 px-3 py-1.5 border-b border-surface-100-900">
+                    <span class="text-xs text-surface-600-400">{label}</span>
+                    {@render controlOnly(ctrl)}
                 </div>
             {:else}
-                {#if attrValue(ctrl.attribute) !== null}
-                    <span class="text-xs overflow-hidden text-ellipsis whitespace-nowrap" title={attrValue(ctrl.attribute) ?? ""}>
-                        {attrValue(ctrl.attribute)}
-                    </span>
-                {:else}
-                    <em class="text-xs text-surface-400-500">null</em>
-                {/if}
+                <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900 min-h-8">
+                    <span class="text-xs text-surface-600-400 w-32 flex-shrink-0">{label}</span>
+                    {@render controlOnly(ctrl)}
+                </div>
             {/if}
-        </div>
+        {/if}
     {/if}
 {/snippet}

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -8,6 +8,7 @@ export type AddElementModalState = { type: "room" | "object" | "function" | "tim
 let _bridge: WasmBridge | null = null;
 
 export const isLoaded = writable(false);
+export const loadingStatus = writable<string | null>(null);
 export const addElementModal = writable<AddElementModalState>(null);
 
 export function openAddModal(type: "room" | "object" | "function" | "timer", parent: string | null) {
@@ -28,15 +29,24 @@ function refreshUndoRedo() {
 }
 
 export async function openGame(file: File): Promise<boolean> {
+    loadingStatus.set("Starting editor…");
     const bytes = new Uint8Array(await file.arrayBuffer());
     _bridge = await loadWasm();
+    loadingStatus.set("Loading game…");
+    // Double rAF ensures the browser actually paints the status update before
+    // Initialise blocks the JS thread (C# WASM calls are synchronous).
+    await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     const ok = await _bridge.Initialise(bytes, file.name);
+    loadingStatus.set(null);
     if (ok) {
-        treeNodes.set(JSON.parse(_bridge.GetTreeNodes()));
+        const nodes: TreeNode[] = JSON.parse(_bridge.GetTreeNodes());
+        treeNodes.set(nodes);
         isLoaded.set(true);
         gameFilename.set(file.name);
         refreshUndoRedo();
         scriptClipboardHasContent.set(false);
+        const gameNode = nodes.find(n => n.nodeType === "game");
+        if (gameNode) selectNode(gameNode.key);
     }
     return ok;
 }

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -74,6 +74,14 @@ export function setAttribute(elementKey: string, attribute: string, controlType:
     return result;
 }
 
+export function setObjectReference(elementKey: string, attribute: string, objectName: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetObjectReference(elementKey, attribute, objectName);
+    refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
 export function setDropdownType(elementKey: string, controlId: string, selectedType: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SetDropdownType(elementKey, controlId, selectedType);

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -74,6 +74,14 @@ export function setAttribute(elementKey: string, attribute: string, controlType:
     return result;
 }
 
+export function setMultiType(elementKey: string, attribute: string, newType: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetMultiType(elementKey, attribute, newType);
+    refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
 export function setObjectReference(elementKey: string, attribute: string, objectName: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SetObjectReference(elementKey, attribute, objectName);

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -16,6 +16,8 @@ export interface ControlInfo {
   controlType: string
   caption: string | null
   options: ControlOption[] | null
+  subEditors: ControlOption[] | null
+  subAttribute: string | null
 }
 
 export interface TabInfo {

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -3,6 +3,7 @@ export interface WasmBridge {
   GetTreeNodes(): string
   GetEditorData(key: string): string | null
   SetAttribute(elementKey: string, attribute: string, controlType: string, value: string): string
+  SetObjectReference(elementKey: string, attribute: string, objectName: string): string
   SetDropdownType(elementKey: string, controlId: string, selectedType: string): string
   Save(): string
   CanUndo(): boolean

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -3,6 +3,7 @@ export interface WasmBridge {
   GetTreeNodes(): string
   GetEditorData(key: string): string | null
   SetAttribute(elementKey: string, attribute: string, controlType: string, value: string): string
+  SetMultiType(elementKey: string, attribute: string, newType: string): string
   SetObjectReference(elementKey: string, attribute: string, objectName: string): string
   SetDropdownType(elementKey: string, controlId: string, selectedType: string): string
   Save(): string

--- a/src/WebEditor/src/routes/+page.svelte
+++ b/src/WebEditor/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
-    import { openGame } from "$lib/editor-store";
+    import { openGame, loadingStatus } from "$lib/editor-store";
 
     let loading = $state(false);
     let error = $state<string | null>(null);
@@ -14,14 +14,13 @@
             const ok = await openGame(file);
             if (ok) {
                 goto("/editor");
-            } else {
-                error = "Failed to load game file.";
+                return;
             }
+            error = "Failed to load game file.";
         } catch (err) {
             error = String(err);
-        } finally {
-            loading = false;
         }
+        loading = false;
     }
 </script>
 
@@ -29,14 +28,17 @@
     <h1 class="text-3xl font-semibold">Quest Viva Editor</h1>
     <p class="text-surface-500-400">Open an <code>.aslx</code> game file to begin editing.</p>
 
-    <label class="btn preset-filled-primary-500 cursor-pointer" class:opacity-60={loading} class:pointer-events-none={loading}>
-        {#if loading}
-            Loading…
-        {:else}
+    {#if loading}
+        <div class="flex flex-col items-center gap-3">
+            <div class="size-10 rounded-full border-4 border-surface-300-700 border-t-primary-500 animate-spin"></div>
+            <p class="text-surface-500-400 text-sm">{$loadingStatus}</p>
+        </div>
+    {:else}
+        <label class="btn preset-filled-primary-500 cursor-pointer">
             Open game file
-        {/if}
-        <input type="file" accept=".aslx" onchange={handleFile} disabled={loading} class="hidden" />
-    </label>
+            <input type="file" accept=".aslx" onchange={handleFile} class="hidden" />
+        </label>
+    {/if}
 
     {#if error}
         <p class="text-error-500 max-w-[40ch] text-center">{error}</p>


### PR DESCRIPTION
## Summary

- Add accessible combobox component and use it throughout the property editor
- Add loading indicator and auto-select game node on open
- Improve layout: compact numeric inputs, colons on labels, top-aligned labels for multiline controls, remove row dividers
- Add checkbox label click support
- Add richtext textarea and object reference control
- Add multi/objects control types with `SetMultiType` and `SetObjectReference` WASM bridge methods
- Fix modal ARIA warning; various layout polish

## Test plan

- [ ] Open a game in the WebEditor and verify the property panel loads and auto-selects the root game node
- [ ] Check that dropdowns (combobox) filter options and are keyboard-navigable
- [ ] Verify checkbox labels are clickable
- [ ] Verify numeric inputs are compact
- [ ] Verify richtext and object reference fields render and save correctly
- [ ] Verify multi-type controls allow switching between null/string/script/object
- [ ] Verify objects dropdown populates with game object names

🤖 Generated with [Claude Code](https://claude.com/claude-code)