### PR TITLE
Fix map freezing after clearAllLayers when player animation is in progress

### DIFF
--- a/PlayerController/grid.js
+++ b/PlayerController/grid.js
@@ -328,6 +328,10 @@ gridApi.clearCustomLayer = function() {
 
 gridApi.clearAllLayers = function () {
     player = null;
+    playerVector = null;
+    playerDestination = null;
+    offsetVector = null;
+    offsetDestination = null;
     $.each(layers, function(idx, layer) {
         layer.removeChildren();
     });


### PR DESCRIPTION
## Summary

- `clearAllLayers` was nulling `player` but leaving `playerVector` (and the offset vectors) set
- The next `onFrame` tick would see `playerVector` as truthy, attempt `player.position`, and throw `TypeError: Cannot read properties of null`
- paper.js removes the frame handler on an uncaught exception, freezing the map permanently until page reload

## Root cause

The immediate trigger is `GridLineErase` (a custom function reported alongside this bug): it calls `MoveObject` *before* `JS.Grid_ClearAllLayers()`. `MoveObject` fires the standard movement handler → `Grid_DrawPlayerInRoom` → `drawPlayer`, which (since a player already exists on canvas) sets `playerVector` to start animating. The immediately following `clearAllLayers` then nulled `player` while leaving the animation state live.

The CEF update in 5.10 likely tightened frame scheduling enough to make `onFrame` fire in that window consistently, surfacing a pre-existing latent race.

## Fix

Clear all four animation-state variables (`playerVector`, `playerDestination`, `offsetVector`, `offsetDestination`) atomically with `player = null` in `clearAllLayers`, so `onFrame` skips both animation blocks cleanly on the next tick.

## Test plan

- [ ] Reproduce the original freeze using a game with `GridLineErase` — confirm it no longer freezes
- [ ] Verify normal player movement animation still works after a map redraw
- [ ] Verify offset/pan animation still works after a map redraw