### PR TITLE
Prevent crash when game name conflicts with a language template file

### DIFF
--- a/Editor/NewGameWindow.vb
+++ b/Editor/NewGameWindow.vb
@@ -85,6 +85,10 @@ Public Class NewGameWindow
     End Function
 
     Private Sub cmdOK_Click(sender As System.Object, e As System.EventArgs) Handles cmdOK.Click
+        If EditorController.IsReservedFilename(txtGameName.Text) Then
+            MsgBox(String.Format(T("EditorReservedGameName"), txtGameName.Text), MsgBoxStyle.Exclamation)
+            Return
+        End If
         If System.IO.File.Exists(txtFilename.Text) Then
             Dim result = MsgBox(String.Format(T("EditorFileOverwrite"), txtFilename.Text, Environment.NewLine + Environment.NewLine),
                                 MsgBoxStyle.Exclamation Or MsgBoxStyle.YesNoCancel)

--- a/EditorController/EditorController.cs
+++ b/EditorController/EditorController.cs
@@ -2426,6 +2426,13 @@ namespace TextAdventures.Quest
             return result;
         }
 
+        public static bool IsReservedFilename(string gameName, string folder = null)
+        {
+            string safeFilename = GenerateSafeFilename(gameName);
+            if (string.IsNullOrEmpty(safeFilename)) return false;
+            return GetAvailableTemplates(folder).Keys.Any(name => string.Equals(name, safeFilename, StringComparison.OrdinalIgnoreCase));
+        }
+
         internal void UpdateDictionariesReferencingRenamedObject(string oldName, string newName)
         {
             // This function is used so we can safely rename gamebook pages and have the corresponding links

--- a/Utility/Language/Templates.Designer.cs
+++ b/Utility/Language/Templates.Designer.cs
@@ -437,6 +437,15 @@ namespace TextAdventures.Utility.Language {
                 return ResourceManager.GetString("EditorFileOverwrite", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to "{0}" cannot be used as a game name as it conflicts with a language template file..
+        /// </summary>
+        internal static string EditorReservedGameName {
+            get {
+                return ResourceManager.GetString("EditorReservedGameName", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Files can only be created in the game folder..

--- a/Utility/Language/Templates.resx
+++ b/Utility/Language/Templates.resx
@@ -198,6 +198,9 @@
   <data name="EditorFileOverwrite" xml:space="preserve">
     <value>The file {0} already exists.{1}Would you like to overwrite it?</value>
   </data>
+  <data name="EditorReservedGameName" xml:space="preserve">
+    <value>"{0}" cannot be used as a game name as it conflicts with a language template file.</value>
+  </data>
   <data name="EditorFailedCreateFolder" xml:space="preserve">
     <value>Failed to create folder: </value>
   </data>

--- a/WebEditor/WebEditor/Controllers/CreateController.cs
+++ b/WebEditor/WebEditor/Controllers/CreateController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using System.Web.Mvc;
+using TextAdventures.Quest;
 using WebEditor.Services;
 
 namespace WebEditor.Controllers
@@ -28,6 +29,11 @@ namespace WebEditor.Controllers
             EditorService.PopulateCreateModelLists(createModel, TemplateFolder);
             if (ModelState.IsValid)
             {
+                if (EditorController.IsReservedFilename(createModel.GameName, TemplateFolder))
+                {
+                    ModelState.AddModelError("GameName", string.Format("\"{0}\" cannot be used as a game name as it conflicts with a language template file.", createModel.GameName));
+                    return View(createModel);
+                }
                 int newId = EditorService.CreateNewGame(createModel.SelectedType,
                     createModel.SelectedTemplate,
                     createModel.GameName,


### PR DESCRIPTION
## Summary

- Adds `IsReservedFilename()` static method to `EditorController` that checks whether a proposed game name would produce a filename colliding with a language template (e.g. `English.aslx`, `Deutsch.aslx`)
- Desktop editor (`NewGameWindow`) blocks creation with a message box if the name is reserved
- Web editor (`CreateController`) returns a model validation error on the `GameName` field if the name is reserved
- Adds `EditorReservedGameName` localisation string for the desktop error message

## Test plan

- [ ] Try creating a new game named "English" in the desktop editor — should show an error and not create the file
- [ ] Try creating a new game named "deutsch" (case-insensitive) — should also be blocked
- [ ] Try creating a game with a normal name — should work as before
- [ ] Repeat the above in the web editor

Fixes #1721

🤖 Generated with [Claude Code](https://claude.ai/claude-code)