### PR TITLE
WebEditor: remove EditorMode, fix Safari select borders, prevent editor flash

### DIFF
--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -42,13 +42,6 @@ namespace QuestViva.EditorCore
         GameBook
     }
 
-    // TO DO: When WebEditor is fully functional, there should be no need for this
-    public enum EditorMode
-    {
-        Desktop,
-        Web
-    }
-
     public struct ValidationResult
     {
         public bool Valid;
@@ -136,7 +129,6 @@ namespace QuestViva.EditorCore
         private List<IScript> m_clipboardScripts;
         private bool m_simpleMode;
         private EditorStyle m_editorStyle = EditorStyle.TextAdventure;
-        private EditorMode m_editorMode = EditorMode.Desktop;
         private bool m_lastelementscutout;
 
         public event EventHandler ClearTree;
@@ -558,16 +550,13 @@ namespace QuestViva.EditorCore
             AddTreeHeader(null, ElementType.Function, "_functions", "Functions", null, false);
 
             AddTreeHeader(EditorStyle.TextAdventure, ElementType.Timer, "_timers", "Timers", null, false);
-            if (m_editorMode == EditorMode.Desktop)
-            {
-                AddTreeHeader(EditorStyle.TextAdventure, ElementType.Walkthrough, "_walkthrough", "Walkthrough", null, false);
-                AddTreeHeader(null, null, "_advanced", "Advanced", null, false);
-                AddTreeHeader(null, ElementType.IncludedLibrary, "_include", "Included Libraries", "_advanced", false);
-                AddTreeHeader(EditorStyle.TextAdventure, ElementType.Template, "_template", "Templates", "_advanced", false);
-                AddTreeHeader(EditorStyle.TextAdventure, ElementType.DynamicTemplate, "_dynamictemplate", "Dynamic Templates", "_advanced", false);
-                AddTreeHeader(EditorStyle.TextAdventure, ElementType.ObjectType, "_objecttype", "Object Types", "_advanced", false);
-                AddTreeHeader(null, ElementType.Javascript, "_javascript", "Javascript", "_advanced", false);
-            }
+            AddTreeHeader(EditorStyle.TextAdventure, ElementType.Walkthrough, "_walkthrough", "Walkthrough", null, false);
+            AddTreeHeader(null, null, "_advanced", "Advanced", null, false);
+            AddTreeHeader(null, ElementType.IncludedLibrary, "_include", "Included Libraries", "_advanced", false);
+            AddTreeHeader(EditorStyle.TextAdventure, ElementType.Template, "_template", "Templates", "_advanced", false);
+            AddTreeHeader(EditorStyle.TextAdventure, ElementType.DynamicTemplate, "_dynamictemplate", "Dynamic Templates", "_advanced", false);
+            AddTreeHeader(EditorStyle.TextAdventure, ElementType.ObjectType, "_objecttype", "Object Types", "_advanced", false);
+            AddTreeHeader(null, ElementType.Javascript, "_javascript", "Javascript", "_advanced", false);
         }
 
         private void AddTreeHeader(EditorStyle? editorStyle, ElementType? type, string key, string title, string parent, bool simple)
@@ -636,12 +625,7 @@ namespace QuestViva.EditorCore
 
                 if (o.Name == "game" && !SimpleMode && m_editorStyle == EditorStyle.TextAdventure)
                 {
-                    if (m_editorMode == EditorMode.Desktop)
-                    {
-                        // TO DO: When WebEditor is fully functional, there should be no need for this
-                        AddedNode(this, new AddedNodeEventArgs { Key = k_verbs, Text = "Verbs", Parent = "game", IsLibraryNode = false, Position = null, NodeIcon = "s_verb" });
-
-                    }
+                    AddedNode(this, new AddedNodeEventArgs { Key = k_verbs, Text = "Verbs", Parent = "game", IsLibraryNode = false, Position = null, NodeIcon = "s_verb" });
                     AddedNode(this, new AddedNodeEventArgs { Key = k_commands, Text = "Commands", Parent = "game", IsLibraryNode = false, Position = null, NodeIcon = "s_command" });
                 }
             }
@@ -652,16 +636,6 @@ namespace QuestViva.EditorCore
             // Don't display implied types, editor elements etc.
             if (m_ignoredTypes.Contains(e.ElemType)) return false;
             if (SimpleMode && m_advancedTypes.Contains(e.ElemType)) return false;
-
-            // TO DO: When WebEditor is fully functional, there should be no need for this
-            if (m_editorMode == EditorMode.Web)
-            {
-                if (m_webEditorIgnoreTypes.Contains(e.ElemType)) return false;
-                if (e.ElemType == ElementType.Object && e.Type == ObjectType.Command && e.Fields[FieldDefinitions.IsVerb])
-                {
-                    return false;
-                }
-            }
 
             if (SimpleMode)
             {
@@ -2409,13 +2383,7 @@ namespace QuestViva.EditorCore
 
             return selectedAttribute;
         }
-
-        public EditorMode EditorMode
-        {
-            get { return m_editorMode; }
-            set { m_editorMode = value; }
-        }
-
+        
         private static List<string> s_invalidChars = new List<string> { "\\", "/", ":", "*", "?", "\"", "<", ">", "|" };
 
         public static string GenerateSafeFilename(string gameName)

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -84,17 +84,6 @@ namespace QuestViva.EditorCore
             ElementType.Walkthrough
         };
 
-        // TO DO: When WebEditor is fully functional, there should be no need for this
-        private List<ElementType> m_webEditorIgnoreTypes = new List<ElementType>
-        {
-            ElementType.DynamicTemplate,
-            ElementType.IncludedLibrary,
-            ElementType.Javascript,
-            ElementType.ObjectType,
-            ElementType.Template,
-            ElementType.Walkthrough
-        };
-
         private static Dictionary<ValidationMessage, string> s_validationMessages = new Dictionary<ValidationMessage, string> {
             {ValidationMessage.OK, "No error"},
             {ValidationMessage.ItemAlreadyExists, "Item '{0}' already exists in the list"},

--- a/src/WebEditor/src/app.css
+++ b/src/WebEditor/src/app.css
@@ -33,3 +33,17 @@
     background-color: var(--color-surface-200-800);
     color: inherit;
 }
+
+/* Safari ignores box-shadow on <select> elements with native appearance.
+   Use a real border instead, which all browsers respect. */
+select.select {
+    border-width: 1px;
+    border-color: var(--color-surface-200-800);
+    box-shadow: none;
+}
+
+select.select:focus,
+select.select:active {
+    border-color: var(--color-primary-500);
+    outline: none;
+}

--- a/src/WebEditor/src/routes/+page.svelte
+++ b/src/WebEditor/src/routes/+page.svelte
@@ -28,19 +28,21 @@
     }
 </script>
 
-<div class="flex flex-col h-svh overflow-hidden">
-    <Toolbar />
-    <div class="flex flex-1 overflow-hidden">
-        <TreePanel />
-        <PropertyEditor />
+{#if $isLoaded}
+    <div class="flex flex-col h-svh overflow-hidden">
+        <Toolbar />
+        <div class="flex flex-1 overflow-hidden">
+            <TreePanel />
+            <PropertyEditor />
+        </div>
     </div>
-</div>
 
-{#if $addElementModal}
-    <AddElementModal
-        elementType={$addElementModal.type}
-        parent={$addElementModal.parent}
-        onconfirm={handleAddConfirm}
-        oncancel={() => addElementModal.set(null)}
-    />
+    {#if $addElementModal}
+        <AddElementModal
+            elementType={$addElementModal.type}
+            parent={$addElementModal.parent}
+            onconfirm={handleAddConfirm}
+            oncancel={() => addElementModal.set(null)}
+        />
+    {/if}
 {/if}


### PR DESCRIPTION
## Summary

- Remove `EditorMode` enum and `m_webEditorIgnoreTypes` from `EditorController` — the web editor is now capable enough to show all element types (Walkthrough, Advanced, Verbs, etc.) that were previously hidden in web mode
- Fix missing borders on `<select>` elements in Safari: Safari ignores `box-shadow` on native-appearance selects, so replaced with explicit `border` CSS that all browsers respect
- Prevent editor flash before redirect to `/open` when no game is loaded: wrap the main editor UI in `{#if $isLoaded}` so it's not rendered until a game is present

## Test plan

- [ ] Open the web editor with a game loaded — verify all tree nodes (Walkthrough, Advanced, Verbs, etc.) are visible
- [ ] Open the web editor with no game loaded — verify no flash of editor UI before redirect to `/open`
- [ ] Check `<select>` elements in Safari have visible borders matching the design
- [ ] Verify existing editor functionality is unchanged in Chrome/Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)