### PR TITLE
WebEditor: Attributes tab

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,7 @@ on:
       - "src/**"
       - "tests/**"
       - "site/**"
+  workflow_dispatch:
 
 jobs:
   build_site:

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -2499,4 +2499,3 @@ namespace QuestViva.EditorCore
         }
     }
 }
-

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -1132,6 +1132,26 @@ namespace QuestViva.EditorCore
             return newValue;
         }
 
+        public void MakeScriptDictionaryEditable(string parent, string attribute)
+        {
+            Element element = m_worldModel.Elements.Get(parent);
+            QuestDictionary<IScript> existing = element.Fields.GetAsType<QuestDictionary<IScript>>(attribute);
+            if (existing == null) return;
+
+            WorldModel.UndoLogger.StartTransaction($"Copy {attribute} to {parent}");
+            try
+            {
+                QuestDictionary<IScript> newDict = new QuestDictionary<IScript>();
+                foreach (var kvp in existing)
+                    newDict.Add(kvp.Key, (IScript)kvp.Value.Clone());
+                element.Fields.Set(attribute, newDict);
+            }
+            finally
+            {
+                WorldModel.UndoLogger.EndTransaction();
+            }
+        }
+
         public IEditableObjectReference CreateNewEditableObjectReference(string parent, string attribute, bool useTransaction)
         {
             if (useTransaction)

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -2499,3 +2499,4 @@ namespace QuestViva.EditorCore
         }
     }
 }
+

--- a/src/Engine/Core/CoreEditorCommand.aslx
+++ b/src/Engine/Core/CoreEditorCommand.aslx
@@ -49,7 +49,6 @@
 
     <tab>
       <caption>[EditorCommandAttributes]</caption>
-      <desktop/>
 
       <control>
         <controltype>attributes</controltype>

--- a/src/Engine/Core/CoreEditorExit.aslx
+++ b/src/Engine/Core/CoreEditorExit.aslx
@@ -195,7 +195,6 @@
 
     <tab>
       <caption>[EditorExitAttributes]</caption>
-      <desktop/>
       <advanced/>
 
       <control>

--- a/src/Engine/Core/CoreEditorGame.aslx
+++ b/src/Engine/Core/CoreEditorGame.aslx
@@ -1017,7 +1017,6 @@
     <tab>
       <caption>[EditorGameAttributes]</caption>
       <advanced/>
-      <desktop/>
 
       <control>
         <controltype>stringdictionary</controltype>

--- a/src/Engine/Core/CoreEditorObjectAttributes.aslx
+++ b/src/Engine/Core/CoreEditorObjectAttributes.aslx
@@ -3,7 +3,6 @@
     <parent>_ObjectEditor</parent>
     <caption>[EditorObjectAttributesAttributes]</caption>
     <advanced/>
-    <desktop/>
 
     <control>
       <controltype>stringdictionary</controltype>

--- a/src/Engine/Core/CoreEditorVerb.aslx
+++ b/src/Engine/Core/CoreEditorVerb.aslx
@@ -100,7 +100,6 @@
 
     <tab>
       <caption>[EditorVerbAttributes]</caption>
-      <desktop/>
 
       <control>
         <controltype>attributes</controltype>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -9,6 +9,8 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using QuestViva.Common;
 using QuestViva.EditorCore;
+using QuestViva.Engine;
+using QuestViva.Engine.Types;
 
 namespace QuestViva.WasmEditor;
 
@@ -59,7 +61,7 @@ internal record IfExpressionTemplateData(
 );
 internal record IfExpressionTemplate(string Name, string CreateExpression);
 internal record ListItemData(string Key, string Value);
-internal record AttributeDataItem(string Name, string? Value, bool IsInherited, string Source, bool IsDefaultType);
+internal record AttributeDataItem(string Name, string? Value, bool IsInherited, string Source, bool IsDefaultType, string Type);
 internal record FullAttributeData(List<AttributeDataItem> Attributes, List<AttributeDataItem> InheritedTypes);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
@@ -924,11 +926,11 @@ public partial class WasmEditorBridge
         var attributes = extended.GetAttributeData().Select(attr =>
         {
             var val = data.GetAttribute(attr.AttributeName);
-            return new AttributeDataItem(attr.AttributeName, SerializeAttributeValue(val), attr.IsInherited, attr.Source, attr.IsDefaultType);
+            return new AttributeDataItem(attr.AttributeName, SerializeAttributeValue(val), attr.IsInherited, attr.Source, attr.IsDefaultType, DetermineAttributeType(val));
         }).ToList();
 
         var inheritedTypes = extended.GetInheritedTypes()
-            .Select(t => new AttributeDataItem(t.AttributeName, t.AttributeName, t.IsInherited, t.Source, t.IsDefaultType))
+            .Select(t => new AttributeDataItem(t.AttributeName, t.AttributeName, t.IsInherited, t.Source, t.IsDefaultType, "type"))
             .ToList();
 
         return JsonSerializer.Serialize(
@@ -990,6 +992,65 @@ public partial class WasmEditorBridge
     }
 
     [JSExport]
+    public static string ChangeAttributeType(string elementKey, string attribute, string newType)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        _controller.StartTransaction($"Change type of {attribute}");
+        try
+        {
+            if (newType == "script")
+            {
+                _controller.CreateNewEditableScripts(elementKey, attribute, null!, false);
+            }
+            else
+            {
+                object? newValue = newType switch
+                {
+                    "null" => null,
+                    "string" => (object)"",
+                    "boolean" => (object)false,
+                    "int" => (object)0,
+                    "double" => (object)0.0,
+                    "simplepattern" => (object)new EditorCommandPattern(""),
+                    "stringlist" => (object)new QuestList<string>(),
+                    "stringdictionary" => (object)new QuestDictionary<string>(),
+                    _ => null
+                };
+                if (newType != "null" && newValue == null) return $"Unsupported type: {newType}";
+                var result = data.SetAttribute(attribute, newValue!);
+                if (!result.Valid) return result.Message.ToString();
+            }
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+        finally { _controller.EndTransaction(); }
+    }
+
+    [JSExport]
+    public static string SetPatternAttribute(string elementKey, string attribute, string pattern)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        _controller.StartTransaction($"Set {attribute}");
+        try
+        {
+            var cmd = data.GetAttribute(attribute) as IEditableCommandPattern;
+            if (cmd != null)
+                cmd.Pattern = pattern;
+            else
+                data.SetAttribute(attribute, new EditorCommandPattern(pattern));
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+        finally { _controller.EndTransaction(); }
+    }
+
+    [JSExport]
     public static string AddDictionaryItem(string elementKey, string attribute, string key, string value)
     {
         if (_controller == null) return "error";
@@ -1047,6 +1108,9 @@ public partial class WasmEditorBridge
     private static string? SerializeAttributeValue(object? val) => val switch
     {
         null => null,
+        bool b => b.ToString(),
+        int i => i.ToString(),
+        double d => d.ToString(System.Globalization.CultureInfo.InvariantCulture),
         IEditableObjectReference objRef => objRef.Reference,
         IEditableList<string> list => JsonSerializer.Serialize(
             list.ItemsList.Select(i => new ListItemData(i.Key, i.Value)).ToList(),
@@ -1055,7 +1119,24 @@ public partial class WasmEditorBridge
             dict.Items.Values.Select(i => new ListItemData(i.Key, i.Value)).ToList(),
             WasmEditorJsonContext.Default.ListListItemData),
         IEditableScripts => "(script)",
+        IEditableCommandPattern cmd => cmd.Pattern,
+        IEditableDictionary<IEditableScripts> => "(script dictionary)",
         _ => val.ToString()
+    };
+
+    private static string DetermineAttributeType(object? val) => val switch
+    {
+        null => "null",
+        bool => "boolean",
+        int => "int",
+        double => "double",
+        IEditableObjectReference => "object",
+        IEditableList<string> => "stringlist",
+        IEditableDictionary<string> => "stringdictionary",
+        IEditableScripts => "script",
+        IEditableCommandPattern => "simplepattern",
+        IEditableDictionary<IEditableScripts> => "scriptdictionary",
+        _ => "string"
     };
 
     private static IEditableScripts? GetScripts(string elementKey, string attribute)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -377,6 +377,18 @@ public partial class WasmEditorBridge
         return (data.GetAttribute(attribute) as IEditableList<string>)!;
     }
 
+    private static IEditableDictionary<string> EnsureLocalDict(IEditorData data, string attribute, IEditableDictionary<string> dict)
+    {
+        if (data is not IEditorDataExtendedAttributeInfo extended) return dict;
+        var attrInfo = extended.GetAttributeData().FirstOrDefault(a => a.AttributeName == attribute);
+        if (attrInfo is not { IsInherited: true } and not { IsDefaultType: true }) return dict;
+
+        var copy = new QuestDictionary<string>();
+        foreach (var kvp in dict.Items) copy.Add(kvp.Key, (string)kvp.Value.Value);
+        data.SetAttribute(attribute, copy);
+        return (data.GetAttribute(attribute) as IEditableDictionary<string>)!;
+    }
+
     private static void AddDropdownTypeValues(Dictionary<string, string?> attrs, List<IEditorControl> controls, string elementKey, IEditorData data)
     {
         foreach (var ctrl in controls.Where(c => c.ControlType == "dropdowntypes"))
@@ -1089,6 +1101,7 @@ public partial class WasmEditorBridge
             }
             else
             {
+                existing = EnsureLocalDict(data, attribute, existing);
                 var validation = existing.CanAdd(key);
                 if (!validation.Valid) return validation.Message.ToString();
                 existing.Add(key, value);
@@ -1108,7 +1121,12 @@ public partial class WasmEditorBridge
         var dict = data.GetAttribute(attribute) as IEditableDictionary<string>;
         if (dict == null) return "error";
 
-        try { dict.Remove(key); return "ok"; }
+        try
+        {
+            dict = EnsureLocalDict(data, attribute, dict);
+            dict.Remove(key);
+            return "ok";
+        }
         catch (Exception ex) { return ex.Message; }
     }
 
@@ -1122,7 +1140,37 @@ public partial class WasmEditorBridge
         var dict = data.GetAttribute(attribute) as IEditableDictionary<string>;
         if (dict == null) return "error";
 
-        try { dict.Update(key, value); return "ok"; }
+        try
+        {
+            dict = EnsureLocalDict(data, attribute, dict);
+            dict.Update(key, value);
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string MakeScriptEditable(string elementKey, string attribute)
+    {
+        if (_controller == null) return "error";
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null) return "error";
+
+        _controller.StartTransaction($"Copy {attribute} script to {elementKey}");
+        try { scripts.Clone(elementKey, attribute); return "ok"; }
+        catch (Exception ex) { return ex.Message; }
+        finally { _controller.EndTransaction(); }
+    }
+
+    [JSExport]
+    public static string MakeScriptDictEditable(string elementKey, string attribute)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+        if (data.GetAttribute(attribute) is not IEditableDictionary<IEditableScripts>) return "error";
+
+        try { _controller.MakeScriptDictionaryEditable(elementKey, attribute); return "ok"; }
         catch (Exception ex) { return ex.Message; }
     }
 

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -317,6 +317,7 @@ public partial class WasmEditorBridge
             }
             else
             {
+                existing = EnsureLocalList(data, attribute, existing);
                 var validation = existing.CanAdd(value);
                 if (!validation.Valid) return validation.Message.ToString();
                 existing.Add(value);
@@ -338,6 +339,7 @@ public partial class WasmEditorBridge
 
         try
         {
+            list = EnsureLocalList(data, attribute, list);
             list.Remove(key);
             return "ok";
         }
@@ -356,10 +358,23 @@ public partial class WasmEditorBridge
 
         try
         {
+            list = EnsureLocalList(data, attribute, list);
             list.Update(key, value);
             return "ok";
         }
         catch (Exception ex) { return ex.Message; }
+    }
+
+    private static IEditableList<string> EnsureLocalList(IEditorData data, string attribute, IEditableList<string> list)
+    {
+        if (data is not IEditorDataExtendedAttributeInfo extended) return list;
+        var attrInfo = extended.GetAttributeData().FirstOrDefault(a => a.AttributeName == attribute);
+        if (attrInfo is not { IsInherited: true } and not { IsDefaultType: true }) return list;
+
+        var copy = new QuestList<string>();
+        foreach (var item in list.ItemsList) copy.Add(item.Value);
+        data.SetAttribute(attribute, copy);
+        return (data.GetAttribute(attribute) as IEditableList<string>)!;
     }
 
     private static void AddDropdownTypeValues(Dictionary<string, string?> attrs, List<IEditorControl> controls, string elementKey, IEditorData data)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -1020,6 +1020,10 @@ public partial class WasmEditorBridge
             {
                 _controller.CreateNewEditableScripts(elementKey, attribute, null!, false);
             }
+            else if (newType == "scriptdictionary")
+            {
+                _controller.CreateNewEditableScriptDictionary(elementKey, attribute, null!, null!, false);
+            }
             else if (newType == "object")
             {
                 _controller.CreateNewEditableObjectReference(elementKey, attribute, false);
@@ -1122,6 +1126,47 @@ public partial class WasmEditorBridge
         catch (Exception ex) { return ex.Message; }
     }
 
+    [JSExport]
+    public static string AddScriptDictionaryItem(string elementKey, string attribute, string key)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        try
+        {
+            var existing = data.GetAttribute(attribute) as IEditableDictionary<IEditableScripts>;
+            if (existing == null)
+            {
+                var emptyScript = _controller.CreateNewEditableScripts(null!, null!, null!, false);
+                _controller.CreateNewEditableScriptDictionary(elementKey, attribute, key, emptyScript, true);
+            }
+            else
+            {
+                var validation = existing.CanAdd(key);
+                if (!validation.Valid) return validation.Message.ToString();
+                var emptyScript = _controller.CreateNewEditableScripts(null!, null!, null!, false);
+                existing.Add(key, emptyScript);
+            }
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string RemoveScriptDictionaryItem(string elementKey, string attribute, string key)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        var dict = data.GetAttribute(attribute) as IEditableDictionary<IEditableScripts>;
+        if (dict == null) return "error";
+
+        try { dict.Remove(key); return "ok"; }
+        catch (Exception ex) { return ex.Message; }
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     private static string? SerializeAttributeValue(object? val) => val switch
@@ -1139,7 +1184,9 @@ public partial class WasmEditorBridge
             WasmEditorJsonContext.Default.ListListItemData),
         IEditableScripts => "(script)",
         IEditableCommandPattern cmd => cmd.Pattern,
-        IEditableDictionary<IEditableScripts> => "(script dictionary)",
+        IEditableDictionary<IEditableScripts> scriptDict => JsonSerializer.Serialize(
+            scriptDict.Items.Values.Select(i => new ListItemData(i.Key, "(script)")).ToList(),
+            WasmEditorJsonContext.Default.ListListItemData),
         _ => val.ToString()
     };
 
@@ -1162,7 +1209,19 @@ public partial class WasmEditorBridge
     {
         if (_controller == null) return null;
         var data = _controller.GetEditorData(elementKey);
-        return data?.GetAttribute(attribute) as IEditableScripts;
+        if (data == null) return null;
+
+        var bracketIdx = attribute.IndexOf('[');
+        if (bracketIdx >= 0 && attribute.EndsWith(']'))
+        {
+            var attrName = attribute[..bracketIdx];
+            var key = attribute[(bracketIdx + 1)..^1];
+            var dict = data.GetAttribute(attrName) as IEditableDictionary<IEditableScripts>;
+            if (dict == null || !dict.Items.TryGetValue(key, out var item)) return null;
+            return item.Value;
+        }
+
+        return data.GetAttribute(attribute) as IEditableScripts;
     }
 
     private static IEditableScripts? ResolveContainer(IEditableScripts root, string containerPath)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -1230,7 +1230,7 @@ public partial class WasmEditorBridge
         IEditableDictionary<string> dict => JsonSerializer.Serialize(
             dict.Items.Values.Select(i => new ListItemData(i.Key, i.Value)).ToList(),
             WasmEditorJsonContext.Default.ListListItemData),
-        IEditableScripts => "(script)",
+        IEditableScripts scripts => scripts.DisplayString(-1, string.Empty),
         IEditableCommandPattern cmd => cmd.Pattern,
         IEditableDictionary<IEditableScripts> scriptDict => JsonSerializer.Serialize(
             scriptDict.Items.Values.Select(i => new ListItemData(i.Key, "(script)")).ToList(),

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -1005,6 +1005,10 @@ public partial class WasmEditorBridge
             {
                 _controller.CreateNewEditableScripts(elementKey, attribute, null!, false);
             }
+            else if (newType == "object")
+            {
+                _controller.CreateNewEditableObjectReference(elementKey, attribute, false);
+            }
             else
             {
                 object? newValue = newType switch

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -59,6 +59,8 @@ internal record IfExpressionTemplateData(
 );
 internal record IfExpressionTemplate(string Name, string CreateExpression);
 internal record ListItemData(string Key, string Value);
+internal record AttributeDataItem(string Name, string? Value, bool IsInherited, string Source, bool IsDefaultType);
+internal record FullAttributeData(List<AttributeDataItem> Attributes, List<AttributeDataItem> InheritedTypes);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
@@ -70,6 +72,7 @@ internal record ListItemData(string Key, string Value);
 [JsonSerializable(typeof(IfExpressionTemplateData))]
 [JsonSerializable(typeof(int[]))]
 [JsonSerializable(typeof(List<ListItemData>))]
+[JsonSerializable(typeof(FullAttributeData))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext { }
 
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
@@ -130,14 +133,7 @@ public partial class WasmEditorBridge
         foreach (var attr in extended.GetAttributeData())
         {
             var val = data.GetAttribute(attr.AttributeName);
-            attrs[attr.AttributeName] = val switch
-            {
-                IEditableObjectReference objRef => objRef.Reference,
-                IEditableList<string> list => JsonSerializer.Serialize(
-                    list.ItemsList.Select(i => new ListItemData(i.Key, i.Value)).ToList(),
-                    WasmEditorJsonContext.Default.ListListItemData),
-                _ => val?.ToString()
-            };
+            attrs[attr.AttributeName] = SerializeAttributeValue(val);
         }
 
         var tabs = new List<TabInfo>();
@@ -916,7 +912,151 @@ public partial class WasmEditorBridge
         _controller?.DeleteElement(key, true);
     }
 
+    // ── Attributes editor API ──────────────────────────────────────────────────
+
+    [JSExport]
+    public static string? GetFullAttributeData(string elementKey)
+    {
+        if (_controller == null) return null;
+        var data = _controller.GetEditorData(elementKey);
+        if (data is not IEditorDataExtendedAttributeInfo extended) return null;
+
+        var attributes = extended.GetAttributeData().Select(attr =>
+        {
+            var val = data.GetAttribute(attr.AttributeName);
+            return new AttributeDataItem(attr.AttributeName, SerializeAttributeValue(val), attr.IsInherited, attr.Source, attr.IsDefaultType);
+        }).ToList();
+
+        var inheritedTypes = extended.GetInheritedTypes()
+            .Select(t => new AttributeDataItem(t.AttributeName, t.AttributeName, t.IsInherited, t.Source, t.IsDefaultType))
+            .ToList();
+
+        return JsonSerializer.Serialize(
+            new FullAttributeData(attributes, inheritedTypes),
+            WasmEditorJsonContext.Default.FullAttributeData);
+    }
+
+    [JSExport]
+    public static string RemoveAttribute(string elementKey, string attribute)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data is not IEditorDataExtendedAttributeInfo extended) return "error";
+
+        _controller.StartTransaction($"Remove {attribute}");
+        try
+        {
+            extended.RemoveAttribute(attribute);
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+        finally { _controller.EndTransaction(); }
+    }
+
+    [JSExport]
+    public static string AddInheritedType(string elementKey, string typeName)
+    {
+        if (_controller == null) return "error";
+        _controller.StartTransaction($"Add type {typeName}");
+        try
+        {
+            var result = _controller.AddInheritedTypeToElement(elementKey, typeName, false);
+            return result.Valid ? "ok" : result.Message.ToString();
+        }
+        catch (Exception ex) { return ex.Message; }
+        finally { _controller.EndTransaction(); }
+    }
+
+    [JSExport]
+    public static string RemoveInheritedType(string elementKey, string typeName)
+    {
+        if (_controller == null) return "error";
+        _controller.StartTransaction($"Remove type {typeName}");
+        try
+        {
+            _controller.RemoveInheritedTypeFromElement(elementKey, typeName, false);
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+        finally { _controller.EndTransaction(); }
+    }
+
+    [JSExport]
+    public static string GetTypeNames()
+    {
+        if (_controller == null) return "[]";
+        var names = _controller.GetElementNames("type").ToList();
+        return JsonSerializer.Serialize(names, WasmEditorJsonContext.Default.ListString);
+    }
+
+    [JSExport]
+    public static string AddDictionaryItem(string elementKey, string attribute, string key, string value)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        try
+        {
+            var existing = data.GetAttribute(attribute) as IEditableDictionary<string>;
+            if (existing == null)
+            {
+                _controller.CreateNewEditableStringDictionary(elementKey, attribute, key, value, true);
+            }
+            else
+            {
+                var validation = existing.CanAdd(key);
+                if (!validation.Valid) return validation.Message.ToString();
+                existing.Add(key, value);
+            }
+            return "ok";
+        }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string RemoveDictionaryItem(string elementKey, string attribute, string key)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        var dict = data.GetAttribute(attribute) as IEditableDictionary<string>;
+        if (dict == null) return "error";
+
+        try { dict.Remove(key); return "ok"; }
+        catch (Exception ex) { return ex.Message; }
+    }
+
+    [JSExport]
+    public static string UpdateDictionaryItem(string elementKey, string attribute, string key, string value)
+    {
+        if (_controller == null) return "error";
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null) return "error";
+
+        var dict = data.GetAttribute(attribute) as IEditableDictionary<string>;
+        if (dict == null) return "error";
+
+        try { dict.Update(key, value); return "ok"; }
+        catch (Exception ex) { return ex.Message; }
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
+
+    private static string? SerializeAttributeValue(object? val) => val switch
+    {
+        null => null,
+        IEditableObjectReference objRef => objRef.Reference,
+        IEditableList<string> list => JsonSerializer.Serialize(
+            list.ItemsList.Select(i => new ListItemData(i.Key, i.Value)).ToList(),
+            WasmEditorJsonContext.Default.ListListItemData),
+        IEditableDictionary<string> dict => JsonSerializer.Serialize(
+            dict.Items.Values.Select(i => new ListItemData(i.Key, i.Value)).ToList(),
+            WasmEditorJsonContext.Default.ListListItemData),
+        IEditableScripts => "(script)",
+        _ => val.ToString()
+    };
 
     private static IEditableScripts? GetScripts(string elementKey, string attribute)
     {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -1233,7 +1233,7 @@ public partial class WasmEditorBridge
         IEditableScripts scripts => scripts.DisplayString(-1, string.Empty),
         IEditableCommandPattern cmd => cmd.Pattern,
         IEditableDictionary<IEditableScripts> scriptDict => JsonSerializer.Serialize(
-            scriptDict.Items.Values.Select(i => new ListItemData(i.Key, "(script)")).ToList(),
+            scriptDict.Items.Values.Select(i => new ListItemData(i.Key, i.Value.DisplayString(-1, string.Empty))).ToList(),
             WasmEditorJsonContext.Default.ListListItemData),
         _ => val.ToString()
     };

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -144,7 +144,11 @@
         const attr = selectedAttr;
         if (attr.type === "simplepattern") {
             setPatternAttribute($selectedKey, attr.name, editingValue);
-        } else if (attr.type === "string" || attr.type === "int" || attr.type === "double") {
+        } else if (attr.type === "int") {
+            setAttribute($selectedKey, attr.name, "number", editingValue);
+        } else if (attr.type === "double") {
+            setAttribute($selectedKey, attr.name, "numberdouble", editingValue);
+        } else if (attr.type === "string") {
             setAttribute($selectedKey, attr.name, "textbox", editingValue);
         }
         editingValueOriginal = editingValue;

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -2,6 +2,7 @@
     import { fullAttributeData, selectedKey, removeAttribute, addInheritedType, removeInheritedType, getTypeNames, setAttribute, setObjectReference, changeAttributeType, setPatternAttribute, getObjectNames } from "$lib/editor-store";
     import type { AttributeDataItem } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
+    import ListEditor from "./ListEditor.svelte";
 
     const TYPE_OPTIONS = [
         { value: "string",           label: "String" },
@@ -381,7 +382,9 @@
                         {:else if attr.type === "scriptdictionary"}
                             <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
                         {:else if attr.type === "stringlist"}
-                            <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
+                            {#if $selectedKey}
+                                <ListEditor elementKey={$selectedKey} attribute={attr.name} value={attr.value} />
+                            {/if}
                         {:else if attr.type === "stringdictionary"}
                             <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
                         {:else if attr.type === "object"}

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -378,12 +378,12 @@
                         {:else if attr.type === "script"}
                             <div class="min-h-48">
                                 {#if $selectedKey}
-                                    <ScriptEditor elementKey={$selectedKey} attribute={attr.name} />
+                                    <ScriptEditor elementKey={$selectedKey} attribute={attr.name} isLocked={attr.isInherited || attr.isDefaultType} />
                                 {/if}
                             </div>
                         {:else if attr.type === "scriptdictionary"}
                             {#if $selectedKey}
-                                <ScriptDictionaryEditor elementKey={$selectedKey} attribute={attr.name} value={attr.value} />
+                                <ScriptDictionaryEditor elementKey={$selectedKey} attribute={attr.name} value={attr.value} isLocked={attr.isInherited || attr.isDefaultType} />
                             {/if}
                         {:else if attr.type === "stringlist"}
                             {#if $selectedKey}

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -33,6 +33,7 @@
 
     // Editing state for string/pattern/number values
     let editingValue = $state("");
+    let editingValueOriginal = $state("");
     let editingBool = $state(false);
     let editingObject = $state("");
 
@@ -44,6 +45,7 @@
             prevSelectedKey = key;
             selectedAttrName = null;
             editingValue = "";
+            editingValueOriginal = "";
             editingBool = false;
             editingObject = "";
             newAttrName = "";
@@ -62,9 +64,12 @@
             editingObject = attr.value ?? "";
             editingValue = "";
         } else if (isTextEditable(attr)) {
-            editingValue = attr.value ?? "";
+            const v = attr.value ?? "";
+            editingValue = v;
+            editingValueOriginal = v;
         } else {
             editingValue = "";
+            editingValueOriginal = "";
         }
     });
 
@@ -107,12 +112,14 @@
 
     function commitTextEdit() {
         if (!$selectedKey || !selectedAttr) return;
+        if (editingValue === editingValueOriginal) return;
         const attr = selectedAttr;
         if (attr.type === "simplepattern") {
             setPatternAttribute($selectedKey, attr.name, editingValue);
         } else if (attr.type === "string" || attr.type === "int" || attr.type === "double") {
             setAttribute($selectedKey, attr.name, "textbox", editingValue);
         }
+        editingValueOriginal = editingValue;
     }
 
     function onBoolChange(checked: boolean) {
@@ -302,7 +309,7 @@
                             class="select text-xs py-0 px-1.5 h-7"
                             value={attr.type}
                             onchange={(e) => onChangeType((e.target as HTMLSelectElement).value)}
-                            disabled={attr.isInherited || attr.isDefaultType}
+                            disabled={attr.isDefaultType}
                         >
                             {#each TYPE_OPTIONS as opt}
                                 <option value={opt.value}>{opt.label}</option>
@@ -321,7 +328,7 @@
                                     type="checkbox"
                                     class="checkbox"
                                     checked={editingBool}
-                                    disabled={attr.isInherited || attr.isDefaultType}
+                                    disabled={attr.isDefaultType}
                                     onchange={(e) => { editingBool = (e.target as HTMLInputElement).checked; onBoolChange(editingBool); }}
                                 />
                                 <span>{editingBool ? "True" : "False"}</span>
@@ -338,7 +345,7 @@
                             <select
                                 class="select text-xs py-0 px-1.5 h-7"
                                 bind:value={editingObject}
-                                disabled={attr.isInherited || attr.isDefaultType}
+                                disabled={attr.isDefaultType}
                                 onchange={(e) => onObjectChange((e.target as HTMLSelectElement).value)}
                             >
                                 <option value="">(none)</option>
@@ -352,7 +359,7 @@
                                 class="input text-xs py-1 px-1.5 w-full"
                                 step={attr.type === "double" ? "any" : "1"}
                                 value={editingValue}
-                                disabled={attr.isInherited || attr.isDefaultType}
+                                disabled={attr.isDefaultType}
                                 oninput={(e) => { editingValue = (e.target as HTMLInputElement).value; }}
                                 onblur={commitTextEdit}
                                 onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); commitTextEdit(); } }}
@@ -363,7 +370,7 @@
                                 class="input text-xs py-1 px-1.5 w-full resize-none"
                                 rows="4"
                                 value={editingValue}
-                                disabled={attr.isInherited || attr.isDefaultType}
+                                disabled={attr.isDefaultType}
                                 oninput={(e) => { editingValue = (e.target as HTMLTextAreaElement).value; }}
                                 onblur={commitTextEdit}
                                 onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commitTextEdit(); } }}

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -176,6 +176,12 @@
         }
     }
 
+    const UNDELETABLE_ATTRIBUTES = new Set(["name", "type", "elementtype"]);
+
+    function canDeleteAttribute(attr: AttributeDataItem): boolean {
+        return !attr.isInherited && !UNDELETABLE_ATTRIBUTES.has(attr.name);
+    }
+
     function isTextEditable(attr: AttributeDataItem): boolean {
         return attr.type === "string" || attr.type === "int" || attr.type === "double" || attr.type === "simplepattern";
     }
@@ -291,7 +297,7 @@
                                 <td class="py-0.5 px-3 max-w-40 truncate" title={attr.value ?? ""}>{displayValue(attr)}</td>
                                 <td class="py-0.5 px-3 text-surface-400-500 truncate" title={attr.source}>{attr.source}</td>
                                 <td class="py-0.5 pr-2 text-right">
-                                    {#if !attr.isInherited}
+                                    {#if canDeleteAttribute(attr)}
                                         <button
                                             type="button"
                                             class="text-error-500 hover:text-error-700"

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+    import { fullAttributeData, selectedKey, removeAttribute, addInheritedType, removeInheritedType, getTypeNames, setAttribute } from "$lib/editor-store";
+    import type { AttributeDataItem } from "$lib/types";
+
+    let typeNames = $state<string[]>([]);
+    let addTypeValue = $state("");
+    let newAttrName = $state("");
+    let newAttrValue = $state("");
+    let selectedAttr = $state<AttributeDataItem | null>(null);
+    let editingValue = $state("");
+
+    $effect(() => {
+        typeNames = getTypeNames();
+    });
+
+    $effect(() => {
+        // Reset selection when element changes
+        $fullAttributeData;
+        selectedAttr = null;
+        editingValue = "";
+    });
+
+    function availableTypes(): string[] {
+        const inherited = new Set($fullAttributeData?.inheritedTypes.map(t => t.name) ?? []);
+        return typeNames.filter(t => !inherited.has(t));
+    }
+
+    function onDeleteInheritedType(typeName: string) {
+        if ($selectedKey) removeInheritedType($selectedKey, typeName);
+    }
+
+    function onAddType() {
+        if ($selectedKey && addTypeValue) {
+            addInheritedType($selectedKey, addTypeValue);
+            addTypeValue = "";
+        }
+    }
+
+    function onDeleteAttribute(attr: AttributeDataItem, e: MouseEvent) {
+        e.stopPropagation();
+        if ($selectedKey) removeAttribute($selectedKey, attr.name);
+        if (selectedAttr?.name === attr.name) selectedAttr = null;
+    }
+
+    function onSelectAttribute(attr: AttributeDataItem) {
+        selectedAttr = attr;
+        editingValue = attr.value ?? "";
+    }
+
+    function commitEdit() {
+        if ($selectedKey && selectedAttr) {
+            setAttribute($selectedKey, selectedAttr.name, "textbox", editingValue);
+        }
+    }
+
+    function onAddAttribute() {
+        if ($selectedKey && newAttrName.trim()) {
+            setAttribute($selectedKey, newAttrName.trim(), "textbox", newAttrValue);
+            newAttrName = "";
+            newAttrValue = "";
+        }
+    }
+
+    function displayValue(attr: AttributeDataItem): string {
+        if (attr.value === null) return "(null)";
+        if (attr.value.startsWith("[")) {
+            try {
+                const items = JSON.parse(attr.value) as {key: string, value: string}[];
+                return `(list: ${items.length} item${items.length === 1 ? "" : "s"})`;
+            } catch { /* not a list */ }
+        }
+        return attr.value;
+    }
+
+    function isEditable(attr: AttributeDataItem): boolean {
+        return attr.value !== "(script)" && !attr.value?.startsWith("[");
+    }
+</script>
+
+<div class="flex flex-col gap-0 p-3 text-xs">
+    <!-- Inherited types -->
+    <div class="mb-4">
+        <div class="flex items-center gap-2 mb-1">
+            <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Inherited types</span>
+        </div>
+        <div class="flex items-center gap-1 mb-1">
+            <select
+                class="select text-xs py-0.5 px-1.5 flex-1"
+                bind:value={addTypeValue}
+            >
+                <option value="">Add type…</option>
+                {#each availableTypes() as t}
+                    <option value={t}>{t}</option>
+                {/each}
+            </select>
+            <button
+                type="button"
+                disabled={!addTypeValue}
+                onclick={onAddType}
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
+            >Add</button>
+        </div>
+        <table class="w-full border-collapse">
+            <thead>
+                <tr class="text-surface-400-500 border-b border-surface-200-800">
+                    <th class="text-left py-1 pr-3 font-medium">Name</th>
+                    <th class="text-left py-1 pr-3 font-medium">Source</th>
+                    <th class="w-6"></th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each $fullAttributeData?.inheritedTypes ?? [] as t}
+                    <tr class="border-b border-surface-100-900">
+                        <td class="py-0.5 pr-3">{t.name}</td>
+                        <td class="py-0.5 pr-3 text-surface-400-500">{t.source}</td>
+                        <td class="py-0.5 text-right">
+                            {#if !t.isDefaultType}
+                                <button
+                                    type="button"
+                                    class="text-error-500 hover:text-error-700 px-1"
+                                    onclick={() => onDeleteInheritedType(t.name)}
+                                    title="Remove type"
+                                >✕</button>
+                            {/if}
+                        </td>
+                    </tr>
+                {:else}
+                    <tr><td colspan="3" class="py-1 text-surface-400-500 italic">No inherited types</td></tr>
+                {/each}
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Attributes -->
+    <div>
+        <div class="flex items-center gap-2 mb-1">
+            <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Attributes</span>
+        </div>
+
+        <!-- Add new attribute -->
+        <div class="flex items-center gap-1 mb-2">
+            <input
+                type="text"
+                placeholder="Name"
+                class="input text-xs py-0.5 px-1.5 w-32"
+                bind:value={newAttrName}
+                onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
+            />
+            <input
+                type="text"
+                placeholder="Value"
+                class="input text-xs py-0.5 px-1.5 flex-1"
+                bind:value={newAttrValue}
+                onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
+            />
+            <button
+                type="button"
+                disabled={!newAttrName.trim()}
+                onclick={onAddAttribute}
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
+            >Add</button>
+        </div>
+
+        <!-- Inline editor for selected attribute -->
+        {#if selectedAttr && isEditable(selectedAttr)}
+            <div class="flex items-center gap-1 mb-2 p-2 bg-surface-100-900 rounded border border-surface-200-800">
+                <span class="text-surface-600-400 w-32 flex-shrink-0 truncate" title={selectedAttr.name}>{selectedAttr.name}:</span>
+                <input
+                    type="text"
+                    class="input text-xs py-0.5 px-1.5 flex-1"
+                    bind:value={editingValue}
+                    onblur={commitEdit}
+                    onkeydown={(e) => {
+                        if (e.key === "Enter") commitEdit();
+                        if (e.key === "Escape") { selectedAttr = null; }
+                    }}
+                />
+            </div>
+        {/if}
+
+        <table class="w-full border-collapse">
+            <thead>
+                <tr class="text-surface-400-500 border-b border-surface-200-800">
+                    <th class="text-left py-1 pr-3 font-medium w-40">Name</th>
+                    <th class="text-left py-1 pr-3 font-medium">Value</th>
+                    <th class="text-left py-1 pr-3 font-medium w-24">Source</th>
+                    <th class="w-6"></th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each $fullAttributeData?.attributes ?? [] as attr}
+                    {@const dimmed = attr.isInherited || attr.isDefaultType}
+                    {@const isSelected = selectedAttr?.name === attr.name}
+                    <tr
+                        class="border-b border-surface-100-900 cursor-pointer {dimmed ? 'text-surface-400-500' : 'hover:bg-surface-100-900'} {isSelected ? 'bg-primary-50-950' : ''}"
+                        onclick={() => onSelectAttribute(attr)}
+                    >
+                        <td class="py-0.5 pr-3 truncate max-w-40 {!dimmed ? 'font-medium' : ''}" title={attr.name}>{attr.name}</td>
+                        <td class="py-0.5 pr-3 max-w-48 truncate" title={attr.value ?? ""}>{displayValue(attr)}</td>
+                        <td class="py-0.5 pr-3 text-surface-400-500 truncate" title={attr.source}>{attr.source}</td>
+                        <td class="py-0.5 text-right">
+                            {#if !attr.isInherited}
+                                <button
+                                    type="button"
+                                    class="text-error-500 hover:text-error-700 px-1"
+                                    onclick={(e) => onDeleteAttribute(attr, e)}
+                                    title="Remove attribute"
+                                >✕</button>
+                            {/if}
+                        </td>
+                    </tr>
+                {:else}
+                    <tr><td colspan="4" class="py-1 text-surface-400-500 italic">No attributes</td></tr>
+                {/each}
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -1,25 +1,76 @@
 <script lang="ts">
-    import { fullAttributeData, selectedKey, removeAttribute, addInheritedType, removeInheritedType, getTypeNames, setAttribute } from "$lib/editor-store";
+    import { fullAttributeData, selectedKey, removeAttribute, addInheritedType, removeInheritedType, getTypeNames, setAttribute, changeAttributeType, setPatternAttribute, getObjectNames } from "$lib/editor-store";
     import type { AttributeDataItem } from "$lib/types";
 
+    const TYPE_OPTIONS = [
+        { value: "string",           label: "String" },
+        { value: "boolean",          label: "Boolean" },
+        { value: "int",              label: "Integer" },
+        { value: "double",           label: "Double" },
+        { value: "script",           label: "Script" },
+        { value: "stringlist",       label: "String List" },
+        { value: "object",           label: "Object" },
+        { value: "simplepattern",    label: "Command pattern" },
+        { value: "stringdictionary", label: "String dictionary" },
+        { value: "scriptdictionary", label: "Script dictionary" },
+        { value: "null",             label: "Null" },
+    ];
+
     let typeNames = $state<string[]>([]);
+    let objectNames = $state<string[]>([]);
     let addTypeValue = $state("");
     let newAttrName = $state("");
     let newAttrValue = $state("");
-    let selectedAttr = $state<AttributeDataItem | null>(null);
-    let editingValue = $state("");
 
+    // Track selected attribute by name so selection survives data refreshes
+    let selectedAttrName = $state<string | null>(null);
+
+    let selectedAttr = $derived(
+        selectedAttrName
+            ? ($fullAttributeData?.attributes.find(a => a.name === selectedAttrName) ?? null)
+            : null
+    );
+
+    // Editing state for string/pattern/number values
+    let editingValue = $state("");
+    let editingBool = $state(false);
+    let editingObject = $state("");
+
+    // Reset when element changes (selectedKey changes)
+    let prevSelectedKey = $state<string | null>(null);
     $effect(() => {
-        typeNames = getTypeNames();
+        const key = $selectedKey;
+        if (key !== prevSelectedKey) {
+            prevSelectedKey = key;
+            selectedAttrName = null;
+            editingValue = "";
+            editingBool = false;
+            editingObject = "";
+            newAttrName = "";
+            newAttrValue = "";
+        }
+    });
+
+    // Sync editing state when selectedAttr changes
+    $effect(() => {
+        const attr = selectedAttr;
+        if (!attr) return;
+        if (attr.type === "boolean") {
+            editingBool = attr.value?.toLowerCase() === "true";
+            editingValue = "";
+        } else if (attr.type === "object") {
+            editingObject = attr.value ?? "";
+            editingValue = "";
+        } else if (isTextEditable(attr)) {
+            editingValue = attr.value ?? "";
+        } else {
+            editingValue = "";
+        }
     });
 
     $effect(() => {
-        // Reset selection when element changes
-        $fullAttributeData;
-        selectedAttr = null;
-        editingValue = "";
-        newAttrName = "";
-        newAttrValue = "";
+        typeNames = getTypeNames();
+        objectNames = getObjectNames() ?? [];
     });
 
     function availableTypes(): string[] {
@@ -41,17 +92,38 @@
     function onDeleteAttribute(attr: AttributeDataItem, e: MouseEvent) {
         e.stopPropagation();
         if ($selectedKey) removeAttribute($selectedKey, attr.name);
-        if (selectedAttr?.name === attr.name) selectedAttr = null;
+        if (selectedAttrName === attr.name) selectedAttrName = null;
     }
 
     function onSelectAttribute(attr: AttributeDataItem) {
-        selectedAttr = attr;
-        editingValue = (attr.value === null || attr.value === "(script)" || isComplex(attr)) ? "" : attr.value;
+        selectedAttrName = attr.name;
     }
 
-    function commitEdit() {
-        if ($selectedKey && selectedAttr && !isComplex(selectedAttr) && selectedAttr.value !== "(script)") {
-            setAttribute($selectedKey, selectedAttr.name, "textbox", editingValue);
+    function onChangeType(newType: string) {
+        if ($selectedKey && selectedAttrName) {
+            changeAttributeType($selectedKey, selectedAttrName, newType);
+        }
+    }
+
+    function commitTextEdit() {
+        if (!$selectedKey || !selectedAttr) return;
+        const attr = selectedAttr;
+        if (attr.type === "simplepattern") {
+            setPatternAttribute($selectedKey, attr.name, editingValue);
+        } else if (attr.type === "string" || attr.type === "int" || attr.type === "double") {
+            setAttribute($selectedKey, attr.name, "textbox", editingValue);
+        }
+    }
+
+    function onBoolChange(checked: boolean) {
+        if ($selectedKey && selectedAttr) {
+            setAttribute($selectedKey, selectedAttr.name, "checkbox", checked ? "true" : "false");
+        }
+    }
+
+    function onObjectChange(value: string) {
+        if ($selectedKey && selectedAttr) {
+            setAttribute($selectedKey, selectedAttr.name, "textbox", value);
         }
     }
 
@@ -63,24 +135,25 @@
         }
     }
 
-    function isComplex(attr: AttributeDataItem): boolean {
-        if (attr.value === null || attr.value === "(script)") return true;
-        if (attr.value.startsWith("[")) {
-            try { JSON.parse(attr.value); return true; } catch { /* not JSON */ }
-        }
-        return false;
+    function isTextEditable(attr: AttributeDataItem): boolean {
+        return attr.type === "string" || attr.type === "int" || attr.type === "double" || attr.type === "simplepattern";
     }
 
     function displayValue(attr: AttributeDataItem): string {
-        if (attr.value === null) return "";
-        if (attr.value === "(script)") return "(script)";
-        if (attr.value.startsWith("[")) {
+        if (attr.value === null) return "(null)";
+        if (attr.type === "script") return "(script)";
+        if (attr.type === "scriptdictionary") return "(script dictionary)";
+        if (attr.type === "stringlist" || attr.type === "stringdictionary") {
             try {
                 const items = JSON.parse(attr.value) as {key: string, value: string}[];
-                return `(list: ${items.length})`;
-            } catch { /* not a list */ }
+                return `(${attr.type === "stringlist" ? "list" : "dict"}: ${items.length})`;
+            } catch { /* fall through */ }
         }
         return attr.value;
+    }
+
+    function typeLabel(type: string): string {
+        return TYPE_OPTIONS.find(o => o.value === type)?.label ?? type;
     }
 </script>
 
@@ -109,7 +182,6 @@
             <thead>
                 <tr class="text-surface-400-500 border-b border-surface-100-900">
                     <th class="text-left py-1 px-3 font-medium">Name</th>
-                    <th class="text-left py-1 px-3 font-medium">Value</th>
                     <th class="text-left py-1 px-3 font-medium">Source</th>
                     <th class="w-6"></th>
                 </tr>
@@ -117,7 +189,6 @@
             <tbody>
                 {#each $fullAttributeData?.inheritedTypes ?? [] as t}
                     <tr class="border-b border-surface-100-900">
-                        <td class="py-0.5 px-3">{t.name}</td>
                         <td class="py-0.5 px-3">{t.name}</td>
                         <td class="py-0.5 px-3 text-surface-400-500">{t.source}</td>
                         <td class="py-0.5 pr-2 text-right">
@@ -132,7 +203,7 @@
                         </td>
                     </tr>
                 {:else}
-                    <tr><td colspan="4" class="py-1 px-3 text-surface-400-500 italic">No inherited types</td></tr>
+                    <tr><td colspan="3" class="py-1 px-3 text-surface-400-500 italic">No inherited types</td></tr>
                 {/each}
             </tbody>
         </table>
@@ -181,10 +252,10 @@
                     <tbody>
                         {#each $fullAttributeData?.attributes ?? [] as attr}
                             {@const dimmed = attr.isInherited || attr.isDefaultType}
-                            {@const isSelected = selectedAttr?.name === attr.name}
+                            {@const isSelected = selectedAttrName === attr.name}
                             <tr
                                 class="border-b border-surface-100-900 cursor-pointer
-                                    {isSelected ? 'bg-primary-100-900' : dimmed ? 'hover:bg-surface-100-900' : 'hover:bg-surface-100-900'}
+                                    {isSelected ? 'bg-primary-100-900' : 'hover:bg-surface-100-900'}
                                     {dimmed ? 'text-surface-400-500' : ''}"
                                 onclick={() => onSelectAttribute(attr)}
                             >
@@ -211,30 +282,94 @@
         </div>
 
         <!-- Right: assignment panel -->
-        <div class="w-56 flex-shrink-0 flex flex-col overflow-y-auto">
+        <div class="w-64 flex-shrink-0 flex flex-col overflow-y-auto">
             <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-500-400 uppercase tracking-wide flex-shrink-0">
                 Assignment
             </div>
             {#if selectedAttr}
+                {@const attr = selectedAttr}
                 <div class="p-3 flex flex-col gap-2">
-                    <div class="font-medium text-surface-700-300 truncate" title={selectedAttr.name}>{selectedAttr.name}</div>
-                    {#if selectedAttr.isInherited || selectedAttr.isDefaultType}
-                        <p class="text-surface-400-500 italic text-xs">Inherited from <span class="font-medium">{selectedAttr.source}</span></p>
+                    <div class="font-medium text-surface-700-300 truncate" title={attr.name}>{attr.name}</div>
+
+                    {#if attr.isInherited || attr.isDefaultType}
+                        <p class="text-surface-400-500 italic text-xs">Inherited from <span class="font-medium">{attr.source}</span></p>
                     {/if}
-                    {#if selectedAttr.value === "(script)"}
-                        <p class="text-surface-400-500 italic">Edit via the Scripts tab</p>
-                    {:else if isComplex(selectedAttr)}
-                        <p class="text-surface-400-500 italic">Complex type — edit via the relevant tab</p>
-                    {:else}
-                        <textarea
-                            class="input text-xs py-1 px-1.5 w-full resize-none"
-                            rows="4"
-                            value={editingValue}
-                            oninput={(e) => { editingValue = (e.target as HTMLTextAreaElement).value; }}
-                            onblur={commitEdit}
-                            onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commitEdit(); } }}
-                        ></textarea>
-                    {/if}
+
+                    <!-- Type selector -->
+                    <div class="flex flex-col gap-1">
+                        <span class="text-surface-400-500 uppercase tracking-wide text-xs">Type</span>
+                        <select
+                            class="select text-xs py-0 px-1.5 h-7"
+                            value={attr.type}
+                            onchange={(e) => onChangeType((e.target as HTMLSelectElement).value)}
+                            disabled={attr.isInherited || attr.isDefaultType}
+                        >
+                            {#each TYPE_OPTIONS as opt}
+                                <option value={opt.value}>{opt.label}</option>
+                            {/each}
+                        </select>
+                    </div>
+
+                    <!-- Value editor -->
+                    <div class="flex flex-col gap-1">
+                        <span class="text-surface-400-500 uppercase tracking-wide text-xs">Value</span>
+                        {#if attr.type === "null"}
+                            <p class="text-surface-400-500 italic">(no value)</p>
+                        {:else if attr.type === "boolean"}
+                            <label class="flex items-center gap-2 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    class="checkbox"
+                                    checked={editingBool}
+                                    disabled={attr.isInherited || attr.isDefaultType}
+                                    onchange={(e) => { editingBool = (e.target as HTMLInputElement).checked; onBoolChange(editingBool); }}
+                                />
+                                <span>{editingBool ? "True" : "False"}</span>
+                            </label>
+                        {:else if attr.type === "script"}
+                            <p class="text-surface-400-500 italic">Edit via the Scripts tab</p>
+                        {:else if attr.type === "scriptdictionary"}
+                            <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
+                        {:else if attr.type === "stringlist"}
+                            <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
+                        {:else if attr.type === "stringdictionary"}
+                            <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
+                        {:else if attr.type === "object"}
+                            <select
+                                class="select text-xs py-0 px-1.5 h-7"
+                                bind:value={editingObject}
+                                disabled={attr.isInherited || attr.isDefaultType}
+                                onchange={(e) => onObjectChange((e.target as HTMLSelectElement).value)}
+                            >
+                                <option value="">(none)</option>
+                                {#each objectNames as name}
+                                    <option value={name}>{name}</option>
+                                {/each}
+                            </select>
+                        {:else if attr.type === "int" || attr.type === "double"}
+                            <input
+                                type="number"
+                                class="input text-xs py-1 px-1.5 w-full"
+                                step={attr.type === "double" ? "any" : "1"}
+                                value={editingValue}
+                                disabled={attr.isInherited || attr.isDefaultType}
+                                oninput={(e) => { editingValue = (e.target as HTMLInputElement).value; }}
+                                onblur={commitTextEdit}
+                                onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); commitTextEdit(); } }}
+                            />
+                        {:else}
+                            <!-- string, simplepattern -->
+                            <textarea
+                                class="input text-xs py-1 px-1.5 w-full resize-none"
+                                rows="4"
+                                value={editingValue}
+                                disabled={attr.isInherited || attr.isDefaultType}
+                                oninput={(e) => { editingValue = (e.target as HTMLTextAreaElement).value; }}
+                                onblur={commitTextEdit}
+                                onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commitTextEdit(); } }}
+                            ></textarea>
+                        {/if}
+                    </div>
                 </div>
             {:else}
                 <p class="p-3 text-surface-400-500 italic">Select an attribute to edit it.</p>

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { fullAttributeData, selectedKey, removeAttribute, addInheritedType, removeInheritedType, getTypeNames, setAttribute, changeAttributeType, setPatternAttribute, getObjectNames } from "$lib/editor-store";
+    import { fullAttributeData, selectedKey, removeAttribute, addInheritedType, removeInheritedType, getTypeNames, setAttribute, setObjectReference, changeAttributeType, setPatternAttribute, getObjectNames } from "$lib/editor-store";
     import type { AttributeDataItem } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
 
@@ -162,7 +162,7 @@
 
     function onObjectChange(value: string) {
         if ($selectedKey && selectedAttr) {
-            setAttribute($selectedKey, selectedAttr.name, "textbox", value);
+            setObjectReference($selectedKey, selectedAttr.name, value);
         }
     }
 
@@ -391,7 +391,6 @@
                                 disabled={attr.isDefaultType}
                                 onchange={(e) => onObjectChange((e.target as HTMLSelectElement).value)}
                             >
-                                <option value="">(none)</option>
                                 {#each objectNames as name}
                                     <option value={name}>{name}</option>
                                 {/each}

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { fullAttributeData, selectedKey, removeAttribute, addInheritedType, removeInheritedType, getTypeNames, setAttribute, setObjectReference, changeAttributeType, setPatternAttribute, getObjectNames } from "$lib/editor-store";
     import type { AttributeDataItem } from "$lib/types";
+    import { Switch } from "@skeletonlabs/skeleton-svelte";
     import ScriptEditor from "./ScriptEditor.svelte";
     import ListEditor from "./ListEditor.svelte";
     import DictionaryEditor from "./DictionaryEditor.svelte";
@@ -396,16 +397,15 @@
                         {#if attr.type === "null"}
                             <p class="text-surface-400-500 italic">(no value)</p>
                         {:else if attr.type === "boolean"}
-                            <label class="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    class="checkbox"
-                                    checked={editingBool}
-                                    disabled={attr.isDefaultType}
-                                    onchange={(e) => { editingBool = (e.target as HTMLInputElement).checked; onBoolChange(editingBool); }}
-                                />
-                                <span>{editingBool ? "True" : "False"}</span>
-                            </label>
+                            <Switch
+                                checked={editingBool}
+                                disabled={attr.isDefaultType}
+                                onCheckedChange={(e) => { editingBool = e.checked; onBoolChange(editingBool); }}
+                            >
+                                <Switch.Control><Switch.Thumb /></Switch.Control>
+                                <Switch.HiddenInput />
+                                <Switch.Label>{editingBool ? "True" : "False"}</Switch.Label>
+                            </Switch>
                         {:else if attr.type === "script"}
                             <div class="min-h-48">
                                 {#if $selectedKey}

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -129,8 +129,39 @@
         if (selectedAttrName === attr.name) selectedAttrName = null;
     }
 
+    let attrTbodyEl = $state<HTMLTableSectionElement | null>(null);
+
     function onSelectAttribute(attr: AttributeDataItem) {
         selectedAttrName = attr.name;
+    }
+
+    function focusAttrRow(name: string) {
+        const el = attrTbodyEl?.querySelector<HTMLTableRowElement>(`[data-attr="${CSS.escape(name)}"]`);
+        el?.focus();
+        el?.scrollIntoView({ block: "nearest" });
+    }
+
+    function onAttrRowKeydown(e: KeyboardEvent, attr: AttributeDataItem) {
+        const attrs = $fullAttributeData?.attributes ?? [];
+        const idx = attrs.findIndex(a => a.name === attr.name);
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            if (idx < attrs.length - 1) { onSelectAttribute(attrs[idx + 1]); focusAttrRow(attrs[idx + 1].name); }
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            if (idx > 0) { onSelectAttribute(attrs[idx - 1]); focusAttrRow(attrs[idx - 1].name); }
+        } else if (e.key === "Home") {
+            e.preventDefault();
+            if (attrs.length > 0) { onSelectAttribute(attrs[0]); focusAttrRow(attrs[0].name); }
+        } else if (e.key === "End") {
+            e.preventDefault();
+            if (attrs.length > 0) { onSelectAttribute(attrs[attrs.length - 1]); focusAttrRow(attrs[attrs.length - 1].name); }
+        } else if (e.key === "Delete" && $selectedKey && canDeleteAttribute(attr)) {
+            e.preventDefault();
+            removeAttribute($selectedKey, attr.name);
+            const next = attrs[idx + 1] ?? attrs[idx - 1];
+            if (next) { onSelectAttribute(next); focusAttrRow(next.name); } else { selectedAttrName = null; }
+        }
     }
 
     function onChangeType(newType: string) {
@@ -173,6 +204,8 @@
             setAttribute($selectedKey, name, "textbox", "");
             newAttrName = "";
             selectedAttrName = name;
+            // Focus the new row after Svelte renders it
+            Promise.resolve().then(() => requestAnimationFrame(() => focusAttrRow(name)));
         }
     }
 
@@ -283,15 +316,19 @@
                             <th class="w-6"></th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody bind:this={attrTbodyEl}>
                         {#each $fullAttributeData?.attributes ?? [] as attr}
                             {@const dimmed = attr.isInherited || attr.isDefaultType}
                             {@const isSelected = selectedAttrName === attr.name}
                             <tr
-                                class="border-b border-surface-100-900 cursor-pointer
+                                class="border-b border-surface-100-900 cursor-pointer outline-none
+                                    focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500
                                     {isSelected ? 'bg-primary-100-900' : 'hover:bg-surface-100-900'}
                                     {dimmed ? 'text-surface-400-500' : ''}"
+                                tabindex={isSelected ? 0 : -1}
+                                data-attr={attr.name}
                                 onclick={() => onSelectAttribute(attr)}
+                                onkeydown={(e) => onAttrRowKeydown(e, attr)}
                             >
                                 <td class="py-0.5 px-3 truncate max-w-36 {!dimmed ? 'font-medium' : ''}" title={attr.name}>{attr.name}</td>
                                 <td class="py-0.5 px-3 max-w-40 truncate" title={attr.value ?? ""}>{displayValue(attr)}</td>
@@ -300,9 +337,10 @@
                                     {#if canDeleteAttribute(attr)}
                                         <button
                                             type="button"
+                                            tabindex="-1"
                                             class="text-error-500 hover:text-error-700"
                                             onclick={(e) => onDeleteAttribute(attr, e)}
-                                            title="Remove attribute"
+                                            title="Remove attribute (or press Delete)"
                                         >✕</button>
                                     {/if}
                                 </td>
@@ -314,24 +352,6 @@
                 </table>
             </div>
 
-            <!-- Add new attribute -->
-            <div class="px-3 py-1.5 flex-shrink-0">
-                <div class="flex items-center gap-2 max-w-xs">
-                    <input
-                        type="text"
-                        placeholder="Add attribute..."
-                        class="input text-xs py-0 px-1.5 h-6 flex-1 min-w-0"
-                        bind:value={newAttrName}
-                        onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
-                    />
-                    <button
-                        type="button"
-                        disabled={!newAttrName.trim()}
-                        onclick={onAddAttribute}
-                        class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6 flex-shrink-0"
-                    >Add</button>
-                </div>
-            </div>
         </div>
 
         <!-- Splitter -->
@@ -443,6 +463,25 @@
             {:else}
                 <p class="p-3 text-surface-400-500 italic">Select an attribute to edit it.</p>
             {/if}
+        </div>
+    </div>
+
+    <!-- Add new attribute -->
+    <div class="px-3 py-1.5 flex-shrink-0 border-t border-surface-200-800">
+        <div class="flex items-center gap-2 max-w-xs">
+            <input
+                type="text"
+                placeholder="Add attribute..."
+                class="input text-xs py-0 px-1.5 h-6 flex-1 min-w-0"
+                bind:value={newAttrName}
+                onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
+            />
+            <button
+                type="button"
+                disabled={!newAttrName.trim()}
+                onclick={onAddAttribute}
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6 flex-shrink-0"
+            >Add</button>
         </div>
     </div>
 </div>

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -24,7 +24,6 @@
     let objectNames = $state<string[]>([]);
     let addTypeValue = $state("");
     let newAttrName = $state("");
-    let newAttrValue = $state("");
 
     // Track selected attribute by name so selection survives data refreshes
     let selectedAttrName = $state<string | null>(null);
@@ -53,7 +52,6 @@
             editingBool = false;
             editingObject = "";
             newAttrName = "";
-            newAttrValue = "";
         }
     });
 
@@ -171,9 +169,10 @@
 
     function onAddAttribute() {
         if ($selectedKey && newAttrName.trim()) {
-            setAttribute($selectedKey, newAttrName.trim(), "textbox", newAttrValue);
+            const name = newAttrName.trim();
+            setAttribute($selectedKey, name, "textbox", "");
             newAttrName = "";
-            newAttrValue = "";
+            selectedAttrName = name;
         }
     }
 
@@ -202,23 +201,8 @@
 <div class="flex flex-col flex-1 min-h-0 text-xs">
     <!-- Inherited types section -->
     <div class="flex-shrink-0 border-b border-surface-200-800">
-        <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900">
-            <span class="font-semibold text-surface-500-400 uppercase tracking-wide flex-1">Inherited types</span>
-            <select
-                class="select text-xs py-0 px-1.5 h-6"
-                bind:value={addTypeValue}
-            >
-                <option value="">Add type…</option>
-                {#each availableTypes() as t}
-                    <option value={t}>{t}</option>
-                {/each}
-            </select>
-            <button
-                type="button"
-                disabled={!addTypeValue}
-                onclick={onAddType}
-                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6"
-            >Add</button>
+        <div class="px-3 py-1.5 border-b border-surface-100-900">
+            <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Inherited types</span>
         </div>
         <table class="w-full">
             <thead>
@@ -248,6 +232,29 @@
                     <tr><td colspan="3" class="py-1 px-3 text-surface-400-500 italic">No inherited types</td></tr>
                 {/each}
             </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="3" class="px-3 py-1.5">
+                        <div class="flex items-center gap-2 max-w-xs">
+                            <select
+                                class="select text-xs py-0 px-1.5 h-6 flex-1"
+                                bind:value={addTypeValue}
+                            >
+                                <option value="">Add type…</option>
+                                {#each availableTypes() as t}
+                                    <option value={t}>{t}</option>
+                                {/each}
+                            </select>
+                            <button
+                                type="button"
+                                disabled={!addTypeValue}
+                                onclick={onAddType}
+                                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6 flex-shrink-0"
+                            >Add</button>
+                        </div>
+                    </td>
+                </tr>
+            </tfoot>
         </table>
     </div>
 
@@ -255,29 +262,8 @@
     <div class="flex flex-1 min-h-0">
         <!-- Left: attributes list -->
         <div class="flex flex-col flex-1 min-w-0 overflow-hidden">
-            <!-- Add new attribute -->
-            <div class="flex items-center gap-1 px-3 py-1.5 border-b border-surface-100-900 flex-shrink-0">
-                <span class="font-semibold text-surface-500-400 uppercase tracking-wide mr-1">Attributes</span>
-                <input
-                    type="text"
-                    placeholder="Name"
-                    class="input text-xs py-0 px-1.5 h-6 w-28 flex-shrink-0"
-                    bind:value={newAttrName}
-                    onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
-                />
-                <input
-                    type="text"
-                    placeholder="Value"
-                    class="input text-xs py-0 px-1.5 h-6 flex-1 min-w-0"
-                    bind:value={newAttrValue}
-                    onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
-                />
-                <button
-                    type="button"
-                    disabled={!newAttrName.trim()}
-                    onclick={onAddAttribute}
-                    class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6 flex-shrink-0"
-                >Add</button>
+            <div class="px-3 py-1.5 border-b border-surface-100-900 flex-shrink-0">
+                <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Attributes</span>
             </div>
 
             <!-- Scrollable table -->
@@ -320,6 +306,25 @@
                         {/each}
                     </tbody>
                 </table>
+            </div>
+
+            <!-- Add new attribute -->
+            <div class="px-3 py-1.5 flex-shrink-0">
+                <div class="flex items-center gap-2 max-w-xs">
+                    <input
+                        type="text"
+                        placeholder="Add attribute..."
+                        class="input text-xs py-0 px-1.5 h-6 flex-1 min-w-0"
+                        bind:value={newAttrName}
+                        onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
+                    />
+                    <button
+                        type="button"
+                        disabled={!newAttrName.trim()}
+                        onclick={onAddAttribute}
+                        class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6 flex-shrink-0"
+                    >Add</button>
+                </div>
             </div>
         </div>
 

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { fullAttributeData, selectedKey, removeAttribute, addInheritedType, removeInheritedType, getTypeNames, setAttribute, changeAttributeType, setPatternAttribute, getObjectNames } from "$lib/editor-store";
     import type { AttributeDataItem } from "$lib/types";
+    import ScriptEditor from "./ScriptEditor.svelte";
 
     const TYPE_OPTIONS = [
         { value: "string",           label: "String" },
@@ -76,6 +77,33 @@
     $effect(() => {
         typeNames = getTypeNames();
         objectNames = getObjectNames() ?? [];
+    });
+
+    // Resizable splitter
+    let panelWidth = $state(360);
+    let isDragging = $state(false);
+    let dragStartX = 0;
+    let dragStartWidth = 0;
+
+    function onSplitterMousedown(e: MouseEvent) {
+        isDragging = true;
+        dragStartX = e.clientX;
+        dragStartWidth = panelWidth;
+        e.preventDefault();
+    }
+
+    $effect(() => {
+        if (!isDragging) return;
+        function onMousemove(e: MouseEvent) {
+            panelWidth = Math.max(180, Math.min(900, dragStartWidth + (dragStartX - e.clientX)));
+        }
+        function onMouseup() { isDragging = false; }
+        window.addEventListener("mousemove", onMousemove);
+        window.addEventListener("mouseup", onMouseup);
+        return () => {
+            window.removeEventListener("mousemove", onMousemove);
+            window.removeEventListener("mouseup", onMouseup);
+        };
     });
 
     function availableTypes(): string[] {
@@ -219,7 +247,7 @@
     <!-- Attributes section: split pane -->
     <div class="flex flex-1 min-h-0">
         <!-- Left: attributes list -->
-        <div class="flex flex-col flex-1 min-w-0 overflow-hidden border-r border-surface-200-800">
+        <div class="flex flex-col flex-1 min-w-0 overflow-hidden">
             <!-- Add new attribute -->
             <div class="flex items-center gap-1 px-3 py-1.5 border-b border-surface-100-900 flex-shrink-0">
                 <span class="font-semibold text-surface-500-400 uppercase tracking-wide mr-1">Attributes</span>
@@ -288,22 +316,29 @@
             </div>
         </div>
 
+        <!-- Splitter -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+            class="w-1 flex-shrink-0 cursor-col-resize bg-surface-200-800 hover:bg-primary-400 transition-colors"
+            onmousedown={onSplitterMousedown}
+        ></div>
+
         <!-- Right: assignment panel -->
-        <div class="w-64 flex-shrink-0 flex flex-col overflow-y-auto">
+        <div class="flex-shrink-0 flex flex-col overflow-hidden" style="width: {panelWidth}px">
             <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-500-400 uppercase tracking-wide flex-shrink-0">
                 Assignment
             </div>
             {#if selectedAttr}
                 {@const attr = selectedAttr}
-                <div class="p-3 flex flex-col gap-2">
-                    <div class="font-medium text-surface-700-300 truncate" title={attr.name}>{attr.name}</div>
+                <div class="p-3 flex flex-col gap-2 overflow-y-auto">
+                    <div class="font-medium text-surface-700-300 truncate flex-shrink-0" title={attr.name}>{attr.name}</div>
 
                     {#if attr.isInherited || attr.isDefaultType}
-                        <p class="text-surface-400-500 italic text-xs">Inherited from <span class="font-medium">{attr.source}</span></p>
+                        <p class="text-surface-400-500 italic text-xs flex-shrink-0">Inherited from <span class="font-medium">{attr.source}</span></p>
                     {/if}
 
                     <!-- Type selector -->
-                    <div class="flex flex-col gap-1">
+                    <div class="flex flex-col gap-1 flex-shrink-0">
                         <span class="text-surface-400-500 uppercase tracking-wide text-xs">Type</span>
                         <select
                             class="select text-xs py-0 px-1.5 h-7"
@@ -319,7 +354,7 @@
 
                     <!-- Value editor -->
                     <div class="flex flex-col gap-1">
-                        <span class="text-surface-400-500 uppercase tracking-wide text-xs">Value</span>
+                        <span class="text-surface-400-500 uppercase tracking-wide text-xs flex-shrink-0">Value</span>
                         {#if attr.type === "null"}
                             <p class="text-surface-400-500 italic">(no value)</p>
                         {:else if attr.type === "boolean"}
@@ -334,7 +369,11 @@
                                 <span>{editingBool ? "True" : "False"}</span>
                             </label>
                         {:else if attr.type === "script"}
-                            <p class="text-surface-400-500 italic">Edit via the Scripts tab</p>
+                            <div class="min-h-48">
+                                {#if $selectedKey}
+                                    <ScriptEditor elementKey={$selectedKey} attribute={attr.name} />
+                                {/if}
+                            </div>
                         {:else if attr.type === "scriptdictionary"}
                             <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
                         {:else if attr.type === "stringlist"}
@@ -384,3 +423,8 @@
         </div>
     </div>
 </div>
+
+<!-- Drag overlay: keeps col-resize cursor while dragging over other elements -->
+{#if isDragging}
+    <div class="fixed inset-0 z-50 cursor-col-resize select-none"></div>
+{/if}

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -3,6 +3,8 @@
     import type { AttributeDataItem } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
     import ListEditor from "./ListEditor.svelte";
+    import DictionaryEditor from "./DictionaryEditor.svelte";
+    import ScriptDictionaryEditor from "./ScriptDictionaryEditor.svelte";
 
     const TYPE_OPTIONS = [
         { value: "string",           label: "String" },
@@ -182,11 +184,11 @@
     function displayValue(attr: AttributeDataItem): string {
         if (attr.value === null) return "(null)";
         if (attr.type === "script") return "(script)";
-        if (attr.type === "scriptdictionary") return "(script dictionary)";
-        if (attr.type === "stringlist" || attr.type === "stringdictionary") {
+        if (attr.type === "stringlist" || attr.type === "stringdictionary" || attr.type === "scriptdictionary") {
             try {
                 const items = JSON.parse(attr.value) as {key: string, value: string}[];
-                return `(${attr.type === "stringlist" ? "list" : "dict"}: ${items.length})`;
+                const label = attr.type === "stringlist" ? "list" : "dict";
+                return `(${label}: ${items.length})`;
             } catch { /* fall through */ }
         }
         return attr.value;
@@ -380,13 +382,17 @@
                                 {/if}
                             </div>
                         {:else if attr.type === "scriptdictionary"}
-                            <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
+                            {#if $selectedKey}
+                                <ScriptDictionaryEditor elementKey={$selectedKey} attribute={attr.name} value={attr.value} />
+                            {/if}
                         {:else if attr.type === "stringlist"}
                             {#if $selectedKey}
                                 <ListEditor elementKey={$selectedKey} attribute={attr.name} value={attr.value} />
                             {/if}
                         {:else if attr.type === "stringdictionary"}
-                            <p class="text-surface-400-500 italic">Edit via the relevant tab</p>
+                            {#if $selectedKey}
+                                <DictionaryEditor elementKey={$selectedKey} attribute={attr.name} value={attr.value} />
+                            {/if}
                         {:else if attr.type === "object"}
                             <select
                                 class="select text-xs py-0 px-1.5 h-7"

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -222,12 +222,22 @@
 
     function displayValue(attr: AttributeDataItem): string {
         if (attr.value === null) return "(null)";
-        if (attr.type === "script") return "(script)";
-        if (attr.type === "stringlist" || attr.type === "stringdictionary" || attr.type === "scriptdictionary") {
+        if (attr.type === "stringlist") {
             try {
                 const items = JSON.parse(attr.value) as {key: string, value: string}[];
-                const label = attr.type === "stringlist" ? "list" : "dict";
-                return `(${label}: ${items.length})`;
+                return items.map(i => i.value).join(", ") || "(empty list)";
+            } catch { /* fall through */ }
+        }
+        if (attr.type === "stringdictionary") {
+            try {
+                const items = JSON.parse(attr.value) as {key: string, value: string}[];
+                return items.map(i => `${i.key}=${i.value}`).join(", ") || "(empty dict)";
+            } catch { /* fall through */ }
+        }
+        if (attr.type === "scriptdictionary") {
+            try {
+                const items = JSON.parse(attr.value) as {key: string, value: string}[];
+                return `(dict: ${items.length})`;
             } catch { /* fall through */ }
         }
         return attr.value;

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -234,11 +234,6 @@
                             onblur={commitEdit}
                             onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commitEdit(); } }}
                         ></textarea>
-                        <button
-                            type="button"
-                            class="btn btn-sm preset-filled-primary-500 text-xs px-3 py-0.5 self-start"
-                            onclick={commitEdit}
-                        >Set</button>
                     {/if}
                 </div>
             {:else}

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -18,6 +18,8 @@
         $fullAttributeData;
         selectedAttr = null;
         editingValue = "";
+        newAttrName = "";
+        newAttrValue = "";
     });
 
     function availableTypes(): string[] {
@@ -44,11 +46,11 @@
 
     function onSelectAttribute(attr: AttributeDataItem) {
         selectedAttr = attr;
-        editingValue = attr.value ?? "";
+        editingValue = (attr.value === null || attr.value === "(script)" || isComplex(attr)) ? "" : attr.value;
     }
 
     function commitEdit() {
-        if ($selectedKey && selectedAttr) {
+        if ($selectedKey && selectedAttr && !isComplex(selectedAttr) && selectedAttr.value !== "(script)") {
             setAttribute($selectedKey, selectedAttr.name, "textbox", editingValue);
         }
     }
@@ -61,31 +63,34 @@
         }
     }
 
+    function isComplex(attr: AttributeDataItem): boolean {
+        if (attr.value === null || attr.value === "(script)") return true;
+        if (attr.value.startsWith("[")) {
+            try { JSON.parse(attr.value); return true; } catch { /* not JSON */ }
+        }
+        return false;
+    }
+
     function displayValue(attr: AttributeDataItem): string {
-        if (attr.value === null) return "(null)";
+        if (attr.value === null) return "";
+        if (attr.value === "(script)") return "(script)";
         if (attr.value.startsWith("[")) {
             try {
                 const items = JSON.parse(attr.value) as {key: string, value: string}[];
-                return `(list: ${items.length} item${items.length === 1 ? "" : "s"})`;
+                return `(list: ${items.length})`;
             } catch { /* not a list */ }
         }
         return attr.value;
     }
-
-    function isEditable(attr: AttributeDataItem): boolean {
-        return attr.value !== "(script)" && !attr.value?.startsWith("[");
-    }
 </script>
 
-<div class="flex flex-col gap-0 p-3 text-xs">
-    <!-- Inherited types -->
-    <div class="mb-4">
-        <div class="flex items-center gap-2 mb-1">
-            <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Inherited types</span>
-        </div>
-        <div class="flex items-center gap-1 mb-1">
+<div class="flex flex-col flex-1 min-h-0 text-xs">
+    <!-- Inherited types section -->
+    <div class="flex-shrink-0 border-b border-surface-200-800">
+        <div class="flex items-center gap-2 px-3 py-1.5 border-b border-surface-100-900">
+            <span class="font-semibold text-surface-500-400 uppercase tracking-wide flex-1">Inherited types</span>
             <select
-                class="select text-xs py-0.5 px-1.5 flex-1"
+                class="select text-xs py-0 px-1.5 h-6"
                 bind:value={addTypeValue}
             >
                 <option value="">Add type…</option>
@@ -97,27 +102,29 @@
                 type="button"
                 disabled={!addTypeValue}
                 onclick={onAddType}
-                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6"
             >Add</button>
         </div>
-        <table class="w-full border-collapse">
+        <table class="w-full">
             <thead>
-                <tr class="text-surface-400-500 border-b border-surface-200-800">
-                    <th class="text-left py-1 pr-3 font-medium">Name</th>
-                    <th class="text-left py-1 pr-3 font-medium">Source</th>
+                <tr class="text-surface-400-500 border-b border-surface-100-900">
+                    <th class="text-left py-1 px-3 font-medium">Name</th>
+                    <th class="text-left py-1 px-3 font-medium">Value</th>
+                    <th class="text-left py-1 px-3 font-medium">Source</th>
                     <th class="w-6"></th>
                 </tr>
             </thead>
             <tbody>
                 {#each $fullAttributeData?.inheritedTypes ?? [] as t}
                     <tr class="border-b border-surface-100-900">
-                        <td class="py-0.5 pr-3">{t.name}</td>
-                        <td class="py-0.5 pr-3 text-surface-400-500">{t.source}</td>
-                        <td class="py-0.5 text-right">
+                        <td class="py-0.5 px-3">{t.name}</td>
+                        <td class="py-0.5 px-3">{t.name}</td>
+                        <td class="py-0.5 px-3 text-surface-400-500">{t.source}</td>
+                        <td class="py-0.5 pr-2 text-right">
                             {#if !t.isDefaultType}
                                 <button
                                     type="button"
-                                    class="text-error-500 hover:text-error-700 px-1"
+                                    class="text-error-500 hover:text-error-700"
                                     onclick={() => onDeleteInheritedType(t.name)}
                                     title="Remove type"
                                 >✕</button>
@@ -125,94 +132,118 @@
                         </td>
                     </tr>
                 {:else}
-                    <tr><td colspan="3" class="py-1 text-surface-400-500 italic">No inherited types</td></tr>
+                    <tr><td colspan="4" class="py-1 px-3 text-surface-400-500 italic">No inherited types</td></tr>
                 {/each}
             </tbody>
         </table>
     </div>
 
-    <!-- Attributes -->
-    <div>
-        <div class="flex items-center gap-2 mb-1">
-            <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Attributes</span>
-        </div>
-
-        <!-- Add new attribute -->
-        <div class="flex items-center gap-1 mb-2">
-            <input
-                type="text"
-                placeholder="Name"
-                class="input text-xs py-0.5 px-1.5 w-32"
-                bind:value={newAttrName}
-                onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
-            />
-            <input
-                type="text"
-                placeholder="Value"
-                class="input text-xs py-0.5 px-1.5 flex-1"
-                bind:value={newAttrValue}
-                onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
-            />
-            <button
-                type="button"
-                disabled={!newAttrName.trim()}
-                onclick={onAddAttribute}
-                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
-            >Add</button>
-        </div>
-
-        <!-- Inline editor for selected attribute -->
-        {#if selectedAttr && isEditable(selectedAttr)}
-            <div class="flex items-center gap-1 mb-2 p-2 bg-surface-100-900 rounded border border-surface-200-800">
-                <span class="text-surface-600-400 w-32 flex-shrink-0 truncate" title={selectedAttr.name}>{selectedAttr.name}:</span>
+    <!-- Attributes section: split pane -->
+    <div class="flex flex-1 min-h-0">
+        <!-- Left: attributes list -->
+        <div class="flex flex-col flex-1 min-w-0 overflow-hidden border-r border-surface-200-800">
+            <!-- Add new attribute -->
+            <div class="flex items-center gap-1 px-3 py-1.5 border-b border-surface-100-900 flex-shrink-0">
+                <span class="font-semibold text-surface-500-400 uppercase tracking-wide mr-1">Attributes</span>
                 <input
                     type="text"
-                    class="input text-xs py-0.5 px-1.5 flex-1"
-                    bind:value={editingValue}
-                    onblur={commitEdit}
-                    onkeydown={(e) => {
-                        if (e.key === "Enter") commitEdit();
-                        if (e.key === "Escape") { selectedAttr = null; }
-                    }}
+                    placeholder="Name"
+                    class="input text-xs py-0 px-1.5 h-6 w-28 flex-shrink-0"
+                    bind:value={newAttrName}
+                    onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
                 />
+                <input
+                    type="text"
+                    placeholder="Value"
+                    class="input text-xs py-0 px-1.5 h-6 flex-1 min-w-0"
+                    bind:value={newAttrValue}
+                    onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
+                />
+                <button
+                    type="button"
+                    disabled={!newAttrName.trim()}
+                    onclick={onAddAttribute}
+                    class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6 flex-shrink-0"
+                >Add</button>
             </div>
-        {/if}
 
-        <table class="w-full border-collapse">
-            <thead>
-                <tr class="text-surface-400-500 border-b border-surface-200-800">
-                    <th class="text-left py-1 pr-3 font-medium w-40">Name</th>
-                    <th class="text-left py-1 pr-3 font-medium">Value</th>
-                    <th class="text-left py-1 pr-3 font-medium w-24">Source</th>
-                    <th class="w-6"></th>
-                </tr>
-            </thead>
-            <tbody>
-                {#each $fullAttributeData?.attributes ?? [] as attr}
-                    {@const dimmed = attr.isInherited || attr.isDefaultType}
-                    {@const isSelected = selectedAttr?.name === attr.name}
-                    <tr
-                        class="border-b border-surface-100-900 cursor-pointer {dimmed ? 'text-surface-400-500' : 'hover:bg-surface-100-900'} {isSelected ? 'bg-primary-50-950' : ''}"
-                        onclick={() => onSelectAttribute(attr)}
-                    >
-                        <td class="py-0.5 pr-3 truncate max-w-40 {!dimmed ? 'font-medium' : ''}" title={attr.name}>{attr.name}</td>
-                        <td class="py-0.5 pr-3 max-w-48 truncate" title={attr.value ?? ""}>{displayValue(attr)}</td>
-                        <td class="py-0.5 pr-3 text-surface-400-500 truncate" title={attr.source}>{attr.source}</td>
-                        <td class="py-0.5 text-right">
-                            {#if !attr.isInherited}
-                                <button
-                                    type="button"
-                                    class="text-error-500 hover:text-error-700 px-1"
-                                    onclick={(e) => onDeleteAttribute(attr, e)}
-                                    title="Remove attribute"
-                                >✕</button>
-                            {/if}
-                        </td>
-                    </tr>
-                {:else}
-                    <tr><td colspan="4" class="py-1 text-surface-400-500 italic">No attributes</td></tr>
-                {/each}
-            </tbody>
-        </table>
+            <!-- Scrollable table -->
+            <div class="overflow-y-auto flex-1">
+                <table class="w-full">
+                    <thead class="sticky top-0 bg-surface-50-950 z-10">
+                        <tr class="text-surface-400-500 border-b border-surface-200-800">
+                            <th class="text-left py-1 px-3 font-medium">Name</th>
+                            <th class="text-left py-1 px-3 font-medium">Value</th>
+                            <th class="text-left py-1 px-3 font-medium">Source</th>
+                            <th class="w-6"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {#each $fullAttributeData?.attributes ?? [] as attr}
+                            {@const dimmed = attr.isInherited || attr.isDefaultType}
+                            {@const isSelected = selectedAttr?.name === attr.name}
+                            <tr
+                                class="border-b border-surface-100-900 cursor-pointer
+                                    {isSelected ? 'bg-primary-100-900' : dimmed ? 'hover:bg-surface-100-900' : 'hover:bg-surface-100-900'}
+                                    {dimmed ? 'text-surface-400-500' : ''}"
+                                onclick={() => onSelectAttribute(attr)}
+                            >
+                                <td class="py-0.5 px-3 truncate max-w-36 {!dimmed ? 'font-medium' : ''}" title={attr.name}>{attr.name}</td>
+                                <td class="py-0.5 px-3 max-w-40 truncate" title={attr.value ?? ""}>{displayValue(attr)}</td>
+                                <td class="py-0.5 px-3 text-surface-400-500 truncate" title={attr.source}>{attr.source}</td>
+                                <td class="py-0.5 pr-2 text-right">
+                                    {#if !attr.isInherited}
+                                        <button
+                                            type="button"
+                                            class="text-error-500 hover:text-error-700"
+                                            onclick={(e) => onDeleteAttribute(attr, e)}
+                                            title="Remove attribute"
+                                        >✕</button>
+                                    {/if}
+                                </td>
+                            </tr>
+                        {:else}
+                            <tr><td colspan="4" class="py-2 px-3 text-surface-400-500 italic">No attributes</td></tr>
+                        {/each}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Right: assignment panel -->
+        <div class="w-56 flex-shrink-0 flex flex-col overflow-y-auto">
+            <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-500-400 uppercase tracking-wide flex-shrink-0">
+                Assignment
+            </div>
+            {#if selectedAttr}
+                <div class="p-3 flex flex-col gap-2">
+                    <div class="font-medium text-surface-700-300 truncate" title={selectedAttr.name}>{selectedAttr.name}</div>
+                    {#if selectedAttr.isInherited || selectedAttr.isDefaultType}
+                        <p class="text-surface-400-500 italic text-xs">Inherited from <span class="font-medium">{selectedAttr.source}</span></p>
+                    {/if}
+                    {#if selectedAttr.value === "(script)"}
+                        <p class="text-surface-400-500 italic">Edit via the Scripts tab</p>
+                    {:else if isComplex(selectedAttr)}
+                        <p class="text-surface-400-500 italic">Complex type — edit via the relevant tab</p>
+                    {:else}
+                        <textarea
+                            class="input text-xs py-1 px-1.5 w-full resize-none"
+                            rows="4"
+                            value={editingValue}
+                            oninput={(e) => { editingValue = (e.target as HTMLTextAreaElement).value; }}
+                            onblur={commitEdit}
+                            onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commitEdit(); } }}
+                        ></textarea>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-filled-primary-500 text-xs px-3 py-0.5 self-start"
+                            onclick={commitEdit}
+                        >Set</button>
+                    {/if}
+                </div>
+            {:else}
+                <p class="p-3 text-surface-400-500 italic">Select an attribute to edit it.</p>
+            {/if}
+        </div>
     </div>
 </div>

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -237,7 +237,7 @@
         if (attr.type === "scriptdictionary") {
             try {
                 const items = JSON.parse(attr.value) as {key: string, value: string}[];
-                return `(dict: ${items.length})`;
+                return items.map(i => `${i.key}=${i.value}`).join(", ") || "(empty dict)";
             } catch { /* fall through */ }
         }
         return attr.value;

--- a/src/WebEditor/src/components/DictionaryEditor.svelte
+++ b/src/WebEditor/src/components/DictionaryEditor.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+    import { addDictItem, removeDictItem, updateDictItem } from "$lib/editor-store";
+
+    interface Props {
+        elementKey: string;
+        attribute: string;
+        value: string | null;
+    }
+
+    let { elementKey, attribute, value }: Props = $props();
+
+    let items = $derived.by<{key: string, value: string}[]>(() => {
+        try { return JSON.parse(value ?? "[]"); } catch { return []; }
+    });
+
+    let editingKey = $state<string | null>(null);
+    let editingValue = $state("");
+
+    let newKey = $state("");
+    let newValue = $state("");
+
+    function startEdit(key: string, currentValue: string) {
+        editingKey = key;
+        editingValue = currentValue;
+    }
+
+    function commitEdit() {
+        if (editingKey) {
+            updateDictItem(elementKey, attribute, editingKey, editingValue);
+        }
+        editingKey = null;
+        editingValue = "";
+    }
+
+    function onAdd() {
+        if (newKey.trim()) {
+            addDictItem(elementKey, attribute, newKey.trim(), newValue);
+            newKey = "";
+            newValue = "";
+        }
+    }
+</script>
+
+<div class="flex flex-col gap-1 w-full">
+    {#each items as item (item.key)}
+        <div class="flex items-center gap-1">
+            <span class="text-xs text-surface-500-400 px-1 flex-shrink-0">{item.key}:</span>
+            {#if editingKey === item.key}
+                <input
+                    type="text"
+                    class="input text-xs py-0.5 px-1.5 flex-1"
+                    value={editingValue}
+                    oninput={(e) => { editingValue = (e.target as HTMLInputElement).value; }}
+                    onkeydown={(e) => {
+                        if (e.key === "Enter") commitEdit();
+                        else if (e.key === "Escape") { editingKey = null; }
+                    }}
+                    onblur={commitEdit}
+                />
+            {:else}
+                <button
+                    type="button"
+                    class="text-xs flex-1 text-left px-1.5 py-0.5 hover:text-primary-600-400 truncate"
+                    onclick={() => startEdit(item.key, item.value)}
+                >{item.value}</button>
+            {/if}
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5 flex-shrink-0"
+                onclick={() => removeDictItem(elementKey, attribute, item.key)}
+            >✕</button>
+        </div>
+    {/each}
+    <div class="flex items-center gap-1 mt-0.5">
+        <input
+            type="text"
+            class="input text-xs py-0.5 px-1.5 w-20 flex-shrink-0"
+            placeholder="Key"
+            bind:value={newKey}
+            onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
+        />
+        <input
+            type="text"
+            class="input text-xs py-0.5 px-1.5 flex-1"
+            placeholder="Value"
+            bind:value={newValue}
+            onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
+        />
+        <button
+            type="button"
+            class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0"
+            onclick={onAdd}
+        >Add</button>
+    </div>
+</div>

--- a/src/WebEditor/src/components/ListEditor.svelte
+++ b/src/WebEditor/src/components/ListEditor.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+    import { addListItem, removeListItem, updateListItem } from "$lib/editor-store";
+
+    interface Props {
+        elementKey: string;
+        attribute: string;
+        value: string | null;
+        addPrompt?: string;
+    }
+
+    let { elementKey, attribute, value, addPrompt = "Add item…" }: Props = $props();
+
+    let items = $derived.by<{key: string, value: string}[]>(() => {
+        try { return JSON.parse(value ?? "[]"); } catch { return []; }
+    });
+
+    let editingItem = $state<{key: string, value: string} | null>(null);
+    let newItemValue = $state("");
+
+    function commitEdit() {
+        if (editingItem) {
+            updateListItem(elementKey, attribute, editingItem.key, editingItem.value);
+            editingItem = null;
+        }
+    }
+
+    function onAdd() {
+        if (newItemValue.trim()) {
+            addListItem(elementKey, attribute, newItemValue.trim());
+            newItemValue = "";
+        }
+    }
+</script>
+
+<div class="flex flex-col gap-1 w-full">
+    {#each items as item (item.key)}
+        <div class="flex items-center gap-1">
+            {#if editingItem?.key === item.key}
+                <input
+                    type="text"
+                    class="input text-xs py-0.5 px-1.5 flex-1"
+                    value={editingItem.value}
+                    oninput={(e) => { if (editingItem) editingItem.value = (e.target as HTMLInputElement).value; }}
+                    onkeydown={(e) => {
+                        if (e.key === "Enter") commitEdit();
+                        else if (e.key === "Escape") editingItem = null;
+                    }}
+                    onblur={commitEdit}
+                />
+            {:else}
+                <button
+                    type="button"
+                    class="text-xs flex-1 text-left px-1.5 py-0.5 hover:text-primary-600-400"
+                    onclick={() => { editingItem = {key: item.key, value: item.value}; }}
+                >{item.value}</button>
+            {/if}
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5"
+                onclick={() => removeListItem(elementKey, attribute, item.key)}
+            >✕</button>
+        </div>
+    {/each}
+    <div class="flex items-center gap-1 mt-0.5">
+        <input
+            type="text"
+            class="input text-xs py-0.5 px-1.5 flex-1"
+            placeholder={addPrompt}
+            bind:value={newItemValue}
+            onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
+        />
+        <button
+            type="button"
+            class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
+            onclick={onAdd}
+        >Add</button>
+    </div>
+</div>

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-    import { selectedKey, selectedData, setAttribute, setDropdownType, setMultiType, setObjectReference, addListItem, removeListItem, updateListItem } from "$lib/editor-store";
+    import { selectedKey, selectedData, setAttribute, setDropdownType, setMultiType, setObjectReference, addListItem, removeListItem, updateListItem, addDictItem, removeDictItem, updateDictItem } from "$lib/editor-store";
     import type { ControlInfo, TextProcessorCommand } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
     import Combobox from "./Combobox.svelte";
+    import AttributesEditor from "./AttributesEditor.svelte";
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
     let newListItemValues = $state<Record<string, string>>({});
     let editingItem = $state<{attribute: string, key: string, value: string} | null>(null);
+    let newDictItems = $state<Record<string, {key: string, value: string}>>({});
 
     $effect(() => {
         const key = $selectedKey;
@@ -273,6 +275,83 @@
                 >Add</button>
             </div>
         </div>
+    {:else if ctrl.controlType === "stringdictionary" && ctrl.attribute}
+        {@const items = (() => { try { return JSON.parse(attrValue(ctrl.attribute) ?? "[]") as {key: string, value: string}[] } catch { return [] } })()}
+        {@const dk = ctrl.attribute}
+        <div class="flex flex-col gap-1 w-full">
+            {#each items as item (item.key)}
+                {@const isEditing = editingItem?.attribute === dk && editingItem?.key === item.key}
+                <div class="flex items-center gap-1">
+                    <span class="text-xs text-surface-500-400 w-24 flex-shrink-0 truncate" title={item.key}>{item.key}</span>
+                    {#if isEditing}
+                        <input
+                            type="text"
+                            class="input text-xs py-0.5 px-1.5 flex-1"
+                            use:focusOnMount
+                            value={editingItem!.value}
+                            oninput={(e) => { if (editingItem) editingItem.value = (e.target as HTMLInputElement).value; }}
+                            onkeydown={(e) => {
+                                if (e.key === "Enter" && $selectedKey && editingItem) {
+                                    updateDictItem($selectedKey, dk, editingItem.key, editingItem.value);
+                                    editingItem = null;
+                                } else if (e.key === "Escape") {
+                                    editingItem = null;
+                                }
+                            }}
+                            onblur={() => {
+                                if ($selectedKey && editingItem) {
+                                    updateDictItem($selectedKey, dk, editingItem.key, editingItem.value);
+                                    editingItem = null;
+                                }
+                            }}
+                        />
+                    {:else}
+                        <button
+                            type="button"
+                            class="text-xs flex-1 text-left px-1.5 py-0.5 hover:text-primary-600-400 truncate"
+                            onclick={() => { editingItem = {attribute: dk, key: item.key, value: item.value}; }}
+                        >{item.value}</button>
+                    {/if}
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5 flex-shrink-0"
+                        onclick={() => $selectedKey && removeDictItem($selectedKey, dk, item.key)}
+                    >✕</button>
+                </div>
+            {/each}
+            <div class="flex items-center gap-1 mt-0.5">
+                <input
+                    type="text"
+                    class="input text-xs py-0.5 px-1.5 w-24 flex-shrink-0"
+                    placeholder={ctrl.caption ? "Key" : "Key"}
+                    value={newDictItems[dk]?.key ?? ""}
+                    oninput={(e) => { newDictItems[dk] = {...(newDictItems[dk] ?? {key: "", value: ""}), key: (e.target as HTMLInputElement).value}; }}
+                />
+                <input
+                    type="text"
+                    class="input text-xs py-0.5 px-1.5 flex-1"
+                    placeholder="Value"
+                    value={newDictItems[dk]?.value ?? ""}
+                    oninput={(e) => { newDictItems[dk] = {...(newDictItems[dk] ?? {key: "", value: ""}), value: (e.target as HTMLInputElement).value}; }}
+                    onkeydown={(e) => {
+                        if (e.key === "Enter" && $selectedKey && newDictItems[dk]?.key?.trim()) {
+                            addDictItem($selectedKey, dk, newDictItems[dk].key.trim(), newDictItems[dk].value ?? "");
+                            newDictItems[dk] = {key: "", value: ""};
+                        }
+                    }}
+                />
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0"
+                    onclick={() => {
+                        if ($selectedKey && newDictItems[dk]?.key?.trim()) {
+                            addDictItem($selectedKey, dk, newDictItems[dk].key.trim(), newDictItems[dk].value ?? "");
+                            newDictItems[dk] = {key: "", value: ""};
+                        }
+                    }}
+                >Add</button>
+            </div>
+        </div>
     {:else if ctrl.controlType === "objects" && ctrl.options}
         <Combobox
             value={attrValue(ctrl.attribute!) ?? ""}
@@ -337,7 +416,9 @@
 {/snippet}
 
 {#snippet controlRow(ctrl: ControlInfo)}
-    {#if ctrl.controlType === "title"}
+    {#if ctrl.controlType === "attributes"}
+        <AttributesEditor />
+    {:else if ctrl.controlType === "title"}
         <div class="px-3 pt-3 pb-1 text-xs font-semibold text-surface-500-400 uppercase tracking-wide">
             {ctrl.caption ?? ""}
         </div>
@@ -406,7 +487,7 @@
         {:else}
             {@const label = ctrl.caption ?? ctrl.attribute}
             {@const isLong = label.length > 20}
-            {@const isMultiline = ctrl.controlType === "richtext" || ctrl.controlType === "script" || ctrl.controlType === "list"}
+            {@const isMultiline = ctrl.controlType === "richtext" || ctrl.controlType === "script" || ctrl.controlType === "list" || ctrl.controlType === "stringdictionary"}
             {#if isLong}
                 <div class="flex flex-col gap-1 px-3 py-1.5">
                     <span class="text-xs text-surface-600-400">{label}:</span>

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    import { selectedKey, selectedData, setAttribute, setDropdownType, setMultiType, setObjectReference, addListItem, removeListItem, updateListItem, addDictItem, removeDictItem, updateDictItem } from "$lib/editor-store";
+    import { selectedKey, selectedData, setAttribute, setDropdownType, setMultiType, setObjectReference, addDictItem, removeDictItem, updateDictItem } from "$lib/editor-store";
     import type { ControlInfo, TextProcessorCommand } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
     import Combobox from "./Combobox.svelte";
     import AttributesEditor from "./AttributesEditor.svelte";
+    import ListEditor from "./ListEditor.svelte";
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
-    let newListItemValues = $state<Record<string, string>>({});
     let editingItem = $state<{attribute: string, key: string, value: string} | null>(null);
     let newDictItems = $state<Record<string, {key: string, value: string}>>({});
 
@@ -217,75 +217,8 @@
         </div>
     {:else if ctrl.controlType === "file"}
         <em class="text-xs text-surface-400-500">File picker not yet implemented</em>
-    {:else if ctrl.controlType === "list"}
-        {@const items = (() => { try { return JSON.parse(attrValue(ctrl.attribute!) ?? "[]") as {key: string, value: string}[] } catch { return [] } })()}
-        {@const inputKey = ctrl.attribute!}
-        <div class="flex flex-col gap-1 w-full">
-            {#each items as item (item.key)}
-                {@const isEditing = editingItem?.attribute === ctrl.attribute! && editingItem?.key === item.key}
-                <div class="flex items-center gap-1">
-                    {#if isEditing}
-                        <input
-                            type="text"
-                            class="input text-xs py-0.5 px-1.5 flex-1"
-                            use:focusOnMount
-                            value={editingItem!.value}
-                            oninput={(e) => { if (editingItem) editingItem.value = (e.target as HTMLInputElement).value; }}
-                            onkeydown={(e) => {
-                                if (e.key === "Enter" && $selectedKey && editingItem) {
-                                    updateListItem($selectedKey, ctrl.attribute!, editingItem.key, editingItem.value);
-                                    editingItem = null;
-                                } else if (e.key === "Escape") {
-                                    editingItem = null;
-                                }
-                            }}
-                            onblur={() => {
-                                if ($selectedKey && editingItem) {
-                                    updateListItem($selectedKey, ctrl.attribute!, editingItem.key, editingItem.value);
-                                    editingItem = null;
-                                }
-                            }}
-                        />
-                    {:else}
-                        <button
-                            type="button"
-                            class="text-xs flex-1 text-left px-1.5 py-0.5 hover:text-primary-600-400"
-                            onclick={() => { editingItem = {attribute: ctrl.attribute!, key: item.key, value: item.value}; }}
-                        >{item.value}</button>
-                    {/if}
-                    <button
-                        type="button"
-                        class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5"
-                        onclick={() => $selectedKey && removeListItem($selectedKey, ctrl.attribute!, item.key)}
-                    >✕</button>
-                </div>
-            {/each}
-            <div class="flex items-center gap-1 mt-0.5">
-                <input
-                    type="text"
-                    class="input text-xs py-0.5 px-1.5 flex-1"
-                    placeholder={ctrl.addPrompt ?? "Add item…"}
-                    value={newListItemValues[inputKey] ?? ""}
-                    oninput={(e) => { newListItemValues[inputKey] = (e.target as HTMLInputElement).value; }}
-                    onkeydown={(e) => {
-                        if (e.key === "Enter" && $selectedKey && newListItemValues[inputKey]?.trim()) {
-                            addListItem($selectedKey, ctrl.attribute!, newListItemValues[inputKey].trim());
-                            newListItemValues[inputKey] = "";
-                        }
-                    }}
-                />
-                <button
-                    type="button"
-                    class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
-                    onclick={() => {
-                        if ($selectedKey && newListItemValues[inputKey]?.trim()) {
-                            addListItem($selectedKey, ctrl.attribute!, newListItemValues[inputKey].trim());
-                            newListItemValues[inputKey] = "";
-                        }
-                    }}
-                >Add</button>
-            </div>
-        </div>
+    {:else if ctrl.controlType === "list" && ctrl.attribute && $selectedKey}
+        <ListEditor elementKey={$selectedKey} attribute={ctrl.attribute} value={attrValue(ctrl.attribute)} addPrompt={ctrl.addPrompt ?? undefined} />
     {:else if ctrl.controlType === "stringdictionary" && ctrl.attribute}
         {@const items = (() => { try { return JSON.parse(attrValue(ctrl.attribute) ?? "[]") as {key: string, value: string}[] } catch { return [] } })()}
         {@const dk = ctrl.attribute}

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -109,11 +109,22 @@
             </div>
         {/if}
 
-        <div class="flex-1 overflow-y-auto">
-            {#each getControlsForView() as ctrl, i (i)}
-                {@render controlRow(ctrl)}
-            {/each}
-        </div>
+        {@const viewControls = getControlsForView()}
+        {@const hasAttributesPanel = viewControls.some(c => c.controlType === "attributes")}
+        {#if hasAttributesPanel}
+            <div class="flex-1 overflow-hidden flex flex-col min-h-0">
+                {#each viewControls.filter(c => c.controlType !== "attributes") as ctrl, i (i)}
+                    {@render controlRow(ctrl)}
+                {/each}
+                <AttributesEditor />
+            </div>
+        {:else}
+            <div class="flex-1 overflow-y-auto">
+                {#each viewControls as ctrl, i (i)}
+                    {@render controlRow(ctrl)}
+                {/each}
+            </div>
+        {/if}
     {/if}
 </div>
 

--- a/src/WebEditor/src/components/ScriptDictionaryEditor.svelte
+++ b/src/WebEditor/src/components/ScriptDictionaryEditor.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-    import { addScriptDictItem, removeScriptDictItem } from "$lib/editor-store";
+    import { addScriptDictItem, removeScriptDictItem, makeScriptDictEditable } from "$lib/editor-store";
     import ScriptEditor from "./ScriptEditor.svelte";
 
     interface Props {
         elementKey: string;
         attribute: string;
         value: string | null;
+        isLocked?: boolean;
     }
 
-    let { elementKey, attribute, value }: Props = $props();
+    let { elementKey, attribute, value, isLocked = false }: Props = $props();
 
     let keys = $derived.by<string[]>(() => {
         try {
@@ -37,41 +38,57 @@
 </script>
 
 <div class="flex flex-col gap-1 w-full">
-    {#each keys as key (key)}
-        <div class="border border-surface-200-800 rounded">
-            <div class="flex items-center gap-1 px-2 py-1">
-                <button
-                    type="button"
-                    class="flex-1 text-left text-xs font-medium hover:text-primary-600-400"
-                    onclick={() => toggleExpanded(key)}
-                >
-                    <span class="mr-1 text-surface-400-500">{expandedKeys.has(key) ? "▼" : "▶"}</span>{key}
-                </button>
-                <button
-                    type="button"
-                    class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5 flex-shrink-0"
-                    onclick={() => removeScriptDictItem(elementKey, attribute, key)}
-                >✕</button>
-            </div>
-            {#if expandedKeys.has(key)}
-                <div class="px-2 pb-2 border-t border-surface-100-900">
-                    <ScriptEditor elementKey={elementKey} attribute="{attribute}[{key}]" />
-                </div>
-            {/if}
+    {#if isLocked}
+        <div class="flex items-center gap-2 py-1 px-2 mb-1 text-xs text-surface-400-500 italic border border-surface-200-800 rounded">
+            <span class="flex-1">This script dictionary is inherited — read-only.</span>
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0 not-italic"
+                onclick={() => makeScriptDictEditable(elementKey, attribute)}
+            >Make editable copy</button>
         </div>
-    {/each}
-    <div class="flex items-center gap-1 mt-0.5">
-        <input
-            type="text"
-            class="input text-xs py-0.5 px-1.5 flex-1"
-            placeholder="Add entry key…"
-            bind:value={newKey}
-            onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
-        />
-        <button
-            type="button"
-            class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0"
-            onclick={onAdd}
-        >Add</button>
-    </div>
+    {/if}
+    {#if isLocked}
+        {#each keys as key (key)}
+            <div class="border border-surface-200-800 rounded px-2 py-1 text-xs text-surface-400-500 opacity-60">{key} <span class="italic">(script)</span></div>
+        {/each}
+    {:else}
+        {#each keys as key (key)}
+            <div class="border border-surface-200-800 rounded">
+                <div class="flex items-center gap-1 px-2 py-1">
+                    <button
+                        type="button"
+                        class="flex-1 text-left text-xs font-medium hover:text-primary-600-400"
+                        onclick={() => toggleExpanded(key)}
+                    >
+                        <span class="mr-1 text-surface-400-500">{expandedKeys.has(key) ? "▼" : "▶"}</span>{key}
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5 flex-shrink-0"
+                        onclick={() => removeScriptDictItem(elementKey, attribute, key)}
+                    >✕</button>
+                </div>
+                {#if expandedKeys.has(key)}
+                    <div class="px-2 pb-2 border-t border-surface-100-900">
+                        <ScriptEditor elementKey={elementKey} attribute="{attribute}[{key}]" />
+                    </div>
+                {/if}
+            </div>
+        {/each}
+        <div class="flex items-center gap-1 mt-0.5">
+            <input
+                type="text"
+                class="input text-xs py-0.5 px-1.5 flex-1"
+                placeholder="Add entry key…"
+                bind:value={newKey}
+                onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
+            />
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0"
+                onclick={onAdd}
+            >Add</button>
+        </div>
+    {/if}
 </div>

--- a/src/WebEditor/src/components/ScriptDictionaryEditor.svelte
+++ b/src/WebEditor/src/components/ScriptDictionaryEditor.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+    import { addScriptDictItem, removeScriptDictItem } from "$lib/editor-store";
+    import ScriptEditor from "./ScriptEditor.svelte";
+
+    interface Props {
+        elementKey: string;
+        attribute: string;
+        value: string | null;
+    }
+
+    let { elementKey, attribute, value }: Props = $props();
+
+    let keys = $derived.by<string[]>(() => {
+        try {
+            const items = JSON.parse(value ?? "[]") as {key: string, value: string}[];
+            return items.map(i => i.key);
+        } catch { return []; }
+    });
+
+    let expandedKeys = $state(new Set<string>());
+    let newKey = $state("");
+
+    function onAdd() {
+        const k = newKey.trim();
+        if (k) {
+            const result = addScriptDictItem(elementKey, attribute, k);
+            if (result === "ok") expandedKeys = new Set([...expandedKeys, k]);
+            newKey = "";
+        }
+    }
+
+    function toggleExpanded(key: string) {
+        const next = new Set(expandedKeys);
+        if (next.has(key)) next.delete(key); else next.add(key);
+        expandedKeys = next;
+    }
+</script>
+
+<div class="flex flex-col gap-1 w-full">
+    {#each keys as key (key)}
+        <div class="border border-surface-200-800 rounded">
+            <div class="flex items-center gap-1 px-2 py-1">
+                <button
+                    type="button"
+                    class="flex-1 text-left text-xs font-medium hover:text-primary-600-400"
+                    onclick={() => toggleExpanded(key)}
+                >
+                    <span class="mr-1 text-surface-400-500">{expandedKeys.has(key) ? "▼" : "▶"}</span>{key}
+                </button>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5 flex-shrink-0"
+                    onclick={() => removeScriptDictItem(elementKey, attribute, key)}
+                >✕</button>
+            </div>
+            {#if expandedKeys.has(key)}
+                <div class="px-2 pb-2 border-t border-surface-100-900">
+                    <ScriptEditor elementKey={elementKey} attribute="{attribute}[{key}]" />
+                </div>
+            {/if}
+        </div>
+    {/each}
+    <div class="flex items-center gap-1 mt-0.5">
+        <input
+            type="text"
+            class="input text-xs py-0.5 px-1.5 flex-1"
+            placeholder="Add entry key…"
+            bind:value={newKey}
+            onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
+        />
+        <button
+            type="button"
+            class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0"
+            onclick={onAdd}
+        >Add</button>
+    </div>
+</div>

--- a/src/WebEditor/src/components/ScriptDictionaryEditor.svelte
+++ b/src/WebEditor/src/components/ScriptDictionaryEditor.svelte
@@ -11,12 +11,13 @@
 
     let { elementKey, attribute, value, isLocked = false }: Props = $props();
 
-    let keys = $derived.by<string[]>(() => {
+    let items = $derived.by<{key: string, value: string}[]>(() => {
         try {
-            const items = JSON.parse(value ?? "[]") as {key: string, value: string}[];
-            return items.map(i => i.key);
+            return JSON.parse(value ?? "[]") as {key: string, value: string}[];
         } catch { return []; }
     });
+
+    let keys = $derived(items.map(i => i.key));
 
     let expandedKeys = $state(new Set<string>());
     let newKey = $state("");
@@ -49,8 +50,8 @@
         </div>
     {/if}
     {#if isLocked}
-        {#each keys as key (key)}
-            <div class="border border-surface-200-800 rounded px-2 py-1 text-xs text-surface-400-500 opacity-60">{key} <span class="italic">(script)</span></div>
+        {#each items as item (item.key)}
+            <div class="border border-surface-200-800 rounded px-2 py-1 text-xs text-surface-400-500 opacity-60"><span class="font-medium">{item.key}</span> = <span class="italic">{item.value || "(empty)"}</span></div>
         {/each}
     {:else}
         {#each keys as key (key)}

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -25,6 +25,7 @@
         getObjectNames,
         getIfExpressionTemplates,
         getIfExpressionTemplateData,
+        makeScriptEditable,
     } from "$lib/editor-store";
     import type {
         ScriptBlockData,
@@ -42,6 +43,7 @@
         // Pre-loaded data for nested blocks (avoids extra WASM round-trips)
         initialData?: ScriptNodeData[] | null;
         depth?: number;
+        isLocked?: boolean;
     }
 
     let {
@@ -50,6 +52,7 @@
         containerPath = "",
         initialData = null,
         depth = 0,
+        isLocked = false,
     }: Props = $props();
 
     let scriptData = $state<ScriptBlockData | null>(null);
@@ -341,132 +344,153 @@
 </script>
 
 <div class={indentClass}>
+    {#if isRoot && isLocked}
+        <div class="flex items-center gap-2 py-1 px-2 mb-1 text-xs text-surface-400-500 italic border border-surface-200-800 rounded">
+            <span class="flex-1">This script is inherited — read-only.</span>
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0 not-italic"
+                onclick={onToggleCodeView}
+            >{codeViewMode ? "Visual view" : "Code view"}</button>
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0 not-italic"
+                onclick={() => makeScriptEditable(elementKey, attribute)}
+            >Make editable copy</button>
+        </div>
+    {/if}
     {#if codeViewMode}
         <textarea
             class="textarea text-xs font-mono w-full"
             rows={10}
+            readonly={isLocked}
             value={scriptCode}
             onchange={(e) => onCodeViewSave((e.target as HTMLTextAreaElement).value)}
         ></textarea>
     {:else}
-        {#each scripts() as script, i (script.id)}
-            <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-start">
-                {#if isRoot}
-                    <label class="flex items-start pt-1.5 pl-1.5 pr-0.5 cursor-pointer flex-shrink-0">
-                        <input
-                            type="checkbox"
-                            class="checkbox size-3.5"
-                            checked={selectedIndices.has(i)}
-                            onchange={(e) => toggleSelection(i, (e.target as HTMLInputElement).checked)}
-                        />
-                    </label>
-                {/if}
-                <div class="flex-1 min-w-0">
-                    <!-- Script row actions (hover) -->
-                    <div class="absolute right-1 top-1 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10">
-                        <button
-                            type="button"
-                            class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
-                            title="Move up"
-                            disabled={i === 0}
-                            onclick={() => onMoveUp(i)}
-                        >↑</button>
-                        <button
-                            type="button"
-                            class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
-                            title="Move down"
-                            disabled={i === scripts().length - 1}
-                            onclick={() => onMoveDown(i)}
-                        >↓</button>
-                        <button
-                            type="button"
-                            class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
-                            title="Delete"
-                            onclick={() => onDelete(i)}
-                        >×</button>
-                    </div>
-
-                    {#if script.type === "if"}
-                        {@render ifBlock(script, i)}
-                    {:else}
-                        {@render normalBlock(script, i)}
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <div role="region" inert={isLocked || undefined} class={isLocked ? "opacity-60" : ""}>
+            {#each scripts() as script, i (script.id)}
+                <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-start">
+                    {#if isRoot}
+                        <label class="flex items-start pt-1.5 pl-1.5 pr-0.5 cursor-pointer flex-shrink-0">
+                            <input
+                                type="checkbox"
+                                class="checkbox size-3.5"
+                                checked={selectedIndices.has(i)}
+                                onchange={(e) => toggleSelection(i, (e.target as HTMLInputElement).checked)}
+                            />
+                        </label>
                     {/if}
-                </div>
-            </div>
-        {/each}
+                    <div class="flex-1 min-w-0">
+                        <!-- Script row actions (hover) -->
+                        <div class="absolute right-1 top-1 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10">
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                                title="Move up"
+                                disabled={i === 0}
+                                onclick={() => onMoveUp(i)}
+                            >↑</button>
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                                title="Move down"
+                                disabled={i === scripts().length - 1}
+                                onclick={() => onMoveDown(i)}
+                            >↓</button>
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
+                                title="Delete"
+                                onclick={() => onDelete(i)}
+                            >×</button>
+                        </div>
 
-        <!-- Selection toolbar -->
-        {#if isRoot && selectedIndices.size > 0}
-            {@const sel = sortedSelection()}
-            <div class="flex items-center gap-1 mb-1 px-1 py-1 bg-surface-100-900 rounded border border-surface-200-800 text-xs">
-                <button
-                    type="button"
-                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-                    onclick={onCutSelected}
-                >Cut</button>
-                <button
-                    type="button"
-                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-                    onclick={onCopySelected}
-                >Copy</button>
-                <button
-                    type="button"
-                    class="btn btn-sm preset-tonal-error text-xs py-0.5"
-                    onclick={onDeleteSelected}
-                >Delete</button>
-                {#if sel.length === 1}
-                    <span class="w-px h-4 bg-surface-300-700 mx-0.5"></span>
+                        {#if script.type === "if"}
+                            {@render ifBlock(script, i)}
+                        {:else}
+                            {@render normalBlock(script, i)}
+                        {/if}
+                    </div>
+                </div>
+            {/each}
+
+            <!-- Selection toolbar -->
+            {#if isRoot && selectedIndices.size > 0}
+                {@const sel = sortedSelection()}
+                <div class="flex items-center gap-1 mb-1 px-1 py-1 bg-surface-100-900 rounded border border-surface-200-800 text-xs">
                     <button
                         type="button"
                         class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-                        disabled={sel[0] === 0}
-                        onclick={onMoveUpSelected}
-                    >↑ Move up</button>
+                        onclick={onCutSelected}
+                    >Cut</button>
                     <button
                         type="button"
                         class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-                        disabled={sel[0] === scripts().length - 1}
-                        onclick={onMoveDownSelected}
-                    >↓ Move down</button>
-                {/if}
-                <span class="ml-auto text-surface-400-500">{sel.length} selected</span>
-            </div>
-        {/if}
+                        onclick={onCopySelected}
+                    >Copy</button>
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-tonal-error text-xs py-0.5"
+                        onclick={onDeleteSelected}
+                    >Delete</button>
+                    {#if sel.length === 1}
+                        <span class="w-px h-4 bg-surface-300-700 mx-0.5"></span>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                            disabled={sel[0] === 0}
+                            onclick={onMoveUpSelected}
+                        >↑ Move up</button>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                            disabled={sel[0] === scripts().length - 1}
+                            onclick={onMoveDownSelected}
+                        >↓ Move down</button>
+                    {/if}
+                    <span class="ml-auto text-surface-400-500">{sel.length} selected</span>
+                </div>
+            {/if}
+        </div>
     {/if}
 
-    <!-- Add script row -->
-    <div class="flex items-center gap-1 mt-1 flex-wrap">
-        {#if !codeViewMode && categories.length > 0}
-            <button
-                type="button"
-                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-                onclick={() => (showAddModal = true)}
-            >+ Add script</button>
-        {:else if !codeViewMode && isRoot}
-            <span class="text-xs text-surface-400-500 italic">Loading commands…</span>
-        {/if}
-        {#if isRoot && $scriptClipboardHasContent && !codeViewMode}
-            <button
-                type="button"
-                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-                onclick={onPaste}
-            >Paste</button>
-        {/if}
-        {#if isRoot}
-            <button
-                type="button"
-                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-                onclick={onToggleCodeView}
-            >{codeViewMode ? "Visual editor" : "Code view"}</button>
-        {/if}
-    </div>
+    {#if !(isRoot && isLocked)}
+        <!-- Add script row -->
+        <div class="flex items-center gap-1 mt-1 flex-wrap">
+            {#if !codeViewMode && categories.length > 0}
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                    onclick={() => (showAddModal = true)}
+                >+ Add script</button>
+            {:else if !codeViewMode && isRoot}
+                <span class="text-xs text-surface-400-500 italic">Loading commands…</span>
+            {/if}
+            {#if isRoot && $scriptClipboardHasContent && !codeViewMode}
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                    onclick={onPaste}
+                >Paste</button>
+            {/if}
+            {#if isRoot}
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                    onclick={onToggleCodeView}
+                >{codeViewMode ? "Visual editor" : "Code view"}</button>
+            {/if}
+        </div>
 
-    {#if showAddModal}
-        <AddScriptModal
-            {categories}
-            onAdd={onAddScript}
-            onClose={() => (showAddModal = false)}
-        />
+        {#if showAddModal}
+            <AddScriptModal
+                {categories}
+                onAdd={onAddScript}
+                onClose={() => (showAddModal = false)}
+            />
+        {/if}
     {/if}
 </div>
 

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -36,7 +36,7 @@ export async function openGame(file: File): Promise<boolean> {
     loadingStatus.set("Loading game…");
     // Double rAF ensures the browser actually paints the status update before
     // Initialise blocks the JS thread (C# WASM calls are synchronous).
-    await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
     const ok = await _bridge.Initialise(bytes, file.name);
     loadingStatus.set(null);
     if (ok) {

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -203,6 +203,22 @@ export function updateDictItem(elementKey: string, attribute: string, key: strin
     return result;
 }
 
+export function addScriptDictItem(elementKey: string, attribute: string, key: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.AddScriptDictionaryItem(elementKey, attribute, key);
+    if (result === "ok") { refreshSelectedData(); bumpScriptVersion(); }
+    refreshUndoRedo();
+    return result;
+}
+
+export function removeScriptDictItem(elementKey: string, attribute: string, key: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.RemoveScriptDictionaryItem(elementKey, attribute, key);
+    if (result === "ok") { refreshSelectedData(); bumpScriptVersion(); }
+    refreshUndoRedo();
+    return result;
+}
+
 export function changeAttributeType(elementKey: string, attribute: string, newType: string): string {
     if (!_bridge) return "error";
     const result = _bridge.ChangeAttributeType(elementKey, attribute, newType);

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -203,6 +203,22 @@ export function updateDictItem(elementKey: string, attribute: string, key: strin
     return result;
 }
 
+export function changeAttributeType(elementKey: string, attribute: string, newType: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.ChangeAttributeType(elementKey, attribute, newType);
+    if (result === "ok") refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
+export function setPatternAttribute(elementKey: string, attribute: string, pattern: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetPatternAttribute(elementKey, attribute, pattern);
+    if (result === "ok") refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
 // ── Script editor functions ─────────────────────────────────────────────────
 
 export function getScriptCode(elementKey: string, attribute: string): string {

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -1,7 +1,7 @@
 import { writable, get } from "svelte/store";
 import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
-import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate } from "./types";
+import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData } from "./types";
 
 export type AddElementModalState = { type: "room" | "object" | "function" | "timer"; parent: string | null } | null;
 
@@ -18,6 +18,7 @@ export const gameFilename = writable<string | null>(null);
 export const treeNodes = writable<TreeNode[]>([]);
 export const selectedKey = writable<string | null>(null);
 export const selectedData = writable<EditorDataResponse | null>(null);
+export const fullAttributeData = writable<FullAttributeData | null>(null);
 export const canUndo = writable(false);
 export const canRedo = writable(false);
 export const scriptVersion = writable(0);
@@ -56,6 +57,8 @@ export function selectNode(key: string) {
     selectedKey.set(key);
     const json = _bridge.GetEditorData(key);
     selectedData.set(json ? JSON.parse(json) : null);
+    const attrJson = _bridge.GetFullAttributeData(key);
+    fullAttributeData.set(attrJson ? JSON.parse(attrJson) : null);
 }
 
 export function setAttribute(elementKey: string, attribute: string, controlType: string, value: string): string {
@@ -140,6 +143,62 @@ export function updateListItem(elementKey: string, attribute: string, key: strin
     if (!_bridge) return "error";
     const result = _bridge.UpdateListItem(elementKey, attribute, key, value);
     refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
+// ── Attributes editor functions ─────────────────────────────────────────────
+
+export function removeAttribute(elementKey: string, attribute: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.RemoveAttribute(elementKey, attribute);
+    if (result === "ok") refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
+export function addInheritedType(elementKey: string, typeName: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.AddInheritedType(elementKey, typeName);
+    if (result === "ok") refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
+export function removeInheritedType(elementKey: string, typeName: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.RemoveInheritedType(elementKey, typeName);
+    if (result === "ok") refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
+export function getTypeNames(): string[] {
+    if (!_bridge) return [];
+    try { return JSON.parse(_bridge.GetTypeNames()); }
+    catch { return []; }
+}
+
+export function addDictItem(elementKey: string, attribute: string, key: string, value: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.AddDictionaryItem(elementKey, attribute, key, value);
+    if (result === "ok") refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
+export function removeDictItem(elementKey: string, attribute: string, key: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.RemoveDictionaryItem(elementKey, attribute, key);
+    if (result === "ok") refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
+export function updateDictItem(elementKey: string, attribute: string, key: string, value: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.UpdateDictionaryItem(elementKey, attribute, key, value);
+    if (result === "ok") refreshSelectedData();
     refreshUndoRedo();
     return result;
 }
@@ -312,6 +371,8 @@ function refreshSelectedData() {
     if (!_bridge || !key) return;
     const json = _bridge.GetEditorData(key);
     selectedData.set(json ? JSON.parse(json) : null);
+    const attrJson = _bridge.GetFullAttributeData(key);
+    fullAttributeData.set(attrJson ? JSON.parse(attrJson) : null);
 }
 
 function refreshTree() {

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -203,6 +203,22 @@ export function updateDictItem(elementKey: string, attribute: string, key: strin
     return result;
 }
 
+export function makeScriptEditable(elementKey: string, attribute: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.MakeScriptEditable(elementKey, attribute);
+    if (result === "ok") { refreshSelectedData(); bumpScriptVersion(); }
+    refreshUndoRedo();
+    return result;
+}
+
+export function makeScriptDictEditable(elementKey: string, attribute: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.MakeScriptDictEditable(elementKey, attribute);
+    if (result === "ok") { refreshSelectedData(); bumpScriptVersion(); }
+    refreshUndoRedo();
+    return result;
+}
+
 export function addScriptDictItem(elementKey: string, attribute: string, key: string): string {
     if (!_bridge) return "error";
     const result = _bridge.AddScriptDictionaryItem(elementKey, attribute, key);

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -106,3 +106,16 @@ export interface IfExpressionTemplate {
   name: string
   createExpression: string
 }
+
+export interface AttributeDataItem {
+  name: string
+  value: string | null
+  isInherited: boolean
+  source: string
+  isDefaultType: boolean
+}
+
+export interface FullAttributeData {
+  attributes: AttributeDataItem[]
+  inheritedTypes: AttributeDataItem[]
+}

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -113,6 +113,7 @@ export interface AttributeDataItem {
   isInherited: boolean
   source: string
   isDefaultType: boolean
+  type: string
 }
 
 export interface FullAttributeData {

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -47,6 +47,8 @@ export interface WasmBridge {
   AddDictionaryItem(elementKey: string, attribute: string, key: string, value: string): string
   RemoveDictionaryItem(elementKey: string, attribute: string, key: string): string
   UpdateDictionaryItem(elementKey: string, attribute: string, key: string, value: string): string
+  MakeScriptEditable(elementKey: string, attribute: string): string
+  MakeScriptDictEditable(elementKey: string, attribute: string): string
   AddScriptDictionaryItem(elementKey: string, attribute: string, key: string): string
   RemoveScriptDictionaryItem(elementKey: string, attribute: string, key: string): string
   ChangeAttributeType(elementKey: string, attribute: string, newType: string): string

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -38,6 +38,15 @@ export interface WasmBridge {
   AddListItem(elementKey: string, attribute: string, value: string): string
   RemoveListItem(elementKey: string, attribute: string, key: string): string
   UpdateListItem(elementKey: string, attribute: string, key: string, value: string): string
+  // Attributes editor API
+  GetFullAttributeData(elementKey: string): string | null
+  RemoveAttribute(elementKey: string, attribute: string): string
+  AddInheritedType(elementKey: string, typeName: string): string
+  RemoveInheritedType(elementKey: string, typeName: string): string
+  GetTypeNames(): string
+  AddDictionaryItem(elementKey: string, attribute: string, key: string, value: string): string
+  RemoveDictionaryItem(elementKey: string, attribute: string, key: string): string
+  UpdateDictionaryItem(elementKey: string, attribute: string, key: string, value: string): string
   // Element creation / deletion
   ValidateName(name: string): string
   GetUniqueName(baseName: string): string

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -47,6 +47,8 @@ export interface WasmBridge {
   AddDictionaryItem(elementKey: string, attribute: string, key: string, value: string): string
   RemoveDictionaryItem(elementKey: string, attribute: string, key: string): string
   UpdateDictionaryItem(elementKey: string, attribute: string, key: string, value: string): string
+  AddScriptDictionaryItem(elementKey: string, attribute: string, key: string): string
+  RemoveScriptDictionaryItem(elementKey: string, attribute: string, key: string): string
   ChangeAttributeType(elementKey: string, attribute: string, newType: string): string
   SetPatternAttribute(elementKey: string, attribute: string, pattern: string): string
   // Element creation / deletion

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -47,6 +47,8 @@ export interface WasmBridge {
   AddDictionaryItem(elementKey: string, attribute: string, key: string, value: string): string
   RemoveDictionaryItem(elementKey: string, attribute: string, key: string): string
   UpdateDictionaryItem(elementKey: string, attribute: string, key: string, value: string): string
+  ChangeAttributeType(elementKey: string, attribute: string, newType: string): string
+  SetPatternAttribute(elementKey: string, attribute: string, pattern: string): string
   // Element creation / deletion
   ValidateName(name: string): string
   GetUniqueName(baseName: string): string


### PR DESCRIPTION
## Summary

- Adds a full **Attributes tab** to the WebEditor with split-pane layout and resizable splitter
- Type-aware attribute editing with type dropdown (string, int, double, boolean, object, script, list, dictionary, script dictionary)
- Inline editors for all attribute types: scripts, string lists, string dictionaries, script dictionaries
- Copy-on-write for inherited scripts, lists, and dictionaries
- Hides delete button for built-in attributes (`name`, `type`, `elementtype`)
- Improves keyboard accessibility, adder UI, and attribute value display strings
- Backend additions in `EditorController` and `WasmEditorBridge` to support get/set/delete operations for all attribute types

## Test plan

- [ ] Open a game in the WebEditor and navigate to the Attributes tab
- [ ] Verify split-pane layout renders correctly and splitter is draggable
- [ ] Add, edit, and delete attributes of each type (string, int, double, boolean, object, script, list, dictionary, script dictionary)
- [ ] Verify inherited attributes show copy-on-write behaviour for scripts, lists, and dictionaries
- [ ] Confirm `name`, `type`, and `elementtype` attributes cannot be deleted
- [ ] Check keyboard navigation in the attributes list and adder UI
- [ ] Verify boolean attributes use the Switch component
- [ ] Confirm int/double values are saved as the correct type (not as strings)
- [ ] Test object attribute type — confirm reference is created on type change

🤖 Generated with [Claude Code](https://claude.com/claude-code)