### PR TITLE
Fix OOM in WPF compositor when rendering XAML icons

### DIFF
--- a/EditorControls/EditorControls.csproj
+++ b/EditorControls/EditorControls.csproj
@@ -296,6 +296,7 @@
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="WindowHelpers.cs" />
+    <Compile Include="XamlIconRenderer.cs" />
     <EmbeddedResource Include="InputWindow.de.resx">
       <DependentUpon>InputWindow.cs</DependentUpon>
     </EmbeddedResource>

--- a/EditorControls/WFAttributesControl.cs
+++ b/EditorControls/WFAttributesControl.cs
@@ -91,41 +91,13 @@ namespace TextAdventures.Quest.EditorControls
                 string xamlName;
                 if (xamlNames.TryGetValue(item.Name, out xamlName))
                 {
-                    var bmp = RenderXaml(xamlName, size);
+                    var bmp = XamlIconRenderer.RenderXaml(xamlName, size);
                     if (bmp != null)
                     {
                         var old = item.Image;
                         item.Image = bmp;
                         if (old != null) old.Dispose();
                     }
-                }
-            }
-        }
-
-        private static Bitmap RenderXaml(string name, int size)
-        {
-            var asm = System.Reflection.Assembly.GetExecutingAssembly();
-            var resourceName = asm.GetManifestResourceNames()
-                .FirstOrDefault(n => n.EndsWith("." + name + ".xaml", StringComparison.OrdinalIgnoreCase));
-            if (resourceName == null) return null;
-            using (var stream = asm.GetManifestResourceStream(resourceName))
-            {
-                var visual = System.Windows.Markup.XamlReader.Load(stream) as System.Windows.FrameworkElement;
-                if (visual == null) return null;
-                visual.Width = size;
-                visual.Height = size;
-                visual.Measure(new System.Windows.Size(size, size));
-                visual.Arrange(new System.Windows.Rect(0, 0, size, size));
-                var rtb = new System.Windows.Media.Imaging.RenderTargetBitmap(size, size, 96, 96, System.Windows.Media.PixelFormats.Pbgra32);
-                rtb.Render(visual);
-                var encoder = new System.Windows.Media.Imaging.PngBitmapEncoder();
-                encoder.Frames.Add(System.Windows.Media.Imaging.BitmapFrame.Create(rtb));
-                using (var ms = new System.IO.MemoryStream())
-                {
-                    encoder.Save(ms);
-                    ms.Position = 0;
-                    using (var raw = new Bitmap(ms))
-                        return new Bitmap(raw);
                 }
             }
         }

--- a/EditorControls/WFEditorTree.cs
+++ b/EditorControls/WFEditorTree.cs
@@ -188,7 +188,7 @@ namespace TextAdventures.Quest.EditorControls
                 Bitmap bmp = null;
                 string xamlName;
                 if (_treeXamlNames.TryGetValue(key, out xamlName))
-                    bmp = RenderXaml(xamlName, newSize);
+                    bmp = XamlIconRenderer.RenderXaml(xamlName, newSize);
                 if (bmp == null)
                     bmp = newSize == 16
                         ? new Bitmap(sourceList.Images[i])
@@ -334,41 +334,13 @@ namespace TextAdventures.Quest.EditorControls
                 string xamlName;
                 if (_contextMenuXamlNames.TryGetValue(item.Name, out xamlName))
                 {
-                    var bmp = RenderXaml(xamlName, size);
+                    var bmp = XamlIconRenderer.RenderXaml(xamlName, size);
                     if (bmp != null)
                     {
                         var old = item.Image;
                         item.Image = bmp;
                         if (old != null) old.Dispose();
                     }
-                }
-            }
-        }
-
-        private static Bitmap RenderXaml(string name, int size)
-        {
-            var asm = System.Reflection.Assembly.GetExecutingAssembly();
-            var resourceName = asm.GetManifestResourceNames()
-                .FirstOrDefault(n => n.EndsWith("." + name + ".xaml", StringComparison.OrdinalIgnoreCase));
-            if (resourceName == null) return null;
-            using (var stream = asm.GetManifestResourceStream(resourceName))
-            {
-                var visual = System.Windows.Markup.XamlReader.Load(stream) as System.Windows.FrameworkElement;
-                if (visual == null) return null;
-                visual.Width = size;
-                visual.Height = size;
-                visual.Measure(new System.Windows.Size(size, size));
-                visual.Arrange(new System.Windows.Rect(0, 0, size, size));
-                var rtb = new System.Windows.Media.Imaging.RenderTargetBitmap(size, size, 96, 96, System.Windows.Media.PixelFormats.Pbgra32);
-                rtb.Render(visual);
-                var encoder = new System.Windows.Media.Imaging.PngBitmapEncoder();
-                encoder.Frames.Add(System.Windows.Media.Imaging.BitmapFrame.Create(rtb));
-                using (var ms = new System.IO.MemoryStream())
-                {
-                    encoder.Save(ms);
-                    ms.Position = 0;
-                    using (var raw = new Bitmap(ms))
-                        return new Bitmap(raw);
                 }
             }
         }

--- a/EditorControls/WFListEditor.cs
+++ b/EditorControls/WFListEditor.cs
@@ -71,7 +71,7 @@ namespace TextAdventures.Quest.EditorControls
                 string xamlName;
                 if (_toolbarXamlNames.TryGetValue(item.Name, out xamlName))
                 {
-                    var bmp = RenderXaml(xamlName, size);
+                    var bmp = XamlIconRenderer.RenderXaml(xamlName, size);
                     if (bmp != null)
                     {
                         var old = item.Image;
@@ -82,33 +82,6 @@ namespace TextAdventures.Quest.EditorControls
             }
         }
 
-        internal static Bitmap RenderXaml(string name, int size)
-        {
-            var asm = System.Reflection.Assembly.GetExecutingAssembly();
-            var resourceName = asm.GetManifestResourceNames()
-                .FirstOrDefault(n => n.EndsWith("." + name + ".xaml", StringComparison.OrdinalIgnoreCase));
-            if (resourceName == null) return null;
-            using (var stream = asm.GetManifestResourceStream(resourceName))
-            {
-                var visual = System.Windows.Markup.XamlReader.Load(stream) as System.Windows.FrameworkElement;
-                if (visual == null) return null;
-                visual.Width = size;
-                visual.Height = size;
-                visual.Measure(new System.Windows.Size(size, size));
-                visual.Arrange(new System.Windows.Rect(0, 0, size, size));
-                var rtb = new System.Windows.Media.Imaging.RenderTargetBitmap(size, size, 96, 96, System.Windows.Media.PixelFormats.Pbgra32);
-                rtb.Render(visual);
-                var encoder = new System.Windows.Media.Imaging.PngBitmapEncoder();
-                encoder.Frames.Add(System.Windows.Media.Imaging.BitmapFrame.Create(rtb));
-                using (var ms = new System.IO.MemoryStream())
-                {
-                    encoder.Save(ms);
-                    ms.Position = 0;
-                    using (var raw = new Bitmap(ms))
-                        return new Bitmap(raw);
-                }
-            }
-        }
 
         public WFListEditor()
         {

--- a/EditorControls/WFToolbar.cs
+++ b/EditorControls/WFToolbar.cs
@@ -60,7 +60,7 @@ namespace TextAdventures.Quest.EditorControls
                 string xamlName;
                 if (_toolbarXamlNames.TryGetValue(item.Name, out xamlName))
                 {
-                    var bmp = WFListEditor.RenderXaml(xamlName, size);
+                    var bmp = XamlIconRenderer.RenderXaml(xamlName, size);
                     if (bmp != null)
                     {
                         var old = item.Image;

--- a/EditorControls/XamlIconRenderer.cs
+++ b/EditorControls/XamlIconRenderer.cs
@@ -1,0 +1,37 @@
+using System.Drawing;
+using System.Linq;
+
+namespace TextAdventures.Quest.EditorControls
+{
+    internal static class XamlIconRenderer
+    {
+        internal static Bitmap RenderXaml(string name, int size)
+        {
+            var asm = System.Reflection.Assembly.GetExecutingAssembly();
+            var resourceName = asm.GetManifestResourceNames()
+                .FirstOrDefault(n => n.EndsWith("." + name + ".xaml", System.StringComparison.OrdinalIgnoreCase));
+            if (resourceName == null) return null;
+            using (var stream = asm.GetManifestResourceStream(resourceName))
+            {
+                var visual = System.Windows.Markup.XamlReader.Load(stream) as System.Windows.FrameworkElement;
+                if (visual == null) return null;
+                visual.Width = size;
+                visual.Height = size;
+                visual.Measure(new System.Windows.Size(size, size));
+                visual.Arrange(new System.Windows.Rect(0, 0, size, size));
+                var rtb = new System.Windows.Media.Imaging.RenderTargetBitmap(size, size, 96, 96, System.Windows.Media.PixelFormats.Pbgra32);
+                rtb.Render(visual);
+                rtb.Freeze();
+                var encoder = new System.Windows.Media.Imaging.PngBitmapEncoder();
+                encoder.Frames.Add(System.Windows.Media.Imaging.BitmapFrame.Create(rtb));
+                using (var ms = new System.IO.MemoryStream())
+                {
+                    encoder.Save(ms);
+                    ms.Position = 0;
+                    using (var raw = new Bitmap(ms))
+                        return new Bitmap(raw);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `RenderTargetBitmap` was never frozen after rendering, leaving DUCE compositor channels open until GC collected them. Repeated icon renders (DPI changes, context menu opens) accumulated GPU resources until `DUCE.Channel.SyncFlush` threw `OutOfMemoryException` — even when process heap looked healthy.
- Added `rtb.Freeze()` immediately after `rtb.Render(visual)` to release compositor resources as soon as the pixels are captured.
- Consolidated three identical private `RenderXaml` copies (in `WFListEditor`, `WFEditorTree`, `WFAttributesControl`) plus the existing `WFToolbar` call into a new `XamlIconRenderer` utility class so the fix lives in one place.

## Test plan

- [ ] Open a game in the editor and click around menus/tabs for an extended session — confirm no OOM crash
- [ ] Change display DPI while the editor is open — icons should re-render correctly
- [ ] Open the context menu on the editor tree repeatedly — confirm icons render correctly each time

🤖 Generated with [Claude Code](https://claude.ai/claude-code)