### PR TITLE
WebEditor: element lists for Objects, Verbs, Commands, Functions, Timers and more

### DIFF
--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -17,7 +17,7 @@ namespace QuestViva.WasmEditor;
 internal record TreeNodeData(string Key, string Text, string? Parent, string? NodeIcon, string NodeType);
 internal record ControlOption(string Value, string Label);
 internal record TextProcessorCommand(string Command, string Info, string InsertBefore, string InsertAfter);
-internal record ControlInfo(string? Attribute, string ControlType, string? Caption, List<ControlOption>? Options, List<ControlOption>? SubEditors = null, string? SubAttribute = null, List<TextProcessorCommand>? TextProcessorCommands = null, string? AddPrompt = null);
+internal record ControlInfo(string? Attribute, string ControlType, string? Caption, List<ControlOption>? Options, List<ControlOption>? SubEditors = null, string? SubAttribute = null, List<TextProcessorCommand>? TextProcessorCommands = null, string? AddPrompt = null, string? ElementType = null, string? ObjectType = null, string? ListFilter = null);
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 internal record EditorDataResponse(Dictionary<string, string?> Attributes, List<TabInfo> Tabs, List<ControlInfo> Controls);
 
@@ -83,6 +83,7 @@ public partial class WasmEditorBridge
     private static EditorController? _controller;
     private static readonly List<TreeNodeData> TreeNodes = [];
     private static bool _isRebuilding;
+    private static bool _suppressTreeEvents;
     private static string? _pendingRenameNewKey;
 
     [JSExport]
@@ -96,7 +97,7 @@ public partial class WasmEditorBridge
         _controller.BeginTreeUpdate += (_, _) => { };
         _controller.EndTreeUpdate += (_, _) => { _isRebuilding = false; };
         _controller.AddedNode += OnAddedNode;
-        _controller.RemovedNode += (_, e) => TreeNodes.RemoveAll(n => n.Key == e.Key);
+        _controller.RemovedNode += (_, e) => { if (!_suppressTreeEvents) TreeNodes.RemoveAll(n => n.Key == e.Key); };
         _controller.RenamedNode += (_, e) =>
         {
             _pendingRenameNewKey = e.NewName;
@@ -129,13 +130,19 @@ public partial class WasmEditorBridge
     {
         if (_controller == null) return null;
         var data = _controller.GetEditorData(key);
-        if (data is not IEditorDataExtendedAttributeInfo extended) return null;
+
+        // data is null for synthetic header nodes (e.g. _objects, _functions) which don't
+        // exist as world model elements but do have editor definitions in the ASLX.
+        var extended = data as IEditorDataExtendedAttributeInfo;
 
         var attrs = new Dictionary<string, string?>();
-        foreach (var attr in extended.GetAttributeData())
+        if (extended != null)
         {
-            var val = data.GetAttribute(attr.AttributeName);
-            attrs[attr.AttributeName] = SerializeAttributeValue(val);
+            foreach (var attr in extended.GetAttributeData())
+            {
+                var val = data!.GetAttribute(attr.AttributeName);
+                attrs[attr.AttributeName] = SerializeAttributeValue(val);
+            }
         }
 
         var tabs = new List<TabInfo>();
@@ -147,14 +154,22 @@ public partial class WasmEditorBridge
             var def = _controller.GetEditorDefinition(editorName);
             foreach (var tab in def.Tabs.Values)
             {
-                if (!tab.IsTabVisible(data)) continue;
-                var visibleControls = tab.Controls.Where(c => c.IsControlVisible(data)).ToList();
-                AddDropdownTypeValues(attrs, visibleControls, key, data);
+                if (data != null && !tab.IsTabVisible(data)) continue;
+                var visibleControls = data != null
+                    ? tab.Controls.Where(c => c.IsControlVisible(data)).ToList()
+                    : tab.Controls.ToList();
+                if (data != null) AddDropdownTypeValues(attrs, visibleControls, key, data);
                 tabs.Add(new TabInfo(tab.Caption, visibleControls.Select(ToControlInfo).ToList()));
             }
-            var visibleTopControls = def.Controls.Where(c => c.IsControlVisible(data)).ToList();
-            AddDropdownTypeValues(attrs, visibleTopControls, key, data);
+            var visibleTopControls = data != null
+                ? def.Controls.Where(c => c.IsControlVisible(data)).ToList()
+                : def.Controls.ToList();
+            if (data != null) AddDropdownTypeValues(attrs, visibleTopControls, key, data);
             topControls.AddRange(visibleTopControls.Select(ToControlInfo));
+        }
+        else if (data == null)
+        {
+            return null;
         }
 
         return JsonSerializer.Serialize(
@@ -940,6 +955,21 @@ public partial class WasmEditorBridge
         _controller?.DeleteElement(key, true);
     }
 
+    [JSExport]
+    public static string SwapElements(string key1, string key2)
+    {
+        if (_controller == null) return "error";
+        // Capture positions before SwapElements fires tree events (Remove+AddToEnd) that would scramble the list.
+        var i1 = TreeNodes.FindIndex(n => n.Key == key1);
+        var i2 = TreeNodes.FindIndex(n => n.Key == key2);
+        _suppressTreeEvents = true;
+        try { _controller.SwapElements(key1, key2); }
+        finally { _suppressTreeEvents = false; }
+        if (i1 >= 0 && i2 >= 0)
+            (TreeNodes[i1], TreeNodes[i2]) = (TreeNodes[i2], TreeNodes[i1]);
+        return "ok";
+    }
+
     // ── Attributes editor API ──────────────────────────────────────────────────
 
     [JSExport]
@@ -1468,6 +1498,7 @@ public partial class WasmEditorBridge
 
     private static void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e)
     {
+        if (_suppressTreeEvents) return;
         var node = new TreeNodeData(e.Key, e.Text, e.Parent, e.NodeIcon, GetNodeType(e.Key, e.NodeIcon));
         if (_isRebuilding)
         {
@@ -1557,6 +1588,13 @@ public partial class WasmEditorBridge
 
             var caption = ctrl.Caption ?? ctrl.GetString("selfcaption");
             return new ControlInfo(ctrl.Id, ctrl.ControlType, caption, options, subEditors, ctrl.Attribute, multiTpCommands);
+        }
+        else if (ctrl.ControlType == "elementslist")
+        {
+            return new ControlInfo(null, "elementslist", null, null, null, null, null, null,
+                ctrl.GetString("elementtype"),
+                ctrl.GetString("objecttype"),
+                ctrl.GetString("listfilter"));
         }
 
         List<TextProcessorCommand>? textProcessorCommands = null;

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -950,6 +950,60 @@ public partial class WasmEditorBridge
     }
 
     [JSExport]
+    public static string CreateWalkthrough(string name, string? parent)
+    {
+        if (_controller == null) return "error:Not initialised";
+        var validation = _controller.CanAdd(name);
+        if (!validation.Valid) return $"error:{EditorController.GetValidationError(validation, name)}";
+        try { _controller.CreateNewWalkthrough(name, string.IsNullOrEmpty(parent) ? null : parent); return name; }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateTemplate(string name)
+    {
+        if (_controller == null) return "error:Not initialised";
+        try { return _controller.CreateNewTemplate(name); }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateDynamicTemplate(string name)
+    {
+        if (_controller == null) return "error:Not initialised";
+        var validation = _controller.CanAdd(name);
+        if (!validation.Valid) return $"error:{EditorController.GetValidationError(validation, name)}";
+        try { _controller.CreateNewDynamicTemplate(name); return name; }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateObjectType(string name)
+    {
+        if (_controller == null) return "error:Not initialised";
+        var validation = _controller.CanAdd(name);
+        if (!validation.Valid) return $"error:{EditorController.GetValidationError(validation, name)}";
+        try { _controller.CreateNewType(name); return name; }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateIncludedLibrary()
+    {
+        if (_controller == null) return "error:Not initialised";
+        try { return _controller.CreateNewIncludedLibrary(); }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
+    public static string CreateJavascript()
+    {
+        if (_controller == null) return "error:Not initialised";
+        try { return _controller.CreateNewJavascript(); }
+        catch (Exception ex) { return $"error:{ex.Message}"; }
+    }
+
+    [JSExport]
     public static void DeleteElement(string key)
     {
         _controller?.DeleteElement(key, true);

--- a/src/WebEditor/src/components/AddElementModal.svelte
+++ b/src/WebEditor/src/components/AddElementModal.svelte
@@ -2,7 +2,7 @@
     import { validateName } from "$lib/editor-store";
 
     interface Props {
-        elementType: "room" | "object" | "function" | "timer";
+        elementType: "room" | "object" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type";
         parent?: string | null;
         onconfirm: (name: string) => void;
         oncancel: () => void;
@@ -15,6 +15,10 @@
         object: "Object",
         function: "Function",
         timer: "Timer",
+        walkthrough: "Walkthrough",
+        template: "Template",
+        dynamictemplate: "Dynamic Template",
+        type: "Type",
     };
 
     let dialogEl: HTMLDivElement;

--- a/src/WebEditor/src/components/AddElementModal.svelte
+++ b/src/WebEditor/src/components/AddElementModal.svelte
@@ -18,6 +18,9 @@
     };
 
     let dialogEl: HTMLDivElement;
+    let inputEl: HTMLInputElement;
+
+    $effect(() => { inputEl?.focus(); });
 
     let name = $state("");
     let error = $state("");
@@ -60,13 +63,12 @@
 
         <div class="flex flex-col gap-1">
             <label for="element-name" class="text-xs text-surface-500-400">Name</label>
-            <!-- svelte-ignore a11y_autofocus -->
             <input
                 id="element-name"
                 type="text"
                 class={"input bg-white px-2 py-1 text-sm" + (error ? " !border-error-500" : "")}
+                bind:this={inputEl}
                 bind:value={name}
-                autofocus
                 placeholder="Enter a name..."
             />
             {#if error}

--- a/src/WebEditor/src/components/ElementsList.svelte
+++ b/src/WebEditor/src/components/ElementsList.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, swapElements } from "$lib/editor-store";
+
+    interface Props {
+        elementKey: string;
+        elementType: string;
+        objectType?: string | null;
+        listFilter?: string | null;
+    }
+
+    let { elementKey, elementType, objectType, listFilter }: Props = $props();
+
+    function resolveNodeTypes(et: string, ot?: string | null, lf?: string | null): string[] {
+        if (et === "object") {
+            if (ot === "command") {
+                if (lf === "verb") return ["verb"];
+                return ["command"];
+            }
+            return ["room", "object"];
+        }
+        return [et];
+    }
+
+    let nodeTypes = $derived(resolveNodeTypes(elementType, objectType, listFilter));
+    let isHeaderNode = $derived(elementKey.startsWith("_"));
+    let showAll = $derived(isHeaderNode && (nodeTypes.includes("room") || nodeTypes.includes("object")));
+
+    let items = $derived(
+        $treeNodes.filter(n =>
+            nodeTypes.includes(n.nodeType) &&
+            (showAll || n.parent === elementKey)
+        )
+    );
+
+    // ── Selection ──────────────────────────────────────────────────────────────
+
+    let selectedKeys = $state(new Set<string>());
+
+    // Derive selection in item-list order, excluding any stale keys (deleted items)
+    let activeSelection = $derived(
+        items.filter(item => selectedKeys.has(item.key)).map(item => item.key)
+    );
+
+    function toggleSelect(key: string, checked: boolean) {
+        const next = new Set(selectedKeys);
+        if (checked) next.add(key); else next.delete(key);
+        selectedKeys = next;
+    }
+
+    // ── Add actions ────────────────────────────────────────────────────────────
+
+    let isObjectList = $derived(nodeTypes.includes("room") || nodeTypes.includes("object"));
+    let showRoomButton = $derived(!isHeaderNode && isObjectList);
+
+    let addLabel = $derived(
+        nodeTypes.includes("function") ? "Add Function" :
+        nodeTypes.includes("timer") ? "Add Timer" :
+        nodeTypes.includes("verb") ? "Add Verb" :
+        nodeTypes.includes("command") ? "Add Command" :
+        isHeaderNode ? "Add Room" :
+        "Add Object"
+    );
+
+    function addPrimary() {
+        const parent = isHeaderNode ? null : elementKey;
+        if (nodeTypes.includes("function")) openAddModal("function", null);
+        else if (nodeTypes.includes("timer")) openAddModal("timer", null);
+        else if (nodeTypes.includes("verb")) createVerb(parent);
+        else if (nodeTypes.includes("command")) createCommand(parent);
+        else openAddModal(isHeaderNode ? "room" : "object", parent);
+    }
+
+    function addRoom() {
+        openAddModal("room", isHeaderNode ? null : elementKey);
+    }
+
+    // ── Move / delete ──────────────────────────────────────────────────────────
+
+    function moveUp(index: number) {
+        if (index <= 0) return;
+        swapElements(items[index].key, items[index - 1].key);
+    }
+
+    function moveDown(index: number) {
+        if (index >= items.length - 1) return;
+        swapElements(items[index].key, items[index + 1].key);
+    }
+
+    function onMoveUpSelected() {
+        const key = activeSelection[0];
+        const idx = items.findIndex(i => i.key === key);
+        if (idx > 0) swapElements(items[idx].key, items[idx - 1].key);
+    }
+
+    function onMoveDownSelected() {
+        const key = activeSelection[0];
+        const idx = items.findIndex(i => i.key === key);
+        if (idx >= 0 && idx < items.length - 1) swapElements(items[idx].key, items[idx + 1].key);
+    }
+
+    function onDeleteSelected() {
+        for (const key of activeSelection) {
+            if ($selectedKey === key) selectNode(elementKey);
+            deleteElement(key);
+        }
+        selectedKeys = new Set();
+    }
+
+    function onDeleteItem(key: string) {
+        if ($selectedKey === key) selectNode(elementKey);
+        deleteElement(key);
+        const next = new Set(selectedKeys);
+        next.delete(key);
+        selectedKeys = next;
+    }
+</script>
+
+<div class="flex flex-col w-full px-3 py-2">
+    <!-- Add toolbar -->
+    <div class="flex items-center gap-1 mb-2">
+        <button
+            type="button"
+            class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+            onclick={addPrimary}
+        >+ {addLabel}</button>
+        {#if showRoomButton}
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                onclick={addRoom}
+            >+ Add Room</button>
+        {/if}
+    </div>
+
+    <!-- Item rows -->
+    {#if items.length === 0}
+        <p class="text-xs text-surface-400-500 italic">No items.</p>
+    {:else}
+        {#each items as item, i (item.key)}
+            <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-center">
+                <label class="flex items-center pt-1 pb-1 pl-1.5 pr-0.5 cursor-pointer flex-shrink-0">
+                    <input
+                        type="checkbox"
+                        class="checkbox size-3.5"
+                        checked={selectedKeys.has(item.key)}
+                        onchange={(e) => toggleSelect(item.key, (e.target as HTMLInputElement).checked)}
+                    />
+                </label>
+                <!-- pr-20 keeps name clear of the hover buttons (≈3×24px) -->
+                <button
+                    type="button"
+                    class="flex-1 text-left text-xs px-1.5 py-1 pr-20 text-primary-600-400 hover:underline truncate"
+                    onclick={() => selectNode(item.key)}
+                >{item.text}</button>
+                <!-- pointer-events-none when invisible so clicks reach the name button -->
+                <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                        title="Move up"
+                        disabled={i === 0}
+                        onclick={() => moveUp(i)}
+                    >↑</button>
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                        title="Move down"
+                        disabled={i === items.length - 1}
+                        onclick={() => moveDown(i)}
+                    >↓</button>
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
+                        title="Delete"
+                        onclick={() => onDeleteItem(item.key)}
+                    >×</button>
+                </div>
+            </div>
+        {/each}
+    {/if}
+
+    <!-- Selection toolbar -->
+    {#if activeSelection.length > 0}
+        {@const sel = activeSelection}
+        <div class="flex items-center gap-1 mt-1 px-1 py-1 bg-surface-100-900 rounded border border-surface-200-800 text-xs">
+            <button
+                type="button"
+                class="btn btn-sm preset-tonal-error text-xs py-0.5"
+                onclick={onDeleteSelected}
+            >Delete</button>
+            {#if sel.length === 1}
+                {@const idx = items.findIndex(i => i.key === sel[0])}
+                <span class="w-px h-4 bg-surface-300-700 mx-0.5"></span>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                    disabled={idx === 0}
+                    onclick={onMoveUpSelected}
+                >↑ Move up</button>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                    disabled={idx === items.length - 1}
+                    onclick={onMoveDownSelected}
+                >↓ Move down</button>
+            {/if}
+            <span class="ml-auto text-surface-400-500">{sel.length} selected</span>
+        </div>
+    {/if}
+</div>

--- a/src/WebEditor/src/components/ElementsList.svelte
+++ b/src/WebEditor/src/components/ElementsList.svelte
@@ -50,15 +50,15 @@
     // ── Add actions ────────────────────────────────────────────────────────────
 
     let isObjectList = $derived(nodeTypes.includes("room") || nodeTypes.includes("object"));
-    let showRoomButton = $derived(!isHeaderNode && isObjectList);
+    let showRoomButton = $derived(isObjectList);
 
     let addLabel = $derived(
         nodeTypes.includes("function") ? "Add Function" :
         nodeTypes.includes("timer") ? "Add Timer" :
         nodeTypes.includes("verb") ? "Add Verb" :
         nodeTypes.includes("command") ? "Add Command" :
-        isHeaderNode ? "Add Room" :
-        "Add Object"
+        isObjectList ? "Add Object" :
+        null
     );
 
     function addPrimary() {
@@ -67,7 +67,7 @@
         else if (nodeTypes.includes("timer")) openAddModal("timer", null);
         else if (nodeTypes.includes("verb")) createVerb(parent);
         else if (nodeTypes.includes("command")) createCommand(parent);
-        else openAddModal(isHeaderNode ? "room" : "object", parent);
+        else if (isObjectList) openAddModal("object", parent);
     }
 
     function addRoom() {
@@ -118,11 +118,13 @@
 <div class="flex flex-col w-full px-3 py-2">
     <!-- Add toolbar -->
     <div class="flex items-center gap-1 mb-2">
+        {#if addLabel !== null}
         <button
             type="button"
             class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
             onclick={addPrimary}
         >+ {addLabel}</button>
+        {/if}
         {#if showRoomButton}
             <button
                 type="button"

--- a/src/WebEditor/src/components/ElementsList.svelte
+++ b/src/WebEditor/src/components/ElementsList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, swapElements } from "$lib/editor-store";
+    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createIncludedLibrary, createJavascript, swapElements } from "$lib/editor-store";
 
     interface Props {
         elementKey: string;
@@ -57,6 +57,12 @@
         nodeTypes.includes("timer") ? "Add Timer" :
         nodeTypes.includes("verb") ? "Add Verb" :
         nodeTypes.includes("command") ? "Add Command" :
+        nodeTypes.includes("walkthrough") ? "Add Walkthrough" :
+        nodeTypes.includes("template") ? "Add Template" :
+        nodeTypes.includes("dynamictemplate") ? "Add Dynamic Template" :
+        nodeTypes.includes("type") ? "Add Type" :
+        nodeTypes.includes("include") ? "Add Library" :
+        nodeTypes.includes("javascript") ? "Add JavaScript" :
         isObjectList ? "Add Object" :
         null
     );
@@ -67,6 +73,12 @@
         else if (nodeTypes.includes("timer")) openAddModal("timer", null);
         else if (nodeTypes.includes("verb")) createVerb(parent);
         else if (nodeTypes.includes("command")) createCommand(parent);
+        else if (nodeTypes.includes("walkthrough")) openAddModal("walkthrough", null);
+        else if (nodeTypes.includes("template")) openAddModal("template", null);
+        else if (nodeTypes.includes("dynamictemplate")) openAddModal("dynamictemplate", null);
+        else if (nodeTypes.includes("type")) openAddModal("type", null);
+        else if (nodeTypes.includes("include")) createIncludedLibrary();
+        else if (nodeTypes.includes("javascript")) createJavascript();
         else if (isObjectList) openAddModal("object", parent);
     }
 

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -5,6 +5,7 @@
     import Combobox from "./Combobox.svelte";
     import AttributesEditor from "./AttributesEditor.svelte";
     import ListEditor from "./ListEditor.svelte";
+    import ElementsList from "./ElementsList.svelte";
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
@@ -370,6 +371,13 @@
         <div class="px-3 py-1 text-xs text-surface-500-400 italic">
             {ctrl.caption ?? ""}
         </div>
+    {:else if ctrl.controlType === "elementslist" && $selectedKey}
+        <ElementsList
+            elementKey={$selectedKey}
+            elementType={ctrl.elementType ?? "object"}
+            objectType={ctrl.objectType}
+            listFilter={ctrl.listFilter}
+        />
     {:else if ctrl.attribute !== null}
         {#if ctrl.controlType === "checkbox"}
             <label class="flex items-center gap-2 px-3 py-1.5 min-h-8 cursor-pointer">

--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -5,6 +5,7 @@
         gameFilename, saveGame, undo, redo, canUndo, canRedo,
         treeNodes, selectedKey, openAddModal,
         createExit, createTurnScript, createCommand, createVerb,
+        createIncludedLibrary, createJavascript,
         deleteElement,
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
@@ -37,6 +38,12 @@
         { label: "Add Room", action: () => openAddModal("room", null) },
         { label: "Add Function", action: () => openAddModal("function", null) },
         { label: "Add Timer", action: () => openAddModal("timer", null) },
+        { label: "Add Walkthrough", action: () => openAddModal("walkthrough", null) },
+        { label: "Add Template", action: () => openAddModal("template", null) },
+        { label: "Add Dynamic Template", action: () => openAddModal("dynamictemplate", null) },
+        { label: "Add Type", action: () => openAddModal("type", null) },
+        { label: "Add Library", action: () => createIncludedLibrary() },
+        { label: "Add JavaScript", action: () => createJavascript() },
         // Context-sensitive: when a room or object is selected
         ...(nt === "room" || nt === "object" ? [
             { label: `Add Object in "${selectedNode!.text}"`, action: () => openAddModal("object", selectedNode!.key) },

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -4,6 +4,7 @@
     import {
         treeNodes, selectedKey, selectNode,
         openAddModal, createExit, createTurnScript, createCommand, createVerb,
+        createIncludedLibrary, createJavascript,
         deleteElement,
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
@@ -150,6 +151,12 @@
             else if (id === "_timers") opts.push({ label: "Add Timer", action: () => openAddModal("timer", null) });
             else if (id === "_gameVerbs") opts.push({ label: "Add Verb", action: () => createVerb(null) });
             else if (id === "_gameCommands") opts.push({ label: "Add Command", action: () => createCommand(null) });
+            else if (id === "_walkthrough") opts.push({ label: "Add Walkthrough", action: () => openAddModal("walkthrough", null) });
+            else if (id === "_template") opts.push({ label: "Add Template", action: () => openAddModal("template", null) });
+            else if (id === "_dynamictemplate") opts.push({ label: "Add Dynamic Template", action: () => openAddModal("dynamictemplate", null) });
+            else if (id === "_objecttype") opts.push({ label: "Add Type", action: () => openAddModal("type", null) });
+            else if (id === "_include") opts.push({ label: "Add Library", action: () => createIncludedLibrary() });
+            else if (id === "_javascript") opts.push({ label: "Add JavaScript", action: () => createJavascript() });
         } else if (nt === "room") {
             opts.push(
                 { label: "Add Object here", action: () => openAddModal("object", id) },

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -494,3 +494,10 @@ export function deleteElement(key: string) {
     refreshTree();
     refreshUndoRedo();
 }
+
+export function swapElements(key1: string, key2: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SwapElements(key1, key2);
+    if (result === "ok") refreshTree();
+    return result;
+}

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -3,7 +3,7 @@ import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
 import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData } from "./types";
 
-export type AddElementModalState = { type: "room" | "object" | "function" | "timer"; parent: string | null } | null;
+export type AddElementModalState = { type: "room" | "object" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
 
 let _bridge: WasmBridge | null = null;
 
@@ -11,7 +11,7 @@ export const isLoaded = writable(false);
 export const loadingStatus = writable<string | null>(null);
 export const addElementModal = writable<AddElementModalState>(null);
 
-export function openAddModal(type: "room" | "object" | "function" | "timer", parent: string | null) {
+export function openAddModal(type: "room" | "object" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type", parent: string | null) {
     addElementModal.set({ type, parent });
 }
 export const gameFilename = writable<string | null>(null);
@@ -484,6 +484,36 @@ export function createCommand(parent: string | null): string {
 export function createVerb(parent: string | null): string {
     if (!_bridge) return "error:not loaded";
     return afterCreate(_bridge.CreateVerb(parent ?? ""));
+}
+
+export function createWalkthrough(name: string): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateWalkthrough(name, ""));
+}
+
+export function createTemplate(name: string): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateTemplate(name));
+}
+
+export function createDynamicTemplate(name: string): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateDynamicTemplate(name));
+}
+
+export function createObjectType(name: string): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateObjectType(name));
+}
+
+export function createIncludedLibrary(): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateIncludedLibrary());
+}
+
+export function createJavascript(): string {
+    if (!_bridge) return "error:not loaded";
+    return afterCreate(_bridge.CreateJavascript());
 }
 
 export function deleteElement(key: string) {

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -27,6 +27,9 @@ export interface ControlInfo {
   subAttribute: string | null
   textProcessorCommands: TextProcessorCommand[] | null
   addPrompt: string | null
+  elementType?: string | null
+  objectType?: string | null
+  listFilter?: string | null
 }
 
 export interface TabInfo {

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -65,6 +65,7 @@ export interface WasmBridge {
   CreateCommand(parent: string): string
   CreateVerb(parent: string): string
   DeleteElement(key: string): void
+  SwapElements(key1: string, key2: string): string
 }
 
 let _bridge: WasmBridge | null = null;

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -64,6 +64,12 @@ export interface WasmBridge {
   CreateTurnScript(parent: string): string
   CreateCommand(parent: string): string
   CreateVerb(parent: string): string
+  CreateWalkthrough(name: string, parent: string): string
+  CreateTemplate(name: string): string
+  CreateDynamicTemplate(name: string): string
+  CreateObjectType(name: string): string
+  CreateIncludedLibrary(): string
+  CreateJavascript(): string
   DeleteElement(key: string): void
   SwapElements(key1: string, key2: string): string
 }

--- a/src/WebEditor/src/routes/+page.svelte
+++ b/src/WebEditor/src/routes/+page.svelte
@@ -4,7 +4,7 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { get } from "svelte/store";
-    import { isLoaded, addElementModal, createRoom, createObject, createFunction, createTimer } from "$lib/editor-store";
+    import { isLoaded, addElementModal, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType } from "$lib/editor-store";
     import Toolbar from "$components/Toolbar.svelte";
     import TreePanel from "$components/TreePanel.svelte";
     import PropertyEditor from "$components/PropertyEditor.svelte";
@@ -25,6 +25,10 @@
         else if (mode.type === "object") createObject(name, mode.parent);
         else if (mode.type === "function") createFunction(name);
         else if (mode.type === "timer") createTimer(name);
+        else if (mode.type === "walkthrough") createWalkthrough(name);
+        else if (mode.type === "template") createTemplate(name);
+        else if (mode.type === "dynamictemplate") createDynamicTemplate(name);
+        else if (mode.type === "type") createObjectType(name);
     }
 </script>
 


### PR DESCRIPTION
## Summary

- Adds a new `ElementsList` Svelte component that renders lists of elements (Objects, Verbs, Commands, Functions, Timers, Walkthroughs, Templates, Dynamic Templates, Types, Libraries, Javascript) within the property editor tabs
- Adds WASM bridge methods for creating Walkthroughs, Templates, Dynamic Templates, Object Types, Included Libraries, and Javascript elements, plus a `SwapElements` method for reordering
- Wires new element types into the tree panel context menu and toolbar "Add" button
- Fixes the `Add` button labels in `ElementsList`
- Focuses the name input when the "Add element" modal opens
- Handles synthetic header tree nodes (e.g. `_objects`, `_functions`) that have no corresponding world model element — `GetEditorData` now returns `null` for these, and the bridge handles that gracefully
- Suppresses tree events during `SwapElements` to avoid scrambling the local node list

## Test plan

- [ ] Open a game in the WebEditor and navigate to the Objects/Verbs/Commands/Functions/Timers tabs — element lists should display correctly
- [ ] Add elements via the toolbar "Add" button for each element type
- [ ] Reorder elements using swap — order should be reflected in the tree
- [ ] Delete elements from the list
- [ ] Verify the "Add element" modal focuses the name input on open

🤖 Generated with [Claude Code](https://claude.ai/claude-code)