### PR TITLE
WebEditor: Create New Game

### DIFF
--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -2275,8 +2275,9 @@ public sealed class EditorController : IDisposable
 
     private static void AddTemplateData(Dictionary<string, TemplateData> templates, string resourceName)
     {
-        // TODO: Tidy up default template name
-        var templateName = resourceName;
+        // Default to the stem of the resource name (e.g. "Dansk" from "QuestViva.Engine.Core.Templates.Dansk.template")
+        var stem = resourceName[(resourceName.LastIndexOf('.', resourceName.Length - ".template".Length - 1) + 1)..^".template".Length];
+        var templateName = stem;
         var templateEditorStyle = EditorStyle.TextAdventure;
 
         var stream = WorldModel.GetEmbeddedResourceStream(resourceName);

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -101,6 +101,8 @@ internal record AttributeDataItem(
 
 internal record FullAttributeData(List<AttributeDataItem> Attributes, List<AttributeDataItem> InheritedTypes);
 
+internal record GameTemplateInfo(string Id, string Label, string Type);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
 [JsonSerializable(typeof(EditorDataResponse))]
@@ -112,6 +114,7 @@ internal record FullAttributeData(List<AttributeDataItem> Attributes, List<Attri
 [JsonSerializable(typeof(int[]))]
 [JsonSerializable(typeof(List<ListItemData>))]
 [JsonSerializable(typeof(FullAttributeData))]
+[JsonSerializable(typeof(List<GameTemplateInfo>))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext
 {
 }
@@ -2688,5 +2691,26 @@ public partial class WasmEditorBridge
 
         return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
             null, null, textProcessorCommands, addPrompt);
+    }
+
+    [JSExport]
+    public static string GetGameTemplates()
+    {
+        var templates = EditorController.GetAvailableTemplates()
+            .Values
+            .OrderBy(t => t.Type)
+            .ThenBy(t => t.TemplateName)
+            .Select(t => new GameTemplateInfo(
+                t.ResourceName,
+                t.TemplateName,
+                t.Type == EditorStyle.GameBook ? "gamebook" : "textadventure"))
+            .ToList();
+        return JsonSerializer.Serialize(templates, WasmEditorJsonContext.Default.ListGameTemplateInfo);
+    }
+
+    [JSExport]
+    public static string CreateGameFromTemplate(string templateId, string gameName)
+    {
+        return EditorController.CreateNewGameFile(templateId, gameName);
     }
 }

--- a/src/WebEditor/src/lib/filesystem/browser-adapter.ts
+++ b/src/WebEditor/src/lib/filesystem/browser-adapter.ts
@@ -18,7 +18,7 @@ const ASLX_FILE_TYPE = {
     accept: { "application/xml": [".aslx"] as `.${string}`[] },
 };
 
-// ── Loaders ──────────────────────────────────────────────────────────────────
+// ── Loaders / creators ───────────────────────────────────────────────────────
 
 export function hasFSA(): boolean {
     return "showDirectoryPicker" in window;
@@ -75,6 +75,38 @@ export function loadLocalFile(): Promise<LoadedFile | null> {
         input.addEventListener("cancel", () => resolve(null), { once: true });
         input.click();
     });
+}
+
+/**
+ * Creates a new game file with the given content.
+ *
+ * FSA path: opens a directory picker, writes the file, and returns a LoadedFile
+ * so the editor can open it immediately. Returns null if the user cancels the picker.
+ *
+ * Non-FSA path: triggers a download and returns "downloaded" so the caller can
+ * show a message telling the user to open the file with the Open button.
+ */
+export async function createLocalGame(
+    filename: string,
+    content: string,
+): Promise<{ kind: "opened"; loaded: LoadedFile } | { kind: "downloaded" } | null> {
+    if (hasFSA()) {
+        try {
+            const dir = await showDirectoryPicker({ mode: "readwrite" });
+            const fh = await dir.getFileHandle(filename, { create: true });
+            await writeToHandle(fh, content);
+            const bytes = new TextEncoder().encode(content);
+            return {
+                kind: "opened",
+                loaded: { bytes, adapter: new BrowserFileAdapter(filename, { kind: "directory", dir }) },
+            };
+        } catch (err: unknown) {
+            if (err instanceof Error && err.name === "AbortError") return null;
+            throw err;
+        }
+    }
+    triggerDownload(content, filename);
+    return { kind: "downloaded" };
 }
 
 // ── Adapter ───────────────────────────────────────────────────────────────────

--- a/src/WebEditor/src/lib/filesystem/server-adapter.ts
+++ b/src/WebEditor/src/lib/filesystem/server-adapter.ts
@@ -1,92 +1,20 @@
 import type { AssetInfo, FileAdapter, LoadedFile } from "./types";
+import { loadWasm } from "$lib/wasm";
 
-export interface LanguageOption {
+export interface GameTemplate {
     id: string;
     label: string;
+    type: "textadventure" | "gamebook";
 }
 
-export const LANGUAGES: LanguageOption[] = [
-    { id: "English", label: "English" },
-    { id: "Dansk", label: "Dansk (Danish)" },
-    { id: "Deutsch", label: "Deutsch (German)" },
-    { id: "Espanol", label: "Español (Spanish)" },
-    { id: "Esperanto", label: "Esperanto" },
-    { id: "Francais", label: "Français (French)" },
-    { id: "Greek", label: "Greek" },
-    { id: "Icelandic", label: "Icelandic" },
-    { id: "Italiano", label: "Italiano (Italian)" },
-    { id: "Nederlands", label: "Nederlands (Dutch)" },
-    { id: "Norsk", label: "Norsk (Norwegian)" },
-    { id: "Portugues", label: "Português (Portuguese)" },
-    { id: "Portugues-Portugal", label: "Português - Portugal" },
-    { id: "Romana", label: "Română (Romanian)" },
-    { id: "Russian", label: "Russian" },
-];
-
-function escapeXml(s: string): string {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+export async function getGameTemplates(): Promise<GameTemplate[]> {
+    const bridge = await loadWasm();
+    return JSON.parse(bridge.GetGameTemplates()) as GameTemplate[];
 }
 
-function generateGameTemplate(name: string, type: "textadventure" | "gamebook", language: string): string {
-    const escapedName = escapeXml(name);
-    const id = crypto.randomUUID();
-    const year = new Date().getFullYear();
-
-    if (type === "gamebook") {
-        return `<asl version="580" templatetype="gamebook">
-
-  <include ref="GamebookCore.aslx"/>
-
-  <game name="${escapedName}">
-    <gameid>${id}</gameid>
-    <version>1.0</version>
-    <firstpublished>${year}</firstpublished>
-  </game>
-
-  <object name="Page1">
-    <object name="player">
-      <inherit name="defaultplayer"/>
-    </object>
-    <description>This is page 1. Type a description here, and then create links to other pages below.</description>
-    <options type="simplestringdictionary">Page2 = This link goes to page 2;Page3 = And this link goes to page 3</options>
-  </object>
-
-  <object name="Page2">
-    <description>This is page 2. Type a description here, and then create links to other pages below.</description>
-  </object>
-
-  <object name="Page3">
-    <description>This is page 3. Type a description here, and then create links to other pages below.</description>
-  </object>
-
-</asl>`;
-    }
-
-    return `<asl version="580">
-
-  <include ref="${language}.aslx"/>
-  <include ref="Core.aslx"/>
-
-  <game name="${escapedName}">
-    <gameid>${id}</gameid>
-    <version>1.0</version>
-    <firstpublished>${year}</firstpublished>
-  </game>
-
-  <object name="room">
-    <inherit name="editor_room" />
-
-    <object name="player">
-      <inherit name="editor_object" />
-      <inherit name="editor_player" />
-    </object>
-  </object>
-
-</asl>`;
-}
-
-export async function createNewGame(name: string, type: "textadventure" | "gamebook", language: string): Promise<string> {
-    const content = generateGameTemplate(name, type, language);
+export async function createNewGame(name: string, templateId: string): Promise<string> {
+    const bridge = await loadWasm();
+    const content = bridge.CreateGameFromTemplate(templateId, name);
     const filename = name.replace(/[^a-zA-Z0-9 _-]/g, "").trim() || "game";
     const file = new File([content], `${filename}.aslx`, { type: "application/xml" });
     const form = new FormData();

--- a/src/WebEditor/src/lib/filesystem/server-adapter.ts
+++ b/src/WebEditor/src/lib/filesystem/server-adapter.ts
@@ -1,5 +1,103 @@
 import type { AssetInfo, FileAdapter, LoadedFile } from "./types";
 
+export interface LanguageOption {
+    id: string;
+    label: string;
+}
+
+export const LANGUAGES: LanguageOption[] = [
+    { id: "English", label: "English" },
+    { id: "Dansk", label: "Dansk (Danish)" },
+    { id: "Deutsch", label: "Deutsch (German)" },
+    { id: "Espanol", label: "Español (Spanish)" },
+    { id: "Esperanto", label: "Esperanto" },
+    { id: "Francais", label: "Français (French)" },
+    { id: "Greek", label: "Greek" },
+    { id: "Icelandic", label: "Icelandic" },
+    { id: "Italiano", label: "Italiano (Italian)" },
+    { id: "Nederlands", label: "Nederlands (Dutch)" },
+    { id: "Norsk", label: "Norsk (Norwegian)" },
+    { id: "Portugues", label: "Português (Portuguese)" },
+    { id: "Portugues-Portugal", label: "Português - Portugal" },
+    { id: "Romana", label: "Română (Romanian)" },
+    { id: "Russian", label: "Russian" },
+];
+
+function escapeXml(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function generateGameTemplate(name: string, type: "textadventure" | "gamebook", language: string): string {
+    const escapedName = escapeXml(name);
+    const id = crypto.randomUUID();
+    const year = new Date().getFullYear();
+
+    if (type === "gamebook") {
+        return `<asl version="580" templatetype="gamebook">
+
+  <include ref="GamebookCore.aslx"/>
+
+  <game name="${escapedName}">
+    <gameid>${id}</gameid>
+    <version>1.0</version>
+    <firstpublished>${year}</firstpublished>
+  </game>
+
+  <object name="Page1">
+    <object name="player">
+      <inherit name="defaultplayer"/>
+    </object>
+    <description>This is page 1. Type a description here, and then create links to other pages below.</description>
+    <options type="simplestringdictionary">Page2 = This link goes to page 2;Page3 = And this link goes to page 3</options>
+  </object>
+
+  <object name="Page2">
+    <description>This is page 2. Type a description here, and then create links to other pages below.</description>
+  </object>
+
+  <object name="Page3">
+    <description>This is page 3. Type a description here, and then create links to other pages below.</description>
+  </object>
+
+</asl>`;
+    }
+
+    return `<asl version="580">
+
+  <include ref="${language}.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <game name="${escapedName}">
+    <gameid>${id}</gameid>
+    <version>1.0</version>
+    <firstpublished>${year}</firstpublished>
+  </game>
+
+  <object name="room">
+    <inherit name="editor_room" />
+
+    <object name="player">
+      <inherit name="editor_object" />
+      <inherit name="editor_player" />
+    </object>
+  </object>
+
+</asl>`;
+}
+
+export async function createNewGame(name: string, type: "textadventure" | "gamebook", language: string): Promise<string> {
+    const content = generateGameTemplate(name, type, language);
+    const filename = name.replace(/[^a-zA-Z0-9 _-]/g, "").trim() || "game";
+    const file = new File([content], `${filename}.aslx`, { type: "application/xml" });
+    const form = new FormData();
+    form.append("name", name);
+    form.append("file", file);
+    const resp = await fetch("/api/editor/games", { method: "POST", body: form });
+    if (!resp.ok) throw new Error(`Failed to create game: ${resp.status} ${resp.statusText}`);
+    const data = await resp.json() as { gameId: string };
+    return data.gameId;
+}
+
 export class ServerFileAdapter implements FileAdapter {
     constructor(
         private readonly _gameId: string,

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -73,6 +73,9 @@ export interface WasmBridge {
   CreateJavascript(): string
   DeleteElement(key: string): void
   SwapElements(key1: string, key2: string): string
+  // New game
+  GetGameTemplates(): string
+  CreateGameFromTemplate(templateId: string, gameName: string): string
 }
 
 let _bridge: WasmBridge | null = null;

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -3,7 +3,8 @@
     import { base } from "$app/paths";
     import { openGame, loadingStatus } from "$lib/editor-store";
     import { hasFSA, openDirectory, loadFileFromDirectory, loadLocalFile } from "$lib/filesystem/browser-adapter";
-    import { createNewGame, loadFromServer, LANGUAGES } from "$lib/filesystem/server-adapter";
+    import { createNewGame, getGameTemplates, loadFromServer } from "$lib/filesystem/server-adapter";
+    import type { GameTemplate } from "$lib/filesystem/server-adapter";
 
     let loading = $state(false);
     let error = $state<string | null>(null);
@@ -14,10 +15,33 @@
 
     // Create new game form
     let createName = $state("");
-    let createType = $state<"textadventure" | "gamebook">("textadventure");
-    let createLanguage = $state("English");
+    let templates = $state<GameTemplate[]>([]);
+    let selectedTemplateId = $state("");
     let creating = $state(false);
     let createError = $state<string | null>(null);
+
+    // Derived views into the template list
+    let textAdventureTemplates = $derived(templates.filter(t => t.type === "textadventure"));
+    let gamebookTemplates = $derived(templates.filter(t => t.type === "gamebook"));
+    let selectedTemplate = $derived(templates.find(t => t.id === selectedTemplateId) ?? null);
+
+    // Load templates lazily when the section is first needed — WASM must be loaded
+    let templatesLoading = $state(false);
+    let templatesError = $state<string | null>(null);
+
+    async function ensureTemplates() {
+        if (templates.length > 0 || templatesLoading) return;
+        templatesLoading = true;
+        try {
+            templates = await getGameTemplates();
+            // Default to English text adventure
+            const defaultTemplate = templates.find(t => t.label === "English") ?? templates[0];
+            if (defaultTemplate) selectedTemplateId = defaultTemplate.id;
+        } catch (err) {
+            templatesError = String(err);
+        }
+        templatesLoading = false;
+    }
 
     async function handleOpenFolder() {
         error = null;
@@ -80,9 +104,10 @@
         createError = null;
         const trimmed = createName.trim();
         if (!trimmed) { createError = "Please enter a game name."; return; }
+        if (!selectedTemplateId) { createError = "Please select a template."; return; }
         creating = true;
         try {
-            const gameId = await createNewGame(trimmed, createType, createLanguage);
+            const gameId = await createNewGame(trimmed, selectedTemplateId);
             const loaded = await loadFromServer(gameId);
             const ok = await openGame(loaded.bytes, loaded.adapter.filename, loaded.adapter);
             if (ok) { goto(base || "/"); return; }
@@ -143,54 +168,76 @@
 
             <p class="text-surface-500-400 text-sm font-medium self-start">Create new game</p>
 
-            <div class="flex flex-col gap-3 w-full">
-                <input
-                    type="text"
-                    class="input"
-                    placeholder="Game name"
-                    bind:value={createName}
-                    onkeydown={(e) => e.key === "Enter" && handleCreateGame()}
-                />
+            {#if templatesError}
+                <p class="text-error-500 text-sm">{templatesError}</p>
+            {:else}
+                <div class="flex flex-col gap-3 w-full">
+                    <input
+                        type="text"
+                        class="input"
+                        placeholder="Game name"
+                        bind:value={createName}
+                        onfocus={ensureTemplates}
+                        onkeydown={(e) => e.key === "Enter" && handleCreateGame()}
+                    />
 
-                <div class="flex gap-4">
-                    <label class="flex items-center gap-2 cursor-pointer">
-                        <input type="radio" class="radio" bind:group={createType} value="textadventure" />
-                        <span class="text-sm">Text adventure</span>
-                    </label>
-                    <label class="flex items-center gap-2 cursor-pointer">
-                        <input type="radio" class="radio" bind:group={createType} value="gamebook" />
-                        <span class="text-sm">Gamebook</span>
-                    </label>
+                    {#if templatesLoading}
+                        <div class="flex items-center gap-2 text-surface-500-400 text-sm">
+                            <div class="size-4 rounded-full border-2 border-surface-300-700 border-t-primary-500 animate-spin"></div>
+                            Loading templates...
+                        </div>
+                    {:else if templates.length > 0}
+                        <div class="flex flex-col gap-1">
+                            <p class="text-sm text-surface-500-400">Game type</p>
+                            <div class="flex gap-4">
+                                {#each [{ value: "textadventure", label: "Text adventure" }, { value: "gamebook", label: "Gamebook" }] as type (type.value)}
+                                    <label class="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            class="radio"
+                                            name="gametype"
+                                            checked={selectedTemplate?.type === type.value}
+                                            onchange={() => {
+                                                const list = type.value === "gamebook" ? gamebookTemplates : textAdventureTemplates;
+                                                selectedTemplateId = list[0]?.id ?? "";
+                                            }}
+                                        />
+                                        <span class="text-sm">{type.label}</span>
+                                    </label>
+                                {/each}
+                            </div>
+                        </div>
+
+                        {#if selectedTemplate?.type === "textadventure" && textAdventureTemplates.length > 1}
+                            <select class="select" bind:value={selectedTemplateId}>
+                                {#each textAdventureTemplates as t (t.id)}
+                                    <option value={t.id}>{t.label}</option>
+                                {/each}
+                            </select>
+                        {/if}
+                    {/if}
+
+                    {#if creating}
+                        <div class="flex items-center gap-3">
+                            <div class="size-5 rounded-full border-2 border-surface-300-700 border-t-primary-500 animate-spin"></div>
+                            <span class="text-surface-500-400 text-sm">{$loadingStatus || "Creating..."}</span>
+                        </div>
+                    {:else}
+                        <button
+                            type="button"
+                            class="btn preset-filled-primary-500 w-full"
+                            onclick={handleCreateGame}
+                            disabled={!createName.trim()}
+                        >
+                            Create game
+                        </button>
+                    {/if}
+
+                    {#if createError}
+                        <p class="text-error-500 text-sm">{createError}</p>
+                    {/if}
                 </div>
-
-                {#if createType === "textadventure"}
-                    <select class="select" bind:value={createLanguage}>
-                        {#each LANGUAGES as lang (lang.id)}
-                            <option value={lang.id}>{lang.label}</option>
-                        {/each}
-                    </select>
-                {/if}
-
-                {#if creating}
-                    <div class="flex items-center gap-3">
-                        <div class="size-5 rounded-full border-2 border-surface-300-700 border-t-primary-500 animate-spin"></div>
-                        <span class="text-surface-500-400 text-sm">{$loadingStatus || "Creating..."}</span>
-                    </div>
-                {:else}
-                    <button
-                        type="button"
-                        class="btn preset-filled-primary-500 w-full"
-                        onclick={handleCreateGame}
-                        disabled={!createName.trim()}
-                    >
-                        Create game
-                    </button>
-                {/if}
-
-                {#if createError}
-                    <p class="text-error-500 text-sm">{createError}</p>
-                {/if}
-            </div>
+            {/if}
         </div>
     {/if}
 </main>

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -3,7 +3,7 @@
     import { base } from "$app/paths";
     import { openGame, loadingStatus } from "$lib/editor-store";
     import { hasFSA, openDirectory, loadFileFromDirectory, loadLocalFile, createLocalGame } from "$lib/filesystem/browser-adapter";
-    import { createNewGame, getGameTemplates, loadFromServer } from "$lib/filesystem/server-adapter";
+    import { createNewGame, getGameTemplates } from "$lib/filesystem/server-adapter";
     import type { GameTemplate } from "$lib/filesystem/server-adapter";
     import { loadWasm } from "$lib/wasm";
 
@@ -142,14 +142,11 @@
         creatingServer = true;
         try {
             const gameId = await createNewGame(trimmed, selectedTemplateId);
-            const loaded = await loadFromServer(gameId);
-            const ok = await openGame(loaded.bytes, loaded.adapter.filename, loaded.adapter);
-            if (ok) { goto(`${base || ""}/?game=${gameId}`); return; }
-            createServerError = "Failed to load new game.";
+            goto(`${base || ""}/?game=${gameId}`);
         } catch (err) {
             createServerError = String(err);
+            creatingServer = false;
         }
-        creatingServer = false;
     }
 
     const creating = $derived(creatingLocal || creatingServer);

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -3,6 +3,7 @@
     import { base } from "$app/paths";
     import { openGame, loadingStatus } from "$lib/editor-store";
     import { hasFSA, openDirectory, loadFileFromDirectory, loadLocalFile } from "$lib/filesystem/browser-adapter";
+    import { createNewGame, loadFromServer, LANGUAGES } from "$lib/filesystem/server-adapter";
 
     let loading = $state(false);
     let error = $state<string | null>(null);
@@ -10,6 +11,13 @@
     // Set when a directory was opened but contained multiple .aslx files
     let pendingDir = $state<FileSystemDirectoryHandle | null>(null);
     let pendingFiles = $state<string[]>([]);
+
+    // Create new game form
+    let createName = $state("");
+    let createType = $state<"textadventure" | "gamebook">("textadventure");
+    let createLanguage = $state("English");
+    let creating = $state(false);
+    let createError = $state<string | null>(null);
 
     async function handleOpenFolder() {
         error = null;
@@ -67,6 +75,23 @@
         }
         loading = false;
     }
+
+    async function handleCreateGame() {
+        createError = null;
+        const trimmed = createName.trim();
+        if (!trimmed) { createError = "Please enter a game name."; return; }
+        creating = true;
+        try {
+            const gameId = await createNewGame(trimmed, createType, createLanguage);
+            const loaded = await loadFromServer(gameId);
+            const ok = await openGame(loaded.bytes, loaded.adapter.filename, loaded.adapter);
+            if (ok) { goto(base || "/"); return; }
+            createError = "Failed to load new game.";
+        } catch (err) {
+            createError = String(err);
+        }
+        creating = false;
+    }
 </script>
 
 <main class="flex flex-col items-center justify-center min-h-svh gap-6 p-8">
@@ -93,22 +118,79 @@
                 onclick={() => { pendingDir = null; pendingFiles = []; }}
             >Cancel</button>
         </div>
-    {:else if hasFSA()}
-        <p class="text-surface-500-400">Open a game folder to begin editing.</p>
-        <button type="button" class="btn preset-filled-primary-500" onclick={handleOpenFolder}>
-            Open game folder
-        </button>
     {:else}
-        <p class="text-surface-500-400">Open an <code>.aslx</code> game file to begin editing.</p>
-        <button type="button" class="btn preset-filled-primary-500" onclick={handleOpenFile}>
-            Open game file
-        </button>
-        <p class="text-sm text-surface-500-400 max-w-[40ch] text-center">
-            For full support including image assets, use Chrome or Edge.
-        </p>
-    {/if}
+        <div class="flex flex-col items-center gap-4 w-full max-w-sm">
+            <p class="text-surface-500-400 text-sm font-medium self-start">Open existing game</p>
 
-    {#if error}
-        <p class="text-error-500 max-w-[40ch] text-center">{error}</p>
+            {#if hasFSA()}
+                <button type="button" class="btn preset-filled-primary-500 w-full" onclick={handleOpenFolder}>
+                    Open game folder
+                </button>
+            {:else}
+                <button type="button" class="btn preset-filled-primary-500 w-full" onclick={handleOpenFile}>
+                    Open game file
+                </button>
+                <p class="text-sm text-surface-500-400 max-w-[40ch] text-center">
+                    For full support including image assets, use Chrome or Edge.
+                </p>
+            {/if}
+
+            {#if error}
+                <p class="text-error-500 text-sm">{error}</p>
+            {/if}
+
+            <hr class="w-full border-surface-300-700 my-2" />
+
+            <p class="text-surface-500-400 text-sm font-medium self-start">Create new game</p>
+
+            <div class="flex flex-col gap-3 w-full">
+                <input
+                    type="text"
+                    class="input"
+                    placeholder="Game name"
+                    bind:value={createName}
+                    onkeydown={(e) => e.key === "Enter" && handleCreateGame()}
+                />
+
+                <div class="flex gap-4">
+                    <label class="flex items-center gap-2 cursor-pointer">
+                        <input type="radio" class="radio" bind:group={createType} value="textadventure" />
+                        <span class="text-sm">Text adventure</span>
+                    </label>
+                    <label class="flex items-center gap-2 cursor-pointer">
+                        <input type="radio" class="radio" bind:group={createType} value="gamebook" />
+                        <span class="text-sm">Gamebook</span>
+                    </label>
+                </div>
+
+                {#if createType === "textadventure"}
+                    <select class="select" bind:value={createLanguage}>
+                        {#each LANGUAGES as lang (lang.id)}
+                            <option value={lang.id}>{lang.label}</option>
+                        {/each}
+                    </select>
+                {/if}
+
+                {#if creating}
+                    <div class="flex items-center gap-3">
+                        <div class="size-5 rounded-full border-2 border-surface-300-700 border-t-primary-500 animate-spin"></div>
+                        <span class="text-surface-500-400 text-sm">{$loadingStatus || "Creating..."}</span>
+                    </div>
+                {:else}
+                    <button
+                        type="button"
+                        class="btn preset-filled-primary-500 w-full"
+                        onclick={handleCreateGame}
+                        disabled={!createName.trim()}
+                    >
+                        Create game
+                    </button>
+                {/if}
+
+                {#if createError}
+                    <p class="text-error-500 text-sm">{createError}</p>
+                {/if}
+            </div>
+        </div>
     {/if}
 </main>

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -2,9 +2,10 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { openGame, loadingStatus } from "$lib/editor-store";
-    import { hasFSA, openDirectory, loadFileFromDirectory, loadLocalFile } from "$lib/filesystem/browser-adapter";
+    import { hasFSA, openDirectory, loadFileFromDirectory, loadLocalFile, createLocalGame } from "$lib/filesystem/browser-adapter";
     import { createNewGame, getGameTemplates, loadFromServer } from "$lib/filesystem/server-adapter";
     import type { GameTemplate } from "$lib/filesystem/server-adapter";
+    import { loadWasm } from "$lib/wasm";
 
     let loading = $state(false);
     let error = $state<string | null>(null);
@@ -13,34 +14,41 @@
     let pendingDir = $state<FileSystemDirectoryHandle | null>(null);
     let pendingFiles = $state<string[]>([]);
 
-    // Create new game form
+    // Create new game form (shared)
     let createName = $state("");
     let templates = $state<GameTemplate[]>([]);
     let selectedTemplateId = $state("");
-    let creating = $state(false);
-    let createError = $state<string | null>(null);
-
-    // Derived views into the template list
-    let textAdventureTemplates = $derived(templates.filter(t => t.type === "textadventure"));
-    let gamebookTemplates = $derived(templates.filter(t => t.type === "gamebook"));
-    let selectedTemplate = $derived(templates.find(t => t.id === selectedTemplateId) ?? null);
-
-    // Load templates lazily when the section is first needed — WASM must be loaded
     let templatesLoading = $state(false);
     let templatesError = $state<string | null>(null);
+
+    let selectedTemplate = $derived(templates.find(t => t.id === selectedTemplateId) ?? null);
+    let textAdventureTemplates = $derived(templates.filter(t => t.type === "textadventure"));
+    let gamebookTemplates = $derived(templates.filter(t => t.type === "gamebook"));
+
+    // Local creation state
+    let creatingLocal = $state(false);
+    let createLocalError = $state<string | null>(null);
+    let localDownloaded = $state(false);
+
+    // Server creation state
+    let creatingServer = $state(false);
+    let createServerError = $state<string | null>(null);
 
     async function ensureTemplates() {
         if (templates.length > 0 || templatesLoading) return;
         templatesLoading = true;
         try {
             templates = await getGameTemplates();
-            // Default to English text adventure
             const defaultTemplate = templates.find(t => t.label === "English") ?? templates[0];
             if (defaultTemplate) selectedTemplateId = defaultTemplate.id;
         } catch (err) {
             templatesError = String(err);
         }
         templatesLoading = false;
+    }
+
+    function safeFilename(name: string): string {
+        return (name.replace(/[^a-zA-Z0-9 _-]/g, "").trim() || "game") + ".aslx";
     }
 
     async function handleOpenFolder() {
@@ -100,23 +108,51 @@
         loading = false;
     }
 
-    async function handleCreateGame() {
-        createError = null;
+    async function handleCreateLocal() {
+        createLocalError = null;
+        localDownloaded = false;
         const trimmed = createName.trim();
-        if (!trimmed) { createError = "Please enter a game name."; return; }
-        if (!selectedTemplateId) { createError = "Please select a template."; return; }
-        creating = true;
+        if (!trimmed) { createLocalError = "Please enter a game name."; return; }
+        if (!selectedTemplateId) { createLocalError = "Please select a template."; return; }
+        creatingLocal = true;
+        try {
+            const bridge = await loadWasm();
+            const content = bridge.CreateGameFromTemplate(selectedTemplateId, trimmed);
+            const result = await createLocalGame(safeFilename(trimmed), content);
+            if (result === null) {
+                // user cancelled directory picker — do nothing
+            } else if (result.kind === "opened") {
+                const ok = await openGame(result.loaded.bytes, result.loaded.adapter.filename, result.loaded.adapter);
+                if (ok) { goto(base || "/"); return; }
+                createLocalError = "Failed to load new game.";
+            } else {
+                localDownloaded = true;
+            }
+        } catch (err) {
+            createLocalError = String(err);
+        }
+        creatingLocal = false;
+    }
+
+    async function handleCreateServer() {
+        createServerError = null;
+        const trimmed = createName.trim();
+        if (!trimmed) { createServerError = "Please enter a game name."; return; }
+        if (!selectedTemplateId) { createServerError = "Please select a template."; return; }
+        creatingServer = true;
         try {
             const gameId = await createNewGame(trimmed, selectedTemplateId);
             const loaded = await loadFromServer(gameId);
             const ok = await openGame(loaded.bytes, loaded.adapter.filename, loaded.adapter);
             if (ok) { goto(base || "/"); return; }
-            createError = "Failed to load new game.";
+            createServerError = "Failed to load new game.";
         } catch (err) {
-            createError = String(err);
+            createServerError = String(err);
         }
-        creating = false;
+        creatingServer = false;
     }
+
+    const creating = $derived(creatingLocal || creatingServer);
 </script>
 
 <main class="flex flex-col items-center justify-center min-h-svh gap-6 p-8">
@@ -145,6 +181,8 @@
         </div>
     {:else}
         <div class="flex flex-col items-center gap-4 w-full max-w-sm">
+
+            <!-- Open existing game -->
             <p class="text-surface-500-400 text-sm font-medium self-start">Open existing game</p>
 
             {#if hasFSA()}
@@ -166,6 +204,7 @@
 
             <hr class="w-full border-surface-300-700 my-2" />
 
+            <!-- Create new game -->
             <p class="text-surface-500-400 text-sm font-medium self-start">Create new game</p>
 
             {#if templatesError}
@@ -178,7 +217,8 @@
                         placeholder="Game name"
                         bind:value={createName}
                         onfocus={ensureTemplates}
-                        onkeydown={(e) => e.key === "Enter" && handleCreateGame()}
+                        onkeydown={(e) => { if (e.key === "Enter") handleCreateLocal(); }}
+                        disabled={creating}
                     />
 
                     {#if templatesLoading}
@@ -197,6 +237,7 @@
                                             class="radio"
                                             name="gametype"
                                             checked={selectedTemplate?.type === type.value}
+                                            disabled={creating}
                                             onchange={() => {
                                                 const list = type.value === "gamebook" ? gamebookTemplates : textAdventureTemplates;
                                                 selectedTemplateId = list[0]?.id ?? "";
@@ -209,7 +250,7 @@
                         </div>
 
                         {#if selectedTemplate?.type === "textadventure" && textAdventureTemplates.length > 1}
-                            <select class="select" bind:value={selectedTemplateId}>
+                            <select class="select" bind:value={selectedTemplateId} disabled={creating}>
                                 {#each textAdventureTemplates as t (t.id)}
                                     <option value={t.id}>{t.label}</option>
                                 {/each}
@@ -223,21 +264,43 @@
                             <span class="text-surface-500-400 text-sm">{$loadingStatus || "Creating..."}</span>
                         </div>
                     {:else}
-                        <button
-                            type="button"
-                            class="btn preset-filled-primary-500 w-full"
-                            onclick={handleCreateGame}
-                            disabled={!createName.trim()}
-                        >
-                            Create game
-                        </button>
+                        <div class="flex gap-2">
+                            <button
+                                type="button"
+                                class="btn preset-filled-primary-500 flex-1"
+                                onclick={handleCreateLocal}
+                                disabled={!createName.trim()}
+                                title={hasFSA() ? "Choose a folder to save your game in" : "Download the game file"}
+                            >
+                                {hasFSA() ? "Save to my computer" : "Download"}
+                            </button>
+                            <button
+                                type="button"
+                                class="btn preset-outlined-primary-500 flex-1"
+                                onclick={handleCreateServer}
+                                disabled={!createName.trim()}
+                                title="Save to textadventures.co.uk"
+                            >
+                                Save to server
+                            </button>
+                        </div>
                     {/if}
 
-                    {#if createError}
-                        <p class="text-error-500 text-sm">{createError}</p>
+                    {#if localDownloaded}
+                        <p class="text-sm text-surface-500-400">
+                            Game file downloaded. Use <strong>Open game file</strong> above to open it.
+                        </p>
+                    {/if}
+
+                    {#if createLocalError}
+                        <p class="text-error-500 text-sm">{createLocalError}</p>
+                    {/if}
+                    {#if createServerError}
+                        <p class="text-error-500 text-sm">{createServerError}</p>
                     {/if}
                 </div>
             {/if}
+
         </div>
     {/if}
 </main>

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -144,7 +144,7 @@
             const gameId = await createNewGame(trimmed, selectedTemplateId);
             const loaded = await loadFromServer(gameId);
             const ok = await openGame(loaded.bytes, loaded.adapter.filename, loaded.adapter);
-            if (ok) { goto(base || "/"); return; }
+            if (ok) { goto(`${base || ""}/?game=${gameId}`); return; }
             createServerError = "Failed to load new game.";
         } catch (err) {
             createServerError = String(err);

--- a/src/WebEditor/vite.config.ts
+++ b/src/WebEditor/vite.config.ts
@@ -19,6 +19,10 @@ const mimeTypes: Record<string, string> = {
   '.pdb': 'application/octet-stream',
 }
 
+// Set VITE_API_PROXY=http://localhost:5043 (or your local textadventures.co.uk URL) to proxy
+// /api requests during development. Not needed in production (same-origin).
+const apiProxy = process.env.VITE_API_PROXY
+
 export default defineConfig({
   plugins: [
     tailwindcss(),
@@ -48,6 +52,9 @@ export default defineConfig({
     headers: {
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'require-corp',
-    }
+    },
+    proxy: apiProxy ? {
+      '/api': { target: apiProxy, changeOrigin: true },
+    } : undefined,
   }
 })


### PR DESCRIPTION
## Summary

- Adds a **Create New Game** section to the `/open` page with two paths:
  - **Save to my computer** — uses the File System Access API to pick a folder, write the `.aslx` file, and open it immediately in the editor (FSA browsers); falls back to a download prompt on Firefox
  - **Save to server** — calls `POST /api/editor/games` on textadventures.co.uk, then navigates to `/?game={id}` so the URL is bookmarkable and refresh works
- Template content is generated via the WASM bridge (`CreateGameFromTemplate`) so the template files in `src/Engine/Core/Templates/` are the single source of truth — no duplication in TypeScript
- Template list (`GetGameTemplates`) is also served from the bridge, reading the embedded resources at runtime
- Fixes a bug where templates without a `template="..."` attribute on `<asl>` showed their full resource name (e.g. `QuestViva.Engine.Core.Templates.Dansk.template`) instead of just `Dansk`
- Fixes a double game load that occurred when creating on the server (open page was loading the game before navigating, then the main page loaded it again on mount)
- Adds optional `VITE_API_PROXY` env var to `vite.config.ts` for proxying `/api` requests to a local textadventures.co.uk instance during development

## Test plan

- [ ] `npm run dev` (no proxy): "Save to my computer" opens a folder picker, writes the file, and opens the editor immediately
- [ ] On textadventures.co.uk (or with `VITE_API_PROXY`): "Save to server" creates the game and navigates to `/?game={id}`; refreshing reloads the same game
- [ ] Template dropdown shows clean names (English, Dansk, Deutsch, …) not resource paths
- [ ] Gamebook template works (no language dropdown shown)
- [ ] Cancelling the folder picker does nothing (no error)
- [ ] Non-FSA browser (Firefox): "Save to my computer" triggers a download and shows a message to open the file

🤖 Generated with [Claude Code](https://claude.ai/claude-code)