### PR TITLE
Fix stack overflow from circular parent-child relationships

### DIFF
--- a/src/Engine/Elements.cs
+++ b/src/Engine/Elements.cs
@@ -163,25 +163,19 @@ public class Elements
 
     public IEnumerable<Element> GetChildElements(Element parent)
     {
-        foreach (var e in m_allElements.Values)
+        var visited = new HashSet<Element> { parent };
+        return CollectChildElements(parent, visited);
+    }
+
+    private IEnumerable<Element> CollectChildElements(Element parent, HashSet<Element> visited)
+    {
+        foreach (var e in m_allElements.Values.Where(e => e.Parent == parent))
         {
-            if (e.Parent == parent)
+            if (!visited.Add(e)) continue;
+            yield return e;
+            foreach (var child in CollectChildElements(e, visited))
             {
-                if (e == parent)
-                {
-                    throw new InvalidOperationException("Object's parent is set to self");
-                }
-
-                yield return e;
-                foreach (var child in GetChildElements(e))
-                {
-                    if (child == parent)
-                    {
-                        throw new InvalidOperationException("Circular parent");
-                    }
-
-                    yield return child;
-                }
+                yield return child;
             }
         }
     }

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -773,14 +773,20 @@ internal class ExpressionOwner(WorldModel worldModel)
         ArgumentNullException.ThrowIfNull(obj);
         var element = GetParameter<Element>(obj, "GetAllChildren", "object");
         var result = new QuestList<Element>();
+        var visited = new HashSet<Element>();
+        CollectChildren(element, type, result, visited);
+        return result;
+    }
+
+    private void CollectChildren(Element element, ObjectType type, QuestList<Element> result, HashSet<Element> visited)
+    {
         foreach (var child in worldModel.Elements.GetDirectChildren(element)
                      .Where(e => e.ElemType == ElementType.Object && e.Type == type))
         {
+            if (!visited.Add(child)) continue;
             result.Add(child);
-            result.AddRange(GetAllChildren(child, type));
+            CollectChildren(child, type, result, visited);
         }
-
-        return result;
     }
 
     public QuestList<Element> GetDirectChildren( /* Element */ object? obj)

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -725,12 +725,15 @@ public partial class WorldModel : IGame, IGameDebug
 
     public static bool ObjectContains(Element parent, Element searchObj)
     {
-        if (searchObj.Parent == null)
+        var visited = new HashSet<Element>();
+        var current = searchObj.Parent;
+        while (current != null)
         {
-            return false;
+            if (current == parent) return true;
+            if (!visited.Add(current)) return false;
+            current = current.Parent;
         }
-
-        return searchObj.Parent == parent || ObjectContains(parent, searchObj.Parent);
+        return false;
     }
 
     internal string DisplayMenu(string caption, IDictionary<string, string> options, bool allowCancel, bool async)


### PR DESCRIPTION
## Summary

- A game script can set an object's `parent` attribute at runtime, making it possible to create circular parent-child chains (A is parent of B, B is parent of A)
- Three recursive tree-traversal methods had no cycle protection and would stack overflow in this case
- A stack overflow in .NET kills the entire server process, taking down all active sessions — this caused today's outage

## Changes

- **`GetAllChildren` (ExpressionOwner.cs):** Replace unbounded recursion with a `HashSet`-guarded helper — this was the method that triggered the outage (30,774 recursive calls in the logs)
- **`ObjectContains` (WorldModel.cs):** Replace tail recursion with an iterative walk up the parent chain guarded by a visited set
- **`GetChildElements` (Elements.cs):** Replace a partial cycle check (only caught cycles involving the root element) with a proper `HashSet<Element>` visited set that catches cycles anywhere in the subtree

## Test plan

- [ ] All 261 existing tests pass (`dotnet test --configuration Release`)
- [ ] Verify a game script that creates a circular parent reference no longer crashes the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)