### PR TITLE
Bump NCalcSync from 5.11.0 to 6.3.0

### DIFF
--- a/src/Engine/Engine.csproj
+++ b/src/Engine/Engine.csproj
@@ -23,7 +23,7 @@
         <ProjectReference Include="..\Utility\Utility.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="NCalcSync" Version="5.11.0"/>
+        <PackageReference Include="NCalcSync" Version="6.3.0"/>
         <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -21,10 +21,9 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         _expressionOwner = new ExpressionOwner(scriptContext.WorldModel);
 
         _nCalcExpression = new Expression(expression,
-            new ExpressionContext(ExpressionOptions.NoStringTypeCoercion, null),
+            new ExpressionContext { Options = ExpressionOptions.NoStringTypeCoercion },
             QuestNCalcExpressionFactory.GetInstance(),
-            LogicalExpressionCache.GetInstance(),
-            new EvaluationVisitorFactory());
+            LogicalExpressionCache.GetInstance());
 
         _nCalcExpression.EvaluateFunction += EvaluateFunction;
         _nCalcExpression.EvaluateParameter += EvaluateParameter;
@@ -57,7 +56,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
     private Context _context;
 
-    private void EvaluateParameter(string name, ParameterArgs args)
+    private void EvaluateParameter(string name, ParameterEventArgs args)
     {
         var tryMath = EvaluateVariableFromType(typeof(Math), name);
         if (tryMath.handled)
@@ -128,7 +127,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         }
     }
 
-    private void EvaluateFunction(string name, FunctionArgs args)
+    private void EvaluateFunction(string name, FunctionEventArgs args)
     {
         var tryExpressionOwner =
             EvaluateFunctionFromType(typeof(ExpressionOwner), _expressionOwner, name, args.Parameters);
@@ -163,8 +162,8 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     }
 
 #nullable enable
-    private static (bool handled, object? result) EvaluateFunctionFromType(Type type, object instance, string name,
-        Expression[] parameters)
+    private static (bool handled, object? result) EvaluateFunctionFromType(Type type, object? instance, string name,
+        FunctionData parameters)
     {
         var methods = type.GetMethods()
             .Where(m => m.IsPublic && m.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
@@ -175,7 +174,9 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             return (false, null);
         }
 
-        var evaluatedArgs = parameters.Select(p => CoerceLong(p.Evaluate())).ToArray();
+        var evaluatedArgs = Enumerable.Range(0, parameters.Count)
+            .Select(i => CoerceLong(parameters.Evaluate(i)))
+            .ToArray();
 
         // First, try to find a method with a params parameter.
         var paramsMethods = methods
@@ -275,16 +276,16 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         return (true, field.GetRawConstantValue());
     }
 
-    private object EvaluateAslFunction(string name, FunctionArgs args)
+    private object EvaluateAslFunction(string name, FunctionEventArgs args)
     {
         if (name == "IsDefined")
         {
-            if (args.Parameters.Length != 1)
+            if (args.Parameters.Count != 1)
             {
                 throw new Exception("IsDefined function expects 1 parameter");
             }
 
-            if (args.Parameters[0].Evaluate() is not string variableName)
+            if (args.Parameters.Evaluate(0) is not string variableName)
             {
                 throw new Exception("IsDefined function expects a string parameter");
             }
@@ -300,12 +301,10 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         }
 
         var parameters = new Parameters();
-        var cnt = 0;
 
-        foreach (var val in args.Parameters)
+        for (var cnt = 0; cnt < args.Parameters.Count; cnt++)
         {
-            parameters.Add((string) proc.Fields[FieldDefinitions.ParamNames][cnt], val.Evaluate());
-            cnt++;
+            parameters.Add((string) proc.Fields[FieldDefinitions.ParamNames][cnt], args.Parameters.Evaluate(cnt));
         }
 
         return _scriptContext.WorldModel.RunProcedure(name, parameters, true);

--- a/src/Engine/Expressions/QuestNCalcExpressionFactory.cs
+++ b/src/Engine/Expressions/QuestNCalcExpressionFactory.cs
@@ -2,8 +2,8 @@
 
 using System.Globalization;
 using NCalc;
-using NCalc.Domain;
 using NCalc.Exceptions;
+using NCalc.Extensions;
 using NCalc.Factories;
 using NCalc.Parser;
 
@@ -18,7 +18,8 @@ public class QuestNCalcExpressionFactory : ILogicalExpressionFactory
     {
         try
         {
-            var parserContext = new LogicalExpressionParserContext(expression, options);
+            var parserOptions = LogicalExpressionParserOptionsExtensions.Create(options, CultureInfo.InvariantCulture);
+            var parserContext = new LogicalExpressionParserContext(expression, parserOptions, ct);
             var logicalExpression = QuestNCalcLogicalExpressionParser.Parse(parserContext);
 
             return logicalExpression ?? throw new ArgumentNullException(nameof(logicalExpression));

--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -2,12 +2,11 @@
 
 using ExtendedNumerics;
 using NCalc;
-using NCalc.Domain;
 using NCalc.Exceptions;
 using NCalc.Parser;
 using Parlot;
 using Parlot.Fluent;
-using Identifier = NCalc.Domain.Identifier;
+using Identifier = NCalc.Identifier;
 
 namespace QuestViva.Engine.Expressions;
 
@@ -119,7 +118,7 @@ public static class QuestNCalcLogicalExpressionParser
                         }
                     }
 
-                    if (((LogicalExpressionParserContext) ctx).Options.HasFlag(ExpressionOptions.DecimalAsDefault))
+                    if (((LogicalExpressionParserContext) ctx).ParserOptions.DecimalAsDefault)
                     {
                         return new ValueExpression((decimal) result);
                     }
@@ -218,7 +217,7 @@ public static class QuestNCalcLogicalExpressionParser
                 .Then<LogicalExpression>((ctx, value) =>
                 {
                     if (value.Length == 1 &&
-                        ((LogicalExpressionParserContext) ctx).Options.HasFlag(ExpressionOptions.AllowCharValues))
+                        ((LogicalExpressionParserContext) ctx).ParserOptions.AllowCharValues)
                     {
                         return new ValueExpression(value.Span[0]);
                     }


### PR DESCRIPTION
## Summary

- Updates NCalcSync from 5.11.0 to 6.3.0 (supersedes Dependabot PR #1751 which only targeted 6.1.1)
- Adapts to the v6.0.0 breaking API changes in the three NCalc expression files

## Breaking changes addressed

v6.0.0 reorganised the NCalc API significantly:

- **Namespace**: domain types (`LogicalExpression`, `BinaryExpression`, etc.) moved from `NCalc.Domain` to `NCalc`; they now ship in a dedicated `NCalc.Domain` assembly
- **Handler types**: `FunctionArgs` → `FunctionEventArgs`, `ParameterArgs` → `ParameterEventArgs`
- **Function parameters**: callbacks no longer receive `Expression[]`; replaced by `FunctionData` (an `IList<LogicalExpression>` with an `Evaluate(int)` helper)
- **Expression constructor**: `EvaluationVisitorFactory` removed; constructor now takes 4 args
- **Parser context**: `LogicalExpressionParserContext` constructor now takes `LogicalExpressionParserOptions` (not `ExpressionOptions`), and the context property is `.ParserOptions` not `.Options`

## Test plan

- [x] `dotnet build --configuration Release` succeeds
- [x] All 277 tests pass (`dotnet test --configuration Release`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)