### PR TITLE
NCalc FLEE parity: xor, exponentiation, hex literals, numeric suffixes, Unicode identifiers

### DIFF
--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -33,7 +33,7 @@ public static class QuestNCalcLogicalExpressionParser
          * shift          => additive ( ( "<<" | ">>" ) additive )* ;
          * additive       => multiplicative ( ( "-" | "+" ) multiplicative )* ;
          * multiplicative => exponential ( "/" | "*" | "%") exponential )* ;
-         * exponential    => postfix ( "**" | "^" postfix )* ;
+         * exponential    => postfix ( "^" postfix )* ;
          * postfix        => primary ( "[" expression "]" | "." identifier "(" arguments ")" )* ;
          * unary          => ( "-" | "not" | "!" ) primary
          *
@@ -152,8 +152,7 @@ public static class QuestNCalcLogicalExpressionParser
         var leftShift = Terms.Text("<<");
         var rightShift = Terms.Text(">>");
 
-        // "^" is FLEE's exponentiation operator; "**" is NCalc's. Both mean the same here.
-        var exponent = OneOf(Terms.Text("**"), Terms.Text("^"));
+        var exponent = Terms.Text("^"); // FLEE's exponentiation operator
         var openParen = Terms.Char('(');
         var closeParen = Terms.Char(')');
         var dot = Terms.Char('.');
@@ -372,7 +371,7 @@ public static class QuestNCalcLogicalExpressionParser
         // Deferred so exponential can reference unary (its right operand) before unary is defined.
         var unary = Deferred<LogicalExpression>();
 
-        // exponential => unary ( "**" | "^" unary )* ;
+        // exponential => unary ( "^" unary )* ;
         // Right operand is unary (not postfix) so that e.g. "e ^ -x" parses correctly.
         var exponential = postfix.And(ZeroOrMany(exponent.And(unary)))
             .Then(static x =>

--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -164,7 +164,9 @@ public static class QuestNCalcLogicalExpressionParser
         var colon = Terms.Char(':');
         var semicolon = Terms.Char(';');
 
-        var identifier = Terms.Identifier();
+        // extraStart/extraPart extend the default ASCII-only identifier to include Unicode letters,
+        // so that object names like "sérgio" or "fósforo" (common in non-English FLEE games) are valid.
+        var identifier = Terms.Identifier(extraStart: char.IsLetter, extraPart: char.IsLetterOrDigit);
 
         var not = OneOf(
             Terms.Text("NOT", true).AndSkip(OneOf(Literals.WhiteSpace().Or(Not(AnyCharBefore(openParen))))),

--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -27,7 +27,7 @@ public static class QuestNCalcLogicalExpressionParser
          * Grammar:
          * expression     => ternary ( ( "-" | "+" ) ternary )* ;
          * ternary        => logical ( "?" logical ":" logical)?
-         * logical        => equality ( ( "and" | "or" ) equality )* ;
+         * logical        => equality ( ( "and" | "or" | "xor" ) equality )* ;
          * equality       => relational ( ( "=" | "!=" | ... ) relational )* ;
          * relational     => shift ( ( ">=" | ">" | ... ) shift )* ;
          * shift          => additive ( ( "<<" | ">>" ) additive )* ;
@@ -467,22 +467,39 @@ public static class QuestNCalcLogicalExpressionParser
             (not, value => new UnaryExpression(UnaryExpressionType.Not, value))
         );
 
-        var andParser = and.Then(BinaryExpressionType.And)
-            .Or(bitwiseAnd.Then(BinaryExpressionType.BitwiseAnd));
+        var andParser = and.Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
+                _ => (a, b) => new BinaryExpression(BinaryExpressionType.And, a, b))
+            .Or(bitwiseAnd.Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
+                _ => (a, b) => new BinaryExpression(BinaryExpressionType.BitwiseAnd, a, b)));
 
-        var orParser = or.Then(BinaryExpressionType.Or)
-            .Or(bitwiseOr.Then(BinaryExpressionType.BitwiseOr));
+        var orParser = or.Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
+                _ => (a, b) => new BinaryExpression(BinaryExpressionType.Or, a, b))
+            .Or(bitwiseOr.Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
+                _ => (a, b) => new BinaryExpression(BinaryExpressionType.BitwiseOr, a, b)));
 
-        var xorParser = bitwiseXOr.Then(BinaryExpressionType.BitwiseXOr);
+        // "xor" text keyword → logical XOR: (a or b) and not (a and b), to avoid type issues
+        // with BitwiseXOr which returns UInt64 when applied to booleans.
+        // "^" symbol → bitwise XOR (integer/bool raw bitwise operation).
+        var xorParser = OneOf(
+            Terms.Text("XOR", true).Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
+                _ => (a, b) =>
+                {
+                    var aOrB = new BinaryExpression(BinaryExpressionType.Or, a, b);
+                    var aAndB = new BinaryExpression(BinaryExpressionType.And, a, b);
+                    return new BinaryExpression(BinaryExpressionType.And, aOrB,
+                        new UnaryExpression(UnaryExpressionType.Not, aAndB));
+                }),
+            bitwiseXOr.Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
+                _ => (a, b) => new BinaryExpression(BinaryExpressionType.BitwiseXOr, a, b)));
 
-        // logical => equality ( ( "and" | "or" ) equality )* ;
+        // logical => equality ( ( "and" | "or" | "xor" ) equality )* ;
         var logical = notOperator.And(ZeroOrMany(OneOf(andParser, orParser, xorParser).And(notOperator)))
-            .Then(static x =>
+            .Then(x =>
             {
                 var result = x.Item1;
-                foreach (var op in x.Item2)
+                foreach (var (combiner, right) in x.Item2)
                 {
-                    result = new BinaryExpression(op.Item1, result, op.Item2);
+                    result = combiner(result, right);
                 }
 
                 return result;

--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -369,8 +369,12 @@ public static class QuestNCalcLogicalExpressionParser
                 return result;
             });
 
+        // Deferred so exponential can reference unary (its right operand) before unary is defined.
+        var unary = Deferred<LogicalExpression>();
+
         // exponential => unary ( "**" | "^" unary )* ;
-        var exponential = postfix.And(ZeroOrMany(exponent.And(postfix)))
+        // Right operand is unary (not postfix) so that e.g. "e ^ -x" parses correctly.
+        var exponential = postfix.And(ZeroOrMany(exponent.And(unary)))
             .Then(static x =>
             {
                 LogicalExpression result = null!;
@@ -397,10 +401,9 @@ public static class QuestNCalcLogicalExpressionParser
                 return result;
             });
 
-        // ( "-" | "not" ) unary | primary;
-        var unary = exponential.Unary(
-            // This is where Quest's parser differs from the NCalc default, as we handle "not" further down.
-            // (not, value => new UnaryExpression(UnaryExpressionType.Not, value)),
+        // ( "-" | "~" ) unary | exponential;
+        // This is where Quest's parser differs from the NCalc default, as we handle "not" further down.
+        unary.Parser = exponential.Unary(
             (minus, value => new UnaryExpression(UnaryExpressionType.Negate, value)),
             (bitwiseNot, value => new UnaryExpression(UnaryExpressionType.BitwiseNot, value))
         );

--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -33,7 +33,7 @@ public static class QuestNCalcLogicalExpressionParser
          * shift          => additive ( ( "<<" | ">>" ) additive )* ;
          * additive       => multiplicative ( ( "-" | "+" ) multiplicative )* ;
          * multiplicative => exponential ( "/" | "*" | "%") exponential )* ;
-         * exponential    => postfix ( "**" postfix )* ;
+         * exponential    => postfix ( "**" | "^" postfix )* ;
          * postfix        => primary ( "[" expression "]" | "." identifier "(" arguments ")" )* ;
          * unary          => ( "-" | "not" | "!" ) primary
          *
@@ -152,7 +152,8 @@ public static class QuestNCalcLogicalExpressionParser
         var leftShift = Terms.Text("<<");
         var rightShift = Terms.Text(">>");
 
-        var exponent = Terms.Text("**");
+        // "^" is FLEE's exponentiation operator; "**" is NCalc's. Both mean the same here.
+        var exponent = OneOf(Terms.Text("**"), Terms.Text("^"));
         var openParen = Terms.Char('(');
         var closeParen = Terms.Char(')');
         var dot = Terms.Char('.');
@@ -174,7 +175,6 @@ public static class QuestNCalcLogicalExpressionParser
 
         var bitwiseAnd = Terms.Text("&");
         var bitwiseOr = Terms.Text("|");
-        var bitwiseXOr = Terms.Text("^");
         var bitwiseNot = Terms.Text("~");
 
         // "(" expression ")"
@@ -369,7 +369,7 @@ public static class QuestNCalcLogicalExpressionParser
                 return result;
             });
 
-        // exponential => unary ( "**" unary )* ;
+        // exponential => unary ( "**" | "^" unary )* ;
         var exponential = postfix.And(ZeroOrMany(exponent.And(postfix)))
             .Then(static x =>
             {
@@ -479,18 +479,15 @@ public static class QuestNCalcLogicalExpressionParser
 
         // "xor" text keyword → logical XOR: (a or b) and not (a and b), to avoid type issues
         // with BitwiseXOr which returns UInt64 when applied to booleans.
-        // "^" symbol → bitwise XOR (integer/bool raw bitwise operation).
-        var xorParser = OneOf(
-            Terms.Text("XOR", true).Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
-                _ => (a, b) =>
-                {
-                    var aOrB = new BinaryExpression(BinaryExpressionType.Or, a, b);
-                    var aAndB = new BinaryExpression(BinaryExpressionType.And, a, b);
-                    return new BinaryExpression(BinaryExpressionType.And, aOrB,
-                        new UnaryExpression(UnaryExpressionType.Not, aAndB));
-                }),
-            bitwiseXOr.Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
-                _ => (a, b) => new BinaryExpression(BinaryExpressionType.BitwiseXOr, a, b)));
+        // Note: "^" is exponentiation (FLEE compat), not XOR.
+        var xorParser = Terms.Text("XOR", true).Then<Func<LogicalExpression, LogicalExpression, LogicalExpression>>(
+            _ => (a, b) =>
+            {
+                var aOrB = new BinaryExpression(BinaryExpressionType.Or, a, b);
+                var aAndB = new BinaryExpression(BinaryExpressionType.And, a, b);
+                return new BinaryExpression(BinaryExpressionType.And, aOrB,
+                    new UnaryExpression(UnaryExpressionType.Not, aAndB));
+            });
 
         // logical => equality ( ( "and" | "or" | "xor" ) equality )* ;
         var logical = notOperator.And(ZeroOrMany(OneOf(andParser, orParser, xorParser).And(notOperator)))

--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -326,10 +326,30 @@ public static class QuestNCalcLogicalExpressionParser
 
         var guid = OneOf(guidWithHyphens, guidWithoutHyphens);
 
+        // FLEE hex integer literal: 0x[0-9a-fA-F]+ with optional u/l suffix (suffix ignored for type)
+        var hexLiteralSuffix = Literals.Pattern(c => c is 'u' or 'U' or 'l' or 'L', 1, 2);
+        var hexLiteral = Terms.Text("0x", true)
+            .SkipAnd(Literals.Pattern(Character.IsHexDigit, 1))
+            .AndSkip(ZeroOrOne(hexLiteralSuffix))
+            .Then<LogicalExpression>(hexSpan =>
+            {
+                var value = Convert.ToUInt64(hexSpan.ToString(), 16);
+                if (value <= int.MaxValue) return new ValueExpression((int)value);
+                if (value <= long.MaxValue) return new ValueExpression((long)value);
+                return new ValueExpression(unchecked((long)value));
+            });
+
+        // FLEE numeric type suffix (u, l, ul, lu, f, d, m) — consumed and ignored; type is
+        // determined by the number format, not the suffix.
+        var numericLiteralSuffix = Literals.Pattern(
+            c => c is 'u' or 'U' or 'l' or 'L' or 'f' or 'F' or 'd' or 'D' or 'm' or 'M', 1, 2);
+        var numberWithOptionalSuffix = number.AndSkip(ZeroOrOne(numericLiteralSuffix));
+
         // primary => GUID | NUMBER | identifier| DateTime | string | function | boolean | groupExpression | list ;
         var primary = OneOf(
             guid,
-            number,
+            hexLiteral,
+            numberWithOptionalSuffix,
             decimalOrDoubleNumber,
             booleanTrue,
             booleanFalse,

--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -165,7 +165,7 @@ public static class QuestNCalcLogicalExpressionParser
         var semicolon = Terms.Char(';');
 
         // extraStart/extraPart extend the default ASCII-only identifier to include Unicode letters,
-        // so that object names like "sérgio" or "fósforo" (common in non-English FLEE games) are valid.
+        // so that object names like "sérgio" or "fósforo" (used in non-English Quest games) are valid.
         var identifier = Terms.Identifier(extraStart: char.IsLetter, extraPart: char.IsLetterOrDigit);
 
         var not = OneOf(

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -140,6 +140,7 @@ public abstract class ExpressionTestsBase
     [DataRow("sqrt(4)", 2.0)]
     [DataRow("Abs(-5)", 5.0)]
     [DataRow("2 ^ 3", 8.0)]
+    [DataRow("2 ^ -1", 0.5)]
     [DataRow("E ^ -1", 1.0 / Math.E)]
     public void TestDoubleExpressions(string expression, double expectedResult)
     {

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -484,7 +484,7 @@ public abstract class ExpressionTestsBase
     [TestMethod]
     public void TestUnicodeIdentifiers()
     {
-        if (!UseNCalc) return;  // FLEE parity: non-ASCII object/attribute names (e.g. Portuguese games)
+        if (!UseNCalc) return;  // NCalc-only: non-ASCII object/attribute names (e.g. Portuguese games)
         var expr = new Expression<int>("sérgio + fósforo", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "sérgio", 10 }, { "fósforo", 5 } } };
         expr.Execute(c).ShouldBe(15);

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -139,6 +139,8 @@ public abstract class ExpressionTestsBase
     [DataRow("Sqrt(4)", 2.0)]
     [DataRow("sqrt(4)", 2.0)]
     [DataRow("Abs(-5)", 5.0)]
+    [DataRow("2 ^ 3", 8.0)]
+    [DataRow("E ^ -1", 1.0 / Math.E)]
     public void TestDoubleExpressions(string expression, double expectedResult)
     {
         var result = RunExpression<double>(expression);
@@ -325,6 +327,13 @@ public abstract class ExpressionTestsBase
         resultList.Count.ShouldBe(2);
         resultList[0].ShouldBe("a");
         resultList[1].ShouldBe("b");
+    }
+
+    [TestMethod]
+    public void TestNCalcExponentiationOperator()
+    {
+        if (!UseNCalc) return; // "**" is NCalc syntax; FLEE uses "^" which is tested in TestDoubleExpressions
+        RunExpression<double>("2 ** 3").ShouldBe(8.0);
     }
 
     [TestMethod]

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -484,7 +484,6 @@ public abstract class ExpressionTestsBase
     [TestMethod]
     public void TestUnicodeIdentifiers()
     {
-        if (!UseNCalc) return;  // NCalc-only: non-ASCII object/attribute names (e.g. Portuguese games)
         var expr = new Expression<int>("sérgio + fósforo", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "sérgio", 10 }, { "fósforo", 5 } } };
         expr.Execute(c).ShouldBe(15);

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -480,6 +480,31 @@ public abstract class ExpressionTestsBase
         var expected = (int) now.ToUnixTimeSeconds();
         Math.Abs(result - expected).ShouldBeLessThan(2);
     }
+
+    [DataTestMethod]
+    [DataRow("0xFF", 255)]
+    [DataRow("0x10", 16)]
+    [DataRow("0xABCDEF", 11259375)]
+    [DataRow("0xFF + 1", 256)]
+    [DataRow("0x10u", 16)]
+    [DataRow("42u", 42)]
+    [DataRow("100L", 100)]
+    public void TestFleeCompatNumericLiterals(string expression, int expectedResult)
+    {
+        if (!UseNCalc) return;
+        RunExpression<int>(expression).ShouldBe(expectedResult);
+    }
+
+    [DataTestMethod]
+    [DataRow("1.5f", 1.5)]
+    [DataRow("2.0m", 2.0)]
+    [DataRow("3.14d", 3.14)]
+    public void TestFleeCompatRealSuffixes(string expression, double expectedResult)
+    {
+        if (!UseNCalc) return;
+        var result = RunExpression<double>(expression);
+        Math.Abs(result - expectedResult).ShouldBeLessThan(0.000001);
+    }
 }
 
 [TestClass]

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -159,6 +159,10 @@ public abstract class ExpressionTestsBase
     [DataRow("true or true", true)]
     [DataRow("false or true", true)]
     [DataRow("false or false", false)]
+    [DataRow("true xor true", false)]
+    [DataRow("true xor false", true)]
+    [DataRow("false xor true", true)]
+    [DataRow("false xor false", false)]
     [DataRow($"{ObjectName}.{BoolAttributeName}", BoolAttributeValue)]
     [DataRow($"not {ObjectName}.{BoolAttributeName}", !BoolAttributeValue)]
     [DataRow("1 = 1", true)]
@@ -193,6 +197,8 @@ public abstract class ExpressionTestsBase
     [DataRow("ListContains(AllObjects(), object)", true)]
     [DataRow("listcontains(allobjects(), object)", true)]
     [DataRow("CustomBooleanFunction(true, false)", true)]
+    [DataRow($"{OtherObjectName} = {OtherObjectName} and (true xor false)", true)]
+    [DataRow($"{OtherObjectName} = {OtherObjectName} and (false xor false)", false)]
     public void TestBooleanExpressions(string expression, bool expectedResult)
     {
         var result = RunExpression<bool>(expression);

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -331,13 +331,6 @@ public abstract class ExpressionTestsBase
     }
 
     [TestMethod]
-    public void TestNCalcExponentiationOperator()
-    {
-        if (!UseNCalc) return; // "**" is NCalc syntax; FLEE uses "^" which is tested in TestDoubleExpressions
-        RunExpression<double>("2 ** 3").ShouldBe(8.0);
-    }
-
-    [TestMethod]
     public void TestListIndexingSyntax()
     {
         if (!UseNCalc) return; // FLEE handles [] natively; this verifies the NCalc parser extension

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -489,7 +489,7 @@ public abstract class ExpressionTestsBase
         expr.Execute(c).ShouldBe(15);
     }
 
-[DataTestMethod]
+    [DataTestMethod]
     [DataRow("0xFF", 255)]
     [DataRow("0x10", 16)]
     [DataRow("0xABCDEF", 11259375)]

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -481,7 +481,16 @@ public abstract class ExpressionTestsBase
         Math.Abs(result - expected).ShouldBeLessThan(2);
     }
 
-    [DataTestMethod]
+    [TestMethod]
+    public void TestUnicodeIdentifiers()
+    {
+        if (!UseNCalc) return;  // FLEE parity: non-ASCII object/attribute names (e.g. Portuguese games)
+        var expr = new Expression<int>("sérgio + fósforo", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "sérgio", 10 }, { "fósforo", 5 } } };
+        expr.Execute(c).ShouldBe(15);
+    }
+
+[DataTestMethod]
     [DataRow("0xFF", 255)]
     [DataRow("0x10", 16)]
     [DataRow("0xABCDEF", 11259375)]


### PR DESCRIPTION
## Summary

Closes gaps between FLEE and our NCalc expression evaluator, discovered through code analysis and by scanning 20,000 .aslx game files from textadventures.co.uk.

- **`xor` keyword** — was causing "Parenthesis not closed" errors; desugared to `(a or b) and not (a and b)` to avoid NCalc's `BitwiseXOr` returning `UInt64` on booleans
- **`^` as exponentiation** — FLEE uses `^` for power (not XOR); also fixed negated right operand (`e ^ -x`) by making `exponential` use `unary` as its right-hand operand via a `Deferred` reference
- **Removed `**`** — NCalc-only operator with no FLEE equivalent; parity-only goal
- **Hex literals** (`0xFF`, `0xABCDEF`) and **numeric type suffixes** (`42u`, `100L`, `1.5f`, `2.0m`) — consumed and parsed; suffix is discarded as Quest has no `uint`/`float`/`decimal` attribute types
- **Unicode identifiers** — Parlot's default identifier parser is ASCII-only; extended via `extraStart`/`extraPart` predicates so non-English object names like `sérgio` or `fósforo` work

## Test plan

- [ ] All 397 tests pass (`dotnet test tests/EngineTests`)
- [ ] New `DataRow` entries in `TestBooleanExpressions` cover the xor truth table and compound expressions
- [ ] New `DataRow` entries in `TestDoubleExpressions` cover `^` exponentiation including negative exponent
- [ ] `TestFleeCompatNumericLiterals` and `TestFleeCompatRealSuffixes` cover hex/suffix parsing (NCalc only)
- [ ] `TestUnicodeIdentifiers` runs against both FLEE and NCalc

🤖 Generated with [Claude Code](https://claude.com/claude-code)