### PR TITLE
NCalc: dispatch C# operator overloads (fixes ListExclude errors in production)

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -309,13 +309,8 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     // so we intercept binary operations on non-standard types and dispatch via reflection.
     private void EvaluateBinary(BinaryEventArgs args)
     {
-        var left = args.LeftValue();
-        var right = args.RightValue();
-
-        // Let NCalc handle standard numeric/bool/string/null operations natively
-        if (IsStandardNCalcType(left) && IsStandardNCalcType(right))
-            return;
-
+        // Check operator type BEFORE evaluating args to preserve short-circuit evaluation
+        // for And/Or: calling LeftValue()/RightValue() forces eager evaluation of both sides.
         var operatorName = args.BinaryExpression.Type switch
         {
             BinaryExpressionType.Plus => "op_Addition",
@@ -327,6 +322,13 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         };
 
         if (operatorName == null) return;
+
+        var left = args.LeftValue();
+        var right = args.RightValue();
+
+        // Let NCalc handle standard numeric/bool/string/null operations natively
+        if (IsStandardNCalcType(left) && IsStandardNCalcType(right))
+            return;
 
         var leftType = left?.GetType();
         var rightType = right?.GetType();

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -30,6 +30,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
         _nCalcExpression.EvaluateFunction += EvaluateFunction;
         _nCalcExpression.EvaluateParameter += EvaluateParameter;
+        _nCalcExpression.EvaluateBinary += EvaluateBinary;
     }
 
     object IDynamicExpressionEvaluator.Evaluate(Context c)
@@ -270,6 +271,29 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         var types = evaluatedArgs.Select(a => a?.GetType() ?? typeof(object)).ToArray();
         var methodNoParams = Type.DefaultBinder!.SelectMethod(BindingFlags.Default, methods, types, null);
 
+        // DefaultBinder can't match when null args produce typeof(object) as a stand-in type.
+        // Fall back to the first overload where all non-null args are type-compatible.
+        if (methodNoParams == null && evaluatedArgs.Any(a => a == null))
+        {
+            methodNoParams = methods.OfType<MethodBase>().FirstOrDefault(m =>
+            {
+                var ps = m.GetParameters();
+                if (ps.Length != evaluatedArgs.Length) return false;
+                for (var i = 0; i < evaluatedArgs.Length; i++)
+                {
+                    if (evaluatedArgs[i] == null)
+                    {
+                        if (ps[i].ParameterType.IsValueType &&
+                            Nullable.GetUnderlyingType(ps[i].ParameterType) == null)
+                            return false;
+                        continue;
+                    }
+                    if (!ps[i].ParameterType.IsInstanceOfType(evaluatedArgs[i])) return false;
+                }
+                return true;
+            });
+        }
+
         if (methodNoParams == null)
         {
             throw new Exception(
@@ -279,6 +303,61 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         return (true, methodNoParams.Invoke(instance, evaluatedArgs));
     }
 #nullable disable
+
+    // FLEE compiled expressions to IL so C# operator overloads (e.g. QuestList<T> - Element)
+    // resolved automatically. NCalc evaluates at runtime and doesn't use operator overloads,
+    // so we intercept binary operations on non-standard types and dispatch via reflection.
+    private void EvaluateBinary(BinaryEventArgs args)
+    {
+        var left = args.LeftValue();
+        var right = args.RightValue();
+
+        // Let NCalc handle standard numeric/bool/string/null operations natively
+        if (IsStandardNCalcType(left) && IsStandardNCalcType(right))
+            return;
+
+        var operatorName = args.BinaryExpression.Type switch
+        {
+            BinaryExpressionType.Plus => "op_Addition",
+            BinaryExpressionType.Minus => "op_Subtraction",
+            BinaryExpressionType.Times => "op_Multiply",
+            BinaryExpressionType.Div => "op_Division",
+            BinaryExpressionType.Modulo => "op_Modulus",
+            _ => null
+        };
+
+        if (operatorName == null) return;
+
+        var leftType = left?.GetType();
+        var rightType = right?.GetType();
+
+        foreach (var declaringType in new[] { leftType, rightType }.Where(t => t != null).Distinct())
+        {
+            var method = TryFindOperatorOverload(declaringType, operatorName, leftType, rightType);
+            if (method != null)
+            {
+                args.Result = method.Invoke(null, new[] { left, right });
+                return;
+            }
+        }
+    }
+
+    private static bool IsStandardNCalcType(object value) =>
+        value is null or int or long or double or float or decimal or byte or short or uint or ulong or ushort or sbyte or bool or string;
+
+    private static MethodInfo TryFindOperatorOverload(Type declaringType, string operatorName, Type leftType, Type rightType)
+    {
+        foreach (var method in declaringType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.Name == operatorName))
+        {
+            var ps = method.GetParameters();
+            if (ps.Length != 2) continue;
+            if (leftType != null && !ps[0].ParameterType.IsAssignableFrom(leftType)) continue;
+            if (rightType != null && !ps[1].ParameterType.IsAssignableFrom(rightType)) continue;
+            return method;
+        }
+        return null;
+    }
 
     private static (bool handled, object result) EvaluateVariableFromType(Type type, string name)
     {

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -513,6 +513,29 @@ public abstract class ExpressionTestsBase
         var result = RunExpression<double>(expression);
         Math.Abs(result - expectedResult).ShouldBeLessThan(0.000001);
     }
+
+    [TestMethod]
+    public void TestListMinusElement()
+    {
+        // QuestList<T> defines operator-, which FLEE resolves via IL compilation.
+        // NCalc needs the EvaluateBinary hook to dispatch to the C# operator overload.
+        var list = new QuestList<Element>([_object, _child]);
+        var expr = new ExpressionDynamic("mylist - myobj", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "mylist", list }, { "myobj", _object } } };
+        var result = expr.Execute(c).ShouldBeAssignableTo<QuestList<Element>>();
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(_child);
+    }
+
+    [TestMethod]
+    public void TestListPlusElement()
+    {
+        var list = new QuestList<Element>([_object]);
+        var expr = new ExpressionDynamic("mylist + myobj", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "mylist", list }, { "myobj", _child } } };
+        var result = expr.Execute(c).ShouldBeAssignableTo<QuestList<Element>>();
+        result.Count.ShouldBe(2);
+    }
 }
 
 [TestClass]


### PR DESCRIPTION
## Summary

- NCalc doesn't resolve C# operator overloads at runtime (unlike FLEE which compiled to IL). The ASL `GetScope` function uses `QuestList<T> - Element` (e.g. `items = ListCombine(items, ScopeVisibleNotHeld()) - game.pov` in CoreParser.aslx lines 779/782), which requires `QuestList<T>.operator-`. NCalc silently failed here, causing `GetScope` to return null, which cascaded all the way to the reported error: `ListExclude function does not handle parameters of types Object, Object`.
- Add an `EvaluateBinary` hook to `NcalcExpressionEvaluator` that intercepts arithmetic operators (`+`, `-`, `*`, `/`, `%`) on non-standard types and dispatches to the C# operator overload via reflection, matching FLEE's behaviour.
- Add a null-argument fallback in `EvaluateFunctionFromType` so that if upstream errors still cause null values to flow into a function call, method dispatch finds a compatible overload rather than throwing the confusing "does not handle parameters of types Object, Object" message.

## Root cause chain

1. Command has scope `"notheld"` or `"all"` → `GetScope` evaluates `ListCombine(...) - game.pov`
2. NCalc can't dispatch `QuestList<Element> - Element` → `FormatException` → caught by `RunScript` → `GetScope` returns `null`
3. `FilterByAttribute(null, "scenery", false)` → `foreach` over null → exception caught → returns `null` → `scope = null`
4. `ListExclude(null, FilterByAttribute(null, "not_all", true))` → both args null → `DefaultBinder.SelectMethod` fails → `"does not handle parameters of types Object, Object"`

## Test plan

- [ ] New `TestListMinusElement` and `TestListPlusElement` tests cover the operator dispatch for both NCalc and FLEE evaluators
- [ ] All 441 existing tests continue to pass
- [ ] Verify "TAKE ALL" (or similar `allow_all` commands with custom scope) no longer logs the exception in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)