### PR TITLE
NCalc FLEE parity: integer division, list operators, method null-arg dispatch

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -326,6 +326,15 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         var left = args.LeftValue();
         var right = args.RightValue();
 
+        // NCalc always returns Double for /, but FLEE compiled to IL where int/int = int.
+        // Intercept integer division to match FLEE's behavior.
+        if (args.BinaryExpression.Type == BinaryExpressionType.Div
+            && IsIntegerType(left) && IsIntegerType(right))
+        {
+            args.Result = Convert.ToInt64(left) / Convert.ToInt64(right);
+            return;
+        }
+
         // Let NCalc handle standard numeric/bool/string/null operations natively
         if (IsStandardNCalcType(left) && IsStandardNCalcType(right))
             return;
@@ -346,6 +355,9 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
     private static bool IsStandardNCalcType(object value) =>
         value is null or int or long or double or float or decimal or byte or short or uint or ulong or ushort or sbyte or bool or string;
+
+    private static bool IsIntegerType(object value) =>
+        value is int or long or byte or short or uint or ulong or ushort or sbyte;
 
     private static MethodInfo TryFindOperatorOverload(Type declaringType, string operatorName, Type leftType, Type rightType)
     {
@@ -391,8 +403,33 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
                 .Select(i => CoerceLong(args.Parameters.Evaluate(i)))
                 .ToArray();
             var argTypes = methodArgs.Select(a => a?.GetType() ?? typeof(object)).ToArray();
-            var method = receiver?.GetType().GetMethod(methodName, argTypes)
-                ?? throw new Exception($"Method '{methodName}' not found on '{receiver?.GetType().Name}'");
+            var method = receiver?.GetType().GetMethod(methodName, argTypes);
+
+            if (method == null && methodArgs.Any(a => a == null))
+            {
+                method = receiver?.GetType().GetMethods()
+                    .Where(m => m.Name == methodName)
+                    .FirstOrDefault(m =>
+                    {
+                        var ps = m.GetParameters();
+                        if (ps.Length != methodArgs.Length) return false;
+                        for (var i = 0; i < methodArgs.Length; i++)
+                        {
+                            if (methodArgs[i] == null)
+                            {
+                                if (ps[i].ParameterType.IsValueType &&
+                                    Nullable.GetUnderlyingType(ps[i].ParameterType) == null)
+                                    return false;
+                                continue;
+                            }
+                            if (!ps[i].ParameterType.IsInstanceOfType(methodArgs[i])) return false;
+                        }
+                        return true;
+                    });
+            }
+
+            if (method == null)
+                throw new Exception($"Method '{methodName}' not found on '{receiver?.GetType().Name}'");
             return method.Invoke(receiver, methodArgs);
         }
 

--- a/src/Engine/QuestList.cs
+++ b/src/Engine/QuestList.cs
@@ -268,7 +268,6 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     /// <returns></returns>
     public static QuestList<T> operator +(QuestList<T> list1, QuestList<T> list2)
     {
-        //System.Diagnostics.Debug.Assert(false, "Operators on lists are deprecated");
         if (list1 == null)
         {
             return new QuestList<T>(list2);
@@ -304,7 +303,6 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     /// <returns></returns>
     public static QuestList<T> operator +(QuestList<T> list, T element)
     {
-        //System.Diagnostics.Debug.Assert(false, "Operators on lists are deprecated");
         var result = new QuestList<T>(list);
         result.Add(element);
         return result;
@@ -318,7 +316,6 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     /// <returns></returns>
     public static QuestList<T> operator +(T element, QuestList<T> list)
     {
-        //System.Diagnostics.Debug.Assert(false, "Operators on lists are deprecated");
         var result = new QuestList<T>();
         result.Add(element);
         result.AddRange(list);
@@ -327,7 +324,6 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public static QuestList<T> operator -(QuestList<T> list, T element)
     {
-        //System.Diagnostics.Debug.Assert(false, "Operators on lists are deprecated");
         var result = new QuestList<T>(list);
         result.Remove(element);
         return result;

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -333,8 +333,7 @@ public abstract class ExpressionTestsBase
     [TestMethod]
     public void TestListIndexingSyntax()
     {
-        if (!UseNCalc) return; // FLEE handles [] natively; this verifies the NCalc parser extension
-
+        if (!UseNCalc) return; // FLEE infers QuestList element type as Object, can't return String
         var list = new QuestList<string>(["alpha", "beta", "gamma"]);
         var expr = new Expression<string>("mylist[0]", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "mylist", list } } };
@@ -347,8 +346,7 @@ public abstract class ExpressionTestsBase
     [TestMethod]
     public void TestListIndexingWithVariableIndex()
     {
-        if (!UseNCalc) return; // FLEE handles [] natively; this verifies the NCalc parser extension
-
+        if (!UseNCalc) return; // FLEE infers QuestList element type as Object, can't return String
         var list = new QuestList<string>(["alpha", "beta", "gamma"]);
         var expr = new Expression<string>("mylist[idx]", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "mylist", list }, { "idx", 1 } } };
@@ -358,8 +356,6 @@ public abstract class ExpressionTestsBase
     [TestMethod]
     public void TestDictionaryIndexingSyntax()
     {
-        if (!UseNCalc) return; // FLEE handles [] natively; this verifies the NCalc parser extension
-
         var dict = new QuestDictionary<string> { { "foo", "bar" }, { "baz", "qux" } };
         var expr = new Expression<string>("mydict[\"foo\"]", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "mydict", dict } } };
@@ -369,8 +365,6 @@ public abstract class ExpressionTestsBase
     [TestMethod]
     public void TestDictionaryIndexingWithVariableKey()
     {
-        if (!UseNCalc) return; // FLEE handles [] natively; this verifies the NCalc parser extension
-
         var dict = new QuestDictionary<string> { { "foo", "bar" }, { "baz", "qux" } };
         var expr = new Expression<string>("mydict[k]", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "mydict", dict }, { "k", "baz" } } };
@@ -380,8 +374,6 @@ public abstract class ExpressionTestsBase
     [TestMethod]
     public void TestMethodCallSyntax()
     {
-        if (!UseNCalc) return; // FLEE handles instance method calls natively; this verifies the NCalc parser extension
-
         RunExpressionGeneric("\"hello world\".StartsWith(\"hello\")").ShouldBe(true);
         RunExpressionGeneric("\"hello world\".EndsWith(\"world\")").ShouldBe(true);
         RunExpressionGeneric("\"hello world\".Contains(\"lo wo\")").ShouldBe(true);
@@ -505,24 +497,36 @@ public abstract class ExpressionTestsBase
     [DataRow("0x10", 16)]
     [DataRow("0xABCDEF", 11259375)]
     [DataRow("0xFF + 1", 256)]
+    public void TestFleeCompatHexLiterals(string expression, int expectedResult)
+    {
+        RunExpression<int>(expression).ShouldBe(expectedResult);
+    }
+
+    [DataTestMethod]
     [DataRow("0x10u", 16)]
     [DataRow("42u", 42)]
     [DataRow("100L", 100)]
-    public void TestFleeCompatNumericLiterals(string expression, int expectedResult)
+    public void TestFleeCompatIntegerSuffixes(string expression, int expectedResult)
     {
-        if (!UseNCalc) return;
+        if (!UseNCalc) return; // FLEE returns UInt32/Int64 for u/L suffixes; NCalc normalises to int
         RunExpression<int>(expression).ShouldBe(expectedResult);
     }
 
     [DataTestMethod]
     [DataRow("1.5f", 1.5)]
-    [DataRow("2.0m", 2.0)]
     [DataRow("3.14d", 3.14)]
     public void TestFleeCompatRealSuffixes(string expression, double expectedResult)
     {
-        if (!UseNCalc) return;
         var result = RunExpression<double>(expression);
         Math.Abs(result - expectedResult).ShouldBeLessThan(0.000001);
+    }
+
+    [TestMethod]
+    public void TestFleeCompatDecimalSuffix()
+    {
+        if (!UseNCalc) return; // FLEE returns Decimal for m suffix; NCalc normalises to double
+        var result = RunExpression<double>("2.0m");
+        Math.Abs(result - 2.0).ShouldBeLessThan(0.000001);
     }
 
     [TestMethod]

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -391,9 +391,7 @@ public abstract class ExpressionTestsBase
     [TestMethod]
     public void TestMethodCallWithNullArg()
     {
-        if (!UseNCalc) return; // FLEE handles instance method calls natively; this verifies the NCalc parser extension
-
-        // When a method arg is null, GetMethod(name, [typeof(object)]) won't find
+        // When a method arg is null, NCalc's GetMethod(name, [typeof(object)]) won't find
         // List<Element>.Contains(Element), so the null-arg fallback must kick in.
         // AllObjects() as receiver avoids the ConvertVariablesToFleeFormat (\w\.\w) mangling.
         var expr = new Expression<bool>("AllObjects().Contains(nullobj)", _scriptContext);

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -536,6 +536,71 @@ public abstract class ExpressionTestsBase
         var result = expr.Execute(c).ShouldBeAssignableTo<QuestList<Element>>();
         result.Count.ShouldBe(2);
     }
+
+    [TestMethod]
+    public void TestListPlusList()
+    {
+        var list1 = new QuestList<string>(["a", "b"]);
+        var list2 = new QuestList<string>(["c", "d"]);
+        var expr = new ExpressionDynamic("list1 + list2", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "list1", list1 }, { "list2", list2 } } };
+        var result = expr.Execute(c).ShouldBeAssignableTo<QuestList<string>>();
+        result.ShouldBe(["a", "b", "c", "d"]);
+    }
+
+    [TestMethod]
+    public void TestElementPlusList()
+    {
+        var list = new QuestList<Element>([_child]);
+        var expr = new ExpressionDynamic("myobj + mylist", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "mylist", list }, { "myobj", _object } } };
+        var result = expr.Execute(c).ShouldBeAssignableTo<QuestList<Element>>();
+        result.Count.ShouldBe(2);
+        result[0].ShouldBe(_object);
+        result[1].ShouldBe(_child);
+    }
+
+    [TestMethod]
+    public void TestListTimesListUnionDedup()
+    {
+        var list1 = new QuestList<string>(["a", "b", "c"]);
+        var list2 = new QuestList<string>(["b", "c", "d"]);
+        var expr = new ExpressionDynamic("list1 * list2", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "list1", list1 }, { "list2", list2 } } };
+        var result = expr.Execute(c).ShouldBeAssignableTo<QuestList<string>>();
+        result.ShouldBe(["a", "b", "c", "d"]);
+    }
+
+    [DataTestMethod]
+    [DataRow("5 / 2", 2)]
+    [DataRow("6 / 2", 3)]
+    [DataRow("7 / 2", 3)]
+    [DataRow("100 / 10", 10)]
+    [DataRow("-7 / 2", -3)]
+    public void TestIntegerDivision(string expression, int expectedResult)
+    {
+        RunExpression<int>(expression).ShouldBe(expectedResult);
+    }
+
+    [TestMethod]
+    public void TestIntegerDivisionWithVariables()
+    {
+        // Exercises the NumberToWords pattern: int attribute / int literal
+        var expr = new ExpressionDynamic("number / 100", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "number", 342 } } };
+        var result = expr.Execute(c);
+        result.ShouldBe(3);
+    }
+
+    [TestMethod]
+    public void TestIntegerDivisionThenModulo()
+    {
+        // Mirrors the tens = (number / 10) % 10 pattern in NumberToWords
+        var expr = new ExpressionDynamic("(number / 10) % 10", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "number", 42 } } };
+        var result = expr.Execute(c);
+        result.ShouldBe(4);
+    }
 }
 
 [TestClass]

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -389,6 +389,19 @@ public abstract class ExpressionTestsBase
     }
 
     [TestMethod]
+    public void TestMethodCallWithNullArg()
+    {
+        if (!UseNCalc) return; // FLEE handles instance method calls natively; this verifies the NCalc parser extension
+
+        // When a method arg is null, GetMethod(name, [typeof(object)]) won't find
+        // List<Element>.Contains(Element), so the null-arg fallback must kick in.
+        // AllObjects() as receiver avoids the ConvertVariablesToFleeFormat (\w\.\w) mangling.
+        var expr = new Expression<bool>("AllObjects().Contains(nullobj)", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "nullobj", null } } };
+        expr.Execute(c).ShouldBeFalse();
+    }
+
+    [TestMethod]
     public void TestSplitFunction()
     {
         var result = RunExpressionGeneric("Split(\"a,b,c\", \",\")");


### PR DESCRIPTION
## Summary

- **Integer division**: NCalc always returns `Double` for `/`, but FLEE compiled to IL where `int / int = int`. Fixed by intercepting in `EvaluateBinary` when both operands are integer types and returning a `long` (which `CoerceLong` then converts to `int`). This fixes `NumberToWords` in `English.aslx`, which does `hundreds = number / 100` and `tens = (number / 10) % 10` — with NCalc these stored `3.42` instead of `3`, causing `StringListItem` to fail on the double index.
- **`__Quest_MethodCall__` null-arg dispatch**: Applied the same null-argument fallback already present in `EvaluateFunctionFromType` — without it, `someObject.Method(null)` in an expression would fail to find the right overload because `null` maps to `typeof(object)`.
- **`QuestList<T>` operator deprecation comments**: Removed the commented-out `Debug.Assert("Operators on lists are deprecated")` stubs. We need 100% FLEE compatibility, so these operators must stay supported and exercised.

## Test plan

- [ ] All existing tests pass (421 total)
- [ ] New `TestIntegerDivision` covers `5/2=2`, `7/2=3`, `-7/2=-3` etc. against both evaluators
- [ ] New `TestIntegerDivisionWithVariables` covers `int_var / 100` with a game attribute
- [ ] New `TestIntegerDivisionThenModulo` covers `(number / 10) % 10` — the exact `NumberToWords` pattern
- [ ] New `TestListPlusList`, `TestElementPlusList`, `TestListTimesListUnionDedup` cover the remaining list operator paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)