### PR TITLE
NCalc FLEE parity: return false for cross-type equality instead of throwing IConvertible

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -311,6 +311,8 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     {
         // Check operator type BEFORE evaluating args to preserve short-circuit evaluation
         // for And/Or: calling LeftValue()/RightValue() forces eager evaluation of both sides.
+        var isEquality = args.BinaryExpression.Type is BinaryExpressionType.Equal or BinaryExpressionType.NotEqual;
+
         var operatorName = args.BinaryExpression.Type switch
         {
             BinaryExpressionType.Plus => "op_Addition",
@@ -321,10 +323,21 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             _ => null
         };
 
-        if (operatorName == null) return;
+        if (operatorName == null && !isEquality) return;
 
         var left = args.LeftValue();
         var right = args.RightValue();
+
+        // NCalc's internal equality logic calls Convert.ChangeType() which requires IConvertible.
+        // Element doesn't implement IConvertible, so intercept equality/inequality for non-standard
+        // types and use Equals() instead — matching FLEE's behaviour of returning false for
+        // cross-type comparisons (e.g. string vs Element, or Element vs string).
+        if (isEquality && (!IsStandardNCalcType(left) || !IsStandardNCalcType(right)))
+        {
+            var equal = Equals(left, right);
+            args.Result = args.BinaryExpression.Type == BinaryExpressionType.Equal ? equal : !equal;
+            return;
+        }
 
         // NCalc always returns Double for /, but FLEE compiled to IL where int/int = int.
         // Intercept integer division to match FLEE's behavior.

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -616,6 +616,24 @@ public abstract class ExpressionTestsBase
         var result = expr.Execute(c);
         result.ShouldBe(4);
     }
+
+    [TestMethod]
+    public void TestObjectEqualToStringReturnsFalse()
+    {
+        // Cross-type equality (Element vs string) must return false, not throw IConvertible.
+        var expr = new Expression<bool>("myobj = \"somestring\"", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "myobj", _object } } };
+        expr.Execute(c).ShouldBe(false);
+    }
+
+    [TestMethod]
+    public void TestStringEqualToObjectReturnsFalse()
+    {
+        // Cross-type equality (string vs Element) must return false, not throw IConvertible.
+        var expr = new Expression<bool>("mystr = myobj", _scriptContext);
+        var c = new Context { Parameters = new Parameters { { "mystr", "somestring" }, { "myobj", _object } } };
+        expr.Execute(c).ShouldBe(false);
+    }
 }
 
 [TestClass]


### PR DESCRIPTION
## Summary

- Games can compare an object-typed attribute to a string literal (e.g. a field holding an `Element` checked against `"somevalue"`). FLEE silently returned `false` for such cross-type comparisons.
- NCalc's internal equality logic calls `Convert.ChangeType()`, which requires `IConvertible` — `Element` doesn't implement it, so NCalc threw `"Object must implement IConvertible"` instead.
- Fix: intercept `Equal`/`NotEqual` in `EvaluateBinary` when either side is a non-standard type and use `Equals()` directly, matching FLEE's behaviour.

## Test plan

- [ ] Two new tests in `ExpressionTestsBase` cover Element-vs-string and string-vs-Element equality; both run under NCalc and FLEE evaluators (4 test cases total)
- [ ] Full `EngineTests` suite passes (pre-existing `TestNegateDoubleAsInt` failures are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)