### PR TITLE
NCalc FLEE parity: property access on function return values

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -446,6 +446,24 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             return method.Invoke(receiver, methodArgs);
         }
 
+        if (name == "__Quest_PropertyAccess__")
+        {
+            if (args.Parameters.Count != 2)
+                throw new Exception("__Quest_PropertyAccess__ requires exactly 2 arguments");
+            var receiver = args.Parameters.Evaluate(0);
+            var propertyName = args.Parameters.Evaluate(1) as string
+                ?? throw new Exception("__Quest_PropertyAccess__ second argument must be a property name string");
+            if (receiver is Element element)
+            {
+                return element.Fields.Exists(propertyName, true) ? element.Fields.Get(propertyName) : null;
+            }
+            var prop = receiver?.GetType().GetProperty(propertyName,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (prop != null)
+                return prop.GetValue(receiver);
+            throw new Exception($"Property '{propertyName}' not found on '{receiver?.GetType().Name}'");
+        }
+
         if (name == "__Quest_Index__")
         {
             if (args.Parameters.Count != 2)

--- a/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
+++ b/src/Engine/Expressions/QuestNCalcLogicalExpressionParser.cs
@@ -362,9 +362,10 @@ public static class QuestNCalcLogicalExpressionParser
             identifierExpression,
             list);
 
-        // postfix => primary ( "[" expression "]" | "." identifier "(" args ")" )* ;
-        // Handles Quest's list/dictionary subscript syntax: list[0], dict[key], func()[0]
-        // and instance method call syntax: str.StartsWith("x"), func().Method(args)
+        // postfix => primary ( "[" expression "]" | "." identifier "(" args ")" | "." identifier )* ;
+        // Handles Quest's list/dictionary subscript syntax: list[0], dict[key], func()[0],
+        // instance method call syntax: str.StartsWith("x"), func().Method(args), and
+        // property access on a function return value: ObjectListItem(list, i).parent
         var subscriptSuffix = openBrace.SkipAnd(expression).AndSkip(closeBrace)
             .Then<Func<LogicalExpression, LogicalExpression>>(index =>
                 receiver => new Function(new Identifier("__Quest_Index__"),
@@ -379,7 +380,17 @@ public static class QuestNCalcLogicalExpressionParser
                     new LogicalExpressionList([receiver, new ValueExpression(methodName), ..args]));
             });
 
-        var postfix = primary.And(ZeroOrMany(OneOf(subscriptSuffix, methodCallSuffix)))
+        // Must come after methodCallSuffix in OneOf so that ".method(args)" is not mistakenly
+        // consumed as just a property access.
+        var propertyAccessSuffix = dot.SkipAnd(identifier)
+            .Then<Func<LogicalExpression, LogicalExpression>>(propName =>
+            {
+                var propertyName = propName.ToString()!;
+                return receiver => new Function(new Identifier("__Quest_PropertyAccess__"),
+                    new LogicalExpressionList([receiver, new ValueExpression(propertyName)]));
+            });
+
+        var postfix = primary.And(ZeroOrMany(OneOf(subscriptSuffix, methodCallSuffix, propertyAccessSuffix)))
             .Then<LogicalExpression>(x =>
             {
                 var result = x.Item1;

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -218,6 +218,7 @@ public abstract class ExpressionTestsBase
     [DataRow("GetObject(\"object\")", "object")]
     [DataRow("GetObject(\"invalid\")", "null")]
     [DataRow("ObjectListItem(AllObjects(), 0)", "object")]
+    [DataRow("GetObject(\"child\").parent", "object")]
     public void TestObjectExpressions(string expression, string expectedElementName)
     {
         var result = RunExpressionGeneric(expression);


### PR DESCRIPTION
## Summary

- Adds support for `func().property` syntax in the NCalc expression parser — e.g. `ObjectListItem(list1, idx).parent`
- FLEE handled this natively via C# reflection; NCalc's postfix rule only matched `.identifier(args)` (method calls), causing an `Invalid token in expression` parse error in production
- Fix adds a `propertyAccessSuffix` (`.identifier` without parens) tried after `methodCallSuffix` so method calls remain unambiguous; the evaluator resolves the property via `Element.Fields` for game objects and falls back to C# reflection for other types

## Test plan

- [ ] New `DataRow` in `TestObjectExpressions`: `GetObject("child").parent` → the `object` element
- [ ] All existing tests pass (`dotnet test --configuration Release`)
- [ ] Verified against game `brQObgBnR0yjaZp3FCXgCA` which triggered the production error

🤖 Generated with [Claude Code](https://claude.com/claude-code)