### PR TITLE
Async NCalc: Phases 1, 2, and 2b — async script execution path

### DIFF
--- a/docs/async-ncalc-wasm-plan.md
+++ b/docs/async-ncalc-wasm-plan.md
@@ -23,26 +23,36 @@ event loop at `await` points rather than blocking a thread.
 
 ---
 
-## Phase 1 — Async NCalc
+## Phase 1 — Async NCalc ✅
 
-- Swap `NCalcSync` for NCalc's async package (`NCalc` with async expression support)
-- Add `EvaluateAsync(Context c)` to `IExpression<T>` alongside (or replacing) `Evaluate()`
-- Update `NcalcExpressionEvaluator` to use NCalc's async `EvaluateAsync()` with an async `EvaluateFunction` handler
-- `FleeExpressionEvaluator` gets a shim (wraps sync call in `Task.FromResult`) since Flee has no async path — it stays working but is on the way out
+- Swapped `NCalcSync` for `NCalcAsync` (both redirect to `NCalc.Core`, which already has `EvaluateAsync`, `EvaluateAsyncFunction`, and `EvaluateBinaryAsync` events)
+- Added `EvaluateAsync(Context c)` to `IExpressionEvaluator<T>` and `IDynamicExpressionEvaluator` (removed `out` covariance from `IExpressionEvaluator<T>` since `Task<T>` is invariant)
+- `NcalcExpressionEvaluator` registers async event handlers and implements `EvaluateAsync` using NCalc's async path with full async parameter evaluation (`EvaluateAslFunctionAsync`, `EvaluateFunctionFromTypeAsync`, `EvaluateBinaryAsync`)
+- `FleeExpressionEvaluator` gets `Task.FromResult` shims since Flee has no async path — it stays working but is on the way out
+- `Expression<T>` and `ExpressionDynamic` expose `ExecuteAsync` methods
+- Branch: `async-ncalc`
 
 ---
 
-## Phase 2 — Async script interface
+## Phase 2 — Async script interface ✅
 
-This is the bulk of the work.
+Chose **parallel interface** (Option A): `Task ExecuteAsync(Context c)` added to `IScript`
+alongside `Execute()`, so tests and the editor continue working unchanged.
 
-- Add `Task ExecuteAsync(Context c)` to `IScript` (keep `Execute()` alongside during migration so tests/editor don't break immediately)
-- Propagate async through: `ScriptFactory` → `MultiScript` → individual script classes (`WaitScript`, `ShowMenuScript`, `AskScript`, etc.) in `src/Engine/Scripts/`
-- At each await point that currently calls `Monitor.Wait()`, instead `await` a `TaskCompletionSource.Task`
-
-Risk: this touches every `IScript` implementation and is hard to do incrementally. Worth
-deciding up front whether to run a parallel async interface during migration or do a hard
-cutover.
+- `ScriptBase` has a virtual default shim: `Execute(c); return Task.CompletedTask;`
+- All control-flow scripts have proper async overrides:
+  - `MultiScript` — loops and `await`s each child
+  - `IfScript` — sync condition evaluation, async branches
+  - `ForScript`, `WhileScript`, `ForEachScript` — sync bounds/condition, async loop body
+  - `SwitchScript` (including inner `SwitchCases`) — sync expression, async matched case
+  - `FirstTimeScript` — async branch scripts
+  - `FunctionCallScript` — calls `RunProcedureAsync`
+  - `RunDelegateScript`, `DoActionScript`, `InvokeScript` — call `RunScriptAsync`
+  - `LazyLoadScript` — delegates to inner script's `ExecuteAsync`
+- `WorldModel` gains `RunScriptAsync` and `RunProcedureAsync` parallel variants
+- `NcalcExpressionEvaluator.EvaluateAslFunctionAsync` now uses `RunProcedureAsync` (no more `.GetAwaiter().GetResult()` in the async path)
+- Pause-inducing scripts (`WaitScript`, `ShowMenuScript`, `AskScript`, etc.) still fall through to the sync shim — they'll be wired up properly in Phase 3
+- Branch: `async-ncalc`
 
 ---
 
@@ -141,7 +151,7 @@ A lightweight Svelte (or vanilla JS) frontend analogous to `src/WebEditor/`:
 
 ## Notes and risks
 
-- **Flee must be removed or shimmed first** — it has no async path. This migration is a good forcing function to finish removing Flee entirely.
-- **Tests will need updating** — existing tests call `Execute()` synchronously. Moving to `ExecuteAsync()` means test infrastructure changes too.
+- **Flee must be removed before Phase 3** — it has no async path. The parallel-interface approach keeps it working for now, but once the async path is the live path, Flee will need to be gone. This migration is a good forcing function to finish removing it.
+- **Tests are unaffected so far** — the parallel-interface approach (Option A) means all existing tests continue calling `Execute()` synchronously. Async-specific test coverage will be needed once Phase 3 makes `ExecuteAsync` the live path.
 - **Callback manager overlap** — there's already a partial callback-based async mechanism (`CallbackManager`, `StartWaitAsync`). Phase 3 should decide whether to unify these or remove the old path outright.
 - **SharedArrayBuffer** — even with Quest's own threading removed, the .NET WASM runtime uses `SharedArrayBuffer` internally (for the GC). The COOP/COEP headers required by WasmEditor will be needed for WasmPlayer too. Confirm the CDN target serves these headers.

--- a/docs/async-ncalc-wasm-plan.md
+++ b/docs/async-ncalc-wasm-plan.md
@@ -52,29 +52,74 @@ alongside `Execute()`, so tests and the editor continue working unchanged.
 - `WorldModel` gains `RunScriptAsync` and `RunProcedureAsync` parallel variants
 - `NcalcExpressionEvaluator.EvaluateAslFunctionAsync` now uses `RunProcedureAsync` (no more `.GetAwaiter().GetResult()` in the async path)
 - Pause-inducing scripts (`WaitScript`, `ShowMenuScript`, `AskScript`, etc.) still fall through to the sync shim — they'll be wired up properly in Phase 3
+- `AsyncScriptTests` added to exercise the async execution path end-to-end
 - Branch: `async-ncalc`
+
+---
+
+## Phase 2b — Flip the driver ✅
+
+The async script path was exercised in tests but not in production. Rather than a "big
+bang" switch, the production driver was flipped with a single-line change:
+
+```csharp
+// WorldModel.cs — private core RunScript now delegates to RunScriptAsync
+private object? RunScript(IScript script, Context c, bool expectResult)
+{
+    return RunScriptAsync(script, c, expectResult).GetAwaiter().GetResult();
+}
+```
+
+Every execution path (`RunProcedure`, all `RunScript` overloads, timer callbacks,
+`SendEvent`, `TryFinishTurn`, callbacks) bottoms out at this private core, so a single
+change routes all script execution through `ExecuteAsync`.
+
+Pause-inducing scripts still fall through to the sync shim — `Execute(c)` blocks on
+`Monitor.Wait` as before, and returns `Task.CompletedTask` (already complete), so the
+`await` resumes synchronously on the same thread. **No observable behaviour change**, but
+now 99% of script execution — every `if`, loop, function call, and switch — runs through
+`ExecuteAsync` in production.
+
+Why `.GetAwaiter().GetResult()` doesn't deadlock here: all tasks in the current chain
+complete synchronously (the shim blocks the thread before returning, not after), so no
+async continuation is ever posted to a synchronization context. Even on the ASP.NET Core
+request thread (e.g. `SendEvent`), there is no thread switch and therefore no deadlock
+risk.
+
+Branch: `async-ncalc`
 
 ---
 
 ## Phase 3 — Replace Monitor-based blocking
 
-In `WorldModel.cs`, replace:
+The remaining work to eliminate all thread-blocking:
 
-```csharp
-// current
-lock (_waitForResponseLock) { Monitor.Wait(_waitForResponseLock); }
+1. **Proper `ExecuteAsync` on pause scripts** — `WaitScript`, `ShowMenuScript`,
+   `AskScript`, `GetInputScript` currently fall through to the sync shim. Each needs a
+   real `override async Task ExecuteAsync(Context c)` that `await`s a
+   `TaskCompletionSource` instead of calling `Execute`.
 
-// new
-_inputTcs = new TaskCompletionSource();
-await _inputTcs.Task;
-```
+2. **Replace `Monitor.Wait/Pulse` with `TaskCompletionSource`** in `WorldModel.cs`:
 
-The response handlers (`SetMenuResponse`, `SetQuestionResponse`, `SetWaitFinished`) call
-`_inputTcs.SetResult()` instead of `Monitor.Pulse()`. `DoInNewThreadAndWait()` is
-deleted.
+   ```csharp
+   // current
+   lock (_waitForResponseLock) { Monitor.Wait(_waitForResponseLock); }
 
-The `ThreadState` enum and `_threadLock` go away entirely. `WaitUntilFinishedWorking()`
-in the player becomes `await`-based or disappears.
+   // new
+   _inputTcs = new TaskCompletionSource();
+   await _inputTcs.Task;
+   ```
+
+   The response handlers (`SetMenuResponse`, `SetQuestionResponse`, `FinishWait`) call
+   `_inputTcs.SetResult()` instead of `Monitor.Pulse()`. `DoInNewThreadAndWait()` is
+   deleted.
+
+3. **Thread state cleanup** — `ThreadState` enum and `_threadLock` go away entirely.
+   `WaitUntilFinishedWorking()` in the player becomes `await`-based or disappears.
+
+At this point `GetAwaiter().GetResult()` in the driver core can also be removed — the
+sync `RunScript` wrapper either disappears or is kept as a true fire-and-forget for legacy
+callers (edit mode etc.) that don't need the async path.
 
 ---
 
@@ -82,7 +127,8 @@ in the player becomes `await`-based or disappears.
 
 - `PlayerCore`'s `GameLauncher` and turn-processing become async end-to-end
 - `WebPlayer`'s Blazor components `await` turn execution rather than blocking
-- The existing callback-based path (`CallbackManager`) can be simplified since `async/await` subsumes the callback pattern
+- The existing callback-based path (`CallbackManager`) can be simplified since
+  `async/await` subsumes the callback pattern
 
 ---
 
@@ -151,7 +197,7 @@ A lightweight Svelte (or vanilla JS) frontend analogous to `src/WebEditor/`:
 
 ## Notes and risks
 
-- **Flee must be removed before Phase 3** — it has no async path. The parallel-interface approach keeps it working for now, but once the async path is the live path, Flee will need to be gone. This migration is a good forcing function to finish removing it.
-- **Tests are unaffected so far** — the parallel-interface approach (Option A) means all existing tests continue calling `Execute()` synchronously. Async-specific test coverage will be needed once Phase 3 makes `ExecuteAsync` the live path.
+- **Flee must be removed before Phase 3** — it has no async path. The parallel-interface approach keeps it working for now, but `FleeExpressionEvaluator` only has `Task.FromResult` shims and can't truly await. Since Phase 2b flipped the driver, Flee is already running through `ExecuteAsync` (via the sync shim) in production — but Phase 3 will require removing it entirely before the pause scripts can actually `await`.
+- **Tests now cover the async path** — `AsyncScriptTests` drives all control-flow scripts via `RunProcedureAsync`. The sync tests still pass unchanged (the `RunScript` core now routes through `RunScriptAsync` internally).
 - **Callback manager overlap** — there's already a partial callback-based async mechanism (`CallbackManager`, `StartWaitAsync`). Phase 3 should decide whether to unify these or remove the old path outright.
 - **SharedArrayBuffer** — even with Quest's own threading removed, the .NET WASM runtime uses `SharedArrayBuffer` internally (for the GC). The COOP/COEP headers required by WasmEditor will be needed for WasmPlayer too. Confirm the CDN target serves these headers.

--- a/src/Engine/Engine.csproj
+++ b/src/Engine/Engine.csproj
@@ -23,7 +23,7 @@
         <ProjectReference Include="..\Utility\Utility.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="NCalcSync" Version="6.3.0"/>
+        <PackageReference Include="NCalcAsync" Version="6.3.2"/>
         <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Engine/Expressions/FleeExpressionEvaluator.cs
+++ b/src/Engine/Expressions/FleeExpressionEvaluator.cs
@@ -43,6 +43,8 @@ public class FleeExpressionEvaluator<T>(string expression, ScriptContext scriptC
                 $"Error evaluating expression '{Utility.ConvertFleeFormatToVariables(expression)}': {ex.Message}", ex);
         }
     }
+
+    public Task<T> EvaluateAsync(Context c) => Task.FromResult(Evaluate(c));
 }
 
 public class FleeDynamicExpressionEvaluator(string expression, ScriptContext scriptContext)
@@ -84,4 +86,6 @@ public class FleeDynamicExpressionEvaluator(string expression, ScriptContext scr
                 $"Error evaluating expression '{Utility.ConvertFleeFormatToVariables(expression)}': {ex.Message}", ex);
         }
     }
+
+    public Task<object> EvaluateAsync(Context c) => Task.FromResult(Evaluate(c));
 }

--- a/src/Engine/Expressions/IExpressionEvaluator.cs
+++ b/src/Engine/Expressions/IExpressionEvaluator.cs
@@ -1,14 +1,15 @@
-#nullable disable
 using QuestViva.Engine.Scripts;
 
 namespace QuestViva.Engine.Expressions;
 
-public interface IExpressionEvaluator<out T>
+public interface IExpressionEvaluator<T>
 {
     T Evaluate(Context c);
+    Task<T> EvaluateAsync(Context c);
 }
 
 public interface IDynamicExpressionEvaluator
 {
     object Evaluate(Context c);
+    Task<object> EvaluateAsync(Context c);
 }

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -639,8 +639,8 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             return _context.Parameters.ContainsKey(variableName);
         }
 
-        return RunQuestProcedure(name, args.Parameters.Count,
-            i => args.Parameters.EvaluateAsync(i).GetAwaiter().GetResult());
+        return await RunQuestProcedureAsync(name, args.Parameters.Count,
+            i => args.Parameters.EvaluateAsync(i));
     }
 
     private object RunQuestProcedure(string name, int argCount, Func<int, object> evaluateArg)
@@ -660,6 +660,25 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         }
 
         return _scriptContext.WorldModel.RunProcedure(name, parameters, true);
+    }
+
+    private async Task<object> RunQuestProcedureAsync(string name, int argCount, Func<int, Task<object>> evaluateArgAsync)
+    {
+        var proc = _scriptContext.WorldModel.Procedure(name);
+
+        if (proc == null)
+        {
+            throw new Exception($"Unknown function '{name}'");
+        }
+
+        var parameters = new Parameters();
+
+        for (var cnt = 0; cnt < argCount; cnt++)
+        {
+            parameters.Add((string) proc.Fields[FieldDefinitions.ParamNames][cnt], await evaluateArgAsync(cnt));
+        }
+
+        return await _scriptContext.WorldModel.RunProcedureAsync(name, parameters, true);
     }
 
     private static object DispatchMethodCall(object receiver, string methodName, object[] methodArgs)

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -31,11 +31,18 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         _nCalcExpression.EvaluateFunction += EvaluateFunction;
         _nCalcExpression.EvaluateParameter += EvaluateParameter;
         _nCalcExpression.EvaluateBinary += EvaluateBinary;
+        _nCalcExpression.EvaluateAsyncFunction += EvaluateFunctionAsync;
+        _nCalcExpression.EvaluateBinaryAsync += EvaluateBinaryAsync;
     }
 
     object IDynamicExpressionEvaluator.Evaluate(Context c)
     {
         return Evaluate(c);
+    }
+
+    async Task<object> IDynamicExpressionEvaluator.EvaluateAsync(Context c)
+    {
+        return await EvaluateAsync(c);
     }
 
     public T Evaluate(Context c)
@@ -46,6 +53,27 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             var result = CoerceLong(_nCalcExpression.Evaluate());
 
             // Converting ints to generic doubles is fun
+            if (typeof(T) == typeof(double) && result is int i)
+            {
+                return (T) (object) (double) i;
+            }
+
+            return (T) result;
+        }
+        catch (Exception ex)
+        {
+            var innerMessage = ex.InnerException?.Message ?? ex.Message;
+            throw new Exception($"Error evaluating expression '{_expression}': {innerMessage}", ex);
+        }
+    }
+
+    public async Task<T> EvaluateAsync(Context c)
+    {
+        _context = c;
+        try
+        {
+            var result = CoerceLong(await _nCalcExpression.EvaluateAsync());
+
             if (typeof(T) == typeof(double) && result is int i)
             {
                 return (T) (object) (double) i;
@@ -183,23 +211,78 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         args.Result = EvaluateAslFunction(name, args);
     }
 
+    private async Task EvaluateFunctionAsync(string name, FunctionEventArgs args)
+    {
+        var tryExpressionOwner =
+            await EvaluateFunctionFromTypeAsync(typeof(ExpressionOwner), _expressionOwner, name, args.Parameters);
+        if (tryExpressionOwner.handled)
+        {
+            args.Result = tryExpressionOwner.result;
+            return;
+        }
+
+        var tryMath = await EvaluateFunctionFromTypeAsync(typeof(Math), null, name, args.Parameters);
+        if (tryMath.handled)
+        {
+            args.Result = tryMath.result;
+            return;
+        }
+
+        var tryStringFunctions = await EvaluateFunctionFromTypeAsync(typeof(StringFunctions), null, name, args.Parameters);
+        if (tryStringFunctions.handled)
+        {
+            args.Result = tryStringFunctions.result;
+            return;
+        }
+
+        var tryDateTimeFunctions = await EvaluateFunctionFromTypeAsync(typeof(DateTimeFunctions), null, name, args.Parameters);
+        if (tryDateTimeFunctions.handled)
+        {
+            args.Result = tryDateTimeFunctions.result;
+            return;
+        }
+
+        args.Result = await EvaluateAslFunctionAsync(name, args);
+    }
+
 #nullable enable
     private static (bool handled, object? result) EvaluateFunctionFromType(Type type, object? instance, string name,
         FunctionData parameters)
     {
-        var methods = type.GetMethods()
-            .Where(m => m.IsPublic && m.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
-            .ToArray<MethodBase>();
-
-        if (methods.Length == 0)
-        {
-            return (false, null);
-        }
+        var methods = GetPublicMethodsByName(type, name);
+        if (methods == null) return (false, null);
 
         var evaluatedArgs = Enumerable.Range(0, parameters.Count)
             .Select(i => CoerceLong(parameters.Evaluate(i)))
             .ToArray();
 
+        return DispatchToMethod(methods, instance, name, evaluatedArgs);
+    }
+
+    private static async Task<(bool handled, object? result)> EvaluateFunctionFromTypeAsync(Type type, object? instance,
+        string name, FunctionData parameters)
+    {
+        var methods = GetPublicMethodsByName(type, name);
+        if (methods == null) return (false, null);
+
+        var evaluatedArgs = await Task.WhenAll(
+            Enumerable.Range(0, parameters.Count)
+                .Select(async i => CoerceLong(await parameters.EvaluateAsync(i))));
+
+        return DispatchToMethod(methods, instance, name, evaluatedArgs);
+    }
+
+    private static MethodBase[]? GetPublicMethodsByName(Type type, string name)
+    {
+        var methods = type.GetMethods()
+            .Where(m => m.IsPublic && m.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
+            .ToArray<MethodBase>();
+        return methods.Length == 0 ? null : methods;
+    }
+
+    private static (bool handled, object? result) DispatchToMethod(MethodBase[] methods, object? instance, string name,
+        object?[] evaluatedArgs)
+    {
         // First, try to find a method with a params parameter.
         var paramsMethods = methods
             .Where(m =>
@@ -328,6 +411,33 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         var left = args.LeftValue();
         var right = args.RightValue();
 
+        HandleBinaryResult(args, isEquality, operatorName, left, right);
+    }
+
+    private async Task EvaluateBinaryAsync(BinaryEventArgs args)
+    {
+        var isEquality = args.BinaryExpression.Type is BinaryExpressionType.Equal or BinaryExpressionType.NotEqual;
+
+        var operatorName = args.BinaryExpression.Type switch
+        {
+            BinaryExpressionType.Plus => "op_Addition",
+            BinaryExpressionType.Minus => "op_Subtraction",
+            BinaryExpressionType.Times => "op_Multiply",
+            BinaryExpressionType.Div => "op_Division",
+            BinaryExpressionType.Modulo => "op_Modulus",
+            _ => null
+        };
+
+        if (operatorName == null && !isEquality) return;
+
+        var left = await args.LeftValueAsync();
+        var right = await args.RightValueAsync();
+
+        HandleBinaryResult(args, isEquality, operatorName, left, right);
+    }
+
+    private static void HandleBinaryResult(BinaryEventArgs args, bool isEquality, string operatorName, object left, object right)
+    {
         // NCalc's internal equality logic calls Convert.ChangeType() which requires IConvertible.
         // Element doesn't implement IConvertible, so intercept equality/inequality for non-standard
         // types and use Equals() instead — matching FLEE's behaviour of returning false for
@@ -415,35 +525,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             var methodArgs = Enumerable.Range(2, args.Parameters.Count - 2)
                 .Select(i => CoerceLong(args.Parameters.Evaluate(i)))
                 .ToArray();
-            var argTypes = methodArgs.Select(a => a?.GetType() ?? typeof(object)).ToArray();
-            var method = receiver?.GetType().GetMethod(methodName, argTypes);
-
-            if (method == null && methodArgs.Any(a => a == null))
-            {
-                method = receiver?.GetType().GetMethods()
-                    .Where(m => m.Name == methodName)
-                    .FirstOrDefault(m =>
-                    {
-                        var ps = m.GetParameters();
-                        if (ps.Length != methodArgs.Length) return false;
-                        for (var i = 0; i < methodArgs.Length; i++)
-                        {
-                            if (methodArgs[i] == null)
-                            {
-                                if (ps[i].ParameterType.IsValueType &&
-                                    Nullable.GetUnderlyingType(ps[i].ParameterType) == null)
-                                    return false;
-                                continue;
-                            }
-                            if (!ps[i].ParameterType.IsInstanceOfType(methodArgs[i])) return false;
-                        }
-                        return true;
-                    });
-            }
-
-            if (method == null)
-                throw new Exception($"Method '{methodName}' not found on '{receiver?.GetType().Name}'");
-            return method.Invoke(receiver, methodArgs);
+            return DispatchMethodCall(receiver, methodName, methodArgs);
         }
 
         if (name == "__Quest_Index__")
@@ -468,25 +550,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             finally { _evaluatingCastType = false; }
             var typeName = typeArg as string
                 ?? throw new Exception("cast() second parameter must be a type name (int, double, string, bool)");
-            return typeName switch
-            {
-                "boolean" => Convert.ToBoolean(value),
-                "byte" => Convert.ToByte(value),
-                "sbyte" => Convert.ToSByte(value),
-                "short" => Convert.ToInt16(value),
-                "ushort" => Convert.ToUInt16(value),
-                "int" => (int) Convert.ToDouble(value),
-                "uint" => Convert.ToUInt32(value),
-                "long" => Convert.ToInt64(value),
-                "ulong" => Convert.ToUInt64(value),
-                "single" => Convert.ToSingle(value),
-                "double" => Convert.ToDouble(value),
-                "decimal" => Convert.ToDecimal(value),
-                "char" => Convert.ToChar(value),
-                "object" => value,
-                "string" => Convert.ToString(value),
-                _ => throw new Exception($"cast(): unknown type '{typeName}'")
-            };
+            return CastValue(value, typeName);
         }
 
         if (name.Equals("if", StringComparison.InvariantCultureIgnoreCase))
@@ -514,6 +578,73 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             return _context.Parameters.ContainsKey(variableName);
         }
 
+        return RunQuestProcedure(name, args.Parameters.Count, i => args.Parameters.Evaluate(i));
+    }
+
+    private async Task<object> EvaluateAslFunctionAsync(string name, FunctionEventArgs args)
+    {
+        if (name == "__Quest_MethodCall__")
+        {
+            if (args.Parameters.Count < 2)
+                throw new Exception("__Quest_MethodCall__ requires at least 2 arguments");
+            var receiver = CoerceLong(await args.Parameters.EvaluateAsync(0));
+            var methodName = await args.Parameters.EvaluateAsync(1) as string
+                ?? throw new Exception("__Quest_MethodCall__ second argument must be a string method name");
+            var methodArgs = await Task.WhenAll(Enumerable.Range(2, args.Parameters.Count - 2)
+                .Select(async i => CoerceLong(await args.Parameters.EvaluateAsync(i))));
+            return DispatchMethodCall(receiver, methodName, methodArgs);
+        }
+
+        if (name == "__Quest_Index__")
+        {
+            if (args.Parameters.Count != 2)
+                throw new Exception("Subscript operator requires exactly 2 operands");
+            var collection = await args.Parameters.EvaluateAsync(0);
+            var key = CoerceLong(await args.Parameters.EvaluateAsync(1));
+            if (collection is IQuestList)
+                return _expressionOwner.ListItem(collection, (int) key);
+            return _expressionOwner.DictionaryItem(collection, key?.ToString());
+        }
+
+        if (name.Equals("cast", StringComparison.InvariantCultureIgnoreCase))
+        {
+            if (args.Parameters.Count != 2)
+                throw new Exception("cast() expects 2 parameters: value and type");
+            var value = CoerceLong(await args.Parameters.EvaluateAsync(0));
+            _evaluatingCastType = true;
+            object typeArg;
+            try { typeArg = await args.Parameters.EvaluateAsync(1); }
+            finally { _evaluatingCastType = false; }
+            var typeName = typeArg as string
+                ?? throw new Exception("cast() second parameter must be a type name (int, double, string, bool)");
+            return CastValue(value, typeName);
+        }
+
+        if (name.Equals("if", StringComparison.InvariantCultureIgnoreCase))
+        {
+            if (args.Parameters.Count != 3)
+                throw new Exception("'if' function expects 3 parameters: condition, trueValue, falseValue");
+            var condition = await args.Parameters.EvaluateAsync(0);
+            return condition is true
+                ? await args.Parameters.EvaluateAsync(1)
+                : await args.Parameters.EvaluateAsync(2);
+        }
+
+        if (name == "IsDefined")
+        {
+            if (args.Parameters.Count != 1)
+                throw new Exception("IsDefined function expects 1 parameter");
+            if (await args.Parameters.EvaluateAsync(0) is not string variableName)
+                throw new Exception("IsDefined function expects a string parameter");
+            return _context.Parameters.ContainsKey(variableName);
+        }
+
+        return RunQuestProcedure(name, args.Parameters.Count,
+            i => args.Parameters.EvaluateAsync(i).GetAwaiter().GetResult());
+    }
+
+    private object RunQuestProcedure(string name, int argCount, Func<int, object> evaluateArg)
+    {
         var proc = _scriptContext.WorldModel.Procedure(name);
 
         if (proc == null)
@@ -523,11 +654,64 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
         var parameters = new Parameters();
 
-        for (var cnt = 0; cnt < args.Parameters.Count; cnt++)
+        for (var cnt = 0; cnt < argCount; cnt++)
         {
-            parameters.Add((string) proc.Fields[FieldDefinitions.ParamNames][cnt], args.Parameters.Evaluate(cnt));
+            parameters.Add((string) proc.Fields[FieldDefinitions.ParamNames][cnt], evaluateArg(cnt));
         }
 
         return _scriptContext.WorldModel.RunProcedure(name, parameters, true);
     }
+
+    private static object DispatchMethodCall(object receiver, string methodName, object[] methodArgs)
+    {
+        var argTypes = methodArgs.Select(a => a?.GetType() ?? typeof(object)).ToArray();
+        var method = receiver?.GetType().GetMethod(methodName, argTypes);
+
+        if (method == null && methodArgs.Any(a => a == null))
+        {
+            method = receiver?.GetType().GetMethods()
+                .Where(m => m.Name == methodName)
+                .FirstOrDefault(m =>
+                {
+                    var ps = m.GetParameters();
+                    if (ps.Length != methodArgs.Length) return false;
+                    for (var i = 0; i < methodArgs.Length; i++)
+                    {
+                        if (methodArgs[i] == null)
+                        {
+                            if (ps[i].ParameterType.IsValueType &&
+                                Nullable.GetUnderlyingType(ps[i].ParameterType) == null)
+                                return false;
+                            continue;
+                        }
+                        if (!ps[i].ParameterType.IsInstanceOfType(methodArgs[i])) return false;
+                    }
+                    return true;
+                });
+        }
+
+        if (method == null)
+            throw new Exception($"Method '{methodName}' not found on '{receiver?.GetType().Name}'");
+        return method.Invoke(receiver, methodArgs);
+    }
+
+    private static object CastValue(object value, string typeName) => typeName switch
+    {
+        "boolean" => Convert.ToBoolean(value),
+        "byte" => Convert.ToByte(value),
+        "sbyte" => Convert.ToSByte(value),
+        "short" => Convert.ToInt16(value),
+        "ushort" => Convert.ToUInt16(value),
+        "int" => (int) Convert.ToDouble(value),
+        "uint" => Convert.ToUInt32(value),
+        "long" => Convert.ToInt64(value),
+        "ulong" => Convert.ToUInt64(value),
+        "single" => Convert.ToSingle(value),
+        "double" => Convert.ToDouble(value),
+        "decimal" => Convert.ToDecimal(value),
+        "char" => Convert.ToChar(value),
+        "object" => value,
+        "string" => Convert.ToString(value),
+        _ => throw new Exception($"cast(): unknown type '{typeName}'")
+    };
 }

--- a/src/Engine/Functions/Expression.cs
+++ b/src/Engine/Functions/Expression.cs
@@ -55,6 +55,11 @@ public class Expression<T> : ExpressionBase, IFunction<T>
         return _expressionEvaluator.Evaluate(c);
     }
 
+    public Task<T> ExecuteAsync(Context c)
+    {
+        return _expressionEvaluator.EvaluateAsync(c);
+    }
+
     public string Save()
     {
         return OriginalExpression;
@@ -86,6 +91,11 @@ public class ExpressionDynamic : ExpressionBase, IFunctionDynamic
     public object Execute(Context c)
     {
         return _dynamicExpressionEvaluator.Evaluate(c);
+    }
+
+    public Task<object> ExecuteAsync(Context c)
+    {
+        return _dynamicExpressionEvaluator.EvaluateAsync(c);
     }
 
     public string Save()

--- a/src/Engine/Scripts/DoScript.cs
+++ b/src/Engine/Scripts/DoScript.cs
@@ -79,6 +79,20 @@ public class DoActionScript : ScriptBase
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        var obj = m_obj.Execute(c);
+        var action = obj.GetAction(m_action.Execute(c));
+        if (m_parameters == null)
+        {
+            await m_worldModel.RunScriptAsync(action, obj);
+        }
+        else
+        {
+            await m_worldModel.RunScriptAsync(action, new Parameters(m_parameters.Execute(c)), obj);
+        }
+    }
+
     public override string Save()
     {
         var parameters = m_parameters == null ? null : m_parameters.Save();

--- a/src/Engine/Scripts/FirstTimeScript.cs
+++ b/src/Engine/Scripts/FirstTimeScript.cs
@@ -89,6 +89,23 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        if (!m_hasRun)
+        {
+            m_hasRun = true;
+            m_worldModel.UndoLogger.AddUndoAction(() => new UndoFirstTime(this));
+            await m_firstTimeScript.ExecuteAsync(c);
+        }
+        else
+        {
+            if (m_otherwiseScript != null)
+            {
+                await m_otherwiseScript.ExecuteAsync(c);
+            }
+        }
+    }
+
     public override string Save()
     {
         if (m_worldModel.EditMode || !m_hasRun)

--- a/src/Engine/Scripts/ForEachScript.cs
+++ b/src/Engine/Scripts/ForEachScript.cs
@@ -90,6 +90,40 @@ public class ForEachScript : ScriptBase
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        var result = m_list.Execute(c);
+        IEnumerable resultList = null;
+
+        if (m_scriptContext.WorldModel.Version < WorldModelVersion.v530 || !(result is string))
+        {
+            var resultDictionary = result as IDictionary;
+            if (resultDictionary != null)
+            {
+                resultList = resultDictionary.Keys;
+            }
+            else
+            {
+                resultList = result as IEnumerable;
+            }
+        }
+
+        if (resultList == null)
+        {
+            throw new Exception(string.Format("Cannot foreach over '{0}' as it is not a list", result));
+        }
+
+        foreach (var variable in resultList)
+        {
+            c.Parameters[m_variable] = variable;
+            await m_loopScript.ExecuteAsync(c);
+            if (c.IsReturned)
+            {
+                break;
+            }
+        }
+    }
+
     public override string Save()
     {
         return SaveScript("foreach", m_loopScript, m_variable, m_list.Save());

--- a/src/Engine/Scripts/ForScript.cs
+++ b/src/Engine/Scripts/ForScript.cs
@@ -115,6 +115,35 @@ public class ForScript : ScriptBase
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        var from = m_from.Execute(c);
+        var to = m_to.Execute(c);
+        var step = m_step == null ? 1 : m_step.Execute(c);
+        int count;
+        c.Parameters[m_variable] = 0;
+
+        for (count = from; (step > 0 && count <= to) || (step < 0 && count >= to); count += step)
+        {
+            c.Parameters[m_variable] = count;
+            await m_loopScript.ExecuteAsync(c);
+            if (c.IsReturned)
+            {
+                break;
+            }
+
+            var newCount = c.Parameters[m_variable];
+            if (newCount is int)
+            {
+                count = (int) newCount;
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
     public override string Save()
     {
         if (m_step == null)

--- a/src/Engine/Scripts/FunctionCallScript.cs
+++ b/src/Engine/Scripts/FunctionCallScript.cs
@@ -151,6 +151,62 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        if ((m_parameters.Parameters == null || m_parameters.Parameters.Count == 0) && m_paramFunction == null)
+        {
+            await m_worldModel.RunProcedureAsync(m_procedure);
+        }
+        else
+        {
+            var paramValues = new Parameters();
+            var proc = m_worldModel.Procedure(m_procedure);
+
+            var paramNames = proc.Fields[FieldDefinitions.ParamNames];
+
+            var paramCount = m_parameters.Parameters.Count;
+            if (m_paramFunction != null)
+            {
+                paramCount++;
+            }
+
+            if (paramCount > paramNames.Count)
+            {
+                throw new Exception(string.Format(
+                    "Too many parameters passed to {0} function - {1} passed, but only {2} expected",
+                    m_procedure,
+                    paramCount,
+                    paramNames.Count));
+            }
+
+            if (m_worldModel.Version >= WorldModelVersion.v520)
+            {
+                if (paramCount < paramNames.Count)
+                {
+                    throw new Exception(string.Format(
+                        "Too few parameters passed to {0} function - only {1} passed, but {2} expected",
+                        m_procedure,
+                        paramCount,
+                        paramNames.Count));
+                }
+            }
+
+            var cnt = 0;
+            foreach (var f in m_parameters.Parameters)
+            {
+                paramValues.Add((string) paramNames[cnt], f.Execute(c));
+                cnt++;
+            }
+
+            if (m_paramFunction != null)
+            {
+                paramValues.Add((string) paramNames[cnt], m_paramFunction);
+            }
+
+            await m_worldModel.RunProcedureAsync(m_procedure, paramValues, false);
+        }
+    }
+
     public override string Keyword => "(function)" + m_procedure;
 
     public override string Save()

--- a/src/Engine/Scripts/IScript.cs
+++ b/src/Engine/Scripts/IScript.cs
@@ -56,6 +56,7 @@ public interface IScript : IMutableField
     string Keyword { get; }
     IScriptParent Parent { get; set; }
     void Execute(Context c);
+    Task ExecuteAsync(Context c);
     string Save();
     void SetParameter(int index, object value);
     void SetParameterSilent(int index, object value);
@@ -88,6 +89,8 @@ public abstract class ScriptBase : IScript, IMutableField
     public Element? Owner { get; set; }
 
     public abstract void Execute(Context c);
+
+    public virtual Task ExecuteAsync(Context c) { Execute(c); return Task.CompletedTask; }
 
     public abstract string Save();
 

--- a/src/Engine/Scripts/IfScript.cs
+++ b/src/Engine/Scripts/IfScript.cs
@@ -450,6 +450,32 @@ public class IfScript : ScriptBase, IIfScript
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        if (Expression.Execute(c))
+        {
+            await ThenScript.ExecuteAsync(c);
+            return;
+        }
+
+        if (m_elseIfScript != null)
+        {
+            foreach (ElseIfScript elseIfScript in m_elseIfScript)
+            {
+                if (elseIfScript.Expression.Execute(c))
+                {
+                    await elseIfScript.Script.ExecuteAsync(c);
+                    return;
+                }
+            }
+        }
+
+        if (ElseScript != null)
+        {
+            await ElseScript.ExecuteAsync(c);
+        }
+    }
+
     public override string Save()
     {
         var result = SaveScript("if", ThenScript, Expression.Save());

--- a/src/Engine/Scripts/InvokeScript.cs
+++ b/src/Engine/Scripts/InvokeScript.cs
@@ -68,6 +68,19 @@ public class InvokeScript : ScriptBase
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        var script = m_script.Execute(c);
+        if (m_parameters == null)
+        {
+            await m_worldModel.RunScriptAsync(script);
+        }
+        else
+        {
+            await m_worldModel.RunScriptAsync(script, new Parameters(m_parameters.Execute(c)));
+        }
+    }
+
     public override string Save()
     {
         var parameters = m_parameters == null ? null : m_parameters.Save();

--- a/src/Engine/Scripts/LazyLoadScript.cs
+++ b/src/Engine/Scripts/LazyLoadScript.cs
@@ -202,6 +202,12 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         m_script.Execute(c);
     }
 
+    public Task ExecuteAsync(Context c)
+    {
+        Initialise();
+        return m_script.ExecuteAsync(c);
+    }
+
     public string Line
     {
         get

--- a/src/Engine/Scripts/MultiScript.cs
+++ b/src/Engine/Scripts/MultiScript.cs
@@ -127,6 +127,18 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        foreach (var script in m_scripts)
+        {
+            await script.ExecuteAsync(c);
+            if (c.IsReturned)
+            {
+                break;
+            }
+        }
+    }
+
     public override string Line
     {
         get

--- a/src/Engine/Scripts/RunDelegateScript.cs
+++ b/src/Engine/Scripts/RunDelegateScript.cs
@@ -99,6 +99,35 @@ public class RunDelegateScript : ScriptBase
         m_worldModel.RunScript(impl.Implementation.Fields[FieldDefinitions.Script], paramValues, obj);
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        if (m_parameters == null)
+        {
+            throw new NotImplementedException();
+        }
+
+        var obj = m_appliesTo.Execute(c);
+        var delName = m_delegate.Execute(c);
+        var impl = obj.Fields.Get(delName) as DelegateImplementation;
+
+        if (impl == null)
+        {
+            throw new Exception(
+                string.Format("Object '{0}' has no delegate implementation '{1}'", obj.Name, m_delegate));
+        }
+
+        var paramValues = new Parameters();
+
+        var cnt = 0;
+        foreach (var f in m_parameters.Parameters)
+        {
+            paramValues.Add((string) impl.Definition.Fields[FieldDefinitions.ParamNames][cnt], f.Execute(c));
+            cnt++;
+        }
+
+        await m_worldModel.RunScriptAsync(impl.Implementation.Fields[FieldDefinitions.Script], paramValues, obj);
+    }
+
     public override string Save()
     {
         var saveParameters = new List<string>();

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -131,6 +131,17 @@ public class SwitchScript : ScriptBase
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        var result = m_expr.Execute(c);
+        var success = await m_cases.ExecuteAsync(c, result.ToString());
+
+        if (!success && m_default != null)
+        {
+            await m_default.ExecuteAsync(c);
+        }
+    }
+
     public override string Save()
     {
         var result = SaveScript("switch", m_expr.Save()) + " {" + Environment.NewLine;
@@ -247,6 +258,22 @@ public class SwitchScript : ScriptBase
                 if (result == expr.Execute(c).ToString())
                 {
                     switchCase.Value.Execute(c);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public async Task<bool> ExecuteAsync(Context c, string result)
+        {
+            foreach (var switchCase in CasesAsQuestDictionary)
+            {
+                var expr = m_compiledExpressions[switchCase.Key];
+
+                if (result == expr.Execute(c).ToString())
+                {
+                    await switchCase.Value.ExecuteAsync(c);
                     return true;
                 }
             }

--- a/src/Engine/Scripts/WhileScript.cs
+++ b/src/Engine/Scripts/WhileScript.cs
@@ -64,6 +64,18 @@ public class WhileScript : ScriptBase
         }
     }
 
+    public override async Task ExecuteAsync(Context c)
+    {
+        while (m_expression.Execute(c))
+        {
+            await m_loopScript.ExecuteAsync(c);
+            if (c.IsReturned)
+            {
+                break;
+            }
+        }
+    }
+
     public override string Save()
     {
         return SaveScript("while", m_loopScript, m_expression.Save());

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -1174,24 +1174,7 @@ public partial class WorldModel : IGame, IGameDebug
 
     private object? RunScript(IScript script, Context c, bool expectResult)
     {
-        try
-        {
-            script.Execute(c);
-            if (expectResult && c.ReturnValue is NoReturnValue)
-            {
-                throw new Exception("Function did not return a value");
-            }
-
-            return c.ReturnValue;
-        }
-        catch (Exception ex)
-        {
-            // TODO: Add some way of nicely showing script errors to the user (should be higher up the callstack)
-            Print("Error running script: " + Utility.SafeXML(ex.Message));
-            LogException(ex);
-        }
-
-        return null;
+        return RunScriptAsync(script, c, expectResult).GetAwaiter().GetResult();
     }
 
     public Element AddProcedure(string name)

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -1068,6 +1068,11 @@ public partial class WorldModel : IGame, IGameDebug
         RunScript(script, (Parameters?) null, false);
     }
 
+    public Task RunScriptAsync(IScript script)
+    {
+        return RunScriptAsync(script, (Parameters?) null, false);
+    }
+
     /// <summary>
     ///     Use this version of RunScript when executing an object action. Set thisElement to the object whose action it is.
     /// </summary>
@@ -1078,14 +1083,29 @@ public partial class WorldModel : IGame, IGameDebug
         RunScript(script, null, false, thisElement);
     }
 
+    public Task RunScriptAsync(IScript script, Element thisElement)
+    {
+        return RunScriptAsync(script, null, false, thisElement);
+    }
+
     public void RunScript(IScript script, Parameters parameters)
     {
         RunScript(script, parameters, false);
     }
 
+    public Task RunScriptAsync(IScript script, Parameters parameters)
+    {
+        return RunScriptAsync(script, parameters, false);
+    }
+
     public void RunScript(IScript script, Parameters parameters, Element thisElement)
     {
         RunScript(script, parameters, false, thisElement);
+    }
+
+    public Task RunScriptAsync(IScript script, Parameters parameters, Element thisElement)
+    {
+        return RunScriptAsync(script, parameters, false, thisElement);
     }
 
     public object RunDelegateScript(IScript script, Parameters parameters, Element thisElement)
@@ -1096,6 +1116,41 @@ public partial class WorldModel : IGame, IGameDebug
     private object? RunScript(IScript script, Parameters? parameters, bool expectResult)
     {
         return RunScript(script, parameters, expectResult, null);
+    }
+
+    private Task<object?> RunScriptAsync(IScript script, Parameters? parameters, bool expectResult,
+        Element? thisElement = null)
+    {
+        var c = new Context();
+        parameters ??= new Parameters();
+        if (thisElement != null)
+        {
+            parameters.Add("this", thisElement);
+        }
+
+        c.Parameters = parameters;
+        return RunScriptAsync(script, c, expectResult);
+    }
+
+    private async Task<object?> RunScriptAsync(IScript script, Context c, bool expectResult)
+    {
+        try
+        {
+            await script.ExecuteAsync(c);
+            if (expectResult && c.ReturnValue is NoReturnValue)
+            {
+                throw new Exception("Function did not return a value");
+            }
+
+            return c.ReturnValue;
+        }
+        catch (Exception ex)
+        {
+            Print("Error running script: " + Utility.SafeXML(ex.Message));
+            LogException(ex);
+        }
+
+        return null;
     }
 
     private object? RunScript(IScript script, Parameters? parameters, bool expectResult, Element? thisElement)
@@ -1164,6 +1219,11 @@ public partial class WorldModel : IGame, IGameDebug
         RunProcedure(name, false);
     }
 
+    public Task RunProcedureAsync(string name)
+    {
+        return RunProcedureAsync(name, null, false);
+    }
+
     private object? RunProcedure(string name, bool expectResult)
     {
         return RunProcedure(name, null, expectResult);
@@ -1198,6 +1258,37 @@ public partial class WorldModel : IGame, IGameDebug
             }
 
             return RunScript(function.Fields[FieldDefinitions.Script], parameters, expectResult);
+        }
+
+        Print($"Error - no such procedure '{name}'");
+        return null;
+    }
+
+    public async Task<object?> RunProcedureAsync(string name, Parameters? parameters, bool expectResult)
+    {
+        if (Elements.ContainsKey(ElementType.Function, name))
+        {
+            var function = Elements.Get(ElementType.Function, name);
+
+            var parametersInvalid = false;
+            if (Version == WorldModelVersion.v520)
+            {
+                parametersInvalid = parameters == null && function.Fields[FieldDefinitions.ParamNames].Count > 0;
+            }
+            else if (Version >= WorldModelVersion.v530)
+            {
+                parametersInvalid = (parameters == null || parameters.Count == 0) &&
+                                    function.Fields[FieldDefinitions.ParamNames].Count > 0;
+            }
+
+            if (parametersInvalid)
+            {
+                throw new Exception(string.Format("No parameters passed to {0} function - expected {1} parameters",
+                    name,
+                    function.Fields[FieldDefinitions.ParamNames].Count));
+            }
+
+            return await RunScriptAsync(function.Fields[FieldDefinitions.Script], parameters, expectResult);
         }
 
         Print($"Error - no such procedure '{name}'");

--- a/tests/EngineTests/AsyncScriptTests.cs
+++ b/tests/EngineTests/AsyncScriptTests.cs
@@ -1,0 +1,214 @@
+using QuestViva.Engine;
+using QuestViva.Engine.Scripts;
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+[TestClass]
+public class AsyncScriptTests
+{
+    private WorldModel _worldModel;
+    private ScriptContext _scriptContext;
+    private ScriptFactory _scriptFactory;
+    private Element _obj;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _worldModel = Helpers.CreateWorldModel(useNCalc: true);
+        _scriptContext = new ScriptContext(_worldModel);
+        _scriptFactory = new ScriptFactory(_worldModel);
+        _obj = _worldModel.GetElementFactory(ElementType.Object).Create("obj");
+    }
+
+    private void AddFunction(string name, string script, params string[] paramNames)
+    {
+        var function = _worldModel.GetElementFactory(ElementType.Function).Create(name);
+        function.Fields[FieldDefinitions.ParamNames] = new QuestList<string>(paramNames);
+        function.Fields[FieldDefinitions.Script] = _scriptFactory.CreateScript(script, _scriptContext);
+    }
+
+    private async Task<object> CallAsync(string name, Parameters parameters = null)
+    {
+        return await _worldModel.RunProcedureAsync(name, parameters, true);
+    }
+
+    [TestMethod]
+    public async Task TestSimpleReturnAsync()
+    {
+        AddFunction("SimpleReturn", "return (42)");
+        (await CallAsync("SimpleReturn")).ShouldBe(42);
+    }
+
+    [TestMethod]
+    public async Task TestMultiScriptAsync()
+    {
+        AddFunction("MultiStep",
+            """
+            x = 1
+            x = x + 1
+            x = x + 1
+            return (x)
+            """);
+        (await CallAsync("MultiStep")).ShouldBe(3);
+    }
+
+    [TestMethod]
+    public async Task TestIfTrueBranchAsync()
+    {
+        AddFunction("IfTrue",
+            """
+            if (true) {
+                return ("yes")
+            } else {
+                return ("no")
+            }
+            """);
+        (await CallAsync("IfTrue")).ShouldBe("yes");
+    }
+
+    [TestMethod]
+    public async Task TestIfFalseBranchAsync()
+    {
+        AddFunction("IfFalse",
+            """
+            if (false) {
+                return ("yes")
+            } else {
+                return ("no")
+            }
+            """);
+        (await CallAsync("IfFalse")).ShouldBe("no");
+    }
+
+    [TestMethod]
+    public async Task TestForScriptAsync()
+    {
+        AddFunction("ForLoop",
+            """
+            total = 0
+            for (i, 1, 5) {
+                total = total + i
+            }
+            return (total)
+            """);
+        (await CallAsync("ForLoop")).ShouldBe(15);
+    }
+
+    [TestMethod]
+    public async Task TestWhileScriptAsync()
+    {
+        AddFunction("WhileLoop",
+            """
+            x = 0
+            while (x < 5) {
+                x = x + 1
+            }
+            return (x)
+            """);
+        (await CallAsync("WhileLoop")).ShouldBe(5);
+    }
+
+    [TestMethod]
+    public async Task TestForEachScriptAsync()
+    {
+        AddFunction("ForEachCount",
+            """
+            items = NewStringList()
+            list add (items, "a")
+            list add (items, "b")
+            list add (items, "c")
+            count = 0
+            foreach (item, items) {
+                count = count + 1
+            }
+            return (count)
+            """);
+        (await CallAsync("ForEachCount")).ShouldBe(3);
+    }
+
+    [TestMethod]
+    public async Task TestSwitchMatchesCaseAsync()
+    {
+        AddFunction("SwitchMatch",
+            """
+            switch ("b") {
+                case ("a") {
+                    return ("got a")
+                }
+                case ("b") {
+                    return ("got b")
+                }
+                default {
+                    return ("got default")
+                }
+            }
+            """);
+        (await CallAsync("SwitchMatch")).ShouldBe("got b");
+    }
+
+    [TestMethod]
+    public async Task TestSwitchFallsToDefaultAsync()
+    {
+        AddFunction("SwitchDefault",
+            """
+            switch ("z") {
+                case ("a") {
+                    return ("got a")
+                }
+                default {
+                    return ("got default")
+                }
+            }
+            """);
+        (await CallAsync("SwitchDefault")).ShouldBe("got default");
+    }
+
+    [TestMethod]
+    public async Task TestFirstTimeScriptAsync()
+    {
+        AddFunction("FirstTimeFunc",
+            """
+            firsttime {
+                return ("first")
+            } otherwise {
+                return ("otherwise")
+            }
+            """);
+        (await CallAsync("FirstTimeFunc")).ShouldBe("first");
+        (await CallAsync("FirstTimeFunc")).ShouldBe("otherwise");
+    }
+
+    [TestMethod]
+    public async Task TestNestedFunctionCallAsync()
+    {
+        AddFunction("Double", "return (n * 2)", "n");
+        AddFunction("CallDouble",
+            """
+            result = Double(5)
+            return (result)
+            """);
+        (await CallAsync("CallDouble")).ShouldBe(10);
+    }
+
+    [TestMethod]
+    public async Task TestFunctionCallWithParametersAsync()
+    {
+        AddFunction("Add", "return (a + b)", "a", "b");
+        var result = await _worldModel.RunProcedureAsync("Add",
+            new Parameters { { "a", 3 }, { "b", 7 } }, true);
+        result.ShouldBe(10);
+    }
+
+    [TestMethod]
+    public async Task TestDoScriptAsync()
+    {
+        _obj.Fields.Set("flag", "unset");
+        _obj.Fields.Set("action",
+            _scriptFactory.CreateScript("obj.flag = \"done\"", _scriptContext));
+
+        AddFunction("RunAction", "do (obj, \"action\")");
+        await _worldModel.RunProcedureAsync("RunAction", null, false);
+        _obj.Fields.GetString("flag").ShouldBe("done");
+    }
+}

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -87,11 +87,25 @@ public abstract class ExpressionTestsBase
         return expr.Execute(c);
     }
 
+    private async Task<T> RunExpressionAsync<T>(string expression)
+    {
+        var expr = new Expression<T>(expression, _scriptContext);
+        var c = new Context();
+        return await expr.ExecuteAsync(c);
+    }
+
     private object RunExpressionGeneric(string expression)
     {
         var expr = new ExpressionDynamic(expression, _scriptContext);
         var c = new Context();
         return expr.Execute(c);
+    }
+
+    private async Task<object> RunExpressionGenericAsync(string expression)
+    {
+        var expr = new ExpressionDynamic(expression, _scriptContext);
+        var c = new Context();
+        return await expr.ExecuteAsync(c);
     }
 
     [DataTestMethod]
@@ -633,6 +647,28 @@ public abstract class ExpressionTestsBase
         var expr = new Expression<bool>("mystr = myobj", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "mystr", "somestring" }, { "myobj", _object } } };
         expr.Execute(c).ShouldBe(false);
+    }
+
+    [DataTestMethod]
+    [DataRow("\"hello world\"", "hello world")]
+    [DataRow("CustomStringFunction(\"b\", \"c\")", "abc")]
+    [DataRow("if(true, \"yes\", \"no\")", "yes")]
+    [DataRow("if(false, \"yes\", \"no\")", "no")]
+    public async Task TestStringExpressionsAsync(string expression, string expectedResult)
+    {
+        if (!UseNCalc) return; // async path is NCalc-only; FLEE shims to sync
+        var result = await RunExpressionAsync<string>(expression);
+        result.ShouldBe(expectedResult);
+    }
+
+    [DataTestMethod]
+    [DataRow("1 + 2", 3)]
+    [DataRow("CustomIntFunction(1, 2)", 3)]
+    public async Task TestIntExpressionsAsync(string expression, int expectedResult)
+    {
+        if (!UseNCalc) return; // async path is NCalc-only; FLEE shims to sync
+        var result = await RunExpressionAsync<int>(expression);
+        result.ShouldBe(expectedResult);
     }
 }
 


### PR DESCRIPTION
## Summary

- **Phase 1**: Swap `NCalcSync` for `NCalcAsync` and add `EvaluateAsync` to expression evaluators (`IExpressionEvaluator<T>`, `IDynamicExpressionEvaluator`, `NcalcExpressionEvaluator`, `FleeExpressionEvaluator` shim)
- **Phase 2**: Add `Task ExecuteAsync(Context c)` to `IScript` as a parallel interface; implement proper async overrides on all control-flow scripts (`MultiScript`, `IfScript`, `For*Script`, `SwitchScript`, `FunctionCallScript`, etc.); add `RunScriptAsync`/`RunProcedureAsync` to `WorldModel`
- **Phase 2b**: Flip the production driver — the private `RunScript` core now delegates to `RunScriptAsync`, routing all script execution through the async path with no observable behaviour change (pause-inducing scripts still fall through to the sync shim)

## Test plan

- [ ] `dotnet test tests/EngineTests` — `AsyncScriptTests` exercises `ExecuteAsync` end-to-end through `RunProcedureAsync`; `ExpressionTests` covers `EvaluateAsync`
- [ ] `dotnet test` — full suite passes (sync path unchanged; `Execute()` and editor continue to work)
- [ ] Manual smoke test: load and play a game in WebPlayer to confirm no regressions in production script execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)