### PR TITLE
Async NCalc: Phase 5 — full async V4Game interpreter, WASM-compatible

### DIFF
--- a/docs/async-ncalc-wasm-plan.md
+++ b/docs/async-ncalc-wasm-plan.md
@@ -137,16 +137,29 @@ eliminated as part of Phase 4.
 
 ---
 
-## Phase 5 — Legacy asyncification
+## Phase 5 — Legacy asyncification ✅
 
 Legacy (`src/Legacy/`) implements its own Q4 format interpreter (`V4Game.cs`) rather than
-sharing the Engine's script execution pipeline. Quest 4 scripting is much more limited
-than ASLX, so the surface area is a fraction of the Engine work — but it needs the same
-treatment (replace blocking waits with `TaskCompletionSource`, make execution methods
-async).
+sharing the Engine's script execution pipeline. The entire interpreter was made async — no
+background threads, no blocking waits — making it fully WASM-compatible.
 
-Do this in the same phase as the Engine rather than after, so the stack isn't partially
-threaded when the WasmPlayer is built.
+- **`TaskCompletionSource` trio** replaces all threading machinery:
+  - `_turnSuspendedTcs` — signals the IGame caller (SendCommand/Tick) that the turn has suspended
+  - `_waitTcs` — awaited by pause points (DoWait, Pause, ShowMenu, ExecuteIfAsk, PlayMedia sync)
+  - `_commandTcs` — awaited by `ExecuteEnter` (ASL `enter` keyword)
+- **`SignalTurnSuspended()`** helper sets `_readyForCommand = true` and fires `_turnSuspendedTcs`
+- **All `Monitor.Wait/Pulse`, `SemaphoreSlim`, `Task.Run`, `new Thread()`** removed
+- **`ExecuteScript` and `ExecCommand`** are now `async Task` / `async Task<bool>` — the entire
+  recursive descent interpreter propagates async (55+ methods made async across V4Game.cs,
+  V4Game.Part2.cs, RoomExit.cs, RoomExits.cs)
+- **Pause points** (`DoWaitAsync`, `PauseAsync`, `ShowMenuAsync`, `ExecuteIfAskAsync`,
+  `PlayMediaAsync`, `ExecuteEnterAsync`, `ExecuteWaitAsync`) create `_waitTcs`, call
+  `SignalTurnSuspended()`, then `await _waitTcs.Task` — exact same pattern as the Engine
+- **IGame methods** (`SendCommand`, `Tick`, `FinishWait`, `SetMenuResponse`, `SetQuestionResponse`)
+  create `_turnSuspendedTcs`, fire the async work, `await _turnSuspendedTcs.Task`
+- **`Begin()`** remains `void` / fire-and-forget (`_ = DoBeginAsync()`) matching WorldModel
+- **`Legacy.csproj`** has `<SupportedPlatform Include="browser" />` — zero CA1416 warnings confirm
+  no remaining browser-incompatible calls
 
 ---
 

--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -22,7 +22,7 @@ public interface IGame
     event FinishedHandler? Finished;
     event ErrorHandler? LogError;
     void Finish();
-    byte[] Save(string html);
+    Task<byte[]> SaveAsync(string html);
     Task FinishWait();
     Task FinishPause();
 

--- a/src/Common/IGameDebug.cs
+++ b/src/Common/IGameDebug.cs
@@ -14,7 +14,7 @@ public interface IGameDebug
     event EventHandler<ObjectsUpdatedEventArgs>? ObjectsUpdated;
     List<string> GetObjects(string type);
     DebugData GetDebugData(string tab, string obj);
-    bool Assert(string expression);
+    Task<bool> AssertAsync(string expression);
 }
 
 public class DebugDataItem

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -427,10 +427,10 @@ public partial class WorldModel : IGame, IGameDebug
         return result;
     }
 
-    public byte[] Save(string html)
+    public Task<byte[]> SaveAsync(string html)
     {
         var saveData = Save(SaveMode.SavedGame, html: html);
-        return Encoding.UTF8.GetBytes(saveData);
+        return Task.FromResult(Encoding.UTF8.GetBytes(saveData));
     }
 
     public Task Tick(int elapsedTime)

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -518,11 +518,11 @@ public partial class WorldModel : IGame, IGameDebug
         return Elements.Get(el).GetDebugData();
     }
 
-    public bool Assert(string expr)
+    public Task<bool> AssertAsync(string expr)
     {
         var expression = new Expression<bool>(expr, new ScriptContext(this));
         var c = new Context();
-        return expression.Execute(c);
+        return Task.FromResult(expression.Execute(c));
     }
 
     public event EventHandler<ElementFieldUpdatedEventArgs>? ElementFieldUpdated;

--- a/src/Legacy/Legacy.csproj
+++ b/src/Legacy/Legacy.csproj
@@ -22,4 +22,8 @@
         <ProjectReference Include="..\Utility\Utility.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <SupportedPlatform Include="browser" />
+    </ItemGroup>
+
 </Project>

--- a/src/Legacy/RoomExit.cs
+++ b/src/Legacy/RoomExit.cs
@@ -53,9 +53,9 @@ internal class RoomExit
         return _game.GetObjectProperty(propertyName, _objId, true, false) == "yes";
     }
 
-    private void SetAction(string actionName, string value)
+    private async Task SetAction(string actionName, string value)
     {
-        _game.AddToObjectActions("<" + actionName + "> " + value, _objId, _game._nullContext);
+        await _game.AddToObjectActions("<" + actionName + "> " + value, _objId, _game._nullContext);
     }
 
     public void SetToRoom(string value)
@@ -79,11 +79,11 @@ internal class RoomExit
         return GetExitProperty("prefix");
     }
 
-    public void SetScript(string value)
+    public async Task SetScript(string value)
     {
         if (Strings.Len(value) > 0)
         {
-            SetAction("script", value);
+            await SetAction("script", value);
         }
     }
 
@@ -161,15 +161,15 @@ internal class RoomExit
         return GetExitProperty("lockmessage");
     }
 
-    private void RunAction(ref string actionName, ref V4Game.Context ctx)
+    private async Task RunAction(string actionName, V4Game.Context ctx)
     {
-        _game.DoAction(_objId, actionName, ctx);
+        await _game.DoAction(_objId, actionName, ctx);
     }
 
-    internal void RunScript(ref V4Game.Context ctx)
+    internal async Task RunScript(V4Game.Context ctx)
     {
         var argactionName = "script";
-        RunAction(ref argactionName, ref ctx);
+        await RunAction(argactionName, ctx);
     }
 
     private void UpdateObjectName()
@@ -237,26 +237,26 @@ internal class RoomExit
         _objName = objName;
     }
 
-    internal void Go(ref V4Game.Context ctx)
+    internal async Task Go(V4Game.Context ctx)
     {
         if (GetIsLocked())
         {
             if (GetExitPropertyBool("lockmessage"))
             {
-                _game.Print(GetExitProperty("lockmessage"), ctx);
+                await _game.Print(GetExitProperty("lockmessage"), ctx);
             }
             else
             {
-                _game.PlayerErrorMessage(V4Game.PlayerError.Locked, ctx);
+                await _game.PlayerErrorMessage(V4Game.PlayerError.Locked, ctx);
             }
         }
         else if (IsScript())
         {
-            RunScript(ref ctx);
+            await RunScript(ctx);
         }
         else
         {
-            _game.PlayGame(GetToRoom(), ctx);
+            await _game.PlayGame(GetToRoom(), ctx);
         }
     }
 }

--- a/src/Legacy/RoomExit.cs
+++ b/src/Legacy/RoomExit.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualBasic;
+using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
 
 namespace QuestViva.Legacy;
@@ -26,9 +26,9 @@ internal class RoomExit
         o.Exists = true;
     }
 
-    private void SetExitProperty(string propertyName, string value)
+    private async Task SetExitProperty(string propertyName, string value)
     {
-        _game.AddToObjectProperties(propertyName + "=" + value, _objId, _game._nullContext);
+        await _game.AddToObjectProperties(propertyName + "=" + value, _objId, _game._nullContext);
     }
 
     private string GetExitProperty(string propertyName)
@@ -36,7 +36,7 @@ internal class RoomExit
         return _game.GetObjectProperty(propertyName, _objId, false, false);
     }
 
-    private void SetExitPropertyBool(string propertyName, bool value)
+    private async Task SetExitPropertyBool(string propertyName, bool value)
     {
         string sPropertyString;
         sPropertyString = propertyName;
@@ -45,7 +45,7 @@ internal class RoomExit
             sPropertyString = "not " + sPropertyString;
         }
 
-        _game.AddToObjectProperties(sPropertyString, _objId, _game._nullContext);
+        await _game.AddToObjectProperties(sPropertyString, _objId, _game._nullContext);
     }
 
     private bool GetExitPropertyBool(string propertyName)
@@ -58,10 +58,10 @@ internal class RoomExit
         await _game.AddToObjectActions("<" + actionName + "> " + value, _objId, _game._nullContext);
     }
 
-    public void SetToRoom(string value)
+    public async Task SetToRoom(string value)
     {
-        SetExitProperty("to", value);
-        UpdateObjectName();
+        await SetExitProperty("to", value);
+        await UpdateObjectName();
     }
 
     public string GetToRoom()
@@ -69,9 +69,9 @@ internal class RoomExit
         return GetExitProperty("to");
     }
 
-    public void SetPrefix(string value)
+    public async Task SetPrefix(string value)
     {
-        SetExitProperty("prefix", value);
+        await SetExitProperty("prefix", value);
     }
 
     public string GetPrefix()
@@ -92,12 +92,12 @@ internal class RoomExit
         return _game.HasAction(_objId, "script");
     }
 
-    public void SetDirection(V4Game.Direction value)
+    public async Task SetDirection(V4Game.Direction value)
     {
         _direction = value;
         if (value != V4Game.Direction.None)
         {
-            UpdateObjectName();
+            await UpdateObjectName();
         }
     }
 
@@ -141,9 +141,9 @@ internal class RoomExit
         return _displayName;
     }
 
-    public void SetIsLocked(bool value)
+    public async Task SetIsLocked(bool value)
     {
-        SetExitPropertyBool("locked", value);
+        await SetExitPropertyBool("locked", value);
     }
 
     public bool GetIsLocked()
@@ -151,9 +151,9 @@ internal class RoomExit
         return GetExitPropertyBool("locked");
     }
 
-    public void SetLockMessage(string value)
+    public async Task SetLockMessage(string value)
     {
-        SetExitProperty("lockmessage", value);
+        await SetExitProperty("lockmessage", value);
     }
 
     public string GetLockMessage()
@@ -172,7 +172,7 @@ internal class RoomExit
         await RunAction(argactionName, ctx);
     }
 
-    private void UpdateObjectName()
+    private async Task UpdateObjectName()
     {
         string objName;
         var lastExitId = default(int);
@@ -210,7 +210,7 @@ internal class RoomExit
             }
 
             lastExitId = lastExitId + 1;
-            _game.AddToObjectProperties("quest.lastexitid=" + lastExitId, _parent.GetObjId(), _game._nullContext);
+            await _game.AddToObjectProperties("quest.lastexitid=" + lastExitId, _parent.GetObjId(), _game._nullContext);
             objName = objName + ".exit" + lastExitId;
 
             if (GetRoomId() == 0)
@@ -228,7 +228,7 @@ internal class RoomExit
             }
 
             _game._objs[_objId].ObjectAlias = _displayName;
-            SetPrefix(_game._rooms[GetRoomId()].Prefix);
+            await SetPrefix(_game._rooms[GetRoomId()].Prefix);
         }
 
         _game._objs[_objId].ObjectName = objName;

--- a/src/Legacy/RoomExits.cs
+++ b/src/Legacy/RoomExits.cs
@@ -55,7 +55,7 @@ internal class RoomExits
         _regenerateAllExits = true;
     }
 
-    public void AddExitFromTag(string tag)
+    public async Task AddExitFromTag(string tag)
     {
         V4Game.Direction thisDir;
         var roomExit = (RoomExit) null;
@@ -150,7 +150,7 @@ internal class RoomExits
 
         if (Strings.Left(Strings.Trim(tag), 1) == "<")
         {
-            @params = Strings.Split(_game.GetParameter(tag, _game._nullContext), ";");
+            @params = Strings.Split(await _game.GetParameter(tag, _game._nullContext), ";");
             afterParam = Strings.Trim(Strings.Mid(tag, Strings.InStr(tag, ">") + 1));
             param = true;
         }
@@ -197,7 +197,7 @@ internal class RoomExits
         }
     }
 
-    internal void AddExitFromCreateScript(string script, ref V4Game.Context ctx)
+    internal async Task AddExitFromCreateScript(string script, V4Game.Context ctx)
     {
         // sScript is the "create exit ..." script, but without the "create exit" at the beginning.
         // So it's very similar to creating an exit from a tag, except we have the source room
@@ -221,7 +221,7 @@ internal class RoomExits
         // to
         // north <dest_room>
 
-        param = _game.GetParameter(script, ctx);
+        param = await _game.GetParameter(script, ctx);
         @params = Strings.Split(param, ";");
 
         paramStart = Strings.InStr(script, "<");
@@ -233,13 +233,13 @@ internal class RoomExits
             if (Information.UBound(@params) == 0)
             {
                 // Script directional exit
-                AddExitFromTag(Strings.Trim(Strings.Left(script, paramStart - 1)) + " " +
+                await AddExitFromTag(Strings.Trim(Strings.Left(script, paramStart - 1)) + " " +
                                Strings.Trim(Strings.Mid(script, paramEnd + 1)));
             }
             else
             {
                 // "Normal" directional exit
-                AddExitFromTag(Strings.Trim(Strings.Left(script, paramStart - 1)) + " <" + Strings.Trim(@params[1]) +
+                await AddExitFromTag(Strings.Trim(Strings.Left(script, paramStart - 1)) + " <" + Strings.Trim(@params[1]) +
                                ">");
             }
         }
@@ -253,7 +253,7 @@ internal class RoomExits
             }
 
             // Place exit so add "place" tag at the beginning
-            AddExitFromTag("place <" + Strings.Trim(@params[1]) + Strings.Mid(script, paramEnd));
+            await AddExitFromTag("place <" + Strings.Trim(@params[1]) + Strings.Mid(script, paramEnd));
         }
     }
 
@@ -272,7 +272,7 @@ internal class RoomExits
         return _places;
     }
 
-    internal void ExecuteGo(string cmd, ref V4Game.Context ctx)
+    internal async Task ExecuteGo(string cmd, V4Game.Context ctx)
     {
         // This will handle "n", "go east", "go [to] library" etc.
 
@@ -288,16 +288,16 @@ internal class RoomExits
             cmd = _game.GetEverythingAfter(cmd, "go ");
         }
 
-        lExitID = _game.Disambiguate(cmd, _game._currentRoom, ctx, true);
+        lExitID = await _game.Disambiguate(cmd, _game._currentRoom, ctx, true);
 
         if (lExitID == -1)
         {
-            _game.PlayerErrorMessage(V4Game.PlayerError.BadPlace, ctx);
+            await _game.PlayerErrorMessage(V4Game.PlayerError.BadPlace, ctx);
         }
         else
         {
             oExit = GetExitByObjectId(ref lExitID);
-            oExit.Go(ref ctx);
+            await oExit.Go(ctx);
         }
     }
 

--- a/src/Legacy/RoomExits.cs
+++ b/src/Legacy/RoomExits.cs
@@ -140,11 +140,11 @@ internal class RoomExits
         }
 
         roomExit.SetParent(this);
-        roomExit.SetDirection(thisDir);
+        await roomExit.SetDirection(thisDir);
 
         if (_game.BeginsWith(tag, "locked "))
         {
-            roomExit.SetIsLocked(true);
+            await roomExit.SetIsLocked(true);
             tag = _game.GetEverythingAfter(tag, "locked ");
         }
 
@@ -162,32 +162,32 @@ internal class RoomExits
         if (Strings.Len(afterParam) > 0)
         {
             // Script exit
-            roomExit.SetScript(afterParam);
+            await roomExit.SetScript(afterParam);
 
             if (thisDir == V4Game.Direction.None)
             {
                 // A place exit with a script still has a ToRoom
-                roomExit.SetToRoom(@params[0]);
+                await roomExit.SetToRoom(@params[0]);
 
                 // and may have a lock message
                 if (Information.UBound(@params) > 0)
                 {
-                    roomExit.SetLockMessage(@params[1]);
+                    await roomExit.SetLockMessage(@params[1]);
                 }
             }
             // A directional exit with a script may have no parameter.
             // If it does have a parameter it will be a lock message.
             else if (param)
             {
-                roomExit.SetLockMessage(@params[0]);
+                await roomExit.SetLockMessage(@params[0]);
             }
         }
         else
         {
-            roomExit.SetToRoom(@params[0]);
+            await roomExit.SetToRoom(@params[0]);
             if (Information.UBound(@params) > 0)
             {
-                roomExit.SetLockMessage(@params[1]);
+                await roomExit.SetLockMessage(@params[1]);
             }
         }
 

--- a/src/Legacy/V4Game.Debug.cs
+++ b/src/Legacy/V4Game.Debug.cs
@@ -67,9 +67,9 @@ public partial class V4Game
 
     public IWalkthroughs Walkthroughs => _walkthroughs ??= new WalkthroughList(this);
 
-    public bool Assert(string expression)
+    public Task<bool> AssertAsync(string expression)
     {
-        return ExecuteConditions(expression, _nullContext).GetAwaiter().GetResult();
+        return ExecuteConditions(expression, _nullContext);
     }
 
     private DebugData GetVariableDebugData(VariableType[] variable)
@@ -142,7 +142,10 @@ public partial class V4Game
                     continue;
                 }
 
-                var name = game.GetParameter(startLine, game._nullContext, false).GetAwaiter().GetResult();
+                var paramStart = startLine.IndexOf('<');
+                var paramEnd = startLine.IndexOf('>');
+                if (paramStart < 0 || paramEnd < 0) continue;
+                var name = startLine.Substring(paramStart + 1, paramEnd - paramStart - 1);
 
                 var steps = new List<string>();
                 for (var i = section.StartLine + 1; i < section.EndLine; i++)

--- a/src/Legacy/V4Game.Debug.cs
+++ b/src/Legacy/V4Game.Debug.cs
@@ -69,7 +69,7 @@ public partial class V4Game
 
     public bool Assert(string expression)
     {
-        return ExecuteConditions(expression, _nullContext);
+        return ExecuteConditions(expression, _nullContext).GetAwaiter().GetResult();
     }
 
     private DebugData GetVariableDebugData(VariableType[] variable)
@@ -142,7 +142,7 @@ public partial class V4Game
                     continue;
                 }
 
-                var name = game.GetParameter(startLine, game._nullContext, false);
+                var name = game.GetParameter(startLine, game._nullContext, false).GetAwaiter().GetResult();
 
                 var steps = new List<string>();
                 for (var i = section.StartLine + 1; i < section.EndLine; i++)

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -137,7 +137,7 @@ public partial class V4Game
 
     public Task FinishPause() => FinishWait();
 
-    public async Task SetMenuResponse(string? response)
+    public async Task SetMenuResponse(string response)
     {
         m_menuResponse = response;
         _turnSuspendedTcs = new TaskCompletionSource();
@@ -8157,7 +8157,7 @@ public partial class V4Game
 
 
 
-    private async Task<string?> ShowMenuAsync(MenuData menuData)
+    private async Task<string> ShowMenuAsync(MenuData menuData)
     {
         _player.ShowMenu(menuData);
         _waitTcs = new TaskCompletionSource();

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -21,7 +21,7 @@ public partial class V4Game
 
         if (ASLVersion >= 391)
         {
-            ExecuteScript(_beforeSaveScript, ctx);
+            ExecuteScript(_beforeSaveScript, ctx).GetAwaiter().GetResult();
         }
 
         if (ASLVersion >= 280)
@@ -38,17 +38,7 @@ public partial class V4Game
 
     public void Begin()
     {
-        var runnerThread = new Thread(DoBegin);
-        ChangeState(State.Working);
-        runnerThread.Start();
-
-        lock (_stateLock)
-        {
-            while ((_state == State.Working) & !_gameFinished)
-            {
-                Monitor.Wait(_stateLock);
-            }
-        }
+        _ = DoBeginAsync();
     }
 
     public List<string> Errors => new();
@@ -69,36 +59,15 @@ public partial class V4Game
         return SendCommand(command, 0, null);
     }
 
-    public Task SendCommand(string command, int elapsedTime, IDictionary<string, string> metadata)
+    public async Task SendCommand(string command, int elapsedTime, IDictionary<string, string> metadata)
     {
-        // The processing of commands is done in a separate thread, so things like the "enter" command can
-        // lock the thread while waiting for further input. After starting to process the command, we wait
-        // for something to happen before returning from the SendCommand call - either the command will have
-        // finished processing, or perhaps a prompt has been printed and now the game is waiting for further
-        // user input after hitting an "enter" script command.
-
-        if (!_readyForCommand)
-        {
-            return Task.CompletedTask;
-        }
-
-        var runnerThread =
-            new Thread(ProcessCommandInNewThread);
-        ChangeState(State.Working);
-        runnerThread.Start(command);
-
-        WaitForStateChange(State.Working);
-
-        if (elapsedTime > 0)
-        {
-            Tick(elapsedTime);
-        }
-        else
-        {
-            RaiseNextTimerTickRequest();
-        }
-
-        return Task.CompletedTask;
+        if (!_readyForCommand) return;
+        _readyForCommand = false;
+        _turnSuspendedTcs = new TaskCompletionSource();
+        _ = HandleCommandAsync(command);
+        await _turnSuspendedTcs.Task;
+        if (elapsedTime > 0) await Tick(elapsedTime);
+        else RaiseNextTimerTickRequest();
     }
 
     public Task SendEvent(string eventName, string param)
@@ -119,7 +88,7 @@ public partial class V4Game
         return await InitialiseGame(_gameData);
     }
 
-    public Task Tick(int elapsedTime)
+    public async Task Tick(int elapsedTime)
     {
         int i;
         var timerScripts = new List<string>();
@@ -151,45 +120,29 @@ public partial class V4Game
 
         if (timerScripts.Count > 0)
         {
-            var runnerThread =
-                new Thread(RunTimersInNewThread);
-
-            ChangeState(State.Working);
-            runnerThread.Start(timerScripts);
-            WaitForStateChange(State.Working);
+            _turnSuspendedTcs = new TaskCompletionSource();
+            _ = RunTimersAsync(timerScripts);
+            await _turnSuspendedTcs.Task;
         }
 
         RaiseNextTimerTickRequest();
-        return Task.CompletedTask;
     }
 
-    public Task FinishWait()
+    public async Task FinishWait()
     {
-        if (_state != State.Waiting)
-        {
-            return Task.CompletedTask;
-        }
-
-        var runnerThread = new Thread(FinishWaitInNewThread);
-        ChangeState(State.Working);
-        runnerThread.Start();
-        WaitForStateChange(State.Working);
-        return Task.CompletedTask;
+        _turnSuspendedTcs = new TaskCompletionSource();
+        _waitTcs?.TrySetResult();
+        await _turnSuspendedTcs.Task;
     }
 
-    public Task FinishPause()
-    {
-        return FinishWait();
-    }
+    public Task FinishPause() => FinishWait();
 
-    public Task SetMenuResponse(string response)
+    public async Task SetMenuResponse(string? response)
     {
-        var runnerThread =
-            new Thread(SetMenuResponseInNewThread);
-        ChangeState(State.Working);
-        runnerThread.Start(response);
-        WaitForStateChange(State.Working);
-        return Task.CompletedTask;
+        m_menuResponse = response;
+        _turnSuspendedTcs = new TaskCompletionSource();
+        _waitTcs?.TrySetResult();
+        await _turnSuspendedTcs.Task;
     }
 
     public IEnumerable<string> GetExternalScripts()
@@ -230,7 +183,7 @@ public partial class V4Game
         }
     }
 
-    private void RestoreGameData(string fileData)
+    private async Task RestoreGameData(string fileData)
     {
         string appliesTo;
         var data = "";
@@ -278,7 +231,7 @@ public partial class V4Game
                 // workaround bug where duplicate "create" entries appear in the restore data
                 if (!createdObjects.Contains(createData))
                 {
-                    ExecuteCreate("object <" + createData + ">", _nullContext);
+                    await ExecuteCreate("object <" + createData + ">", _nullContext);
                     createdObjects.Add(createData);
                 }
             }
@@ -327,11 +280,11 @@ public partial class V4Game
 
             if (BeginsWith(data, "exit "))
             {
-                ExecuteCreate(data, _nullContext);
+                await ExecuteCreate(data, _nullContext);
             }
             else if (data == "create")
             {
-                ExecuteCreate("room <" + appliesTo + ">", _nullContext);
+                await ExecuteCreate("room <" + appliesTo + ">", _nullContext);
             }
             else if (BeginsWith(data, "destroy exit "))
             {
@@ -351,7 +304,7 @@ public partial class V4Game
             }
             else if (BeginsWith(d.Change, "action "))
             {
-                AddToObjectActions(GetEverythingAfter(d.Change, "action "), GetObjectIdNoAlias(d.AppliesTo),
+                await AddToObjectActions(GetEverythingAfter(d.Change, "action "), GetObjectIdNoAlias(d.AppliesTo),
                     _nullContext);
             }
         }
@@ -573,16 +526,16 @@ public partial class V4Game
         if (!string.IsNullOrEmpty(_numericVariable[numNumber].OnChangeScript) & !_gameIsRestoring)
         {
             var script = _numericVariable[numNumber].OnChangeScript;
-            ExecuteScript(script, ctx);
+            _ = ExecuteScript(script, ctx);
         }
 
         if (!string.IsNullOrEmpty(_numericVariable[numNumber].DisplayString))
         {
-            UpdateStatusVars(ctx);
+            _ = UpdateStatusVars(ctx);
         }
     }
 
-    private void SetOpenClose(string name, bool open, Context ctx)
+    private async Task SetOpenClose(string name, bool open, Context ctx)
     {
         string cmd;
 
@@ -602,7 +555,7 @@ public partial class V4Game
             return;
         }
 
-        DoOpenClose(id, open, false, ctx);
+        await DoOpenClose(id, open, false, ctx);
     }
 
     private void SetTimerState(string name, bool state)
@@ -620,7 +573,7 @@ public partial class V4Game
         LogASLError("No such timer '" + name + "'", LogType.WarningError);
     }
 
-    private SetResult SetUnknownVariableType(string variableData, Context ctx)
+    private async Task<SetResult> SetUnknownVariableType(string variableData, Context ctx)
     {
         var scp = Strings.InStr(variableData, ";");
         if (scp == 0)
@@ -667,11 +620,11 @@ public partial class V4Game
         return SetResult.Unfound;
     }
 
-    private string SetUpChoiceForm(string blockName, Context ctx)
+    private async Task<string> SetUpChoiceForm(string blockName, Context ctx)
     {
         // Returns script to execute from choice block
-        var block = DefineBlockParam("selection", blockName);
-        var prompt = FindStatement(block, "info");
+        var block = await DefineBlockParam("selection", blockName);
+        var prompt = await FindStatement(block, "info");
 
         var menuOptions = new Dictionary<string, string>();
         var menuScript = new Dictionary<string, string>();
@@ -680,22 +633,22 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "choice "))
             {
-                menuOptions.Add(i.ToString(), GetParameter(_lines[i], ctx));
+                menuOptions.Add(i.ToString(), await GetParameter(_lines[i], ctx));
                 menuScript.Add(i.ToString(),
                     Strings.Trim(Strings.Right(_lines[i], Strings.Len(_lines[i]) - Strings.InStr(_lines[i], ">"))));
             }
         }
 
-        Print("- |i" + prompt + "|xi", ctx);
+        await Print("- |i" + prompt + "|xi", ctx);
 
         var mnu = new MenuData(prompt, menuOptions, false);
-        var choice = ShowMenu(mnu);
+        var choice = await ShowMenuAsync(mnu);
 
-        Print("- " + menuOptions[choice] + "|n", ctx);
+        await Print("- " + menuOptions[choice] + "|n", ctx);
         return menuScript[choice];
     }
 
-    private void SetUpDefaultFonts()
+    private async Task SetUpDefaultFonts()
     {
         // Sets up default fonts
         var gameblock = GetDefineBlock("game");
@@ -707,7 +660,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "default fontname "))
             {
-                var name = GetParameter(_lines[i], _nullContext);
+                var name = await GetParameter(_lines[i], _nullContext);
                 if (!string.IsNullOrEmpty(name))
                 {
                     _defaultFontName = name;
@@ -715,7 +668,7 @@ public partial class V4Game
             }
             else if (BeginsWith(_lines[i], "default fontsize "))
             {
-                var size = Conversions.ToInteger(GetParameter(_lines[i], _nullContext));
+                var size = Conversions.ToInteger(await GetParameter(_lines[i], _nullContext));
                 if (size != 0)
                 {
                     _defaultFontSize = size;
@@ -724,7 +677,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpDisplayVariables()
+    private async Task SetUpDisplayVariables()
     {
         for (int i = GetDefineBlock("game").StartLine + 1, loopTo = GetDefineBlock("game").EndLine - 1;
              i <= loopTo;
@@ -735,7 +688,7 @@ public partial class V4Game
                 var variable = new VariableType();
                 variable.VariableContents = new string[1];
 
-                variable.VariableName = GetParameter(_lines[i], _nullContext);
+                variable.VariableName = await GetParameter(_lines[i], _nullContext);
                 variable.DisplayString = "";
                 variable.NoZeroDisplay = false;
                 variable.OnChangeScript = "";
@@ -771,11 +724,11 @@ public partial class V4Game
                             variable.NoZeroDisplay = true;
                         }
 
-                        variable.DisplayString = GetParameter(_lines[i], _nullContext, false);
+                        variable.DisplayString = await GetParameter(_lines[i], _nullContext, false);
                     }
                     else if (BeginsWith(_lines[i], "value "))
                     {
-                        variable.VariableContents[0] = GetParameter(_lines[i], _nullContext);
+                        variable.VariableContents[0] = await GetParameter(_lines[i], _nullContext);
                     }
                 } while (Strings.Trim(_lines[i]) != "end define");
 
@@ -805,7 +758,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpGameObject()
+    private async Task SetUpGameObject()
     {
         _numberObjs = 1;
         _objs = new ObjectType[2];
@@ -829,15 +782,15 @@ public partial class V4Game
                 }
                 else if (BeginsWith(_lines[i], "properties "))
                 {
-                    AddToObjectProperties(GetParameter(_lines[i], _nullContext), _numberObjs, _nullContext);
+                    AddToObjectProperties(await GetParameter(_lines[i], _nullContext), _numberObjs, _nullContext);
                 }
                 else if (BeginsWith(_lines[i], "type "))
                 {
                     o.NumberTypesIncluded = o.NumberTypesIncluded + 1;
                     Array.Resize(ref o.TypesIncluded, o.NumberTypesIncluded + 1);
-                    o.TypesIncluded[o.NumberTypesIncluded] = GetParameter(_lines[i], _nullContext);
+                    o.TypesIncluded[o.NumberTypesIncluded] = await GetParameter(_lines[i], _nullContext);
 
-                    var propertyData = GetPropertiesInType(GetParameter(_lines[i], _nullContext));
+                    var propertyData = await GetPropertiesInType(await GetParameter(_lines[i], _nullContext));
                     AddToObjectProperties(propertyData.Properties, _numberObjs, _nullContext);
                     for (int k = 1, loopTo1 = propertyData.NumberActions; k <= loopTo1; k++)
                     {
@@ -847,7 +800,7 @@ public partial class V4Game
                 }
                 else if (BeginsWith(_lines[i], "action "))
                 {
-                    AddToObjectActions(GetEverythingAfter(_lines[i], "action "), _numberObjs, _nullContext);
+                    await AddToObjectActions(GetEverythingAfter(_lines[i], "action "), _numberObjs, _nullContext);
                 }
             }
             else if (Strings.Trim(_lines[i]) == "end define")
@@ -857,7 +810,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpMenus()
+    private async Task SetUpMenus()
     {
         var exists = false;
         var menuTitle = "";
@@ -870,12 +823,12 @@ public partial class V4Game
                 if (exists)
                 {
                     LogASLError(
-                        "Can't load menu '" + GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext) +
+                        "Can't load menu '" + await GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext) +
                         "' - only one menu can be added.", LogType.WarningError);
                 }
                 else
                 {
-                    menuTitle = GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext);
+                    menuTitle = await GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext);
 
                     for (int j = _defineBlocks[i].StartLine + 1, loopTo1 = _defineBlocks[i].EndLine - 1;
                          j <= loopTo1;
@@ -944,7 +897,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpRoomData()
+    private async Task SetUpRoomData()
     {
         var defaultProperties = new PropertiesActions();
 
@@ -955,7 +908,7 @@ public partial class V4Game
             if (Strings.Trim(_lines[_defineBlocks[i].StartLine]) == "define type <defaultroom>")
             {
                 defaultExists = true;
-                defaultProperties = GetPropertiesInType("defaultroom");
+                defaultProperties = await GetPropertiesInType("defaultroom");
                 break;
             }
         }
@@ -974,7 +927,7 @@ public partial class V4Game
 
                 var r = _rooms[_numberRooms];
 
-                r.RoomName = GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext);
+                r.RoomName = await GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext);
                 _objs[_numberObjs].ObjectName = r.RoomName;
                 _objs[_numberObjs].IsRoom = true;
                 _objs[_numberObjs].CorresRoom = r.RoomName;
@@ -1020,7 +973,7 @@ public partial class V4Game
 
                     if ((ASLVersion >= 280) & BeginsWith(_lines[j], "alias "))
                     {
-                        r.RoomAlias = GetParameter(_lines[j], _nullContext);
+                        r.RoomAlias = await GetParameter(_lines[j], _nullContext);
                         _objs[_numberObjs].ObjectAlias = r.RoomAlias;
                         if (ASLVersion >= 350)
                         {
@@ -1029,7 +982,7 @@ public partial class V4Game
                     }
                     else if ((ASLVersion >= 280) & BeginsWith(_lines[j], "description "))
                     {
-                        r.Description = GetTextOrScript(GetEverythingAfter(_lines[j], "description "));
+                        r.Description = await GetTextOrScript(GetEverythingAfter(_lines[j], "description "));
                         if (ASLVersion >= 350)
                         {
                             if (r.Description.Type == TextActionType.Script)
@@ -1044,7 +997,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "out "))
                     {
-                        r.Out.Text = GetParameter(_lines[j], _nullContext);
+                        r.Out.Text = await GetParameter(_lines[j], _nullContext);
                         r.Out.Script = Strings.Trim(Strings.Mid(_lines[j], Strings.InStr(_lines[j], ">") + 1));
                         if (ASLVersion >= 350)
                         {
@@ -1058,7 +1011,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "east "))
                     {
-                        r.East = GetTextOrScript(GetEverythingAfter(_lines[j], "east "));
+                        r.East = await GetTextOrScript(GetEverythingAfter(_lines[j], "east "));
                         if (ASLVersion >= 350)
                         {
                             if (r.East.Type == TextActionType.Script)
@@ -1073,7 +1026,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "west "))
                     {
-                        r.West = GetTextOrScript(GetEverythingAfter(_lines[j], "west "));
+                        r.West = await GetTextOrScript(GetEverythingAfter(_lines[j], "west "));
                         if (ASLVersion >= 350)
                         {
                             if (r.West.Type == TextActionType.Script)
@@ -1088,7 +1041,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "north "))
                     {
-                        r.North = GetTextOrScript(GetEverythingAfter(_lines[j], "north "));
+                        r.North = await GetTextOrScript(GetEverythingAfter(_lines[j], "north "));
                         if (ASLVersion >= 350)
                         {
                             if (r.North.Type == TextActionType.Script)
@@ -1103,7 +1056,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "south "))
                     {
-                        r.South = GetTextOrScript(GetEverythingAfter(_lines[j], "south "));
+                        r.South = await GetTextOrScript(GetEverythingAfter(_lines[j], "south "));
                         if (ASLVersion >= 350)
                         {
                             if (r.South.Type == TextActionType.Script)
@@ -1118,7 +1071,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "northeast "))
                     {
-                        r.NorthEast = GetTextOrScript(GetEverythingAfter(_lines[j], "northeast "));
+                        r.NorthEast = await GetTextOrScript(GetEverythingAfter(_lines[j], "northeast "));
                         if (ASLVersion >= 350)
                         {
                             if (r.NorthEast.Type == TextActionType.Script)
@@ -1133,7 +1086,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "northwest "))
                     {
-                        r.NorthWest = GetTextOrScript(GetEverythingAfter(_lines[j], "northwest "));
+                        r.NorthWest = await GetTextOrScript(GetEverythingAfter(_lines[j], "northwest "));
                         if (ASLVersion >= 350)
                         {
                             if (r.NorthWest.Type == TextActionType.Script)
@@ -1148,7 +1101,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "southeast "))
                     {
-                        r.SouthEast = GetTextOrScript(GetEverythingAfter(_lines[j], "southeast "));
+                        r.SouthEast = await GetTextOrScript(GetEverythingAfter(_lines[j], "southeast "));
                         if (ASLVersion >= 350)
                         {
                             if (r.SouthEast.Type == TextActionType.Script)
@@ -1163,7 +1116,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "southwest "))
                     {
-                        r.SouthWest = GetTextOrScript(GetEverythingAfter(_lines[j], "southwest "));
+                        r.SouthWest = await GetTextOrScript(GetEverythingAfter(_lines[j], "southwest "));
                         if (ASLVersion >= 350)
                         {
                             if (r.SouthWest.Type == TextActionType.Script)
@@ -1178,7 +1131,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "up "))
                     {
-                        r.Up = GetTextOrScript(GetEverythingAfter(_lines[j], "up "));
+                        r.Up = await GetTextOrScript(GetEverythingAfter(_lines[j], "up "));
                         if (ASLVersion >= 350)
                         {
                             if (r.Up.Type == TextActionType.Script)
@@ -1193,7 +1146,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "down "))
                     {
-                        r.Down = GetTextOrScript(GetEverythingAfter(_lines[j], "down "));
+                        r.Down = await GetTextOrScript(GetEverythingAfter(_lines[j], "down "));
                         if (ASLVersion >= 350)
                         {
                             if (r.Down.Type == TextActionType.Script)
@@ -1208,7 +1161,7 @@ public partial class V4Game
                     }
                     else if ((ASLVersion >= 280) & BeginsWith(_lines[j], "indescription "))
                     {
-                        r.InDescription = GetParameter(_lines[j], _nullContext);
+                        r.InDescription = await GetParameter(_lines[j], _nullContext);
                         if (ASLVersion >= 350)
                         {
                             AddToObjectProperties("indescription=" + r.InDescription, _numberObjs, _nullContext);
@@ -1216,7 +1169,7 @@ public partial class V4Game
                     }
                     else if ((ASLVersion >= 280) & BeginsWith(_lines[j], "look "))
                     {
-                        r.Look = GetParameter(_lines[j], _nullContext);
+                        r.Look = await GetParameter(_lines[j], _nullContext);
                         if (ASLVersion >= 350)
                         {
                             AddToObjectProperties("look=" + r.Look, _numberObjs, _nullContext);
@@ -1224,7 +1177,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "prefix "))
                     {
-                        r.Prefix = GetParameter(_lines[j], _nullContext);
+                        r.Prefix = await GetParameter(_lines[j], _nullContext);
                         if (ASLVersion >= 350)
                         {
                             AddToObjectProperties("prefix=" + r.Prefix, _numberObjs, _nullContext);
@@ -1240,7 +1193,7 @@ public partial class V4Game
                         r.NumberCommands = r.NumberCommands + 1;
                         Array.Resize(ref r.Commands, r.NumberCommands + 1);
                         r.Commands[r.NumberCommands] = new UserDefinedCommandType();
-                        r.Commands[r.NumberCommands].CommandText = GetParameter(_lines[j], _nullContext, false);
+                        r.Commands[r.NumberCommands].CommandText = await GetParameter(_lines[j], _nullContext, false);
                         r.Commands[r.NumberCommands].CommandScript =
                             Strings.Trim(Strings.Mid(_lines[j], Strings.InStr(_lines[j], ">") + 1));
                     }
@@ -1249,7 +1202,7 @@ public partial class V4Game
                         r.NumberPlaces = r.NumberPlaces + 1;
                         Array.Resize(ref r.Places, r.NumberPlaces + 1);
                         r.Places[r.NumberPlaces] = new PlaceType();
-                        var placeData = GetParameter(_lines[j], _nullContext);
+                        var placeData = await GetParameter(_lines[j], _nullContext);
                         var scp = Strings.InStr(placeData, ";");
                         if (scp == 0)
                         {
@@ -1269,22 +1222,22 @@ public partial class V4Game
                         r.NumberUse = r.NumberUse + 1;
                         Array.Resize(ref r.Use, r.NumberUse + 1);
                         r.Use[r.NumberUse] = new ScriptText();
-                        r.Use[r.NumberUse].Text = GetParameter(_lines[j], _nullContext);
+                        r.Use[r.NumberUse].Text = await GetParameter(_lines[j], _nullContext);
                         r.Use[r.NumberUse].Script =
                             Strings.Trim(Strings.Mid(_lines[j], Strings.InStr(_lines[j], ">") + 1));
                     }
                     else if (BeginsWith(_lines[j], "properties "))
                     {
-                        AddToObjectProperties(GetParameter(_lines[j], _nullContext), _numberObjs, _nullContext);
+                        AddToObjectProperties(await GetParameter(_lines[j], _nullContext), _numberObjs, _nullContext);
                     }
                     else if (BeginsWith(_lines[j], "type "))
                     {
                         _objs[_numberObjs].NumberTypesIncluded = _objs[_numberObjs].NumberTypesIncluded + 1;
                         Array.Resize(ref _objs[_numberObjs].TypesIncluded, _objs[_numberObjs].NumberTypesIncluded + 1);
                         _objs[_numberObjs].TypesIncluded[_objs[_numberObjs].NumberTypesIncluded] =
-                            GetParameter(_lines[j], _nullContext);
+                            await GetParameter(_lines[j], _nullContext);
 
-                        var propertyData = GetPropertiesInType(GetParameter(_lines[j], _nullContext));
+                        var propertyData = await GetPropertiesInType(await GetParameter(_lines[j], _nullContext));
                         AddToObjectProperties(propertyData.Properties, _numberObjs, _nullContext);
                         for (int k = 1, loopTo4 = propertyData.NumberActions; k <= loopTo4; k++)
                         {
@@ -1294,7 +1247,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "action "))
                     {
-                        AddToObjectActions(GetEverythingAfter(_lines[j], "action "), _numberObjs, _nullContext);
+                        await AddToObjectActions(GetEverythingAfter(_lines[j], "action "), _numberObjs, _nullContext);
                     }
                     else if (BeginsWith(_lines[j], "beforeturn "))
                     {
@@ -1311,7 +1264,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpSynonyms()
+    private async Task SetUpSynonyms()
     {
         var block = GetDefineBlock("synonyms");
         _numberSynonyms = 0;
@@ -1362,7 +1315,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpTimers()
+    private async Task SetUpTimers()
     {
         for (int i = 1, loopTo = _numberSections; i <= loopTo; i++)
         {
@@ -1371,7 +1324,7 @@ public partial class V4Game
                 _numberTimers = _numberTimers + 1;
                 Array.Resize(ref _timers, _numberTimers + 1);
                 _timers[_numberTimers] = new TimerType();
-                _timers[_numberTimers].TimerName = GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext);
+                _timers[_numberTimers].TimerName = await GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext);
                 _timers[_numberTimers].TimerActive = false;
 
                 for (int j = _defineBlocks[i].StartLine + 1, loopTo1 = _defineBlocks[i].EndLine - 1; j <= loopTo1; j++)
@@ -1379,7 +1332,7 @@ public partial class V4Game
                     if (BeginsWith(_lines[j], "interval "))
                     {
                         _timers[_numberTimers].TimerInterval =
-                            Conversions.ToInteger(GetParameter(_lines[j], _nullContext));
+                            Conversions.ToInteger(await GetParameter(_lines[j], _nullContext));
                     }
                     else if (BeginsWith(_lines[j], "action "))
                     {
@@ -1398,7 +1351,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpTurnScript()
+    private async Task SetUpTurnScript()
     {
         var block = GetDefineBlock("game");
 
@@ -1420,7 +1373,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpUserDefinedPlayerErrors()
+    private async Task SetUpUserDefinedPlayerErrors()
     {
         // goes through "define game" block and sets stored error
         // messages accordingly
@@ -1432,7 +1385,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "error "))
             {
-                var errorInfo = GetParameter(_lines[i], _nullContext, false);
+                var errorInfo = await GetParameter(_lines[i], _nullContext, false);
                 var scp = Strings.InStr(errorInfo, ";");
                 var errorName = Strings.Left(errorInfo, scp - 1);
                 var errorMsg = Strings.Trim(Strings.Mid(errorInfo, scp + 1));
@@ -1656,7 +1609,7 @@ public partial class V4Game
         }
     }
 
-    private void SetVisibility(string thing, Thing type, bool visible, Context ctx)
+    private async Task SetVisibility(string thing, Thing type, bool visible, Context ctx)
     {
         // Sets visibilty of objects and characters        
 
@@ -1734,7 +1687,7 @@ public partial class V4Game
             }
         }
 
-        UpdateObjectList(ctx);
+        await UpdateObjectList(ctx);
     }
 
     private void ShowPictureInText(string filename)
@@ -1751,7 +1704,7 @@ public partial class V4Game
         }
     }
 
-    private void ShowRoomInfoV2(string room)
+    private async Task ShowRoomInfoV2(string room)
     {
         // ShowRoomInfo for Quest 2.x games
 
@@ -1781,7 +1734,7 @@ public partial class V4Game
 
         // find the room
         DefineBlock roomBlock;
-        roomBlock = DefineBlockParam("room", room);
+        roomBlock = await DefineBlockParam("room", room);
         bool finishedFindingCommas;
 
         charsViewable = "";
@@ -1792,7 +1745,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "alias"))
             {
-                aliasName = GetParameter(_lines[i], _nullContext);
+                aliasName = await GetParameter(_lines[i], _nullContext);
                 i = roomBlock.EndLine;
             }
         }
@@ -1803,7 +1756,7 @@ public partial class V4Game
         }
 
         // see if room has a prefix
-        prefix = FindStatement(roomBlock, "prefix");
+        prefix = await FindStatement(roomBlock, "prefix");
         if (string.IsNullOrEmpty(prefix))
         {
             prefixAlias = "|cr" + aliasName + "|cb";
@@ -1822,7 +1775,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "indescription"))
             {
-                inDesc = Strings.Trim(GetParameter(_lines[i], _nullContext));
+                inDesc = Strings.Trim(await GetParameter(_lines[i], _nullContext));
                 i = roomBlock.EndLine;
             }
         }
@@ -1967,7 +1920,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "out"))
             {
-                doorways = GetParameter(_lines[i], _nullContext);
+                doorways = await GetParameter(_lines[i], _nullContext);
             }
 
             if (BeginsWith(_lines[i], "north "))
@@ -2014,7 +1967,7 @@ public partial class V4Game
             if (BeginsWith(_lines[i], "place"))
             {
                 // remove any prefix semicolon from printed text
-                place = GetParameter(_lines[i], _nullContext);
+                place = await GetParameter(_lines[i], _nullContext);
                 placeNoFormat = place; // Used in object list - no formatting or prefix
                 if (Strings.InStr(place, ";") > 0)
                 {
@@ -2035,12 +1988,12 @@ public partial class V4Game
         if (!string.IsNullOrEmpty(doorways))
         {
             // see if outside has an alias
-            outside = DefineBlockParam("room", doorways);
+            outside = await DefineBlockParam("room", doorways);
             for (int i = outside.StartLine + 1, loopTo5 = outside.EndLine - 1; i <= loopTo5; i++)
             {
                 if (BeginsWith(_lines[i], "alias"))
                 {
-                    aliasOut = GetParameter(_lines[i], _nullContext);
+                    aliasOut = await GetParameter(_lines[i], _nullContext);
                     i = outside.EndLine;
                 }
             }
@@ -2161,7 +2114,7 @@ public partial class V4Game
         {
             // Remove final newline:
             roomDisplayText = Strings.Left(roomDisplayText, Strings.Len(roomDisplayText) - 2);
-            Print(roomDisplayText, _nullContext);
+            await Print(roomDisplayText, _nullContext);
         }
         else
         {
@@ -2172,15 +2125,15 @@ public partial class V4Game
             descLine = GetEverythingAfter(Strings.Trim(descLine), "description ");
             if (Strings.Left(descLine, 1) == "<")
             {
-                Print(GetParameter(descLine, _nullContext), _nullContext);
+                await Print(await GetParameter(descLine, _nullContext), _nullContext);
             }
             else
             {
-                ExecuteScript(descLine, _nullContext);
+                await ExecuteScript(descLine, _nullContext);
             }
         }
 
-        UpdateObjectList(_nullContext);
+        await UpdateObjectList(_nullContext);
 
         defineBlock = 0;
 
@@ -2199,14 +2152,14 @@ public partial class V4Game
 
             if (BeginsWith(_lines[i], "look") & (defineBlock == 0))
             {
-                lookString = GetParameter(_lines[i], _nullContext);
+                lookString = await GetParameter(_lines[i], _nullContext);
                 i = roomBlock.EndLine;
             }
         }
 
         if (!string.IsNullOrEmpty(lookString))
         {
-            Print(lookString, _nullContext);
+            await Print(lookString, _nullContext);
         }
     }
 
@@ -2230,14 +2183,14 @@ public partial class V4Game
         }
     }
 
-    private void ExecExec(string scriptLine, Context ctx)
+    private async Task ExecExec(string scriptLine, Context ctx)
     {
         if (ctx.CancelExec)
         {
             return;
         }
 
-        var execLine = GetParameter(scriptLine, ctx);
+        var execLine = await GetParameter(scriptLine, ctx);
         var newCtx = CopyContext(ctx);
         newCtx.StackCounter = newCtx.StackCounter + 1;
 
@@ -2257,7 +2210,7 @@ public partial class V4Game
         {
             try
             {
-                ExecCommand(execLine, newCtx, false);
+                await ExecCommand(execLine, newCtx, false);
             }
             catch
             {
@@ -2273,7 +2226,7 @@ public partial class V4Game
             var r = Strings.Trim(Strings.Mid(execLine, scp + 1));
             if (r == "normal")
             {
-                ExecCommand(ex, newCtx, false, false);
+                await ExecCommand(ex, newCtx, false, false);
             }
             else
             {
@@ -2311,7 +2264,7 @@ public partial class V4Game
         SetStringContents(idx.Name, value, ctx, idx.Index);
     }
 
-    private bool ExecUserCommand(string cmd, Context ctx, bool libCommands = false)
+    private async Task<bool> ExecUserCommand(string cmd, Context ctx, bool libCommands = false)
     {
         // Executes a user-defined command. If unavailable, returns
         // false.
@@ -2381,7 +2334,7 @@ public partial class V4Game
             {
                 if (BeginsWith(_lines[i], commandTag))
                 {
-                    commandList = GetParameter(_lines[i], ctx, false);
+                    commandList = await GetParameter(_lines[i], ctx, false);
                     int ep;
                     var exitFor1 = false;
                     do
@@ -2419,21 +2372,21 @@ public partial class V4Game
 
         if (foundCommand)
         {
-            if (GetCommandParameters(cmd, commandLine, ctx))
+            if (await GetCommandParameters(cmd, commandLine, ctx))
             {
-                ExecuteScript(script, ctx);
+                await ExecuteScript(script, ctx);
             }
         }
 
         return foundCommand;
     }
 
-    private void ExecuteChoose(string section, Context ctx)
+    private async Task ExecuteChoose(string section, Context ctx)
     {
-        ExecuteScript(SetUpChoiceForm(section, ctx), ctx);
+        await ExecuteScript(await SetUpChoiceForm(section, ctx), ctx);
     }
 
-    private bool GetCommandParameters(string test, string required, Context ctx)
+    private async Task<bool> GetCommandParameters(string test, string required, Context ctx)
     {
         // Gets parameters from line. For example, if 'required'
         // is "read #1#" and 'test' is "read sign", #1# returns
@@ -2518,17 +2471,17 @@ public partial class V4Game
             if (BeginsWith(varName[i], "@"))
             {
                 varName[i] = GetEverythingAfter(varName[i], "@");
-                var id = Disambiguate(curChunk, _currentRoom + ";" + "inventory", ctx);
+                var id = await Disambiguate(curChunk, _currentRoom + ";" + "inventory", ctx);
 
                 if (id == -1)
                 {
                     if (ASLVersion >= 391)
                     {
-                        PlayerErrorMessage(PlayerError.BadThing, ctx);
+                        await PlayerErrorMessage(PlayerError.BadThing, ctx);
                     }
                     else
                     {
-                        PlayerErrorMessage(PlayerError.BadItem, ctx);
+                        await PlayerErrorMessage(PlayerError.BadItem, ctx);
                     }
 
                     // The Mid$(...,2) and Left$(...,2) removes the initial/final "."
@@ -2557,7 +2510,7 @@ public partial class V4Game
         return success;
     }
 
-    private string GetGender(string character, bool capitalise, Context ctx)
+    private async Task<string> GetGender(string character, bool capitalise, Context ctx)
     {
         string result;
 
@@ -2575,7 +2528,7 @@ public partial class V4Game
             }
             else
             {
-                result = GetParameter(resultLine, ctx) + " ";
+                result = await GetParameter(resultLine, ctx) + " ";
             }
         }
 
@@ -2827,7 +2780,7 @@ public partial class V4Game
         {
             // Open Quest 3.0 saved game file
             _gameLoading = true;
-            RestoreGameData(fileData);
+            await RestoreGameData(fileData);
             _gameLoading = false;
         }
         else
@@ -3038,7 +2991,7 @@ public partial class V4Game
         return string.Join(Constants.vbCrLf, lines);
     }
 
-    private void SetAvailability(string thingString, bool exists, Context ctx, Thing type = Thing.Object)
+    private async Task SetAvailability(string thingString, bool exists, Context ctx, Thing type = Thing.Object)
     {
         // Sets availability of objects (and characters in ASL<281)
 
@@ -3115,8 +3068,8 @@ public partial class V4Game
             }
         }
 
-        UpdateItems(ctx);
-        UpdateObjectList(ctx);
+        await UpdateItems(ctx);
+        await UpdateObjectList(ctx);
     }
 
     internal void SetStringContents(string name, string value, Context ctx, int arrayIndex = 0)
@@ -3187,16 +3140,16 @@ public partial class V4Game
         if (!string.IsNullOrEmpty(_stringVariable[id].OnChangeScript))
         {
             var script = _stringVariable[id].OnChangeScript;
-            ExecuteScript(script, ctx);
+            _ = ExecuteScript(script, ctx);
         }
 
         if (!string.IsNullOrEmpty(_stringVariable[id].DisplayString))
         {
-            UpdateStatusVars(ctx);
+            _ = UpdateStatusVars(ctx);
         }
     }
 
-    private void SetUpCharObjectInfo()
+    private async Task SetUpCharObjectInfo()
     {
         var defaultProperties = new PropertiesActions();
 
@@ -3209,7 +3162,7 @@ public partial class V4Game
             if (Strings.Trim(_lines[_defineBlocks[i].StartLine]) == "define type <default>")
             {
                 defaultExists = true;
-                defaultProperties = GetPropertiesInType("default");
+                defaultProperties = await GetPropertiesInType("default");
                 break;
             }
         }
@@ -3229,7 +3182,7 @@ public partial class V4Game
 
             if (BeginsWith(_lines[block.StartLine], "define room"))
             {
-                origContainerRoomName = GetParameter(_lines[block.StartLine], _nullContext);
+                origContainerRoomName = await GetParameter(_lines[block.StartLine], _nullContext);
             }
             else
             {
@@ -3257,7 +3210,7 @@ public partial class V4Game
 
                     var o = _objs[_numberObjs];
 
-                    o.ObjectName = GetParameter(_lines[j], _nullContext);
+                    o.ObjectName = await GetParameter(_lines[j], _nullContext);
                     o.ObjectAlias = o.ObjectName;
                     o.DefinitionSectionStart = j;
                     o.ContainerRoom = containerRoomName;
@@ -3297,11 +3250,11 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "startin ") & (containerRoomName == "__UNKNOWN"))
                         {
-                            containerRoomName = GetParameter(_lines[j], _nullContext);
+                            containerRoomName = await GetParameter(_lines[j], _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "prefix "))
                         {
-                            o.Prefix = GetParameter(_lines[j], _nullContext) + " ";
+                            o.Prefix = await GetParameter(_lines[j], _nullContext) + " ";
                             if (ASLVersion >= 311)
                             {
                                 AddToObjectProperties("prefix=" + o.Prefix, _numberObjs, _nullContext);
@@ -3309,7 +3262,7 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "suffix "))
                         {
-                            o.Suffix = GetParameter(_lines[j], _nullContext);
+                            o.Suffix = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
                                 AddToObjectProperties("suffix=" + o.Suffix, _numberObjs, _nullContext);
@@ -3325,7 +3278,7 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "alias "))
                         {
-                            o.ObjectAlias = GetParameter(_lines[j], _nullContext);
+                            o.ObjectAlias = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
                                 AddToObjectProperties("alias=" + o.ObjectAlias, _numberObjs, _nullContext);
@@ -3333,11 +3286,11 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "alt "))
                         {
-                            AddToObjectAltNames(GetParameter(_lines[j], _nullContext), _numberObjs);
+                            AddToObjectAltNames(await GetParameter(_lines[j], _nullContext), _numberObjs);
                         }
                         else if (BeginsWith(_lines[j], "detail "))
                         {
-                            o.Detail = GetParameter(_lines[j], _nullContext);
+                            o.Detail = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
                                 AddToObjectProperties("detail=" + o.Detail, _numberObjs, _nullContext);
@@ -3345,7 +3298,7 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "gender "))
                         {
-                            o.Gender = GetParameter(_lines[j], _nullContext);
+                            o.Gender = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
                                 AddToObjectProperties("gender=" + o.Gender, _numberObjs, _nullContext);
@@ -3353,7 +3306,7 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "article "))
                         {
-                            o.Article = GetParameter(_lines[j], _nullContext);
+                            o.Article = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
                                 AddToObjectProperties("article=" + o.Article, _numberObjs, _nullContext);
@@ -3371,7 +3324,7 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "displaytype "))
                         {
-                            o.DisplayType = GetParameter(_lines[j], _nullContext);
+                            o.DisplayType = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
                                 AddToObjectProperties("displaytype=" + o.DisplayType, _numberObjs, _nullContext);
@@ -3384,7 +3337,7 @@ public partial class V4Game
                                 restOfLine = GetEverythingAfter(_lines[j], "look ");
                                 if (Strings.Left(restOfLine, 1) == "<")
                                 {
-                                    AddToObjectProperties("look=" + GetParameter(_lines[j], _nullContext), _numberObjs,
+                                    AddToObjectProperties("look=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                         _nullContext);
                                 }
                                 else
@@ -3400,7 +3353,7 @@ public partial class V4Game
                                 restOfLine = GetEverythingAfter(_lines[j], "examine ");
                                 if (Strings.Left(restOfLine, 1) == "<")
                                 {
-                                    AddToObjectProperties("examine=" + GetParameter(_lines[j], _nullContext),
+                                    AddToObjectProperties("examine=" + await GetParameter(_lines[j], _nullContext),
                                         _numberObjs, _nullContext);
                                 }
                                 else
@@ -3414,7 +3367,7 @@ public partial class V4Game
                             restOfLine = GetEverythingAfter(_lines[j], "speak ");
                             if (Strings.Left(restOfLine, 1) == "<")
                             {
-                                AddToObjectProperties("speak=" + GetParameter(_lines[j], _nullContext), _numberObjs,
+                                AddToObjectProperties("speak=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
@@ -3424,15 +3377,15 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "properties "))
                         {
-                            AddToObjectProperties(GetParameter(_lines[j], _nullContext), _numberObjs, _nullContext);
+                            AddToObjectProperties(await GetParameter(_lines[j], _nullContext), _numberObjs, _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "type "))
                         {
                             o.NumberTypesIncluded = o.NumberTypesIncluded + 1;
                             Array.Resize(ref o.TypesIncluded, o.NumberTypesIncluded + 1);
-                            o.TypesIncluded[o.NumberTypesIncluded] = GetParameter(_lines[j], _nullContext);
+                            o.TypesIncluded[o.NumberTypesIncluded] = await GetParameter(_lines[j], _nullContext);
 
-                            var PropertyData = GetPropertiesInType(GetParameter(_lines[j], _nullContext));
+                            var PropertyData = await GetPropertiesInType(await GetParameter(_lines[j], _nullContext));
                             AddToObjectProperties(PropertyData.Properties, _numberObjs, _nullContext);
                             for (int k = 1, loopTo4 = PropertyData.NumberActions; k <= loopTo4; k++)
                             {
@@ -3451,15 +3404,15 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "action "))
                         {
-                            AddToObjectActions(GetEverythingAfter(_lines[j], "action "), _numberObjs, _nullContext);
+                            await AddToObjectActions(GetEverythingAfter(_lines[j], "action "), _numberObjs, _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "use "))
                         {
-                            AddToUseInfo(_numberObjs, GetEverythingAfter(_lines[j], "use "));
+                            await AddToUseInfo(_numberObjs, GetEverythingAfter(_lines[j], "use "));
                         }
                         else if (BeginsWith(_lines[j], "give "))
                         {
-                            AddToGiveInfo(_numberObjs, GetEverythingAfter(_lines[j], "give "));
+                            await AddToGiveInfo(_numberObjs, GetEverythingAfter(_lines[j], "give "));
                         }
                         else if (Strings.Trim(_lines[j]) == "take")
                         {
@@ -3471,9 +3424,9 @@ public partial class V4Game
                             if (Strings.Left(GetEverythingAfter(_lines[j], "take "), 1) == "<")
                             {
                                 o.Take.Type = TextActionType.Text;
-                                o.Take.Data = GetParameter(_lines[j], _nullContext);
+                                o.Take.Data = await GetParameter(_lines[j], _nullContext);
 
-                                AddToObjectProperties("take=" + GetParameter(_lines[j], _nullContext), _numberObjs,
+                                AddToObjectProperties("take=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
@@ -3522,7 +3475,7 @@ public partial class V4Game
                         {
                             if (Strings.Left(GetEverythingAfter(_lines[j], "open "), 1) == "<")
                             {
-                                AddToObjectProperties("open=" + GetParameter(_lines[j], _nullContext), _numberObjs,
+                                AddToObjectProperties("open=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
@@ -3539,7 +3492,7 @@ public partial class V4Game
                         {
                             if (Strings.Left(GetEverythingAfter(_lines[j], "close "), 1) == "<")
                             {
-                                AddToObjectProperties("close=" + GetParameter(_lines[j], _nullContext), _numberObjs,
+                                AddToObjectProperties("close=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
@@ -3556,7 +3509,7 @@ public partial class V4Game
                         {
                             if (Strings.Left(GetEverythingAfter(_lines[j], "add "), 1) == "<")
                             {
-                                AddToObjectProperties("add=" + GetParameter(_lines[j], _nullContext), _numberObjs,
+                                AddToObjectProperties("add=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
@@ -3573,7 +3526,7 @@ public partial class V4Game
                         {
                             if (Strings.Left(GetEverythingAfter(_lines[j], "remove "), 1) == "<")
                             {
-                                AddToObjectProperties("remove=" + GetParameter(_lines[j], _nullContext), _numberObjs,
+                                AddToObjectProperties("remove=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
@@ -3584,12 +3537,12 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "parent "))
                         {
-                            AddToObjectProperties("parent=" + GetParameter(_lines[j], _nullContext), _numberObjs,
+                            AddToObjectProperties("parent=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                 _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "list"))
                         {
-                            ProcessListInfo(_lines[j], _numberObjs);
+                            await ProcessListInfo(_lines[j], _numberObjs);
                         }
                     } while (Strings.Trim(_lines[j]) != "end define");
 
@@ -3605,7 +3558,7 @@ public partial class V4Game
                     _numberChars = _numberChars + 1;
                     Array.Resize(ref _chars, _numberChars + 1);
                     _chars[_numberChars] = new ObjectType();
-                    _chars[_numberChars].ObjectName = GetParameter(_lines[j], _nullContext);
+                    _chars[_numberChars].ObjectName = await GetParameter(_lines[j], _nullContext);
                     _chars[_numberChars].DefinitionSectionStart = j;
                     _chars[_numberChars].ContainerRoom = "";
                     _chars[_numberChars].Visible = true;
@@ -3620,15 +3573,15 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "startin ") & (containerRoomName == "__UNKNOWN"))
                         {
-                            containerRoomName = GetParameter(_lines[j], _nullContext);
+                            containerRoomName = await GetParameter(_lines[j], _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "prefix "))
                         {
-                            _chars[_numberChars].Prefix = GetParameter(_lines[j], _nullContext) + " ";
+                            _chars[_numberChars].Prefix = await GetParameter(_lines[j], _nullContext) + " ";
                         }
                         else if (BeginsWith(_lines[j], "suffix "))
                         {
-                            _chars[_numberChars].Suffix = " " + GetParameter(_lines[j], _nullContext);
+                            _chars[_numberChars].Suffix = " " + await GetParameter(_lines[j], _nullContext);
                         }
                         else if (Strings.Trim(_lines[j]) == "invisible")
                         {
@@ -3636,11 +3589,11 @@ public partial class V4Game
                         }
                         else if (BeginsWith(_lines[j], "alias "))
                         {
-                            _chars[_numberChars].ObjectAlias = GetParameter(_lines[j], _nullContext);
+                            _chars[_numberChars].ObjectAlias = await GetParameter(_lines[j], _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "detail "))
                         {
-                            _chars[_numberChars].Detail = GetParameter(_lines[j], _nullContext);
+                            _chars[_numberChars].Detail = await GetParameter(_lines[j], _nullContext);
                         }
 
                         _chars[_numberChars].ContainerRoom = containerRoomName;
@@ -3655,40 +3608,40 @@ public partial class V4Game
             }
         }
 
-        UpdateVisibilityInContainers(_nullContext);
+        await UpdateVisibilityInContainers(_nullContext);
     }
 
-    private void ShowGameAbout(Context ctx)
+    private async Task ShowGameAbout(Context ctx)
     {
-        var version = FindStatement(GetDefineBlock("game"), "game version");
-        var author = FindStatement(GetDefineBlock("game"), "game author");
-        var copyright = FindStatement(GetDefineBlock("game"), "game copyright");
-        var info = FindStatement(GetDefineBlock("game"), "game info");
+        var version = await FindStatement(GetDefineBlock("game"), "game version");
+        var author = await FindStatement(GetDefineBlock("game"), "game author");
+        var copyright = await FindStatement(GetDefineBlock("game"), "game copyright");
+        var info = await FindStatement(GetDefineBlock("game"), "game info");
 
-        Print("|bGame name:|cl  " + _gameName + "|cb|xb", ctx);
+        await Print("|bGame name:|cl  " + _gameName + "|cb|xb", ctx);
         if (!string.IsNullOrEmpty(version))
         {
-            Print("|bVersion:|xb    " + version, ctx);
+            await Print("|bVersion:|xb    " + version, ctx);
         }
 
         if (!string.IsNullOrEmpty(author))
         {
-            Print("|bAuthor:|xb     " + author, ctx);
+            await Print("|bAuthor:|xb     " + author, ctx);
         }
 
         if (!string.IsNullOrEmpty(copyright))
         {
-            Print("|bCopyright:|xb  " + copyright, ctx);
+            await Print("|bCopyright:|xb  " + copyright, ctx);
         }
 
         if (!string.IsNullOrEmpty(info))
         {
-            Print("", ctx);
-            Print(info, ctx);
+            await Print("", ctx);
+            await Print(info, ctx);
         }
     }
 
-    private void ShowPicture(string filename)
+    private async Task ShowPicture(string filename)
     {
         // In Quest 4.x this function would be used for showing a picture in a popup window, but
         // this is no longer supported - ALL images are displayed in-line with the game text. Any
@@ -3710,17 +3663,17 @@ public partial class V4Game
 
         if (caption.Length > 0)
         {
-            Print(caption, _nullContext);
+            await Print(caption, _nullContext);
         }
 
         ShowPictureInText(filename);
     }
 
-    private void ShowRoomInfo(string room, Context ctx, bool noPrint = false)
+    private async Task ShowRoomInfo(string room, Context ctx, bool noPrint = false)
     {
         if (ASLVersion < 280)
         {
-            ShowRoomInfoV2(room);
+            await ShowRoomInfoV2(room);
             return;
         }
 
@@ -3955,7 +3908,7 @@ public partial class V4Game
                     descTagExist = true;
                     if (Strings.Left(descLine, 1) == "<")
                     {
-                        descLine = GetParameter(descLine, ctx);
+                        descLine = await GetParameter(descLine, ctx);
                         descType = (int) TextActionType.Text;
                     }
                     else
@@ -3979,10 +3932,10 @@ public partial class V4Game
             {
                 // Remove final vbCrLf:
                 roomDisplayText = Strings.Left(roomDisplayText, Strings.Len(roomDisplayText) - 2);
-                Print(roomDisplayText, ctx);
+                await Print(roomDisplayText, ctx);
                 if (!string.IsNullOrEmpty(doorwayString))
                 {
-                    Print(doorwayString, ctx);
+                    await Print(doorwayString, ctx);
                 }
             }
             // execute description tag:
@@ -3991,14 +3944,14 @@ public partial class V4Game
 
             else if (descType == (int) TextActionType.Text)
             {
-                Print(descLine, ctx);
+                await Print(descLine, ctx);
             }
             else
             {
-                ExecuteScript(descLine, ctx);
+                await ExecuteScript(descLine, ctx);
             }
 
-            UpdateObjectList(ctx);
+            await UpdateObjectList(ctx);
 
             // SHOW "LOOK" DESCRIPTION **************************************************
 
@@ -4006,7 +3959,7 @@ public partial class V4Game
             {
                 if (!string.IsNullOrEmpty(lookDesc))
                 {
-                    Print(lookDesc, ctx);
+                    await Print(lookDesc, ctx);
                 }
             }
         }
@@ -4122,10 +4075,10 @@ public partial class V4Game
         return display;
     }
 
-    private void DisplayTextSection(string section, Context ctx)
+    private async Task DisplayTextSection(string section, Context ctx)
     {
         DefineBlock block;
-        block = DefineBlockParam("text", section);
+        block = await DefineBlockParam("text", section);
 
         if (block.StartLine == 0)
         {
@@ -4137,21 +4090,21 @@ public partial class V4Game
             if (ASLVersion >= 392)
             {
                 // Convert string variables etc.
-                Print(GetParameter("<" + _lines[i] + ">", ctx), ctx);
+                await Print(await GetParameter("<" + _lines[i] + ">", ctx), ctx);
             }
             else
             {
-                Print(_lines[i], ctx);
+                await Print(_lines[i], ctx);
             }
         }
 
-        Print("", ctx);
+        await Print("", ctx);
     }
 
     // Returns true if the system is ready to process a new command after completion - so it will be
     // in most cases, except when ExecCommand just caused an "enter" script command to complete
 
-    private bool ExecCommand(string input, Context ctx, bool echo = true, bool runUserCommand = true,
+    private async Task<bool> ExecCommand(string input, Context ctx, bool echo = true, bool runUserCommand = true,
         bool dontSetIt = false)
     {
         string parameter;
@@ -4169,25 +4122,22 @@ public partial class V4Game
 
         var cmd = Strings.LCase(input);
 
-        lock (_commandLock)
+        if (_commandOverrideModeOn)
         {
-            if (_commandOverrideModeOn)
-            {
-                // Commands have been overridden for this command,
-                // so put input into previously specified variable
-                // and exit:
+            // Commands have been overridden for this command,
+            // so put input into previously specified variable
+            // and exit:
 
-                SetStringContents(_commandOverrideVariable, input, ctx);
-                Monitor.PulseAll(_commandLock);
-                return false;
-            }
+            SetStringContents(_commandOverrideVariable, input, ctx);
+            _commandTcs!.TrySetResult();
+            return false;
         }
 
         bool userCommandReturn;
 
         if (echo)
         {
-            Print("> " + input, ctx);
+            await Print("> " + input, ctx);
         }
 
         input = Strings.LCase(input);
@@ -4230,19 +4180,19 @@ public partial class V4Game
             {
                 if (BeginsWith(_rooms[roomID].BeforeTurnScript, "override"))
                 {
-                    ExecuteScript(GetEverythingAfter(_rooms[roomID].BeforeTurnScript, "override"), newCtx);
+                    await ExecuteScript(GetEverythingAfter(_rooms[roomID].BeforeTurnScript, "override"), newCtx);
                     globalOverride = true;
                 }
                 else
                 {
-                    ExecuteScript(_rooms[roomID].BeforeTurnScript, newCtx);
+                    await ExecuteScript(_rooms[roomID].BeforeTurnScript, newCtx);
                 }
             }
         }
 
         if (!string.IsNullOrEmpty(_beforeTurnScript) & !globalOverride)
         {
-            ExecuteScript(_beforeTurnScript, newCtx);
+            await ExecuteScript(_beforeTurnScript, newCtx);
         }
 
         // In executing BeforeTurn script, "dontprocess" sets ctx.DontProcessCommand,
@@ -4255,23 +4205,23 @@ public partial class V4Game
             userCommandReturn = false;
             if (runUserCommand)
             {
-                userCommandReturn = ExecUserCommand(input, ctx);
+                userCommandReturn = await ExecUserCommand(input, ctx);
 
                 if (!userCommandReturn)
                 {
-                    userCommandReturn = ExecVerb(input, ctx);
+                    userCommandReturn = await ExecVerb(input, ctx);
                 }
 
                 if (!userCommandReturn)
                 {
                     // Try command defined by a library
-                    userCommandReturn = ExecUserCommand(input, ctx, true);
+                    userCommandReturn = await ExecUserCommand(input, ctx, true);
                 }
 
                 if (!userCommandReturn)
                 {
                     // Try verb defined by a library
-                    userCommandReturn = ExecVerb(input, ctx, true);
+                    userCommandReturn = await ExecVerb(input, ctx, true);
                 }
             }
 
@@ -4290,21 +4240,21 @@ public partial class V4Game
             if (CmdStartsWith(input, "speak to "))
             {
                 parameter = GetEverythingAfter(input, "speak to ");
-                ExecSpeak(parameter, ctx);
+                await ExecSpeak(parameter, ctx);
             }
             else if (CmdStartsWith(input, "talk to "))
             {
                 parameter = GetEverythingAfter(input, "talk to ");
-                ExecSpeak(parameter, ctx);
+                await ExecSpeak(parameter, ctx);
             }
             else if ((cmd == "exit") | (cmd == "out") | (cmd == "leave"))
             {
-                GoDirection("out", ctx);
+                await GoDirection("out", ctx);
                 _lastIt = 0;
             }
             else if ((cmd == "north") | (cmd == "south") | (cmd == "east") | (cmd == "west"))
             {
-                GoDirection(input, ctx);
+                await GoDirection(input, ctx);
                 _lastIt = 0;
             }
             else if ((cmd == "n") | (cmd == "s") | (cmd == "w") | (cmd == "e"))
@@ -4313,22 +4263,22 @@ public partial class V4Game
                 {
                     case 1:
                     {
-                        GoDirection("north", ctx);
+                        await GoDirection("north", ctx);
                         break;
                     }
                     case 2:
                     {
-                        GoDirection("south", ctx);
+                        await GoDirection("south", ctx);
                         break;
                     }
                     case 3:
                     {
-                        GoDirection("west", ctx);
+                        await GoDirection("west", ctx);
                         break;
                     }
                     case 4:
                     {
-                        GoDirection("east", ctx);
+                        await GoDirection("east", ctx);
                         break;
                     }
                 }
@@ -4339,67 +4289,67 @@ public partial class V4Game
                      (cmd == "go ne") |
                      (cmd == "go northeast") | (cmd == "go north-east") | (cmd == "go north east"))
             {
-                GoDirection("northeast", ctx);
+                await GoDirection("northeast", ctx);
                 _lastIt = 0;
             }
             else if ((cmd == "nw") | (cmd == "northwest") | (cmd == "north-west") | (cmd == "north west") |
                      (cmd == "go nw") |
                      (cmd == "go northwest") | (cmd == "go north-west") | (cmd == "go north west"))
             {
-                GoDirection("northwest", ctx);
+                await GoDirection("northwest", ctx);
                 _lastIt = 0;
             }
             else if ((cmd == "se") | (cmd == "southeast") | (cmd == "south-east") | (cmd == "south east") |
                      (cmd == "go se") |
                      (cmd == "go southeast") | (cmd == "go south-east") | (cmd == "go south east"))
             {
-                GoDirection("southeast", ctx);
+                await GoDirection("southeast", ctx);
                 _lastIt = 0;
             }
             else if ((cmd == "sw") | (cmd == "southwest") | (cmd == "south-west") | (cmd == "south west") |
                      (cmd == "go sw") |
                      (cmd == "go southwest") | (cmd == "go south-west") | (cmd == "go south west"))
             {
-                GoDirection("southwest", ctx);
+                await GoDirection("southwest", ctx);
                 _lastIt = 0;
             }
             else if ((cmd == "up") | (cmd == "u"))
             {
-                GoDirection("up", ctx);
+                await GoDirection("up", ctx);
                 _lastIt = 0;
             }
             else if ((cmd == "down") | (cmd == "d"))
             {
-                GoDirection("down", ctx);
+                await GoDirection("down", ctx);
                 _lastIt = 0;
             }
             else if (CmdStartsWith(input, "go "))
             {
                 if (ASLVersion >= 410)
                 {
-                    _rooms[GetRoomID(_currentRoom, ctx)].Exits.ExecuteGo(input, ref ctx);
+                    _rooms[GetRoomID(_currentRoom, ctx)].Exits.ExecuteGo(input, ctx);
                 }
                 else
                 {
                     parameter = GetEverythingAfter(input, "go ");
                     if (parameter == "out")
                     {
-                        GoDirection("out", ctx);
+                        await GoDirection("out", ctx);
                     }
                     else if ((parameter == "north") | (parameter == "south") | (parameter == "east") |
                              (parameter == "west") |
                              (parameter == "up") | (parameter == "down"))
                     {
-                        GoDirection(parameter, ctx);
+                        await GoDirection(parameter, ctx);
                     }
                     else if (BeginsWith(parameter, "to "))
                     {
                         parameter = GetEverythingAfter(parameter, "to ");
-                        GoToPlace(parameter, ctx);
+                        await GoToPlace(parameter, ctx);
                     }
                     else
                     {
-                        PlayerErrorMessage(PlayerError.BadGo, ctx);
+                        await PlayerErrorMessage(PlayerError.BadGo, ctx);
                     }
                 }
 
@@ -4408,96 +4358,96 @@ public partial class V4Game
             else if (CmdStartsWith(input, "give "))
             {
                 parameter = GetEverythingAfter(input, "give ");
-                ExecGive(parameter, ctx);
+                await ExecGive(parameter, ctx);
             }
             else if (CmdStartsWith(input, "take "))
             {
                 parameter = GetEverythingAfter(input, "take ");
-                ExecTake(parameter, ctx);
+                await ExecTake(parameter, ctx);
             }
             else if (CmdStartsWith(input, "drop ") & (ASLVersion >= 280))
             {
                 parameter = GetEverythingAfter(input, "drop ");
-                ExecDrop(parameter, ctx);
+                await ExecDrop(parameter, ctx);
             }
             else if (CmdStartsWith(input, "get "))
             {
                 parameter = GetEverythingAfter(input, "get ");
-                ExecTake(parameter, ctx);
+                await ExecTake(parameter, ctx);
             }
             else if (CmdStartsWith(input, "pick up "))
             {
                 parameter = GetEverythingAfter(input, "pick up ");
-                ExecTake(parameter, ctx);
+                await ExecTake(parameter, ctx);
             }
             else if ((cmd == "pick it up") | (cmd == "pick them up") | (cmd == "pick this up") |
                      (cmd == "pick that up") |
                      (cmd == "pick these up") | (cmd == "pick those up") | (cmd == "pick him up") |
                      (cmd == "pick her up"))
             {
-                ExecTake(Strings.Mid(cmd, 6, Strings.InStr(7, cmd, " ") - 6), ctx);
+                await ExecTake(Strings.Mid(cmd, 6, Strings.InStr(7, cmd, " ") - 6), ctx);
             }
             else if (CmdStartsWith(input, "look "))
             {
-                ExecLook(input, ctx);
+                await ExecLook(input, ctx);
             }
             else if (CmdStartsWith(input, "l "))
             {
-                ExecLook("look " + GetEverythingAfter(input, "l "), ctx);
+                await ExecLook("look " + GetEverythingAfter(input, "l "), ctx);
             }
             else if (CmdStartsWith(input, "examine "))
             {
                 if (ASLVersion >= 280)
                 {
-                    ExecExamine(input, ctx);
+                    await ExecExamine(input, ctx);
                 }
                 else
                 {
-                    ExecLook("look " + GetEverythingAfter(input, "examine "), ctx);
+                    await ExecLook("look " + GetEverythingAfter(input, "examine "), ctx);
                 }
             }
             else if (CmdStartsWith(input, "x "))
             {
                 if (ASLVersion >= 280)
                 {
-                    ExecExamine("examine " + GetEverythingAfter(input, "x "), ctx);
+                    await ExecExamine("examine " + GetEverythingAfter(input, "x "), ctx);
                 }
                 else
                 {
-                    ExecLook("look " + GetEverythingAfter(input, "x "), ctx);
+                    await ExecLook("look " + GetEverythingAfter(input, "x "), ctx);
                 }
             }
             else if ((cmd == "l") | (cmd == "look"))
             {
-                ExecLook("look", ctx);
+                await ExecLook("look", ctx);
             }
             else if ((cmd == "x") | (cmd == "examine"))
             {
-                ExecExamine("examine", ctx);
+                await ExecExamine("examine", ctx);
             }
             else if (CmdStartsWith(input, "use "))
             {
-                ExecUse(input, ctx);
+                await ExecUse(input, ctx);
             }
             else if (CmdStartsWith(input, "open ") & (ASLVersion >= 391))
             {
-                ExecOpenClose(input, ctx);
+                await ExecOpenClose(input, ctx);
             }
             else if (CmdStartsWith(input, "close ") & (ASLVersion >= 391))
             {
-                ExecOpenClose(input, ctx);
+                await ExecOpenClose(input, ctx);
             }
             else if (CmdStartsWith(input, "put ") & (ASLVersion >= 391))
             {
-                ExecAddRemove(input, ctx);
+                await ExecAddRemove(input, ctx);
             }
             else if (CmdStartsWith(input, "add ") & (ASLVersion >= 391))
             {
-                ExecAddRemove(input, ctx);
+                await ExecAddRemove(input, ctx);
             }
             else if (CmdStartsWith(input, "remove ") & (ASLVersion >= 391))
             {
-                ExecAddRemove(input, ctx);
+                await ExecAddRemove(input, ctx);
             }
             else if (cmd == "save")
             {
@@ -4509,11 +4459,11 @@ public partial class V4Game
             }
             else if (BeginsWith(cmd, "help"))
             {
-                ShowHelp(ctx);
+                await ShowHelp(ctx);
             }
             else if (cmd == "about")
             {
-                ShowGameAbout(ctx);
+                await ShowGameAbout(ctx);
             }
             else if (cmd == "clear")
             {
@@ -4524,7 +4474,7 @@ public partial class V4Game
                 // TO DO: This is temporary, would be better to have a log viewer built in to Player
                 foreach (var logEntry in _log)
                 {
-                    Print(logEntry, ctx);
+                    await Print(logEntry, ctx);
                 }
             }
             else if ((cmd == "inventory") | (cmd == "inv") | (cmd == "i"))
@@ -4588,24 +4538,24 @@ public partial class V4Game
                         invList = Strings.Left(invList, lastComma - 1) + " and" + Strings.Mid(invList, lastComma + 1);
                     }
 
-                    Print("You are carrying:|n" + invList + ".", ctx);
+                    await Print("You are carrying:|n" + invList + ".", ctx);
                 }
                 else
                 {
-                    Print("You are not carrying anything.", ctx);
+                    await Print("You are not carrying anything.", ctx);
                 }
             }
             else if (CmdStartsWith(input, "oops "))
             {
-                ExecOops(GetEverythingAfter(input, "oops "), ctx);
+                await ExecOops(GetEverythingAfter(input, "oops "), ctx);
             }
             else if (CmdStartsWith(input, "the "))
             {
-                ExecOops(GetEverythingAfter(input, "the "), ctx);
+                await ExecOops(GetEverythingAfter(input, "the "), ctx);
             }
             else
             {
-                PlayerErrorMessage(PlayerError.BadCommand, ctx);
+                await PlayerErrorMessage(PlayerError.BadCommand, ctx);
             }
         }
 
@@ -4620,12 +4570,12 @@ public partial class V4Game
                 {
                     if (BeginsWith(_rooms[roomID].AfterTurnScript, "override"))
                     {
-                        ExecuteScript(GetEverythingAfter(_rooms[roomID].AfterTurnScript, "override"), ctx);
+                        await ExecuteScript(GetEverythingAfter(_rooms[roomID].AfterTurnScript, "override"), ctx);
                         globalOverride = true;
                     }
                     else
                     {
-                        ExecuteScript(_rooms[roomID].AfterTurnScript, ctx);
+                        await ExecuteScript(_rooms[roomID].AfterTurnScript, ctx);
                     }
                 }
             }
@@ -4633,11 +4583,11 @@ public partial class V4Game
             // was set to NullThread here for some reason
             if (!string.IsNullOrEmpty(_afterTurnScript) & !globalOverride)
             {
-                ExecuteScript(_afterTurnScript, ctx);
+                await ExecuteScript(_afterTurnScript, ctx);
             }
         }
 
-        Print("", ctx);
+        await Print("", ctx);
 
         if (!dontSetIt)
         {
@@ -4665,7 +4615,7 @@ public partial class V4Game
         return BeginsWith(Strings.Trim(cmd), startsWith);
     }
 
-    private void ExecGive(string giveString, Context ctx)
+    private async Task ExecGive(string giveString, Context ctx)
     {
         var article = "";
         string item, character;
@@ -4679,7 +4629,7 @@ public partial class V4Game
             toPos = Strings.InStr(giveString, " the ");
             if (toPos == 0)
             {
-                PlayerErrorMessage(PlayerError.BadGive, ctx);
+                await PlayerErrorMessage(PlayerError.BadGive, ctx);
                 return;
             }
 
@@ -4704,11 +4654,11 @@ public partial class V4Game
         // First see if player has "ItemToGive":
         if (ASLVersion >= 280)
         {
-            id = Disambiguate(item, "inventory", ctx);
+            id = await Disambiguate(item, "inventory", ctx);
 
             if (id == -1)
             {
-                PlayerErrorMessage(PlayerError.NoItem, ctx);
+                await PlayerErrorMessage(PlayerError.NoItem, ctx);
                 _badCmdBefore = "give";
                 _badCmdAfter = "to " + character;
                 return;
@@ -4744,7 +4694,7 @@ public partial class V4Game
 
             if (notGot)
             {
-                PlayerErrorMessage(PlayerError.NoItem, ctx);
+                await PlayerErrorMessage(PlayerError.NoItem, ctx);
                 return;
             }
         }
@@ -4754,7 +4704,7 @@ public partial class V4Game
             var foundScript = false;
             var foundObject = false;
 
-            var giveToId = Disambiguate(character, _currentRoom, ctx);
+            var giveToId = await Disambiguate(character, _currentRoom, ctx);
             if (giveToId > 0)
             {
                 foundObject = true;
@@ -4764,7 +4714,7 @@ public partial class V4Game
             {
                 if (giveToId != -2)
                 {
-                    PlayerErrorMessage(PlayerError.BadCharacter, ctx);
+                    await PlayerErrorMessage(PlayerError.BadCharacter, ctx);
                 }
 
                 _badCmdBefore = "give " + item + " to";
@@ -4831,7 +4781,7 @@ public partial class V4Game
 
             if (foundScript)
             {
-                ExecuteScript(script, ctx, id);
+                await ExecuteScript(script, ctx, id);
             }
             else
             {
@@ -4842,7 +4792,7 @@ public partial class V4Game
                 SetStringContents("quest.error.gender", gender, ctx);
 
                 SetStringContents("quest.error.article", article, ctx);
-                PlayerErrorMessage(PlayerError.ItemUnwanted, ctx);
+                await PlayerErrorMessage(PlayerError.ItemUnwanted, ctx);
             }
         }
         else
@@ -4853,7 +4803,7 @@ public partial class V4Game
             if (((block.StartLine == 0) & (block.EndLine == 0)) |
                 !IsAvailable(character + "@" + _currentRoom, type, ctx))
             {
-                PlayerErrorMessage(PlayerError.BadCharacter, ctx);
+                await PlayerErrorMessage(PlayerError.BadCharacter, ctx);
                 return;
             }
 
@@ -4867,7 +4817,7 @@ public partial class V4Game
             {
                 if (BeginsWith(_lines[i], "give"))
                 {
-                    var ItemCheck = GetParameter(_lines[i], ctx);
+                    var ItemCheck = await GetParameter(_lines[i], ctx);
                     if ((Strings.LCase(ItemCheck) ?? "") == (Strings.LCase(item) ?? ""))
                     {
                         giveLine = i;
@@ -4883,24 +4833,24 @@ public partial class V4Game
                 }
 
                 SetStringContents("quest.error.charactername", realName, ctx);
-                SetStringContents("quest.error.gender", Strings.Trim(GetGender(character, true, ctx)), ctx);
+                SetStringContents("quest.error.gender", Strings.Trim(await GetGender(character, true, ctx)), ctx);
                 SetStringContents("quest.error.article", article, ctx);
-                PlayerErrorMessage(PlayerError.ItemUnwanted, ctx);
+                await PlayerErrorMessage(PlayerError.ItemUnwanted, ctx);
                 return;
             }
 
             // now, execute the statement on GiveLine
-            ExecuteScript(GetSecondChunk(_lines[giveLine]), ctx);
+            await ExecuteScript(GetSecondChunk(_lines[giveLine]), ctx);
         }
     }
 
-    private void ExecLook(string lookLine, Context ctx)
+    private async Task ExecLook(string lookLine, Context ctx)
     {
         string item;
 
         if (Strings.Trim(lookLine) == "look")
         {
-            ShowRoomInfo(_currentRoom, ctx);
+            await ShowRoomInfo(_currentRoom, ctx);
         }
         else
         {
@@ -4940,20 +4890,20 @@ public partial class V4Game
 
             if (ASLVersion >= 280)
             {
-                var id = Disambiguate(item, "inventory;" + _currentRoom, ctx);
+                var id = await Disambiguate(item, "inventory;" + _currentRoom, ctx);
 
                 if (id <= 0)
                 {
                     if (id != -2)
                     {
-                        PlayerErrorMessage(PlayerError.BadThing, ctx);
+                        await PlayerErrorMessage(PlayerError.BadThing, ctx);
                     }
 
                     _badCmdBefore = "look at";
                     return;
                 }
 
-                DoLook(id, ctx);
+                await DoLook(id, ctx);
             }
             else
             {
@@ -4987,37 +4937,37 @@ public partial class V4Game
 
                     if (lookLine == "<unfound>")
                     {
-                        PlayerErrorMessage(PlayerError.BadThing, ctx);
+                        await PlayerErrorMessage(PlayerError.BadThing, ctx);
                         return;
                     }
 
                     if (lookLine == "<undefined>")
                     {
-                        PlayerErrorMessage(PlayerError.DefaultLook, ctx);
+                        await PlayerErrorMessage(PlayerError.DefaultLook, ctx);
                         return;
                     }
                 }
                 else if (lookLine == "<undefined>")
                 {
-                    PlayerErrorMessage(PlayerError.DefaultLook, ctx);
+                    await PlayerErrorMessage(PlayerError.DefaultLook, ctx);
                     return;
                 }
 
                 var lookData = Strings.Trim(GetEverythingAfter(Strings.Trim(lookLine), "look "));
                 if (Strings.Left(lookData, 1) == "<")
                 {
-                    var LookText = GetParameter(lookLine, ctx);
-                    Print(LookText, ctx);
+                    var LookText = await GetParameter(lookLine, ctx);
+                    await Print(LookText, ctx);
                 }
                 else
                 {
-                    ExecuteScript(lookData, ctx);
+                    await ExecuteScript(lookData, ctx);
                 }
             }
         }
     }
 
-    private void ExecSpeak(string cmd, Context ctx)
+    private async Task ExecSpeak(string cmd, Context ctx)
     {
         if (BeginsWith(cmd, "the "))
         {
@@ -5034,12 +4984,12 @@ public partial class V4Game
         {
             var speakLine = "";
 
-            var ObjID = Disambiguate(name, "inventory;" + _currentRoom, ctx);
+            var ObjID = await Disambiguate(name, "inventory;" + _currentRoom, ctx);
             if (ObjID <= 0)
             {
                 if (ObjID != -2)
                 {
-                    PlayerErrorMessage(PlayerError.BadThing, ctx);
+                    await PlayerErrorMessage(PlayerError.BadThing, ctx);
                 }
 
                 _badCmdBefore = "speak to";
@@ -5095,7 +5045,7 @@ public partial class V4Game
             {
                 SetStringContents("quest.error.gender",
                     Strings.UCase(Strings.Left(_objs[ObjID].Gender, 1)) + Strings.Mid(_objs[ObjID].Gender, 2), ctx);
-                PlayerErrorMessage(PlayerError.DefaultSpeak, ctx);
+                await PlayerErrorMessage(PlayerError.DefaultSpeak, ctx);
                 return;
             }
 
@@ -5103,19 +5053,19 @@ public partial class V4Game
 
             if (BeginsWith(speakLine, "<"))
             {
-                var text = GetParameter(speakLine, ctx);
+                var text = await GetParameter(speakLine, ctx);
                 if (ASLVersion >= 350)
                 {
-                    Print(text, ctx);
+                    await Print(text, ctx);
                 }
                 else
                 {
-                    Print('"' + text + '"', ctx);
+                    await Print('"' + text + '"', ctx);
                 }
             }
             else
             {
-                ExecuteScript(speakLine, ctx, ObjID);
+                await ExecuteScript(speakLine, ctx, ObjID);
             }
         }
 
@@ -5137,33 +5087,33 @@ public partial class V4Game
 
             if (line == "<undefined>")
             {
-                PlayerErrorMessage(PlayerError.BadCharacter, ctx);
+                await PlayerErrorMessage(PlayerError.BadCharacter, ctx);
             }
             else if (line == "<unfound>")
             {
-                SetStringContents("quest.error.gender", Strings.Trim(GetGender(cmd, true, ctx)), ctx);
+                SetStringContents("quest.error.gender", Strings.Trim(await GetGender(cmd, true, ctx)), ctx);
                 SetStringContents("quest.error.charactername", cmd, ctx);
-                PlayerErrorMessage(PlayerError.DefaultSpeak, ctx);
+                await PlayerErrorMessage(PlayerError.DefaultSpeak, ctx);
             }
             else if (BeginsWith(data, "<"))
             {
-                data = GetParameter(line, ctx);
-                Print('"' + data + '"', ctx);
+                data = await GetParameter(line, ctx);
+                await Print('"' + data + '"', ctx);
             }
             else
             {
-                ExecuteScript(data, ctx);
+                await ExecuteScript(data, ctx);
             }
         }
     }
 
-    private void ExecTake(string item, Context ctx)
+    private async Task ExecTake(string item, Context ctx)
     {
         var parentID = default(int);
         string parentDisplayName;
         var foundItem = true;
         var foundTake = false;
-        var id = Disambiguate(item, _currentRoom, ctx);
+        var id = await Disambiguate(item, _currentRoom, ctx);
 
         if (id < 0)
         {
@@ -5180,24 +5130,24 @@ public partial class V4Game
             {
                 if (ASLVersion >= 410)
                 {
-                    id = Disambiguate(item, "inventory", ctx);
+                    id = await Disambiguate(item, "inventory", ctx);
                     if (id >= 0)
                     {
                         // Player already has this item
-                        PlayerErrorMessage(PlayerError.AlreadyTaken, ctx);
+                        await PlayerErrorMessage(PlayerError.AlreadyTaken, ctx);
                     }
                     else
                     {
-                        PlayerErrorMessage(PlayerError.BadThing, ctx);
+                        await PlayerErrorMessage(PlayerError.BadThing, ctx);
                     }
                 }
                 else if (ASLVersion >= 391)
                 {
-                    PlayerErrorMessage(PlayerError.BadThing, ctx);
+                    await PlayerErrorMessage(PlayerError.BadThing, ctx);
                 }
                 else
                 {
-                    PlayerErrorMessage(PlayerError.BadItem, ctx);
+                    await PlayerErrorMessage(PlayerError.BadItem, ctx);
                 }
             }
 
@@ -5214,7 +5164,7 @@ public partial class V4Game
             var canAccessObject = PlayerCanAccessObject(id);
             if (!canAccessObject.CanAccessObject)
             {
-                PlayerErrorMessage_ExtendInfo(PlayerError.BadTake, ctx, canAccessObject.ErrorMsg);
+                await PlayerErrorMessage_ExtendInfo(PlayerError.BadTake, ctx, canAccessObject.ErrorMsg);
                 return;
             }
 
@@ -5240,11 +5190,11 @@ public partial class V4Game
                     parentDisplayName = _objs[parentID].ObjectName;
                 }
 
-                Print("(first removing " + _objs[id].Article + " from " + parentDisplayName + ")", ctx);
+                await Print("(first removing " + _objs[id].Article + " from " + parentDisplayName + ")", ctx);
 
                 // Try to remove the object
                 ctx.AllowRealNamesInCommand = true;
-                ExecCommand("remove " + _objs[id].ObjectName, ctx, false, dontSetIt: true);
+                await ExecCommand("remove " + _objs[id].ObjectName, ctx, false, dontSetIt: true);
 
                 if (!string.IsNullOrEmpty(GetObjectProperty("parent", id, false, false)))
                 {
@@ -5255,21 +5205,21 @@ public partial class V4Game
 
             if (t.Type == TextActionType.Default)
             {
-                PlayerErrorMessage(PlayerError.DefaultTake, ctx);
-                PlayerItem(item, true, ctx, id);
+                await PlayerErrorMessage(PlayerError.DefaultTake, ctx);
+                await PlayerItem(item, true, ctx, id);
             }
             else if (t.Type == TextActionType.Text)
             {
-                Print(t.Data, ctx);
-                PlayerItem(item, true, ctx, id);
+                await Print(t.Data, ctx);
+                await PlayerItem(item, true, ctx, id);
             }
             else if (t.Type == TextActionType.Script)
             {
-                ExecuteScript(t.Data, ctx, id);
+                await ExecuteScript(t.Data, ctx, id);
             }
             else
             {
-                PlayerErrorMessage(PlayerError.BadTake, ctx);
+                await PlayerErrorMessage(PlayerError.BadTake, ctx);
             }
         }
         else
@@ -5282,7 +5232,7 @@ public partial class V4Game
                 if (BeginsWith(_lines[i], "take"))
                 {
                     var script = Strings.Trim(GetEverythingAfter(Strings.Trim(_lines[i]), "take"));
-                    ExecuteScript(script, ctx, id);
+                    await ExecuteScript(script, ctx, id);
                     foundTake = true;
                     i = _objs[id].DefinitionSectionEnd;
                 }
@@ -5290,12 +5240,12 @@ public partial class V4Game
 
             if (!foundTake)
             {
-                PlayerErrorMessage(PlayerError.BadTake, ctx);
+                await PlayerErrorMessage(PlayerError.BadTake, ctx);
             }
         }
     }
 
-    private void ExecUse(string useLine, Context ctx)
+    private async Task ExecUse(string useLine, Context ctx)
     {
         int endOnWith;
         var useDeclareLine = "";
@@ -5336,7 +5286,7 @@ public partial class V4Game
         {
             var foundItem = false;
 
-            id = Disambiguate(useItem, "inventory", ctx);
+            id = await Disambiguate(useItem, "inventory", ctx);
             if (id > 0)
             {
                 foundItem = true;
@@ -5346,7 +5296,7 @@ public partial class V4Game
             {
                 if (id != -2)
                 {
-                    PlayerErrorMessage(PlayerError.NoItem, ctx);
+                    await PlayerErrorMessage(PlayerError.NoItem, ctx);
                 }
 
                 if (string.IsNullOrEmpty(useOn))
@@ -5384,7 +5334,7 @@ public partial class V4Game
 
             if (notGotItem)
             {
-                PlayerErrorMessage(PlayerError.NoItem, ctx);
+                await PlayerErrorMessage(PlayerError.NoItem, ctx);
                 return;
             }
         }
@@ -5427,14 +5377,14 @@ public partial class V4Game
             {
                 foundUseOnObject = false;
 
-                useOnObjectId = Disambiguate(useOn, _currentRoom, ctx);
+                useOnObjectId = await Disambiguate(useOn, _currentRoom, ctx);
                 if (useOnObjectId > 0)
                 {
                     foundUseOnObject = true;
                 }
                 else
                 {
-                    useOnObjectId = Disambiguate(useOn, "inventory", ctx);
+                    useOnObjectId = await Disambiguate(useOn, "inventory", ctx);
                     if (useOnObjectId > 0)
                     {
                         foundUseOnObject = true;
@@ -5445,7 +5395,7 @@ public partial class V4Game
                 {
                     if (useOnObjectId != -2)
                     {
-                        PlayerErrorMessage(PlayerError.BadThing, ctx);
+                        await PlayerErrorMessage(PlayerError.BadThing, ctx);
                     }
 
                     _badCmdBefore = "use " + useItem + " on";
@@ -5512,18 +5462,18 @@ public partial class V4Game
 
             if (foundUseScript)
             {
-                ExecuteScript(useScript, ctx, id);
+                await ExecuteScript(useScript, ctx, id);
             }
             else
             {
-                PlayerErrorMessage(PlayerError.DefaultUse, ctx);
+                await PlayerErrorMessage(PlayerError.DefaultUse, ctx);
             }
         }
         else
         {
             if (!string.IsNullOrEmpty(useOn))
             {
-                useDeclareLine = RetrLineParam("object", useOn, "use", useItem, ctx);
+                useDeclareLine = await RetrLineParam("object", useOn, "use", useItem, ctx);
             }
             else
             {
@@ -5540,12 +5490,12 @@ public partial class V4Game
 
                 if (!found)
                 {
-                    useDeclareLine = FindLine(GetDefineBlock("game"), "use", useItem);
+                    useDeclareLine = await FindLine(GetDefineBlock("game"), "use", useItem);
                 }
 
                 if (!found & string.IsNullOrEmpty(useDeclareLine))
                 {
-                    PlayerErrorMessage(PlayerError.DefaultUse, ctx);
+                    await PlayerErrorMessage(PlayerError.DefaultUse, ctx);
                     return;
                 }
             }
@@ -5561,7 +5511,7 @@ public partial class V4Game
 
             if (useDeclareLine == "<undefined>")
             {
-                useDeclareLine = RetrLineParam("character", useOn, "use", useItem, ctx);
+                useDeclareLine = await RetrLineParam("character", useOn, "use", useItem, ctx);
 
                 if (useDeclareLine != "<undefined>")
                 {
@@ -5574,29 +5524,29 @@ public partial class V4Game
 
                 if (useDeclareLine == "<undefined>")
                 {
-                    PlayerErrorMessage(PlayerError.BadThing, ctx);
+                    await PlayerErrorMessage(PlayerError.BadThing, ctx);
                     return;
                 }
 
                 if (useDeclareLine == "<unfound>")
                 {
-                    PlayerErrorMessage(PlayerError.DefaultUse, ctx);
+                    await PlayerErrorMessage(PlayerError.DefaultUse, ctx);
                     return;
                 }
             }
             else if (useDeclareLine == "<unfound>")
             {
-                PlayerErrorMessage(PlayerError.DefaultUse, ctx);
+                await PlayerErrorMessage(PlayerError.DefaultUse, ctx);
                 return;
             }
 
             var script = Strings.Right(useDeclareLine,
                 Strings.Len(useDeclareLine) - Strings.InStr(useDeclareLine, ">"));
-            ExecuteScript(script, ctx);
+            await ExecuteScript(script, ctx);
         }
     }
 
-    private void ObjectActionUpdate(int id, string name, string script, bool noUpdate = false)
+    private async Task ObjectActionUpdate(int id, string name, string script, bool noUpdate = false)
     {
         string objectName;
         int sp, ep;
@@ -5611,7 +5561,7 @@ public partial class V4Game
             }
             else if (name == "use")
             {
-                AddToUseInfo(id, script);
+                await AddToUseInfo(id, script);
             }
             else if (name == "gain")
             {
@@ -5636,11 +5586,11 @@ public partial class V4Game
 
                     objectName = Strings.Mid(name, sp + 1, ep - sp - 1);
 
-                    AddToUseInfo(id, Strings.Trim(Strings.Left(name, sp - 1)) + " <" + objectName + "> " + script);
+                    await AddToUseInfo(id, Strings.Trim(Strings.Left(name, sp - 1)) + " <" + objectName + "> " + script);
                 }
                 else
                 {
-                    AddToUseInfo(id, name + " " + script);
+                    await AddToUseInfo(id, name + " " + script);
                 }
             }
             else if (BeginsWith(name, "give "))
@@ -5658,11 +5608,11 @@ public partial class V4Game
 
                     objectName = Strings.Mid(name, sp + 1, ep - sp - 1);
 
-                    AddToGiveInfo(id, Strings.Trim(Strings.Left(name, sp - 1)) + " <" + objectName + "> " + script);
+                    await AddToGiveInfo(id, Strings.Trim(Strings.Left(name, sp - 1)) + " <" + objectName + "> " + script);
                 }
                 else
                 {
-                    AddToGiveInfo(id, name + " " + script);
+                    await AddToGiveInfo(id, name + " " + script);
                 }
             }
         }
@@ -5674,10 +5624,10 @@ public partial class V4Game
         }
     }
 
-    private void ExecuteIf(string scriptLine, Context ctx)
+    private async Task ExecuteIf(string scriptLine, Context ctx)
     {
         var ifLine = Strings.Trim(GetEverythingAfter(Strings.Trim(scriptLine), "if "));
-        var obscuredLine = ObliterateParameters(ifLine);
+        var obscuredLine = await ObliterateParameters(ifLine);
         var thenPos = Strings.InStr(obscuredLine, "then");
 
         if (thenPos == 0)
@@ -5723,17 +5673,17 @@ public partial class V4Game
             elseScript = Strings.Mid(elseScript, 2, Strings.Len(elseScript) - 2);
         }
 
-        if (ExecuteConditions(conditions, ctx))
+        if (await ExecuteConditions(conditions, ctx))
         {
-            ExecuteScript(thenScript, ctx);
+            await ExecuteScript(thenScript, ctx);
         }
         else if (elsePos != 0)
         {
-            ExecuteScript(elseScript, ctx);
+            await ExecuteScript(elseScript, ctx);
         }
     }
 
-    private void ExecuteScript(string scriptLine, Context ctx, int newCallingObjectId = 0)
+    private async Task ExecuteScript(string scriptLine, Context ctx, int newCallingObjectId = 0)
     {
         try
         {
@@ -5763,7 +5713,7 @@ public partial class V4Game
                     var curScriptLine = Strings.Trim(Strings.Mid(scriptLine, curPos, crLfPos - curPos));
                     if ((curScriptLine ?? "") != Constants.vbCrLf)
                     {
-                        ExecuteScript(curScriptLine, ctx);
+                        await ExecuteScript(curScriptLine, ctx);
                     }
 
                     curPos = crLfPos + 2;
@@ -5779,55 +5729,55 @@ public partial class V4Game
 
             if (BeginsWith(scriptLine, "if "))
             {
-                ExecuteIf(scriptLine, ctx);
+                await ExecuteIf(scriptLine, ctx);
             }
             else if (BeginsWith(scriptLine, "select case "))
             {
-                ExecuteSelectCase(scriptLine, ctx);
+                await ExecuteSelectCase(scriptLine, ctx);
             }
             else if (BeginsWith(scriptLine, "choose "))
             {
-                ExecuteChoose(GetParameter(scriptLine, ctx), ctx);
+                await ExecuteChoose(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "set "))
             {
-                ExecuteSet(GetEverythingAfter(scriptLine, "set "), ctx);
+                await ExecuteSet(GetEverythingAfter(scriptLine, "set "), ctx);
             }
             else if (BeginsWith(scriptLine, "inc ") | BeginsWith(scriptLine, "dec "))
             {
-                ExecuteIncDec(scriptLine, ctx);
+                await ExecuteIncDec(scriptLine, ctx);
             }
             else if (BeginsWith(scriptLine, "say "))
             {
-                Print('"' + GetParameter(scriptLine, ctx) + '"', ctx);
+                await Print('"' + await GetParameter(scriptLine, ctx) + '"', ctx);
             }
             else if (BeginsWith(scriptLine, "do "))
             {
-                ExecuteDo(GetParameter(scriptLine, ctx), ctx);
+                await ExecuteDo(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "doaction "))
             {
-                ExecuteDoAction(GetParameter(scriptLine, ctx), ctx);
+                await ExecuteDoAction(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "give "))
             {
-                PlayerItem(GetParameter(scriptLine, ctx), true, ctx);
+                await PlayerItem(await GetParameter(scriptLine, ctx), true, ctx);
             }
             else if (BeginsWith(scriptLine, "lose ") | BeginsWith(scriptLine, "drop "))
             {
-                PlayerItem(GetParameter(scriptLine, ctx), false, ctx);
+                await PlayerItem(await GetParameter(scriptLine, ctx), false, ctx);
             }
             else if (BeginsWith(scriptLine, "msg "))
             {
-                Print(GetParameter(scriptLine, ctx), ctx);
+                await Print(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "speak "))
             {
-                Speak(GetParameter(scriptLine, ctx));
+                Speak(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "helpmsg "))
             {
-                Print(GetParameter(scriptLine, ctx), ctx);
+                await Print(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (Strings.Trim(Strings.LCase(scriptLine)) == "helpclose")
             {
@@ -5835,31 +5785,31 @@ public partial class V4Game
             // This command does nothing in the Quest 5 player, as there is no separate help window
             else if (BeginsWith(scriptLine, "goto "))
             {
-                PlayGame(GetParameter(scriptLine, ctx), ctx);
+                await PlayGame(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "playerwin"))
             {
-                FinishGame(StopType.Win, ctx);
+                await FinishGame(StopType.Win, ctx);
             }
             else if (BeginsWith(scriptLine, "playerlose"))
             {
-                FinishGame(StopType.Lose, ctx);
+                await FinishGame(StopType.Lose, ctx);
             }
             else if (Strings.Trim(Strings.LCase(scriptLine)) == "stop")
             {
-                FinishGame(StopType.Null, ctx);
+                await FinishGame(StopType.Null, ctx);
             }
             else if (BeginsWith(scriptLine, "playwav "))
             {
-                PlayWav(GetParameter(scriptLine, ctx));
+                await PlayWavAsync(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "playmidi "))
             {
-                PlayMedia(GetParameter(scriptLine, ctx));
+                await PlayMediaAsync(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "playmp3 "))
             {
-                PlayMedia(GetParameter(scriptLine, ctx));
+                await PlayMediaAsync(await GetParameter(scriptLine, ctx));
             }
             else if (Strings.Trim(Strings.LCase(scriptLine)) == "picture close")
             {
@@ -5869,167 +5819,167 @@ public partial class V4Game
                      ((ASLVersion >= 282) & (ASLVersion < 390) & BeginsWith(scriptLine, "picture ")) |
                      ((ASLVersion < 282) & BeginsWith(scriptLine, "show ")))
             {
-                ShowPicture(GetParameter(scriptLine, ctx));
+                await ShowPicture(await GetParameter(scriptLine, ctx));
             }
             else if ((ASLVersion >= 390) & BeginsWith(scriptLine, "picture "))
             {
-                ShowPictureInText(GetParameter(scriptLine, ctx));
+                ShowPictureInText(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "animate persist "))
             {
-                ShowPicture(GetParameter(scriptLine, ctx));
+                await ShowPicture(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "animate "))
             {
-                ShowPicture(GetParameter(scriptLine, ctx));
+                await ShowPicture(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "extract "))
             {
-                ExtractFile(GetParameter(scriptLine, ctx));
+                ExtractFile(await GetParameter(scriptLine, ctx));
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "hideobject "))
             {
-                SetAvailability(GetParameter(scriptLine, ctx), false, ctx);
+                await SetAvailability(await GetParameter(scriptLine, ctx), false, ctx);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "showobject "))
             {
-                SetAvailability(GetParameter(scriptLine, ctx), true, ctx);
+                await SetAvailability(await GetParameter(scriptLine, ctx), true, ctx);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "moveobject "))
             {
-                ExecMoveThing(GetParameter(scriptLine, ctx), Thing.Object, ctx);
+                await ExecMoveThing(await GetParameter(scriptLine, ctx), Thing.Object, ctx);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "hidechar "))
             {
-                SetAvailability(GetParameter(scriptLine, ctx), false, ctx, Thing.Character);
+                await SetAvailability(await GetParameter(scriptLine, ctx), false, ctx, Thing.Character);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "showchar "))
             {
-                SetAvailability(GetParameter(scriptLine, ctx), true, ctx, Thing.Character);
+                await SetAvailability(await GetParameter(scriptLine, ctx), true, ctx, Thing.Character);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "movechar "))
             {
-                ExecMoveThing(GetParameter(scriptLine, ctx), Thing.Character, ctx);
+                await ExecMoveThing(await GetParameter(scriptLine, ctx), Thing.Character, ctx);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "revealobject "))
             {
-                SetVisibility(GetParameter(scriptLine, ctx), Thing.Object, true, ctx);
+                await SetVisibility(await GetParameter(scriptLine, ctx), Thing.Object, true, ctx);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "concealobject "))
             {
-                SetVisibility(GetParameter(scriptLine, ctx), Thing.Object, false, ctx);
+                await SetVisibility(await GetParameter(scriptLine, ctx), Thing.Object, false, ctx);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "revealchar "))
             {
-                SetVisibility(GetParameter(scriptLine, ctx), Thing.Character, true, ctx);
+                await SetVisibility(await GetParameter(scriptLine, ctx), Thing.Character, true, ctx);
             }
             else if ((ASLVersion < 281) & BeginsWith(scriptLine, "concealchar "))
             {
-                SetVisibility(GetParameter(scriptLine, ctx), Thing.Character, false, ctx);
+                await SetVisibility(await GetParameter(scriptLine, ctx), Thing.Character, false, ctx);
             }
             else if ((ASLVersion >= 281) & BeginsWith(scriptLine, "hide "))
             {
-                SetAvailability(GetParameter(scriptLine, ctx), false, ctx);
+                await SetAvailability(await GetParameter(scriptLine, ctx), false, ctx);
             }
             else if ((ASLVersion >= 281) & BeginsWith(scriptLine, "show "))
             {
-                SetAvailability(GetParameter(scriptLine, ctx), true, ctx);
+                await SetAvailability(await GetParameter(scriptLine, ctx), true, ctx);
             }
             else if ((ASLVersion >= 281) & BeginsWith(scriptLine, "move "))
             {
-                ExecMoveThing(GetParameter(scriptLine, ctx), Thing.Object, ctx);
+                await ExecMoveThing(await GetParameter(scriptLine, ctx), Thing.Object, ctx);
             }
             else if ((ASLVersion >= 281) & BeginsWith(scriptLine, "reveal "))
             {
-                SetVisibility(GetParameter(scriptLine, ctx), Thing.Object, true, ctx);
+                await SetVisibility(await GetParameter(scriptLine, ctx), Thing.Object, true, ctx);
             }
             else if ((ASLVersion >= 281) & BeginsWith(scriptLine, "conceal "))
             {
-                SetVisibility(GetParameter(scriptLine, ctx), Thing.Object, false, ctx);
+                await SetVisibility(await GetParameter(scriptLine, ctx), Thing.Object, false, ctx);
             }
             else if ((ASLVersion >= 391) & BeginsWith(scriptLine, "open "))
             {
-                SetOpenClose(GetParameter(scriptLine, ctx), true, ctx);
+                await SetOpenClose(await GetParameter(scriptLine, ctx), true, ctx);
             }
             else if ((ASLVersion >= 391) & BeginsWith(scriptLine, "close "))
             {
-                SetOpenClose(GetParameter(scriptLine, ctx), false, ctx);
+                await SetOpenClose(await GetParameter(scriptLine, ctx), false, ctx);
             }
             else if ((ASLVersion >= 391) & BeginsWith(scriptLine, "add "))
             {
-                ExecAddRemoveScript(GetParameter(scriptLine, ctx), true, ctx);
+                await ExecAddRemoveScript(await GetParameter(scriptLine, ctx), true, ctx);
             }
             else if ((ASLVersion >= 391) & BeginsWith(scriptLine, "remove "))
             {
-                ExecAddRemoveScript(GetParameter(scriptLine, ctx), false, ctx);
+                await ExecAddRemoveScript(await GetParameter(scriptLine, ctx), false, ctx);
             }
             else if (BeginsWith(scriptLine, "clone "))
             {
-                ExecClone(GetParameter(scriptLine, ctx), ctx);
+                ExecClone(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "exec "))
             {
-                ExecExec(scriptLine, ctx);
+                await ExecExec(scriptLine, ctx);
             }
             else if (BeginsWith(scriptLine, "setstring "))
             {
-                ExecSetString(GetParameter(scriptLine, ctx), ctx);
+                ExecSetString(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "setvar "))
             {
-                ExecSetVar(GetParameter(scriptLine, ctx), ctx);
+                ExecSetVar(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "for "))
             {
-                ExecFor(GetEverythingAfter(scriptLine, "for "), ctx);
+                await ExecFor(GetEverythingAfter(scriptLine, "for "), ctx);
             }
             else if (BeginsWith(scriptLine, "property "))
             {
-                ExecProperty(GetParameter(scriptLine, ctx), ctx);
+                await ExecProperty(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "type "))
             {
-                ExecType(GetParameter(scriptLine, ctx), ctx);
+                await ExecType(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "action "))
             {
-                ExecuteAction(GetEverythingAfter(scriptLine, "action "), ctx);
+                await ExecuteAction(GetEverythingAfter(scriptLine, "action "), ctx);
             }
             else if (BeginsWith(scriptLine, "flag "))
             {
-                ExecuteFlag(GetEverythingAfter(scriptLine, "flag "), ctx);
+                await ExecuteFlag(GetEverythingAfter(scriptLine, "flag "), ctx);
             }
             else if (BeginsWith(scriptLine, "create "))
             {
-                ExecuteCreate(GetEverythingAfter(scriptLine, "create "), ctx);
+                await ExecuteCreate(GetEverythingAfter(scriptLine, "create "), ctx);
             }
             else if (BeginsWith(scriptLine, "destroy exit "))
             {
-                DestroyExit(GetParameter(scriptLine, ctx), ctx);
+                DestroyExit(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "repeat "))
             {
-                ExecuteRepeat(GetEverythingAfter(scriptLine, "repeat "), ctx);
+                await ExecuteRepeat(GetEverythingAfter(scriptLine, "repeat "), ctx);
             }
             else if (BeginsWith(scriptLine, "enter "))
             {
-                ExecuteEnter(scriptLine, ctx);
+                await ExecuteEnterAsync(scriptLine, ctx);
             }
             else if (BeginsWith(scriptLine, "displaytext "))
             {
-                DisplayTextSection(GetParameter(scriptLine, ctx), ctx);
+                await DisplayTextSection(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "helpdisplaytext "))
             {
-                DisplayTextSection(GetParameter(scriptLine, ctx), ctx);
+                await DisplayTextSection(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "font "))
             {
-                SetFont(GetParameter(scriptLine, ctx));
+                SetFont(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "pause "))
             {
-                Pause(Conversions.ToInteger(GetParameter(scriptLine, ctx)));
+                await PauseAsync(Conversions.ToInteger(await GetParameter(scriptLine, ctx)));
             }
             else if (Strings.Trim(Strings.LCase(scriptLine)) == "clear")
             {
@@ -6041,11 +5991,11 @@ public partial class V4Game
             // This command does nothing in the Quest 5 player, as there is no separate help window
             else if (BeginsWith(scriptLine, "background "))
             {
-                SetBackground(GetParameter(scriptLine, ctx));
+                SetBackground(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "foreground "))
             {
-                SetForeground(GetParameter(scriptLine, ctx));
+                SetForeground(await GetParameter(scriptLine, ctx));
             }
             else if (Strings.Trim(Strings.LCase(scriptLine)) == "nointro")
             {
@@ -6053,11 +6003,11 @@ public partial class V4Game
             }
             else if (BeginsWith(scriptLine, "debug "))
             {
-                LogASLError(GetParameter(scriptLine, ctx));
+                LogASLError(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "mailto "))
             {
-                var emailAddress = GetParameter(scriptLine, ctx);
+                var emailAddress = await GetParameter(scriptLine, ctx);
                 PrintText?.Invoke("<a target=\"_blank\" href=\"mailto:" + emailAddress + "\">" + emailAddress + "</a>");
             }
             else if (BeginsWith(scriptLine, "shell ") & (ASLVersion < 410))
@@ -6070,21 +6020,21 @@ public partial class V4Game
             }
             else if (BeginsWith(scriptLine, "wait"))
             {
-                ExecuteWait(Strings.Trim(GetEverythingAfter(Strings.Trim(scriptLine), "wait")), ctx);
+                await ExecuteWaitAsync(Strings.Trim(GetEverythingAfter(Strings.Trim(scriptLine), "wait")), ctx);
             }
             else if (BeginsWith(scriptLine, "timeron "))
             {
-                SetTimerState(GetParameter(scriptLine, ctx), true);
+                SetTimerState(await GetParameter(scriptLine, ctx), true);
             }
             else if (BeginsWith(scriptLine, "timeroff "))
             {
-                SetTimerState(GetParameter(scriptLine, ctx), false);
+                SetTimerState(await GetParameter(scriptLine, ctx), false);
             }
             else if (Strings.Trim(Strings.LCase(scriptLine)) == "outputon")
             {
                 _outPutOn = true;
-                UpdateObjectList(ctx);
-                UpdateItems(ctx);
+                await UpdateObjectList(ctx);
+                await UpdateItems(ctx);
             }
             else if (Strings.Trim(Strings.LCase(scriptLine)) == "outputoff")
             {
@@ -6100,11 +6050,11 @@ public partial class V4Game
             }
             else if (BeginsWith(scriptLine, "lock "))
             {
-                ExecuteLock(GetParameter(scriptLine, ctx), true);
+                ExecuteLock(await GetParameter(scriptLine, ctx), true);
             }
             else if (BeginsWith(scriptLine, "unlock "))
             {
-                ExecuteLock(GetParameter(scriptLine, ctx), false);
+                ExecuteLock(await GetParameter(scriptLine, ctx), false);
             }
             else if (BeginsWith(scriptLine, "playmod ") & (ASLVersion < 410))
             {
@@ -6120,7 +6070,7 @@ public partial class V4Game
             }
             else if (BeginsWith(scriptLine, "return "))
             {
-                ctx.FunctionReturnValue = GetParameter(scriptLine, ctx);
+                ctx.FunctionReturnValue = await GetParameter(scriptLine, ctx);
             }
             else if (!BeginsWith(scriptLine, "'"))
             {
@@ -6130,41 +6080,30 @@ public partial class V4Game
         }
         catch
         {
-            Print("[An internal error occurred]", ctx);
+            await Print("[An internal error occurred]", ctx);
             LogASLError(
                 Information.Err().Number + " - '" + Information.Err().Description +
                 "' occurred processing script line '" + scriptLine + "'", LogType.InternalError);
         }
     }
 
-    private void ExecuteEnter(string scriptLine, Context ctx)
+    private async Task ExecuteEnterAsync(string scriptLine, Context ctx)
     {
         _commandOverrideModeOn = true;
-        _commandOverrideVariable = GetParameter(scriptLine, ctx);
-
-        // Now, wait for CommandOverrideModeOn to be set
-        // to False by ExecCommand. Execution can then resume.
-
-        ChangeState(State.Waiting, true);
-
-        lock (_commandLock)
-        {
-            Monitor.Wait(_commandLock);
-        }
-
+        _commandOverrideVariable = await GetParameter(scriptLine, ctx);
+        _commandTcs = new TaskCompletionSource();
+        SignalTurnSuspended();
+        await _commandTcs.Task;
         _commandOverrideModeOn = false;
-
-        // State will have been changed to Working when the user typed their response,
-        // and will be set back to Ready when the call to ExecCommand has finished
     }
 
-    private void ExecuteSet(string setInstruction, Context ctx)
+    private async Task ExecuteSet(string setInstruction, Context ctx)
     {
         if (ASLVersion >= 280)
         {
             if (BeginsWith(setInstruction, "interval "))
             {
-                var interval = GetParameter(setInstruction, ctx);
+                var interval = await GetParameter(setInstruction, ctx);
                 var scp = Strings.InStr(interval, ";");
                 if (scp == 0)
                 {
@@ -6193,19 +6132,19 @@ public partial class V4Game
             }
             else if (BeginsWith(setInstruction, "string "))
             {
-                ExecSetString(GetParameter(setInstruction, ctx), ctx);
+                ExecSetString(await GetParameter(setInstruction, ctx), ctx);
             }
             else if (BeginsWith(setInstruction, "numeric "))
             {
-                ExecSetVar(GetParameter(setInstruction, ctx), ctx);
+                ExecSetVar(await GetParameter(setInstruction, ctx), ctx);
             }
             else if (BeginsWith(setInstruction, "collectable "))
             {
-                ExecuteSetCollectable(GetParameter(setInstruction, ctx), ctx);
+                ExecuteSetCollectable(await GetParameter(setInstruction, ctx), ctx);
             }
             else
             {
-                var result = SetUnknownVariableType(GetParameter(setInstruction, ctx), ctx);
+                var result = await SetUnknownVariableType(await GetParameter(setInstruction, ctx), ctx);
                 if (result == SetResult.Error)
                 {
                     LogASLError("Error on setting 'set " + setInstruction + "'", LogType.WarningError);
@@ -6218,11 +6157,11 @@ public partial class V4Game
         }
         else
         {
-            ExecuteSetCollectable(GetParameter(setInstruction, ctx), ctx);
+            ExecuteSetCollectable(await GetParameter(setInstruction, ctx), ctx);
         }
     }
 
-    private string FindStatement(DefineBlock block, string statement)
+    private async Task<string> FindStatement(DefineBlock block, string statement)
     {
         // Finds a statement within a given block of lines
 
@@ -6242,14 +6181,14 @@ public partial class V4Game
             if (BeginsWith(_lines[i], statement))
             {
                 // Return the parameters between < and > :
-                return GetParameter(_lines[i], _nullContext);
+                return await GetParameter(_lines[i], _nullContext);
             }
         }
 
         return "";
     }
 
-    private string FindLine(DefineBlock block, string statement, string statementParam)
+    private async Task<string> FindLine(DefineBlock block, string statement, string statementParam)
     {
         // Finds a statement within a given block of lines
 
@@ -6268,7 +6207,7 @@ public partial class V4Game
             // that is begin searched for
             if (BeginsWith(_lines[i], statement))
             {
-                if ((Strings.UCase(Strings.Trim(GetParameter(_lines[i], _nullContext))) ?? "") ==
+                if ((Strings.UCase(Strings.Trim(await GetParameter(_lines[i], _nullContext))) ?? "") ==
                     (Strings.UCase(Strings.Trim(statementParam)) ?? ""))
                 {
                     return Strings.Trim(_lines[i]);
@@ -6299,7 +6238,7 @@ public partial class V4Game
         return Strings.Trim(Strings.Mid(line, endOfFirstBit, lengthOfKeyword));
     }
 
-    private void GoDirection(string direction, Context ctx)
+    private async Task GoDirection(string direction, Context ctx)
     {
         // leaves the current room in direction specified by
         // 'direction'
@@ -6314,7 +6253,7 @@ public partial class V4Game
 
         if (ASLVersion >= 410)
         {
-            _rooms[id].Exits.ExecuteGo(direction, ref ctx);
+            _rooms[id].Exits.ExecuteGo(direction, ctx);
             return;
         }
 
@@ -6376,7 +6315,7 @@ public partial class V4Game
 
         if ((dirData.Type == TextActionType.Script) & !string.IsNullOrEmpty(dirData.Data))
         {
-            ExecuteScript(dirData.Data, ctx);
+            await ExecuteScript(dirData.Data, ctx);
         }
         else if (!string.IsNullOrEmpty(dirData.Data))
         {
@@ -6387,19 +6326,19 @@ public partial class V4Game
                 newRoom = Strings.Trim(Strings.Mid(newRoom, scp + 1));
             }
 
-            PlayGame(newRoom, ctx);
+            await PlayGame(newRoom, ctx);
         }
         else if (direction == "out")
         {
-            PlayerErrorMessage(PlayerError.DefaultOut, ctx);
+            await PlayerErrorMessage(PlayerError.DefaultOut, ctx);
         }
         else
         {
-            PlayerErrorMessage(PlayerError.BadPlace, ctx);
+            await PlayerErrorMessage(PlayerError.BadPlace, ctx);
         }
     }
 
-    private void GoToPlace(string place, Context ctx)
+    private async Task GoToPlace(string place, Context ctx)
     {
         // leaves the current room in direction specified by
         // 'direction'
@@ -6438,17 +6377,17 @@ public partial class V4Game
             {
                 var s = Strings.Trim(Strings.Right(destination,
                     Strings.Len(destination) - Strings.InStr(destination, ";")));
-                ExecuteScript(s, ctx);
+                await ExecuteScript(s, ctx);
             }
             else
             {
-                PlayGame(destination, ctx);
+                await PlayGame(destination, ctx);
             }
         }
 
         if (disallowed)
         {
-            PlayerErrorMessage(PlayerError.BadPlace, ctx);
+            await PlayerErrorMessage(PlayerError.BadPlace, ctx);
         }
     }
 
@@ -6482,7 +6421,7 @@ public partial class V4Game
                 err = err + ":" + Constants.vbCrLf + Constants.vbCrLf + _openErrorReport;
             }
 
-            Print("Error: " + err, _nullContext);
+            await Print("Error: " + err, _nullContext);
             return false;
         }
 
@@ -6495,7 +6434,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "asl-version "))
             {
-                aslVersion = GetParameter(_lines[i], _nullContext);
+                aslVersion = await GetParameter(_lines[i], _nullContext);
             }
         }
 
@@ -6532,14 +6471,14 @@ public partial class V4Game
         }
 
         // Get the name of the game:
-        _gameName = GetParameter(_lines[GetDefineBlock("game").StartLine], _nullContext);
+        _gameName = await GetParameter(_lines[GetDefineBlock("game").StartLine], _nullContext);
 
         _player.UpdateGameName(_gameName);
         _player.Show("Panes");
         _player.Show("Location");
         _player.Show("Command");
 
-        SetUpGameObject();
+        await SetUpGameObject();
         SetUpOptions();
 
         for (int i = GetDefineBlock("game").StartLine + 1, loopTo1 = GetDefineBlock("game").EndLine - 1;
@@ -6558,12 +6497,12 @@ public partial class V4Game
 
         SetDefaultPlayerErrorMessages();
 
-        SetUpSynonyms();
-        SetUpRoomData();
+        await SetUpSynonyms();
+        await SetUpRoomData();
 
         if (ASLVersion >= 410)
         {
-            SetUpExits();
+            await SetUpExits();
         }
 
         if (ASLVersion < 280)
@@ -6571,33 +6510,33 @@ public partial class V4Game
             // Set up an array containing the names of all the items
             // used in the game, based on the possitems statement
             // of the 'define game' block.
-            SetUpItemArrays();
+            await SetUpItemArrays();
         }
 
         if (ASLVersion < 280)
         {
             // Now, go through the 'startitems' statement and set up
             // the items array so we start with those items mentioned.
-            SetUpStartItems();
+            await SetUpStartItems();
         }
 
         // Set up collectables.
-        SetUpCollectables();
+        await SetUpCollectables();
 
-        SetUpDisplayVariables();
+        await SetUpDisplayVariables();
 
         // Set up characters and objects.
-        SetUpCharObjectInfo();
-        SetUpUserDefinedPlayerErrors();
-        SetUpDefaultFonts();
-        SetUpTurnScript();
-        SetUpTimers();
-        SetUpMenus();
+        await SetUpCharObjectInfo();
+        await SetUpUserDefinedPlayerErrors();
+        await SetUpDefaultFonts();
+        await SetUpTurnScript();
+        await SetUpTimers();
+        await SetUpMenus();
 
         LogASLError("Finished loading file.", LogType.Init);
 
-        _defaultRoomProperties = GetPropertiesInType("defaultroom", false);
-        _defaultProperties = GetPropertiesInType("default", false);
+        _defaultRoomProperties = await GetPropertiesInType("defaultroom", false);
+        _defaultProperties = await GetPropertiesInType("default", false);
 
         return true;
     }
@@ -6652,7 +6591,7 @@ public partial class V4Game
         return "";
     }
 
-    private void PlayerItem(string item, bool got, Context ctx, int objId = 0)
+    private async Task PlayerItem(string item, bool got, Context ctx, int objId = 0)
     {
         // Gives the player an item (if got=True) or takes an
         // item away from the player (if got=False).
@@ -6691,7 +6630,7 @@ public partial class V4Game
 
                     if (!string.IsNullOrEmpty(_objs[objId].GainScript))
                     {
-                        ExecuteScript(_objs[objId].GainScript, ctx);
+                        await ExecuteScript(_objs[objId].GainScript, ctx);
                     }
                 }
                 else
@@ -6700,7 +6639,7 @@ public partial class V4Game
 
                     if (!string.IsNullOrEmpty(_objs[objId].LoseScript))
                     {
-                        ExecuteScript(_objs[objId].LoseScript, ctx);
+                        await ExecuteScript(_objs[objId].LoseScript, ctx);
                     }
                 }
 
@@ -6713,8 +6652,8 @@ public partial class V4Game
             }
             else
             {
-                UpdateItems(ctx);
-                UpdateObjectList(ctx);
+                await UpdateItems(ctx);
+                await UpdateObjectList(ctx);
             }
         }
         else
@@ -6728,11 +6667,11 @@ public partial class V4Game
                 }
             }
 
-            UpdateItems(ctx);
+            await UpdateItems(ctx);
         }
     }
 
-    internal void PlayGame(string room, Context ctx)
+    internal async Task PlayGame(string room, Context ctx)
     {
         // plays the specified room
 
@@ -6753,15 +6692,15 @@ public partial class V4Game
             AddToObjectProperties("visited", _rooms[id].ObjId, ctx);
         }
 
-        ShowRoomInfo(room, ctx);
-        UpdateItems(ctx);
+        await ShowRoomInfo(room, ctx);
+        await UpdateItems(ctx);
 
         // Find script lines and execute them.
 
         if (!string.IsNullOrEmpty(_rooms[id].Script))
         {
             var script = _rooms[id].Script;
-            ExecuteScript(script, ctx);
+            await ExecuteScript(script, ctx);
         }
 
         if (ASLVersion >= 410)
@@ -6770,7 +6709,7 @@ public partial class V4Game
         }
     }
 
-    internal void Print(string txt, Context ctx)
+    internal async Task Print(string txt, Context ctx)
     {
         if (!_outPutOn)
         {
@@ -6795,7 +6734,7 @@ public partial class V4Game
                     printString = "";
                     printThis = false;
                     i = i + 1;
-                    ExecuteScript("wait <>", ctx);
+                    await DoWaitAsync();
                 }
 
                 else if (Strings.Mid(txt, i, 2) == "|c")
@@ -6818,7 +6757,7 @@ public partial class V4Game
                             printString = "";
                             printThis = false;
                             i = i + 1;
-                            ExecuteScript("clear", ctx);
+                            DoClear();
                             break;
                         }
                     }
@@ -6866,7 +6805,7 @@ public partial class V4Game
         return "<unfound>";
     }
 
-    private string RetrLineParam(string blockType, string param, string line, string lineParam, Context ctx)
+    private async Task<string> RetrLineParam(string blockType, string param, string line, string lineParam, Context ctx)
     {
         DefineBlock searchblock;
 
@@ -6887,7 +6826,7 @@ public partial class V4Game
         for (int i = searchblock.StartLine + 1, loopTo = searchblock.EndLine - 1; i <= loopTo; i++)
         {
             if (BeginsWith(_lines[i], line) &&
-                (Strings.LCase(GetParameter(_lines[i], ctx)) ?? "") == (Strings.LCase(lineParam) ?? ""))
+                (Strings.LCase(await GetParameter(_lines[i], ctx)) ?? "") == (Strings.LCase(lineParam) ?? ""))
             {
                 return Strings.Trim(_lines[i]);
             }
@@ -6896,7 +6835,7 @@ public partial class V4Game
         return "<unfound>";
     }
 
-    private void SetUpCollectables()
+    private async Task SetUpCollectables()
     {
         var lastItem = false;
 
@@ -6912,7 +6851,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[a], "collectables "))
             {
-                var collectables = Strings.Trim(GetParameter(_lines[a], _nullContext, false));
+                var collectables = Strings.Trim(await GetParameter(_lines[a], _nullContext, false));
 
                 // if collectables is a null string, there are no
                 // collectables. Otherwise, there is one more object than
@@ -6997,7 +6936,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpItemArrays()
+    private async Task SetUpItemArrays()
     {
         var lastItem = false;
 
@@ -7012,7 +6951,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[a], "possitems ") | BeginsWith(_lines[a], "items "))
             {
-                var possItems = GetParameter(_lines[a], _nullContext);
+                var possItems = await GetParameter(_lines[a], _nullContext);
 
                 if (!string.IsNullOrEmpty(possItems))
                 {
@@ -7054,7 +6993,7 @@ public partial class V4Game
         }
     }
 
-    private void SetUpStartItems()
+    private async Task SetUpStartItems()
     {
         var lastItem = false;
 
@@ -7064,7 +7003,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[a], "startitems "))
             {
-                var startItems = GetParameter(_lines[a], _nullContext);
+                var startItems = await GetParameter(_lines[a], _nullContext);
 
                 if (!string.IsNullOrEmpty(startItems))
                 {
@@ -7109,29 +7048,29 @@ public partial class V4Game
         }
     }
 
-    private void ShowHelp(Context ctx)
+    private async Task ShowHelp(Context ctx)
     {
         // In Quest 4 and below, the help text displays in a separate window. In Quest 5, it displays
         // in the same window as the game text.
-        Print("|b|cl|s14Quest Quick Help|xb|cb|s00", ctx);
-        Print("", ctx);
-        Print(
+        await Print("|b|cl|s14Quest Quick Help|xb|cb|s00", ctx);
+        await Print("", ctx);
+        await Print(
             "|cl|bMoving|xb|cb Press the direction buttons in the 'Compass' pane, or type |bGO NORTH|xb, |bSOUTH|xb, |bE|xb, etc. |xn",
             ctx);
-        Print(
+        await Print(
             "To go into a place, type |bGO TO ...|xb . To leave a place, type |bOUT, EXIT|xb or |bLEAVE|xb, or press the '|crOUT|cb' button.|n",
             ctx);
-        Print(
+        await Print(
             "|cl|bObjects and Characters|xb|cb Use |bTAKE ...|xb, |bGIVE ... TO ...|xb, |bTALK|xb/|bSPEAK TO ...|xb, |bUSE ... ON|xb/|bWITH ...|xb, |bLOOK AT ...|xb, etc.|n",
             ctx);
-        Print("|cl|bExit Quest|xb|cb Type |bQUIT|xb to leave Quest.|n", ctx);
-        Print(
+        await Print("|cl|bExit Quest|xb|cb Type |bQUIT|xb to leave Quest.|n", ctx);
+        await Print(
             "|cl|bMisc|xb|cb Type |bABOUT|xb to get information on the current game. The next turn after referring to an object or character, you can use |bIT|xb, |bHIM|xb etc. as appropriate to refer to it/him/etc. again. If you make a mistake when typing an object's name, type |bOOPS|xb followed by your correction.|n",
             ctx);
-        Print(
+        await Print(
             "|cl|bKeyboard shortcuts|xb|cb Press the |crup arrow|cb and |crdown arrow|cb to scroll through commands you have already typed in. Press |crEsc|cb to clear the command box.|n|n",
             ctx);
-        Print("Further information is available by selecting |iQuest Documentation|xi from the |iHelp|xi menu.", ctx);
+        await Print("Further information is available by selecting |iQuest Documentation|xi from the |iHelp|xi menu.", ctx);
     }
 
     private void ReadCatalog(string data)
@@ -7412,7 +7351,7 @@ public partial class V4Game
         return roomDisplayText;
     }
 
-    private void UpdateItems(Context ctx)
+    private async Task UpdateItems(Context ctx)
     {
         // displays the items a player has
         var invList = new List<ListData>();
@@ -7458,7 +7397,7 @@ public partial class V4Game
 
         if (ASLVersion >= 284)
         {
-            UpdateStatusVars(ctx);
+            await UpdateStatusVars(ctx);
         }
         else if (_numCollectables > 0)
         {
@@ -7482,21 +7421,21 @@ public partial class V4Game
         }
     }
 
-    private void FinishGame(StopType stopType, Context ctx)
+    private async Task FinishGame(StopType stopType, Context ctx)
     {
         if (stopType == StopType.Win)
         {
-            DisplayTextSection("win", ctx);
+            await DisplayTextSection("win", ctx);
         }
         else if (stopType == StopType.Lose)
         {
-            DisplayTextSection("lose", ctx);
+            await DisplayTextSection("lose", ctx);
         }
 
         GameFinished();
     }
 
-    private void UpdateObjectList(Context ctx)
+    private async Task UpdateObjectList(Context ctx)
     {
         // Updates object list
         string shownPlaceName;
@@ -7518,7 +7457,7 @@ public partial class V4Game
 
         // find the room
         DefineBlock roomBlock;
-        roomBlock = DefineBlockParam("room", _currentRoom);
+        roomBlock = await DefineBlockParam("room", _currentRoom);
 
         // FIND CHARACTERS ===
         if (ASLVersion < 281)
@@ -7665,7 +7604,7 @@ public partial class V4Game
         UpdateList?.Invoke(ListType.ExitsList, mergedList);
     }
 
-    private void UpdateStatusVars(Context ctx)
+    private async Task UpdateStatusVars(Context ctx)
     {
         string displayData;
         var status = "";
@@ -7674,7 +7613,7 @@ public partial class V4Game
         {
             for (int i = 1, loopTo = _numDisplayStrings; i <= loopTo; i++)
             {
-                displayData = DisplayStatusVariableInfo(i, VarType.String, ctx);
+                displayData = await DisplayStatusVariableInfo(i, VarType.String, ctx);
 
                 if (!string.IsNullOrEmpty(displayData))
                 {
@@ -7692,7 +7631,7 @@ public partial class V4Game
         {
             for (int i = 1, loopTo1 = _numDisplayNumerics; i <= loopTo1; i++)
             {
-                displayData = DisplayStatusVariableInfo(i, VarType.Numeric, ctx);
+                displayData = await DisplayStatusVariableInfo(i, VarType.Numeric, ctx);
                 if (!string.IsNullOrEmpty(displayData))
                 {
                     if (status.Length > 0)
@@ -7708,7 +7647,7 @@ public partial class V4Game
         _player.SetStatusText(status);
     }
 
-    private void UpdateVisibilityInContainers(Context ctx, string onlyParent = "")
+    private async Task UpdateVisibilityInContainers(Context ctx, string onlyParent = "")
     {
         // Use OnlyParent to only update objects that are contained by a specific parent
 
@@ -7758,11 +7697,11 @@ public partial class V4Game
                         // Otherwise, only if the parent has been seen, AND is either open or transparent,
                         // then the contents are available.
 
-                        SetAvailability(_objs[i].ObjectName, true, ctx);
+                        await SetAvailability(_objs[i].ObjectName, true, ctx);
                     }
                     else
                     {
-                        SetAvailability(_objs[i].ObjectName, false, ctx);
+                        await SetAvailability(_objs[i].ObjectName, false, ctx);
                     }
                 }
             }
@@ -7882,7 +7821,7 @@ public partial class V4Game
         return placeList;
     }
 
-    private void SetUpExits()
+    private async Task SetUpExits()
     {
         // Exits have to be set up after all the rooms have been initialised
 
@@ -7890,7 +7829,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[_defineBlocks[i].StartLine], "define room "))
             {
-                var roomName = GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext);
+                var roomName = await GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext);
                 var roomId = GetRoomID(roomName, _nullContext);
 
                 for (int j = _defineBlocks[i].StartLine + 1, loopTo1 = _defineBlocks[i].EndLine - 1; j <= loopTo1; j++)
@@ -7973,7 +7912,7 @@ public partial class V4Game
         roomExit.SetIsLocked(@lock);
     }
 
-    private void DoBegin()
+    private async Task DoBeginAsync()
     {
         var gameBlock = GetDefineBlock("game");
         var ctx = new Context();
@@ -7987,7 +7926,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "background "))
             {
-                SetBackground(GetParameter(_lines[i], _nullContext));
+                SetBackground(await GetParameter(_lines[i], _nullContext));
             }
         }
 
@@ -7997,7 +7936,7 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "foreground "))
             {
-                SetForeground(GetParameter(_lines[i], _nullContext));
+                SetForeground(await GetParameter(_lines[i], _nullContext));
             }
         }
 
@@ -8021,7 +7960,7 @@ public partial class V4Game
                     if (BeginsWith(_lines[i], "lib startscript "))
                     {
                         ctx = _nullContext;
-                        ExecuteScript(Strings.Trim(GetEverythingAfter(Strings.Trim(_lines[i]), "lib startscript ")),
+                        await ExecuteScript(Strings.Trim(GetEverythingAfter(Strings.Trim(_lines[i]), "lib startscript ")),
                             ctx);
                     }
                 }
@@ -8032,12 +7971,12 @@ public partial class V4Game
                 if (BeginsWith(_lines[i], "startscript "))
                 {
                     ctx = _nullContext;
-                    ExecuteScript(Strings.Trim(GetEverythingAfter(Strings.Trim(_lines[i]), "startscript")), ctx);
+                    await ExecuteScript(Strings.Trim(GetEverythingAfter(Strings.Trim(_lines[i]), "startscript")), ctx);
                 }
                 else if (BeginsWith(_lines[i], "lib startscript ") & (ASLVersion < 311))
                 {
                     ctx = _nullContext;
-                    ExecuteScript(Strings.Trim(GetEverythingAfter(Strings.Trim(_lines[i]), "lib startscript ")), ctx);
+                    await ExecuteScript(Strings.Trim(GetEverythingAfter(Strings.Trim(_lines[i]), "lib startscript ")), ctx);
                 }
             }
         }
@@ -8047,7 +7986,7 @@ public partial class V4Game
         // Display intro text
         if (_autoIntro & (_gameLoadMethod == "normal"))
         {
-            DisplayTextSection("intro", _nullContext);
+            await DisplayTextSection("intro", _nullContext);
         }
 
         // Start game from room specified by "start" statement
@@ -8056,90 +7995,64 @@ public partial class V4Game
         {
             if (BeginsWith(_lines[i], "start "))
             {
-                startRoom = GetParameter(_lines[i], _nullContext);
+                startRoom = await GetParameter(_lines[i], _nullContext);
             }
         }
 
         if (!_loadedFromQsg)
         {
             ctx = _nullContext;
-            PlayGame(startRoom, ctx);
-            Print("", _nullContext);
+            await PlayGame(startRoom, ctx);
+            await Print("", _nullContext);
         }
         else
         {
-            UpdateItems(_nullContext);
+            await UpdateItems(_nullContext);
 
-            Print("Restored saved game", _nullContext);
-            Print("", _nullContext);
-            PlayGame(_currentRoom, _nullContext);
-            Print("", _nullContext);
+            await Print("Restored saved game", _nullContext);
+            await Print("", _nullContext);
+            await PlayGame(_currentRoom, _nullContext);
+            await Print("", _nullContext);
 
             if (ASLVersion >= 391)
             {
                 // For ASL>=391, OnLoad is now run for all games.
                 ctx = _nullContext;
-                ExecuteScript(_onLoadScript, ctx);
+                await ExecuteScript(_onLoadScript, ctx);
             }
         }
 
         RaiseNextTimerTickRequest();
 
-        ChangeState(State.Ready);
+        SignalTurnSuspended();
     }
 
-    private void WaitForStateChange(State changedFromState)
-    {
-        lock (_stateLock)
-        {
-            while ((_state == changedFromState) & !_gameFinished)
-            {
-                Monitor.Wait(_stateLock);
-            }
-        }
-    }
 
-    private void ProcessCommandInNewThread(object command)
-    {
-        // Process command, and change state to Ready if the command finished processing
 
+    private async Task HandleCommandAsync(string command)
+    {
         try
         {
-            if (ExecCommand((string) command, new Context()))
-            {
-                ChangeState(State.Ready);
-            }
+            await ExecCommand(command, new Context());
         }
         catch (Exception ex)
         {
             LogException(ex);
-            ChangeState(State.Ready);
+        }
+        finally
+        {
+            SignalTurnSuspended();
         }
     }
 
     private void GameFinished()
     {
         _gameFinished = true;
-
         Finished?.Invoke();
-
-        ChangeState(State.Finished);
-
-        // In case we're in the middle of processing an "enter" command, nudge the thread along
-        lock (_commandLock)
-        {
-            Monitor.PulseAll(_commandLock);
-        }
-
-        lock (_waitLock)
-        {
-            Monitor.PulseAll(_waitLock);
-        }
-
-        lock (_stateLock)
-        {
-            Monitor.PulseAll(_stateLock);
-        }
+        _readyForCommand = false;
+        _waitTcs?.TrySetResult();
+        _commandTcs?.TrySetResult();
+        _turnSuspendedTcs?.TrySetResult();
     }
 
     private Stream GetResourceStreamInternal(string filename)
@@ -8189,15 +8102,13 @@ public partial class V4Game
         return GetResourceLines(libCode);
     }
 
-    private void RunTimersInNewThread(object scripts)
+    private async Task RunTimersAsync(List<string> timerScripts)
     {
-        var scriptList = (List<string>) scripts;
-
-        foreach (var script in scriptList)
+        foreach (var script in timerScripts)
         {
             try
             {
-                ExecuteScript(script, _nullContext);
+                await ExecuteScript(script, _nullContext);
             }
             catch (Exception ex)
             {
@@ -8205,7 +8116,7 @@ public partial class V4Game
             }
         }
 
-        ChangeState(State.Ready);
+        SignalTurnSuspended();
     }
 
     private void RaiseNextTimerTickRequest()
@@ -8242,52 +8153,20 @@ public partial class V4Game
         RequestNextTimerTick?.Invoke(nextTrigger);
     }
 
-    private void ChangeState(State newState)
-    {
-        var acceptCommands = newState == State.Ready;
-        ChangeState(newState, acceptCommands);
-    }
 
-    private void ChangeState(State newState, bool acceptCommands)
-    {
-        _readyForCommand = acceptCommands;
-        lock (_stateLock)
-        {
-            _state = newState;
-            Monitor.PulseAll(_stateLock);
-        }
-    }
 
-    private void FinishWaitInNewThread()
-    {
-        lock (_waitLock)
-        {
-            Monitor.PulseAll(_waitLock);
-        }
-    }
 
-    private string ShowMenu(MenuData menuData)
+
+    private async Task<string?> ShowMenuAsync(MenuData menuData)
     {
         _player.ShowMenu(menuData);
-        ChangeState(State.Waiting);
-
-        lock (_waitLock)
-        {
-            Monitor.Wait(_waitLock);
-        }
-
+        _waitTcs = new TaskCompletionSource();
+        SignalTurnSuspended();
+        await _waitTcs.Task;
         return m_menuResponse;
     }
 
-    private void SetMenuResponseInNewThread(object response)
-    {
-        m_menuResponse = (string) response;
 
-        lock (_waitLock)
-        {
-            Monitor.PulseAll(_waitLock);
-        }
-    }
 
     private void LogException(Exception ex)
     {

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -14,14 +14,14 @@ public partial class V4Game
 
     public int ASLVersion { get; private set; }
 
-    public byte[] Save(string html)
+    public async Task<byte[]> SaveAsync(string html)
     {
         var ctx = new Context();
         string saveData;
 
         if (ASLVersion >= 391)
         {
-            ExecuteScript(_beforeSaveScript, ctx).GetAwaiter().GetResult();
+            await ExecuteScript(_beforeSaveScript, ctx);
         }
 
         if (ASLVersion >= 280)

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -288,7 +288,7 @@ public partial class V4Game
             }
             else if (BeginsWith(data, "destroy exit "))
             {
-                DestroyExit(appliesTo + "; " + GetEverythingAfter(data, "destroy exit "), _nullContext);
+                await DestroyExit(appliesTo + "; " + GetEverythingAfter(data, "destroy exit "), _nullContext);
             }
         }
 
@@ -299,7 +299,7 @@ public partial class V4Game
             var d = storedData[i];
             if (BeginsWith(d.Change, "properties "))
             {
-                AddToObjectProperties(GetEverythingAfter(d.Change, "properties "), GetObjectIdNoAlias(d.AppliesTo),
+                await AddToObjectProperties(GetEverythingAfter(d.Change, "properties "), GetObjectIdNoAlias(d.AppliesTo),
                     _nullContext);
             }
             else if (BeginsWith(d.Change, "action "))
@@ -782,7 +782,7 @@ public partial class V4Game
                 }
                 else if (BeginsWith(_lines[i], "properties "))
                 {
-                    AddToObjectProperties(await GetParameter(_lines[i], _nullContext), _numberObjs, _nullContext);
+                    await AddToObjectProperties(await GetParameter(_lines[i], _nullContext), _numberObjs, _nullContext);
                 }
                 else if (BeginsWith(_lines[i], "type "))
                 {
@@ -791,10 +791,10 @@ public partial class V4Game
                     o.TypesIncluded[o.NumberTypesIncluded] = await GetParameter(_lines[i], _nullContext);
 
                     var propertyData = await GetPropertiesInType(await GetParameter(_lines[i], _nullContext));
-                    AddToObjectProperties(propertyData.Properties, _numberObjs, _nullContext);
+                    await AddToObjectProperties(propertyData.Properties, _numberObjs, _nullContext);
                     for (int k = 1, loopTo1 = propertyData.NumberActions; k <= loopTo1; k++)
                     {
-                        AddObjectAction(_numberObjs, propertyData.Actions[k].ActionName,
+                        await AddObjectAction(_numberObjs, propertyData.Actions[k].ActionName,
                             propertyData.Actions[k].Script);
                     }
                 }
@@ -943,10 +943,10 @@ public partial class V4Game
 
                 if (defaultExists)
                 {
-                    AddToObjectProperties(defaultProperties.Properties, _numberObjs, _nullContext);
+                    await AddToObjectProperties(defaultProperties.Properties, _numberObjs, _nullContext);
                     for (int k = 1, loopTo2 = defaultProperties.NumberActions; k <= loopTo2; k++)
                     {
-                        AddObjectAction(_numberObjs, defaultProperties.Actions[k].ActionName,
+                        await AddObjectAction(_numberObjs, defaultProperties.Actions[k].ActionName,
                             defaultProperties.Actions[k].Script);
                     }
                 }
@@ -977,7 +977,7 @@ public partial class V4Game
                         _objs[_numberObjs].ObjectAlias = r.RoomAlias;
                         if (ASLVersion >= 350)
                         {
-                            AddToObjectProperties("alias=" + r.RoomAlias, _numberObjs, _nullContext);
+                            await AddToObjectProperties("alias=" + r.RoomAlias, _numberObjs, _nullContext);
                         }
                     }
                     else if ((ASLVersion >= 280) & BeginsWith(_lines[j], "description "))
@@ -987,11 +987,11 @@ public partial class V4Game
                         {
                             if (r.Description.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "description", r.Description.Data);
+                                await AddObjectAction(_numberObjs, "description", r.Description.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("description=" + r.Description.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("description=" + r.Description.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1003,10 +1003,10 @@ public partial class V4Game
                         {
                             if (!string.IsNullOrEmpty(r.Out.Script))
                             {
-                                AddObjectAction(_numberObjs, "out", r.Out.Script);
+                                await AddObjectAction(_numberObjs, "out", r.Out.Script);
                             }
 
-                            AddToObjectProperties("out=" + r.Out.Text, _numberObjs, _nullContext);
+                            await AddToObjectProperties("out=" + r.Out.Text, _numberObjs, _nullContext);
                         }
                     }
                     else if (BeginsWith(_lines[j], "east "))
@@ -1016,11 +1016,11 @@ public partial class V4Game
                         {
                             if (r.East.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "east", r.East.Data);
+                                await AddObjectAction(_numberObjs, "east", r.East.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("east=" + r.East.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("east=" + r.East.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1031,11 +1031,11 @@ public partial class V4Game
                         {
                             if (r.West.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "west", r.West.Data);
+                                await AddObjectAction(_numberObjs, "west", r.West.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("west=" + r.West.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("west=" + r.West.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1046,11 +1046,11 @@ public partial class V4Game
                         {
                             if (r.North.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "north", r.North.Data);
+                                await AddObjectAction(_numberObjs, "north", r.North.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("north=" + r.North.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("north=" + r.North.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1061,11 +1061,11 @@ public partial class V4Game
                         {
                             if (r.South.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "south", r.South.Data);
+                                await AddObjectAction(_numberObjs, "south", r.South.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("south=" + r.South.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("south=" + r.South.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1076,11 +1076,11 @@ public partial class V4Game
                         {
                             if (r.NorthEast.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "northeast", r.NorthEast.Data);
+                                await AddObjectAction(_numberObjs, "northeast", r.NorthEast.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("northeast=" + r.NorthEast.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("northeast=" + r.NorthEast.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1091,11 +1091,11 @@ public partial class V4Game
                         {
                             if (r.NorthWest.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "northwest", r.NorthWest.Data);
+                                await AddObjectAction(_numberObjs, "northwest", r.NorthWest.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("northwest=" + r.NorthWest.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("northwest=" + r.NorthWest.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1106,11 +1106,11 @@ public partial class V4Game
                         {
                             if (r.SouthEast.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "southeast", r.SouthEast.Data);
+                                await AddObjectAction(_numberObjs, "southeast", r.SouthEast.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("southeast=" + r.SouthEast.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("southeast=" + r.SouthEast.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1121,11 +1121,11 @@ public partial class V4Game
                         {
                             if (r.SouthWest.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "southwest", r.SouthWest.Data);
+                                await AddObjectAction(_numberObjs, "southwest", r.SouthWest.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("southwest=" + r.SouthWest.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("southwest=" + r.SouthWest.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1136,11 +1136,11 @@ public partial class V4Game
                         {
                             if (r.Up.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "up", r.Up.Data);
+                                await AddObjectAction(_numberObjs, "up", r.Up.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("up=" + r.Up.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("up=" + r.Up.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1151,11 +1151,11 @@ public partial class V4Game
                         {
                             if (r.Down.Type == TextActionType.Script)
                             {
-                                AddObjectAction(_numberObjs, "down", r.Down.Data);
+                                await AddObjectAction(_numberObjs, "down", r.Down.Data);
                             }
                             else
                             {
-                                AddToObjectProperties("down=" + r.Down.Data, _numberObjs, _nullContext);
+                                await AddToObjectProperties("down=" + r.Down.Data, _numberObjs, _nullContext);
                             }
                         }
                     }
@@ -1164,7 +1164,7 @@ public partial class V4Game
                         r.InDescription = await GetParameter(_lines[j], _nullContext);
                         if (ASLVersion >= 350)
                         {
-                            AddToObjectProperties("indescription=" + r.InDescription, _numberObjs, _nullContext);
+                            await AddToObjectProperties("indescription=" + r.InDescription, _numberObjs, _nullContext);
                         }
                     }
                     else if ((ASLVersion >= 280) & BeginsWith(_lines[j], "look "))
@@ -1172,7 +1172,7 @@ public partial class V4Game
                         r.Look = await GetParameter(_lines[j], _nullContext);
                         if (ASLVersion >= 350)
                         {
-                            AddToObjectProperties("look=" + r.Look, _numberObjs, _nullContext);
+                            await AddToObjectProperties("look=" + r.Look, _numberObjs, _nullContext);
                         }
                     }
                     else if (BeginsWith(_lines[j], "prefix "))
@@ -1180,13 +1180,13 @@ public partial class V4Game
                         r.Prefix = await GetParameter(_lines[j], _nullContext);
                         if (ASLVersion >= 350)
                         {
-                            AddToObjectProperties("prefix=" + r.Prefix, _numberObjs, _nullContext);
+                            await AddToObjectProperties("prefix=" + r.Prefix, _numberObjs, _nullContext);
                         }
                     }
                     else if (BeginsWith(_lines[j], "script "))
                     {
                         r.Script = GetEverythingAfter(_lines[j], "script ");
-                        AddObjectAction(_numberObjs, "script", r.Script);
+                        await AddObjectAction(_numberObjs, "script", r.Script);
                     }
                     else if (BeginsWith(_lines[j], "command "))
                     {
@@ -1228,7 +1228,7 @@ public partial class V4Game
                     }
                     else if (BeginsWith(_lines[j], "properties "))
                     {
-                        AddToObjectProperties(await GetParameter(_lines[j], _nullContext), _numberObjs, _nullContext);
+                        await AddToObjectProperties(await GetParameter(_lines[j], _nullContext), _numberObjs, _nullContext);
                     }
                     else if (BeginsWith(_lines[j], "type "))
                     {
@@ -1238,10 +1238,10 @@ public partial class V4Game
                             await GetParameter(_lines[j], _nullContext);
 
                         var propertyData = await GetPropertiesInType(await GetParameter(_lines[j], _nullContext));
-                        AddToObjectProperties(propertyData.Properties, _numberObjs, _nullContext);
+                        await AddToObjectProperties(propertyData.Properties, _numberObjs, _nullContext);
                         for (int k = 1, loopTo4 = propertyData.NumberActions; k <= loopTo4; k++)
                         {
-                            AddObjectAction(_numberObjs, propertyData.Actions[k].ActionName,
+                            await AddObjectAction(_numberObjs, propertyData.Actions[k].ActionName,
                                 propertyData.Actions[k].Script);
                         }
                     }
@@ -1624,11 +1624,11 @@ public partial class V4Game
                     _objs[i].Visible = visible;
                     if (visible)
                     {
-                        AddToObjectProperties("not invisible", i, ctx);
+                        await AddToObjectProperties("not invisible", i, ctx);
                     }
                     else
                     {
-                        AddToObjectProperties("invisible", i, ctx);
+                        await AddToObjectProperties("invisible", i, ctx);
                     }
 
                     found = true;
@@ -3005,11 +3005,11 @@ public partial class V4Game
                     _objs[i].Exists = exists;
                     if (exists)
                     {
-                        AddToObjectProperties("not hidden", i, ctx);
+                        await AddToObjectProperties("not hidden", i, ctx);
                     }
                     else
                     {
-                        AddToObjectProperties("hidden", i, ctx);
+                        await AddToObjectProperties("hidden", i, ctx);
                     }
 
                     found = true;
@@ -3222,17 +3222,17 @@ public partial class V4Game
 
                     if (defaultExists)
                     {
-                        AddToObjectProperties(defaultProperties.Properties, _numberObjs, _nullContext);
+                        await AddToObjectProperties(defaultProperties.Properties, _numberObjs, _nullContext);
                         for (int k = 1, loopTo3 = defaultProperties.NumberActions; k <= loopTo3; k++)
                         {
-                            AddObjectAction(_numberObjs, defaultProperties.Actions[k].ActionName,
+                            await AddObjectAction(_numberObjs, defaultProperties.Actions[k].ActionName,
                                 defaultProperties.Actions[k].Script);
                         }
                     }
 
                     if (ASLVersion >= 391)
                     {
-                        AddToObjectProperties("list", _numberObjs, _nullContext);
+                        await AddToObjectProperties("list", _numberObjs, _nullContext);
                     }
 
                     var hidden = false;
@@ -3245,7 +3245,7 @@ public partial class V4Game
                             hidden = true;
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("hidden", _numberObjs, _nullContext);
+                                await AddToObjectProperties("hidden", _numberObjs, _nullContext);
                             }
                         }
                         else if (BeginsWith(_lines[j], "startin ") & (containerRoomName == "__UNKNOWN"))
@@ -3257,7 +3257,7 @@ public partial class V4Game
                             o.Prefix = await GetParameter(_lines[j], _nullContext) + " ";
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("prefix=" + o.Prefix, _numberObjs, _nullContext);
+                                await AddToObjectProperties("prefix=" + o.Prefix, _numberObjs, _nullContext);
                             }
                         }
                         else if (BeginsWith(_lines[j], "suffix "))
@@ -3265,7 +3265,7 @@ public partial class V4Game
                             o.Suffix = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("suffix=" + o.Suffix, _numberObjs, _nullContext);
+                                await AddToObjectProperties("suffix=" + o.Suffix, _numberObjs, _nullContext);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "invisible")
@@ -3273,7 +3273,7 @@ public partial class V4Game
                             o.Visible = false;
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("invisible", _numberObjs, _nullContext);
+                                await AddToObjectProperties("invisible", _numberObjs, _nullContext);
                             }
                         }
                         else if (BeginsWith(_lines[j], "alias "))
@@ -3281,7 +3281,7 @@ public partial class V4Game
                             o.ObjectAlias = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("alias=" + o.ObjectAlias, _numberObjs, _nullContext);
+                                await AddToObjectProperties("alias=" + o.ObjectAlias, _numberObjs, _nullContext);
                             }
                         }
                         else if (BeginsWith(_lines[j], "alt "))
@@ -3293,7 +3293,7 @@ public partial class V4Game
                             o.Detail = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("detail=" + o.Detail, _numberObjs, _nullContext);
+                                await AddToObjectProperties("detail=" + o.Detail, _numberObjs, _nullContext);
                             }
                         }
                         else if (BeginsWith(_lines[j], "gender "))
@@ -3301,7 +3301,7 @@ public partial class V4Game
                             o.Gender = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("gender=" + o.Gender, _numberObjs, _nullContext);
+                                await AddToObjectProperties("gender=" + o.Gender, _numberObjs, _nullContext);
                             }
                         }
                         else if (BeginsWith(_lines[j], "article "))
@@ -3309,25 +3309,25 @@ public partial class V4Game
                             o.Article = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("article=" + o.Article, _numberObjs, _nullContext);
+                                await AddToObjectProperties("article=" + o.Article, _numberObjs, _nullContext);
                             }
                         }
                         else if (BeginsWith(_lines[j], "gain "))
                         {
                             o.GainScript = GetEverythingAfter(_lines[j], "gain ");
-                            AddObjectAction(_numberObjs, "gain", o.GainScript);
+                            await AddObjectAction(_numberObjs, "gain", o.GainScript);
                         }
                         else if (BeginsWith(_lines[j], "lose "))
                         {
                             o.LoseScript = GetEverythingAfter(_lines[j], "lose ");
-                            AddObjectAction(_numberObjs, "lose", o.LoseScript);
+                            await AddObjectAction(_numberObjs, "lose", o.LoseScript);
                         }
                         else if (BeginsWith(_lines[j], "displaytype "))
                         {
                             o.DisplayType = await GetParameter(_lines[j], _nullContext);
                             if (ASLVersion >= 311)
                             {
-                                AddToObjectProperties("displaytype=" + o.DisplayType, _numberObjs, _nullContext);
+                                await AddToObjectProperties("displaytype=" + o.DisplayType, _numberObjs, _nullContext);
                             }
                         }
                         else if (BeginsWith(_lines[j], "look "))
@@ -3337,12 +3337,12 @@ public partial class V4Game
                                 restOfLine = GetEverythingAfter(_lines[j], "look ");
                                 if (Strings.Left(restOfLine, 1) == "<")
                                 {
-                                    AddToObjectProperties("look=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
+                                    await AddToObjectProperties("look=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                         _nullContext);
                                 }
                                 else
                                 {
-                                    AddObjectAction(_numberObjs, "look", restOfLine);
+                                    await AddObjectAction(_numberObjs, "look", restOfLine);
                                 }
                             }
                         }
@@ -3353,12 +3353,12 @@ public partial class V4Game
                                 restOfLine = GetEverythingAfter(_lines[j], "examine ");
                                 if (Strings.Left(restOfLine, 1) == "<")
                                 {
-                                    AddToObjectProperties("examine=" + await GetParameter(_lines[j], _nullContext),
+                                    await AddToObjectProperties("examine=" + await GetParameter(_lines[j], _nullContext),
                                         _numberObjs, _nullContext);
                                 }
                                 else
                                 {
-                                    AddObjectAction(_numberObjs, "examine", restOfLine);
+                                    await AddObjectAction(_numberObjs, "examine", restOfLine);
                                 }
                             }
                         }
@@ -3367,17 +3367,17 @@ public partial class V4Game
                             restOfLine = GetEverythingAfter(_lines[j], "speak ");
                             if (Strings.Left(restOfLine, 1) == "<")
                             {
-                                AddToObjectProperties("speak=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
+                                await AddToObjectProperties("speak=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
                             {
-                                AddObjectAction(_numberObjs, "speak", restOfLine);
+                                await AddObjectAction(_numberObjs, "speak", restOfLine);
                             }
                         }
                         else if (BeginsWith(_lines[j], "properties "))
                         {
-                            AddToObjectProperties(await GetParameter(_lines[j], _nullContext), _numberObjs, _nullContext);
+                            await AddToObjectProperties(await GetParameter(_lines[j], _nullContext), _numberObjs, _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "type "))
                         {
@@ -3386,10 +3386,10 @@ public partial class V4Game
                             o.TypesIncluded[o.NumberTypesIncluded] = await GetParameter(_lines[j], _nullContext);
 
                             var PropertyData = await GetPropertiesInType(await GetParameter(_lines[j], _nullContext));
-                            AddToObjectProperties(PropertyData.Properties, _numberObjs, _nullContext);
+                            await AddToObjectProperties(PropertyData.Properties, _numberObjs, _nullContext);
                             for (int k = 1, loopTo4 = PropertyData.NumberActions; k <= loopTo4; k++)
                             {
-                                AddObjectAction(_numberObjs, PropertyData.Actions[k].ActionName,
+                                await AddObjectAction(_numberObjs, PropertyData.Actions[k].ActionName,
                                     PropertyData.Actions[k].Script);
                             }
 
@@ -3417,7 +3417,7 @@ public partial class V4Game
                         else if (Strings.Trim(_lines[j]) == "take")
                         {
                             o.Take.Type = TextActionType.Default;
-                            AddToObjectProperties("take", _numberObjs, _nullContext);
+                            await AddToObjectProperties("take", _numberObjs, _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "take "))
                         {
@@ -3426,7 +3426,7 @@ public partial class V4Game
                                 o.Take.Type = TextActionType.Text;
                                 o.Take.Data = await GetParameter(_lines[j], _nullContext);
 
-                                AddToObjectProperties("take=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
+                                await AddToObjectProperties("take=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
@@ -3435,109 +3435,109 @@ public partial class V4Game
                                 restOfLine = GetEverythingAfter(_lines[j], "take ");
                                 o.Take.Data = restOfLine;
 
-                                AddObjectAction(_numberObjs, "take", restOfLine);
+                                await AddObjectAction(_numberObjs, "take", restOfLine);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "container")
                         {
                             if (ASLVersion >= 391)
                             {
-                                AddToObjectProperties("container", _numberObjs, _nullContext);
+                                await AddToObjectProperties("container", _numberObjs, _nullContext);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "surface")
                         {
                             if (ASLVersion >= 391)
                             {
-                                AddToObjectProperties("container", _numberObjs, _nullContext);
-                                AddToObjectProperties("surface", _numberObjs, _nullContext);
+                                await AddToObjectProperties("container", _numberObjs, _nullContext);
+                                await AddToObjectProperties("surface", _numberObjs, _nullContext);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "opened")
                         {
                             if (ASLVersion >= 391)
                             {
-                                AddToObjectProperties("opened", _numberObjs, _nullContext);
+                                await AddToObjectProperties("opened", _numberObjs, _nullContext);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "transparent")
                         {
                             if (ASLVersion >= 391)
                             {
-                                AddToObjectProperties("transparent", _numberObjs, _nullContext);
+                                await AddToObjectProperties("transparent", _numberObjs, _nullContext);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "open")
                         {
-                            AddToObjectProperties("open", _numberObjs, _nullContext);
+                            await AddToObjectProperties("open", _numberObjs, _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "open "))
                         {
                             if (Strings.Left(GetEverythingAfter(_lines[j], "open "), 1) == "<")
                             {
-                                AddToObjectProperties("open=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
+                                await AddToObjectProperties("open=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
                             {
                                 restOfLine = GetEverythingAfter(_lines[j], "open ");
-                                AddObjectAction(_numberObjs, "open", restOfLine);
+                                await AddObjectAction(_numberObjs, "open", restOfLine);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "close")
                         {
-                            AddToObjectProperties("close", _numberObjs, _nullContext);
+                            await AddToObjectProperties("close", _numberObjs, _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "close "))
                         {
                             if (Strings.Left(GetEverythingAfter(_lines[j], "close "), 1) == "<")
                             {
-                                AddToObjectProperties("close=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
+                                await AddToObjectProperties("close=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
                             {
                                 restOfLine = GetEverythingAfter(_lines[j], "close ");
-                                AddObjectAction(_numberObjs, "close", restOfLine);
+                                await AddObjectAction(_numberObjs, "close", restOfLine);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "add")
                         {
-                            AddToObjectProperties("add", _numberObjs, _nullContext);
+                            await AddToObjectProperties("add", _numberObjs, _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "add "))
                         {
                             if (Strings.Left(GetEverythingAfter(_lines[j], "add "), 1) == "<")
                             {
-                                AddToObjectProperties("add=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
+                                await AddToObjectProperties("add=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
                             {
                                 restOfLine = GetEverythingAfter(_lines[j], "add ");
-                                AddObjectAction(_numberObjs, "add", restOfLine);
+                                await AddObjectAction(_numberObjs, "add", restOfLine);
                             }
                         }
                         else if (Strings.Trim(_lines[j]) == "remove")
                         {
-                            AddToObjectProperties("remove", _numberObjs, _nullContext);
+                            await AddToObjectProperties("remove", _numberObjs, _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "remove "))
                         {
                             if (Strings.Left(GetEverythingAfter(_lines[j], "remove "), 1) == "<")
                             {
-                                AddToObjectProperties("remove=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
+                                await AddToObjectProperties("remove=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                     _nullContext);
                             }
                             else
                             {
                                 restOfLine = GetEverythingAfter(_lines[j], "remove ");
-                                AddObjectAction(_numberObjs, "remove", restOfLine);
+                                await AddObjectAction(_numberObjs, "remove", restOfLine);
                             }
                         }
                         else if (BeginsWith(_lines[j], "parent "))
                         {
-                            AddToObjectProperties("parent=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
+                            await AddToObjectProperties("parent=" + await GetParameter(_lines[j], _nullContext), _numberObjs,
                                 _nullContext);
                         }
                         else if (BeginsWith(_lines[j], "list"))
@@ -4327,7 +4327,7 @@ public partial class V4Game
             {
                 if (ASLVersion >= 410)
                 {
-                    _rooms[GetRoomID(_currentRoom, ctx)].Exits.ExecuteGo(input, ctx);
+                    await _rooms[GetRoomID(_currentRoom, ctx)].Exits.ExecuteGo(input, ctx);
                 }
                 else
                 {
@@ -5915,7 +5915,7 @@ public partial class V4Game
             }
             else if (BeginsWith(scriptLine, "clone "))
             {
-                ExecClone(await GetParameter(scriptLine, ctx), ctx);
+                await ExecClone(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "exec "))
             {
@@ -5955,7 +5955,7 @@ public partial class V4Game
             }
             else if (BeginsWith(scriptLine, "destroy exit "))
             {
-                DestroyExit(await GetParameter(scriptLine, ctx), ctx);
+                await DestroyExit(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "repeat "))
             {
@@ -6050,11 +6050,11 @@ public partial class V4Game
             }
             else if (BeginsWith(scriptLine, "lock "))
             {
-                ExecuteLock(await GetParameter(scriptLine, ctx), true);
+                await ExecuteLock(await GetParameter(scriptLine, ctx), true);
             }
             else if (BeginsWith(scriptLine, "unlock "))
             {
-                ExecuteLock(await GetParameter(scriptLine, ctx), false);
+                await ExecuteLock(await GetParameter(scriptLine, ctx), false);
             }
             else if (BeginsWith(scriptLine, "playmod ") & (ASLVersion < 410))
             {
@@ -6253,7 +6253,7 @@ public partial class V4Game
 
         if (ASLVersion >= 410)
         {
-            _rooms[id].Exits.ExecuteGo(direction, ctx);
+            await _rooms[id].Exits.ExecuteGo(direction, ctx);
             return;
         }
 
@@ -6623,7 +6623,7 @@ public partial class V4Game
                     if (ASLVersion >= 391)
                     {
                         // Unset parent information, if any
-                        AddToObjectProperties("not parent", objId, ctx);
+                        await AddToObjectProperties("not parent", objId, ctx);
                     }
 
                     MoveThing(_objs[objId].ObjectName, "inventory", Thing.Object, ctx);
@@ -6689,7 +6689,7 @@ public partial class V4Game
 
         if ((ASLVersion >= 391) & (ASLVersion < 410))
         {
-            AddToObjectProperties("visited", _rooms[id].ObjId, ctx);
+            await AddToObjectProperties("visited", _rooms[id].ObjId, ctx);
         }
 
         await ShowRoomInfo(room, ctx);
@@ -6705,7 +6705,7 @@ public partial class V4Game
 
         if (ASLVersion >= 410)
         {
-            AddToObjectProperties("visited", _rooms[id].ObjId, ctx);
+            await AddToObjectProperties("visited", _rooms[id].ObjId, ctx);
         }
     }
 
@@ -7852,7 +7852,7 @@ public partial class V4Game
                         } while (nestedBlock != 0);
                     }
 
-                    _rooms[roomId].Exits.AddExitFromTag(_lines[j]);
+                    await _rooms[roomId].Exits.AddExitFromTag(_lines[j]);
                 }
             }
         }
@@ -7897,7 +7897,7 @@ public partial class V4Game
         return null;
     }
 
-    private void ExecuteLock(string tag, bool @lock)
+    private async Task ExecuteLock(string tag, bool @lock)
     {
         RoomExit roomExit;
 
@@ -7909,7 +7909,7 @@ public partial class V4Game
             return;
         }
 
-        roomExit.SetIsLocked(@lock);
+        await roomExit.SetIsLocked(@lock);
     }
 
     private async Task DoBeginAsync()

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -526,6 +526,9 @@ public partial class V4Game
         if (!string.IsNullOrEmpty(_numericVariable[numNumber].OnChangeScript) & !_gameIsRestoring)
         {
             var script = _numericVariable[numNumber].OnChangeScript;
+            // TODO: SetNumericVariableContents should be async Task so this can be awaited.
+            // Fire-and-forget is wrong if the OnChangeScript contains a pause/wait/menu.
+            // See https://github.com/textadventures/quest/issues/1765
             _ = ExecuteScript(script, ctx);
         }
 
@@ -3140,6 +3143,9 @@ public partial class V4Game
         if (!string.IsNullOrEmpty(_stringVariable[id].OnChangeScript))
         {
             var script = _stringVariable[id].OnChangeScript;
+            // TODO: SetStringContents should be async Task so this can be awaited.
+            // Fire-and-forget is wrong if the OnChangeScript contains a pause/wait/menu.
+            // See https://github.com/textadventures/quest/issues/1765
             _ = ExecuteScript(script, ctx);
         }
 

--- a/src/Legacy/V4Game.cs
+++ b/src/Legacy/V4Game.cs
@@ -2114,12 +2114,12 @@ public partial class V4Game : IGame, IGameDebug
     {
         if (add)
         {
-            AddToObjectProperties("parent=" + _objs[parentId].ObjectName, childId, ctx);
+            await AddToObjectProperties("parent=" + _objs[parentId].ObjectName, childId, ctx);
             _objs[childId].ContainerRoom = _objs[parentId].ContainerRoom;
         }
         else
         {
-            AddToObjectProperties("not parent", childId, ctx);
+            await AddToObjectProperties("not parent", childId, ctx);
         }
 
         if (ASLVersion >= 410)
@@ -2127,7 +2127,7 @@ public partial class V4Game : IGame, IGameDebug
             // container "seen". Otherwise we could try to "look at" the
             // object we just put in the container and have disambigution fail!
         {
-            AddToObjectProperties("seen", parentId, ctx);
+            await AddToObjectProperties("seen", parentId, ctx);
         }
 
         await UpdateVisibilityInContainers(ctx, _objs[parentId].ObjectName);
@@ -2143,7 +2143,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (ASLVersion >= 391)
         {
-            AddToObjectProperties("seen", id, ctx);
+            await AddToObjectProperties("seen", id, ctx);
             await UpdateVisibilityInContainers(ctx, _objs[id].ObjectName);
         }
 
@@ -2241,7 +2241,7 @@ public partial class V4Game : IGame, IGameDebug
     {
         if (open)
         {
-            AddToObjectProperties("opened", id, ctx);
+            await AddToObjectProperties("opened", id, ctx);
             if (showLook)
             {
                 await DoLook(id, ctx, showDefaultDescription: false);
@@ -2249,7 +2249,7 @@ public partial class V4Game : IGame, IGameDebug
         }
         else
         {
-            AddToObjectProperties("not opened", id, ctx);
+            await AddToObjectProperties("not opened", id, ctx);
         }
 
         await UpdateVisibilityInContainers(ctx, _objs[id].ObjectName);
@@ -2694,7 +2694,7 @@ public partial class V4Game : IGame, IGameDebug
         }
         else
         {
-            AddToObjectProperties("not parent", childId, ctx);
+            await AddToObjectProperties("not parent", childId, ctx);
             await UpdateVisibilityInContainers(ctx, _objs[parentId].ObjectName);
         }
     }
@@ -3499,7 +3499,7 @@ public partial class V4Game : IGame, IGameDebug
 
         else if (Strings.Trim(line) == "list off")
         {
-            AddToObjectProperties("not list", id, _nullContext);
+            await AddToObjectProperties("not list", id, _nullContext);
             return;
         }
         else if (BeginsWith(line, "list <"))
@@ -3519,7 +3519,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (listInfo.Type == TextActionType.Text)
             {
-                AddToObjectProperties(propName + "=" + listInfo.Data, id, _nullContext);
+                await AddToObjectProperties(propName + "=" + listInfo.Data, id, _nullContext);
             }
             else
             {
@@ -3655,7 +3655,7 @@ public partial class V4Game : IGame, IGameDebug
 
         // Update quest.* vars and obj list
         await ShowRoomInfo(_currentRoom, ctx, true);
-        UpdateObjectList(ctx);
+        await UpdateObjectList(ctx);
 
         AddToChangeLog("room " + fromRoom, "destroy exit " + toRoom);
     }
@@ -3693,7 +3693,7 @@ public partial class V4Game : IGame, IGameDebug
         }
 
         // Game object always has ObjID 1
-        AddToObjectProperties(propertyString, 1, ctx);
+        await AddToObjectProperties(propertyString, 1, ctx);
     }
 
     private bool ExecuteIfFlag(string flag)
@@ -3781,7 +3781,7 @@ public partial class V4Game : IGame, IGameDebug
         return stream;
     }
 
-    private void AddObjectAction(int id, string name, string script, bool noUpdate = false)
+    private async Task AddObjectAction(int id, string name, string script, bool noUpdate = false)
     {
         // Use NoUpdate in e.g. AddToGiveInfo, otherwise ObjectActionUpdate will call
         // AddToGiveInfo again leading to a big loop
@@ -3812,7 +3812,7 @@ public partial class V4Game : IGame, IGameDebug
         o.Actions[actionNum].ActionName = name;
         o.Actions[actionNum].Script = script;
 
-        ObjectActionUpdate(id, name, script, noUpdate);
+        await ObjectActionUpdate(id, name, script, noUpdate);
     }
 
     private void AddToChangeLog(string appliesTo, string changeData)
@@ -3869,7 +3869,7 @@ public partial class V4Game : IGame, IGameDebug
             if (BeginsWith(giveData, "anything "))
             {
                 o.GiveToAnything = GetEverythingAfter(giveData, "anything ");
-                AddObjectAction(id, "give to anything", o.GiveToAnything, true);
+                await AddObjectAction(id, "give to anything", o.GiveToAnything, true);
                 return;
             }
 
@@ -3880,7 +3880,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             o.GiveAnything = GetEverythingAfter(giveData, "anything ");
 
-            AddObjectAction(id, "give anything", o.GiveAnything, true);
+            await AddObjectAction(id, "give anything", o.GiveAnything, true);
             return;
         }
         else
@@ -3922,7 +3922,7 @@ public partial class V4Game : IGame, IGameDebug
             o.GiveData[dataId].GiveScript = Strings.Mid(giveData, EP + 2);
 
             actionScript = o.GiveData[dataId].GiveScript;
-            AddObjectAction(id, actionName, actionScript, true);
+            await AddObjectAction(id, actionName, actionScript, true);
         }
     }
 
@@ -3964,7 +3964,7 @@ public partial class V4Game : IGame, IGameDebug
         o.Actions[actionNum].ActionName = name;
         o.Actions[actionNum].Script = script;
 
-        ObjectActionUpdate(id, name, script);
+        await ObjectActionUpdate(id, name, script);
     }
 
     private void AddToObjectAltNames(string altNames, int id)
@@ -3992,7 +3992,7 @@ public partial class V4Game : IGame, IGameDebug
         } while (!string.IsNullOrEmpty(Strings.Trim(altNames)));
     }
 
-    internal void AddToObjectProperties(string propertyInfo, int id, Context ctx)
+    internal async Task AddToObjectProperties(string propertyInfo, int id, Context ctx)
     {
         if (id == 0)
         {
@@ -4146,7 +4146,7 @@ public partial class V4Game : IGame, IGameDebug
                     o.DisplayType = value;
                     if (_gameFullyLoaded)
                     {
-                        UpdateObjectList(ctx);
+                        await UpdateObjectList(ctx);
                     }
 
                     break;
@@ -4179,7 +4179,7 @@ public partial class V4Game : IGame, IGameDebug
 
                     if (_gameFullyLoaded)
                     {
-                        UpdateObjectList(ctx);
+                        await UpdateObjectList(ctx);
                     }
 
                     break;
@@ -4197,7 +4197,7 @@ public partial class V4Game : IGame, IGameDebug
 
                     if (_gameFullyLoaded)
                     {
-                        UpdateObjectList(ctx);
+                        await UpdateObjectList(ctx);
                     }
 
                     break;
@@ -4349,7 +4349,7 @@ public partial class V4Game : IGame, IGameDebug
         return false;
     }
 
-    private void ExecClone(string cloneString, Context ctx)
+    private async Task ExecClone(string cloneString, Context ctx)
     {
         int id;
         string newName, cloneTo;
@@ -4404,7 +4404,7 @@ public partial class V4Game : IGame, IGameDebug
             AddToChangeLog("object " + newName, "create " + _objs[_numberObjs].ContainerRoom);
         }
 
-        UpdateObjectList(ctx);
+        await UpdateObjectList(ctx);
     }
 
     private async Task ExecOops(string correction, Context ctx)
@@ -4460,10 +4460,10 @@ public partial class V4Game : IGame, IGameDebug
         o.TypesIncluded[o.NumberTypesIncluded] = typeName;
 
         var propertyData = await GetPropertiesInType(typeName);
-        AddToObjectProperties(propertyData.Properties, id, ctx);
+        await AddToObjectProperties(propertyData.Properties, id, ctx);
         for (int i = 1, loopTo1 = propertyData.NumberActions; i <= loopTo1; i++)
         {
-            AddObjectAction(id, propertyData.Actions[i].ActionName, propertyData.Actions[i].Script);
+            await AddObjectAction(id, propertyData.Actions[i].ActionName, propertyData.Actions[i].Script);
         }
 
         // New as of Quest 4.0. Fixes bug that "if type" would fail for any
@@ -5109,7 +5109,7 @@ public partial class V4Game : IGame, IGameDebug
         o.Actions[actionNum].ActionName = actionName;
         o.Actions[actionNum].Script = script;
 
-        ObjectActionUpdate(id, actionName, script);
+        await ObjectActionUpdate(id, actionName, script);
     }
 
     private async Task<bool> ExecuteCondition(string condition, Context ctx)
@@ -5263,10 +5263,10 @@ public partial class V4Game : IGame, IGameDebug
 
             if (ASLVersion >= 410)
             {
-                AddToObjectProperties(_defaultRoomProperties.Properties, _numberObjs, ctx);
+                await AddToObjectProperties(_defaultRoomProperties.Properties, _numberObjs, ctx);
                 for (int j = 1, loopTo = _defaultRoomProperties.NumberActions; j <= loopTo; j++)
                 {
-                    AddObjectAction(_numberObjs, _defaultRoomProperties.Actions[j].ActionName,
+                    await AddObjectAction(_numberObjs, _defaultRoomProperties.Actions[j].ActionName,
                         _defaultRoomProperties.Actions[j].Script);
                 }
 
@@ -5309,17 +5309,17 @@ public partial class V4Game : IGame, IGameDebug
 
             if (ASLVersion >= 410)
             {
-                AddToObjectProperties(_defaultProperties.Properties, _numberObjs, ctx);
+                await AddToObjectProperties(_defaultProperties.Properties, _numberObjs, ctx);
                 for (int j = 1, loopTo1 = _defaultProperties.NumberActions; j <= loopTo1; j++)
                 {
-                    AddObjectAction(_numberObjs, _defaultProperties.Actions[j].ActionName,
+                    await AddObjectAction(_numberObjs, _defaultProperties.Actions[j].ActionName,
                         _defaultProperties.Actions[j].Script);
                 }
             }
 
             if (!_gameLoading)
             {
-                UpdateObjectList(ctx);
+                await UpdateObjectList(ctx);
             }
         }
 
@@ -5501,7 +5501,7 @@ public partial class V4Game : IGame, IGameDebug
             // Update quest.doorways variables
            await ShowRoomInfo(_currentRoom, ctx, true);
 
-            UpdateObjectList(ctx);
+            await UpdateObjectList(ctx);
 
             if (ASLVersion < 410)
             {
@@ -5756,7 +5756,7 @@ public partial class V4Game : IGame, IGameDebug
             return;
         }
 
-        AddToObjectProperties(properties, id, ctx);
+        await AddToObjectProperties(properties, id, ctx);
     }
 
     private async Task ExecuteDo(string procedureName, Context ctx)

--- a/src/Legacy/V4Game.cs
+++ b/src/Legacy/V4Game.cs
@@ -78,9 +78,9 @@ public partial class V4Game : IGame, IGameDebug
     private IPlayer _player;
     private bool _questionResponse;
     private bool _readyForCommand = true;
-    private TaskCompletionSource? _turnSuspendedTcs;
-    private TaskCompletionSource? _waitTcs;
-    private TaskCompletionSource? _commandTcs;
+    private TaskCompletionSource _turnSuspendedTcs;
+    private TaskCompletionSource _waitTcs;
+    private TaskCompletionSource _commandTcs;
     private int _resourceOffset;
     private ResourceType[] _resources;
     internal RoomType[] _rooms;

--- a/src/Legacy/V4Game.cs
+++ b/src/Legacy/V4Game.cs
@@ -9,7 +9,6 @@ namespace QuestViva.Legacy;
 public partial class V4Game : IGame, IGameDebug
 {
     private readonly string[] _casKeywords = new string[256]; // Tokenised CAS keywords
-    private readonly object _commandLock = new();
     private readonly GameChangeDataType _gameChangeData = new();
     private readonly GameData _gameData;
     private readonly Dictionary<ListType, List<string>> _listVerbs = new();
@@ -19,9 +18,7 @@ public partial class V4Game : IGame, IGameDebug
     private readonly Random _random = new();
     private readonly Stream _saveData;
     private readonly string[] _skipCheckFile;
-    private readonly object _stateLock = new();
     private readonly TextFormatter _textFormatter = new();
-    private readonly object _waitLock = new();
     private string _afterTurnScript;
     private bool _autoIntro;
     private string _badCmdAfter;
@@ -81,11 +78,13 @@ public partial class V4Game : IGame, IGameDebug
     private IPlayer _player;
     private bool _questionResponse;
     private bool _readyForCommand = true;
+    private TaskCompletionSource? _turnSuspendedTcs;
+    private TaskCompletionSource? _waitTcs;
+    private TaskCompletionSource? _commandTcs;
     private int _resourceOffset;
     private ResourceType[] _resources;
     internal RoomType[] _rooms;
     private int _startCatPos;
-    private State _state = State.Ready;
     private VariableType[] _stringVariable;
     private SynonymType[] _synonyms;
     private int _thisTurnIt;
@@ -111,10 +110,12 @@ public partial class V4Game : IGame, IGameDebug
         _skipCheckFile[3] = "musicvf1.cas";
     }
 
-    Task IGame.SetQuestionResponse(bool response)
+    async Task IGame.SetQuestionResponse(bool response)
     {
-        SetQuestionResponse(response);
-        return Task.CompletedTask;
+        _questionResponse = response;
+        _turnSuspendedTcs = new TaskCompletionSource();
+        _waitTcs?.TrySetResult();
+        await _turnSuspendedTcs.Task;
     }
 
     private string RemoveFormatting(string s)
@@ -219,7 +220,7 @@ public partial class V4Game : IGame, IGameDebug
         return s;
     }
 
-    private bool CheckSections()
+    private async Task<bool> CheckSections()
     {
         int defines, braces;
         var checkLine = "";
@@ -274,7 +275,7 @@ public partial class V4Game : IGame, IGameDebug
 
                 if ((Strings.Left(_lines[i], 1) != "'") & !skipBlock)
                 {
-                    checkLine = ObliterateParameters(_lines[i]);
+                    checkLine = await ObliterateParameters(_lines[i]);
                     if (BeginsWith(checkLine, "'<ERROR;"))
                     {
                         // ObliterateParameters denotes a mismatched $, ( etc.
@@ -328,7 +329,7 @@ public partial class V4Game : IGame, IGameDebug
         return !hasErrors;
     }
 
-    private bool ConvertFriendlyIfs()
+    private async Task<bool> ConvertFriendlyIfs()
     {
         // Converts
         // if (%something% < 3) then ...
@@ -349,7 +350,7 @@ public partial class V4Game : IGame, IGameDebug
 
         for (int i = 1, loopTo = Information.UBound(_lines); i <= loopTo; i++)
         {
-            obscureLine = ObliterateParameters(_lines[i]);
+            obscureLine = await ObliterateParameters(_lines[i]);
             convPos = Strings.InStr(obscureLine, "if (");
             if (convPos == 0)
             {
@@ -527,7 +528,7 @@ public partial class V4Game : IGame, IGameDebug
         return false;
     }
 
-    private void ConvertMultiLineSections()
+    private async Task ConvertMultiLineSections()
     {
         int startLine, braceCount;
         string thisLine, lineToAdd;
@@ -697,7 +698,7 @@ public partial class V4Game : IGame, IGameDebug
                         for (int k = j, loopTo5 = _defineBlocks[i].StartLine + 1; k >= loopTo5; k -= 1)
                         {
                             if (BeginsWith(_lines[k], "if ") |
-                                (Strings.InStr(ObliterateParameters(_lines[k]), " if ") != 0))
+                                (Strings.InStr(await ObliterateParameters(_lines[k]), " if ") != 0))
                             {
                                 _lines[k] = _lines[k] + " " + Strings.Trim(_lines[j]);
                                 _lines[j] = "";
@@ -710,7 +711,7 @@ public partial class V4Game : IGame, IGameDebug
         }
     }
 
-    private bool ErrorCheck()
+    private async Task<bool> ErrorCheck()
     {
         // Parses ASL script for errors. Returns TRUE if OK;
         // False if a critical error is encountered.
@@ -835,7 +836,7 @@ public partial class V4Game : IGame, IGameDebug
         return Strings.Trim(Strings.Mid(s, eop + 1));
     }
 
-    private string ObliterateParameters(string s)
+    private async Task<string> ObliterateParameters(string s)
     {
         bool inParameter;
         var exitCharacter = "";
@@ -981,7 +982,7 @@ public partial class V4Game : IGame, IGameDebug
         return outputLine;
     }
 
-    private void RemoveComments()
+    private async Task RemoveComments()
     {
         int aposPos;
         var inTextBlock = default(bool);
@@ -1022,7 +1023,7 @@ public partial class V4Game : IGame, IGameDebug
                 {
                     if (Strings.InStr(_lines[i], "'") > 0)
                     {
-                        oblitLine = ObliterateParameters(_lines[i]);
+                        oblitLine = await ObliterateParameters(_lines[i]);
                         if (!BeginsWith(oblitLine, "'<ERROR;"))
                         {
                             aposPos = Strings.InStr(oblitLine, "'");
@@ -1043,7 +1044,7 @@ public partial class V4Game : IGame, IGameDebug
                     else
                     {
                         // we look for " '", not "'" in synonyms lines
-                        aposPos = Strings.InStr(ObliterateParameters(_lines[i]), " '");
+                        aposPos = Strings.InStr(await ObliterateParameters(_lines[i]), " '");
                         if (aposPos != 0)
                         {
                             _lines[i] = Strings.Trim(Strings.Left(_lines[i], aposPos - 1));
@@ -1113,7 +1114,7 @@ public partial class V4Game : IGame, IGameDebug
         return keyword;
     }
 
-    private void ConvertMultiLines()
+    private async Task ConvertMultiLines()
     {
         // Goes through each section capable of containing
         // script commands and puts any multiple-line script commands
@@ -1142,7 +1143,7 @@ public partial class V4Game : IGame, IGameDebug
             }
         }
 
-        RemoveComments();
+        await RemoveComments();
     }
 
     private DefineBlock GetDefineBlock(string blockname)
@@ -1184,7 +1185,7 @@ public partial class V4Game : IGame, IGameDebug
         return result;
     }
 
-    private DefineBlock DefineBlockParam(string blockname, string param)
+    private async Task<DefineBlock> DefineBlockParam(string blockname, string param)
     {
         // Returns the start and end points of a named block
 
@@ -1212,7 +1213,7 @@ public partial class V4Game : IGame, IGameDebug
 
                 if ((blockType ?? "") == (blockname ?? ""))
                 {
-                    var blockKey = GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext, false);
+                    var blockKey = await GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext, false);
 
                     blockKey = "k" + blockKey;
 
@@ -1365,7 +1366,7 @@ public partial class V4Game : IGame, IGameDebug
                     continue;
                 }
 
-                var libFileName = GetParameter(_lines[i], _nullContext);
+                var libFileName = await GetParameter(_lines[i], _nullContext);
                 // Clear !include statement
                 _lines[i] = "";
                 var libraryAlreadyIncluded = false;
@@ -1453,7 +1454,7 @@ public partial class V4Game : IGame, IGameDebug
                         {
                             if (BeginsWith(libCode[c], "!asl-version "))
                             {
-                                libVer = Conversions.ToInteger(GetParameter(libCode[c], _nullContext));
+                                libVer = Conversions.ToInteger(await GetParameter(libCode[c], _nullContext));
                                 break;
                             }
                         }
@@ -1617,7 +1618,7 @@ public partial class V4Game : IGame, IGameDebug
                             else if (BeginsWith(libCode[c], "!addto type "))
                             {
                                 var inDefTypeBlock = 0;
-                                var typeBlockName = Strings.LCase(GetParameter(libCode[c], _nullContext));
+                                var typeBlockName = Strings.LCase(await GetParameter(libCode[c], _nullContext));
                                 var loopTo8 = Information.UBound(_lines);
                                 for (d = 1; d <= loopTo8; d++)
                                 {
@@ -1729,11 +1730,11 @@ public partial class V4Game : IGame, IGameDebug
         }
 
         // RemoveComments called within ConvertMultiLines
-        ConvertMultiLines();
+        await ConvertMultiLines();
 
         if (!skipCheck)
         {
-            if (!CheckSections())
+            if (!await CheckSections())
             {
                 return false;
             }
@@ -1803,12 +1804,12 @@ public partial class V4Game : IGame, IGameDebug
             return false;
         }
 
-        ConvertMultiLineSections();
+        await ConvertMultiLineSections();
 
-        var hasErrors = ConvertFriendlyIfs();
+        var hasErrors = await ConvertFriendlyIfs();
         if (!hasErrors)
         {
-            hasErrors = ErrorCheck();
+            hasErrors = await ErrorCheck();
         }
 
         if (hasErrors)
@@ -1854,7 +1855,7 @@ public partial class V4Game : IGame, IGameDebug
         _player.Log(err);
     }
 
-    internal string GetParameter(string s, Context ctx, bool convertStringVariables = true)
+    internal async Task<string> GetParameter(string s, Context ctx, bool convertStringVariables = true)
     {
         // Returns the parameters between < and > in a string
         string newParam;
@@ -1876,15 +1877,15 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (ASLVersion >= 320)
             {
-                newParam = ConvertParameter(
-                    ConvertParameter(ConvertParameter(retrParam, "#", ConvertType.Strings, ctx), "%",
+                newParam = await ConvertParameter(
+                    await ConvertParameter(await ConvertParameter(retrParam, "#", ConvertType.Strings, ctx), "%",
                         ConvertType.Numeric, ctx), "$", ConvertType.Functions, ctx);
             }
             else if (!(Strings.Left(retrParam, 9) == "~Internal"))
             {
-                newParam = ConvertParameter(
-                    ConvertParameter(
-                        ConvertParameter(ConvertParameter(retrParam, "#", ConvertType.Strings, ctx), "%",
+                newParam = await ConvertParameter(
+                    await ConvertParameter(
+                        await ConvertParameter(await ConvertParameter(retrParam, "#", ConvertType.Strings, ctx), "%",
                             ConvertType.Numeric, ctx), "~", ConvertType.Collectables, ctx), "$", ConvertType.Functions,
                     ctx);
             }
@@ -1898,7 +1899,7 @@ public partial class V4Game : IGame, IGameDebug
             newParam = retrParam;
         }
 
-        return EvaluateInlineExpressions(newParam);
+        return await EvaluateInlineExpressions(newParam);
     }
 
     private void AddLine(string line)
@@ -2109,7 +2110,7 @@ public partial class V4Game : IGame, IGameDebug
         return s;
     }
 
-    private void DoAddRemove(int childId, int parentId, bool add, Context ctx)
+    private async Task DoAddRemove(int childId, int parentId, bool add, Context ctx)
     {
         if (add)
         {
@@ -2129,10 +2130,10 @@ public partial class V4Game : IGame, IGameDebug
             AddToObjectProperties("seen", parentId, ctx);
         }
 
-        UpdateVisibilityInContainers(ctx, _objs[parentId].ObjectName);
+        await UpdateVisibilityInContainers(ctx, _objs[parentId].ObjectName);
     }
 
-    private void DoLook(int id, Context ctx, bool showExamineError = false, bool showDefaultDescription = true)
+    private async Task DoLook(int id, Context ctx, bool showExamineError = false, bool showDefaultDescription = true)
     {
         string objectContents;
         var foundLook = false;
@@ -2143,7 +2144,7 @@ public partial class V4Game : IGame, IGameDebug
         if (ASLVersion >= 391)
         {
             AddToObjectProperties("seen", id, ctx);
-            UpdateVisibilityInContainers(ctx, _objs[id].ObjectName);
+            await UpdateVisibilityInContainers(ctx, _objs[id].ObjectName);
         }
 
         // First look for action, then look
@@ -2158,7 +2159,7 @@ public partial class V4Game : IGame, IGameDebug
             if (o.Actions[i].ActionName == "look")
             {
                 foundLook = true;
-                ExecuteScript(o.Actions[i].Script, ctx);
+                await ExecuteScript(o.Actions[i].Script, ctx);
                 break;
             }
         }
@@ -2170,7 +2171,7 @@ public partial class V4Game : IGame, IGameDebug
                 if (o.Properties[i].PropertyName == "look")
                 {
                     // do this odd RetrieveParameter stuff to convert any variables
-                    Print(GetParameter("<" + o.Properties[i].PropertyValue + ">", ctx), ctx);
+                    await Print(await GetParameter("<" + o.Properties[i].PropertyValue + ">", ctx), ctx);
                     foundLook = true;
                     break;
                 }
@@ -2187,11 +2188,11 @@ public partial class V4Game : IGame, IGameDebug
 
                     if (Strings.Left(lookLine, 1) == "<")
                     {
-                        Print(GetParameter(_lines[i], ctx), ctx);
+                        await Print(await GetParameter(_lines[i], ctx), ctx);
                     }
                     else
                     {
-                        ExecuteScript(lookLine, ctx, id);
+                        await ExecuteScript(lookLine, ctx, id);
                     }
 
                     foundLook = true;
@@ -2201,7 +2202,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (ASLVersion >= 391)
         {
-            objectContents = ListContents(id, ctx);
+            objectContents = await ListContents(id, ctx);
         }
         else
         {
@@ -2226,24 +2227,24 @@ public partial class V4Game : IGame, IGameDebug
 
             if (string.IsNullOrEmpty(objectContents))
             {
-                PlayerErrorMessage(err, ctx);
+                await PlayerErrorMessage(err, ctx);
             }
         }
 
         if (!string.IsNullOrEmpty(objectContents) & (objectContents != "<script>"))
         {
-            Print(objectContents, ctx);
+            await Print(objectContents, ctx);
         }
     }
 
-    private void DoOpenClose(int id, bool open, bool showLook, Context ctx)
+    private async Task DoOpenClose(int id, bool open, bool showLook, Context ctx)
     {
         if (open)
         {
             AddToObjectProperties("opened", id, ctx);
             if (showLook)
             {
-                DoLook(id, ctx, showDefaultDescription: false);
+                await DoLook(id, ctx, showDefaultDescription: false);
             }
         }
         else
@@ -2251,10 +2252,10 @@ public partial class V4Game : IGame, IGameDebug
             AddToObjectProperties("not opened", id, ctx);
         }
 
-        UpdateVisibilityInContainers(ctx, _objs[id].ObjectName);
+        await UpdateVisibilityInContainers(ctx, _objs[id].ObjectName);
     }
 
-    private string EvaluateInlineExpressions(string s)
+    private async Task<string> EvaluateInlineExpressions(string s)
     {
         // Evaluates in-line expressions e.g. msg <Hello, did you know that 2 + 2 = {2+2}?>
 
@@ -2323,7 +2324,7 @@ public partial class V4Game : IGame, IGameDebug
         return resultLine;
     }
 
-    private void ExecAddRemove(string cmd, Context ctx)
+    private async Task ExecAddRemove(string cmd, Context ctx)
     {
         int childId;
         string childName;
@@ -2384,7 +2385,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (childLength < 0)
         {
-            PlayerErrorMessage(PlayerError.BadCommand, ctx);
+            await PlayerErrorMessage(PlayerError.BadCommand, ctx);
             _badCmdBefore = verb;
             return;
         }
@@ -2395,7 +2396,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if ((ASLVersion >= 392) & doAdd)
         {
-            childId = Disambiguate(childName, _currentRoom + ";inventory", ctx);
+            childId = await Disambiguate(childName, _currentRoom + ";inventory", ctx);
 
             if (childId > 0)
             {
@@ -2406,10 +2407,10 @@ public partial class V4Game : IGame, IGameDebug
                 else
                 {
                     // Player is not carrying the object they referred to. So, first take the object.
-                    Print("(first taking " + _objs[childId].Article + ")", ctx);
+                    await Print("(first taking " + _objs[childId].Article + ")", ctx);
                     // Try to take the object
                     ctx.AllowRealNamesInCommand = true;
-                    ExecCommand("take " + _objs[childId].ObjectName, ctx, false, dontSetIt: true);
+                    await ExecCommand("take " + _objs[childId].ObjectName, ctx, false, dontSetIt: true);
 
                     if (_objs[childId].ContainerRoom == "inventory")
                     {
@@ -2427,7 +2428,7 @@ public partial class V4Game : IGame, IGameDebug
             {
                 if (childId != -2)
                 {
-                    PlayerErrorMessage(PlayerError.NoItem, ctx);
+                    await PlayerErrorMessage(PlayerError.NoItem, ctx);
                 }
 
                 _badCmdBefore = verb;
@@ -2437,13 +2438,13 @@ public partial class V4Game : IGame, IGameDebug
 
         else
         {
-            childId = Disambiguate(childName, "inventory;" + _currentRoom, ctx);
+            childId = await Disambiguate(childName, "inventory;" + _currentRoom, ctx);
 
             if (childId <= 0)
             {
                 if (childId != -2)
                 {
-                    PlayerErrorMessage(PlayerError.BadThing, ctx);
+                    await PlayerErrorMessage(PlayerError.BadThing, ctx);
                 }
 
                 _badCmdBefore = verb;
@@ -2454,7 +2455,7 @@ public partial class V4Game : IGame, IGameDebug
         if (noParentSpecified & doAdd)
         {
             SetStringContents("quest.error.article", _objs[childId].Article, ctx);
-            PlayerErrorMessage(PlayerError.BadPut, ctx);
+            await PlayerErrorMessage(PlayerError.BadPut, ctx);
             return;
         }
 
@@ -2471,13 +2472,13 @@ public partial class V4Game : IGame, IGameDebug
         {
             parentName = Strings.Trim(Strings.Mid(cmd, sepPos + sepLen));
 
-            parentId = Disambiguate(parentName, _currentRoom + ";inventory", ctx);
+            parentId = await Disambiguate(parentName, _currentRoom + ";inventory", ctx);
 
             if (parentId <= 0)
             {
                 if (parentId != -2)
                 {
-                    PlayerErrorMessage(PlayerError.BadThing, ctx);
+                    await PlayerErrorMessage(PlayerError.BadThing, ctx);
                 }
 
                 _badCmdBefore = Strings.Left(cmd, sepPos + sepLen);
@@ -2491,7 +2492,7 @@ public partial class V4Game : IGame, IGameDebug
 
             if (!IsYes(GetObjectProperty("parent", childId, true, false)))
             {
-                PlayerErrorMessage(PlayerError.CantRemove, ctx);
+                await PlayerErrorMessage(PlayerError.CantRemove, ctx);
                 return;
             }
 
@@ -2506,11 +2507,11 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (doAdd)
             {
-                PlayerErrorMessage(PlayerError.CantPut, ctx);
+                await PlayerErrorMessage(PlayerError.CantPut, ctx);
             }
             else
             {
-                PlayerErrorMessage(PlayerError.CantRemove, ctx);
+                await PlayerErrorMessage(PlayerError.CantRemove, ctx);
             }
 
             return;
@@ -2523,7 +2524,7 @@ public partial class V4Game : IGame, IGameDebug
             if (doAdd & ((Strings.LCase(GetObjectProperty("parent", childId, false, false)) ?? "") ==
                          (Strings.LCase(_objs[parentId].ObjectName) ?? "")))
             {
-                PlayerErrorMessage(PlayerError.AlreadyPut, ctx);
+                await PlayerErrorMessage(PlayerError.AlreadyPut, ctx);
             }
         }
 
@@ -2533,11 +2534,11 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (doAdd)
             {
-                PlayerErrorMessage_ExtendInfo(PlayerError.CantPut, ctx, canAccessObject.ErrorMsg);
+                await PlayerErrorMessage_ExtendInfo(PlayerError.CantPut, ctx, canAccessObject.ErrorMsg);
             }
             else
             {
-                PlayerErrorMessage_ExtendInfo(PlayerError.CantRemove, ctx, canAccessObject.ErrorMsg);
+                await PlayerErrorMessage_ExtendInfo(PlayerError.CantRemove, ctx, canAccessObject.ErrorMsg);
             }
 
             return;
@@ -2548,11 +2549,11 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (doAdd)
             {
-                PlayerErrorMessage_ExtendInfo(PlayerError.CantPut, ctx, canAccessParent.ErrorMsg);
+                await PlayerErrorMessage_ExtendInfo(PlayerError.CantPut, ctx, canAccessParent.ErrorMsg);
             }
             else
             {
-                PlayerErrorMessage_ExtendInfo(PlayerError.CantRemove, ctx, canAccessParent.ErrorMsg);
+                await PlayerErrorMessage_ExtendInfo(PlayerError.CantRemove, ctx, canAccessParent.ErrorMsg);
             }
 
             return;
@@ -2566,11 +2567,11 @@ public partial class V4Game : IGame, IGameDebug
             // Not a surface and not open, so can't add to this closed container.
             if (doAdd)
             {
-                PlayerErrorMessage(PlayerError.CantPut, ctx);
+                await PlayerErrorMessage(PlayerError.CantPut, ctx);
             }
             else
             {
-                PlayerErrorMessage(PlayerError.CantRemove, ctx);
+                await PlayerErrorMessage(PlayerError.CantRemove, ctx);
             }
 
             return;
@@ -2593,7 +2594,7 @@ public partial class V4Game : IGame, IGameDebug
         if (foundAction)
         {
             SetStringContents("quest." + Strings.LCase(action) + ".object.name", _objs[childId].ObjectName, ctx);
-            ExecuteScript(actionScript, ctx, parentId);
+            await ExecuteScript(actionScript, ctx, parentId);
         }
         else
         {
@@ -2605,11 +2606,11 @@ public partial class V4Game : IGame, IGameDebug
                 // Show error message
                 if (doAdd)
                 {
-                    PlayerErrorMessage(PlayerError.CantPut, ctx);
+                    await PlayerErrorMessage(PlayerError.CantPut, ctx);
                 }
                 else
                 {
-                    PlayerErrorMessage(PlayerError.CantRemove, ctx);
+                    await PlayerErrorMessage(PlayerError.CantRemove, ctx);
                 }
             }
             else
@@ -2620,24 +2621,24 @@ public partial class V4Game : IGame, IGameDebug
                     // Show default message
                     if (doAdd)
                     {
-                        PlayerErrorMessage(PlayerError.DefaultPut, ctx);
+                        await PlayerErrorMessage(PlayerError.DefaultPut, ctx);
                     }
                     else
                     {
-                        PlayerErrorMessage(PlayerError.DefaultRemove, ctx);
+                        await PlayerErrorMessage(PlayerError.DefaultRemove, ctx);
                     }
                 }
                 else
                 {
-                    Print(textToPrint, ctx);
+                    await Print(textToPrint, ctx);
                 }
 
-                DoAddRemove(childId, parentId, doAdd, ctx);
+                await DoAddRemove(childId, parentId, doAdd, ctx);
             }
         }
     }
 
-    private void ExecAddRemoveScript(string parameter, bool add, Context ctx)
+    private async Task ExecAddRemoveScript(string parameter, bool add, Context ctx)
     {
         int childId, parentId = default;
         string commandName;
@@ -2689,16 +2690,16 @@ public partial class V4Game : IGame, IGameDebug
                 return;
             }
 
-            DoAddRemove(childId, parentId, add, ctx);
+            await DoAddRemove(childId, parentId, add, ctx);
         }
         else
         {
             AddToObjectProperties("not parent", childId, ctx);
-            UpdateVisibilityInContainers(ctx, _objs[parentId].ObjectName);
+            await UpdateVisibilityInContainers(ctx, _objs[parentId].ObjectName);
         }
     }
 
-    private void ExecOpenClose(string cmd, Context ctx)
+    private async Task ExecOpenClose(string cmd, Context ctx)
     {
         int id;
         string name;
@@ -2723,13 +2724,13 @@ public partial class V4Game : IGame, IGameDebug
 
         name = GetEverythingAfter(cmd, action + " ");
 
-        id = Disambiguate(name, _currentRoom + ";inventory", ctx);
+        id = await Disambiguate(name, _currentRoom + ";inventory", ctx);
 
         if (id <= 0)
         {
             if (id != -2)
             {
-                PlayerErrorMessage(PlayerError.BadThing, ctx);
+                await PlayerErrorMessage(PlayerError.BadThing, ctx);
             }
 
             _badCmdBefore = action;
@@ -2744,11 +2745,11 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (doOpen)
             {
-                PlayerErrorMessage(PlayerError.CantOpen, ctx);
+                await PlayerErrorMessage(PlayerError.CantOpen, ctx);
             }
             else
             {
-                PlayerErrorMessage(PlayerError.CantClose, ctx);
+                await PlayerErrorMessage(PlayerError.CantClose, ctx);
             }
 
             return;
@@ -2761,14 +2762,14 @@ public partial class V4Game : IGame, IGameDebug
         if (doOpen & isOpen)
         {
             // Object is already open
-            PlayerErrorMessage(PlayerError.AlreadyOpen, ctx);
+            await PlayerErrorMessage(PlayerError.AlreadyOpen, ctx);
             return;
         }
 
         if (!doOpen & !isOpen)
         {
             // Object is already closed
-            PlayerErrorMessage(PlayerError.AlreadyClosed, ctx);
+            await PlayerErrorMessage(PlayerError.AlreadyClosed, ctx);
             return;
         }
 
@@ -2779,11 +2780,11 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (doOpen)
             {
-                PlayerErrorMessage_ExtendInfo(PlayerError.CantOpen, ctx, canAccessObject.ErrorMsg);
+                await PlayerErrorMessage_ExtendInfo(PlayerError.CantOpen, ctx, canAccessObject.ErrorMsg);
             }
             else
             {
-                PlayerErrorMessage_ExtendInfo(PlayerError.CantClose, ctx, canAccessObject.ErrorMsg);
+                await PlayerErrorMessage_ExtendInfo(PlayerError.CantClose, ctx, canAccessObject.ErrorMsg);
             }
 
             return;
@@ -2805,7 +2806,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (foundAction)
         {
-            ExecuteScript(actionScript, ctx, id);
+            await ExecuteScript(actionScript, ctx, id);
         }
         else
         {
@@ -2817,11 +2818,11 @@ public partial class V4Game : IGame, IGameDebug
                 // Show error message
                 if (doOpen)
                 {
-                    PlayerErrorMessage(PlayerError.CantOpen, ctx);
+                    await PlayerErrorMessage(PlayerError.CantOpen, ctx);
                 }
                 else
                 {
-                    PlayerErrorMessage(PlayerError.CantClose, ctx);
+                    await PlayerErrorMessage(PlayerError.CantClose, ctx);
                 }
             }
             else
@@ -2832,24 +2833,24 @@ public partial class V4Game : IGame, IGameDebug
                     // Show default message
                     if (doOpen)
                     {
-                        PlayerErrorMessage(PlayerError.DefaultOpen, ctx);
+                        await PlayerErrorMessage(PlayerError.DefaultOpen, ctx);
                     }
                     else
                     {
-                        PlayerErrorMessage(PlayerError.DefaultClose, ctx);
+                        await PlayerErrorMessage(PlayerError.DefaultClose, ctx);
                     }
                 }
                 else
                 {
-                    Print(textToPrint, ctx);
+                    await Print(textToPrint, ctx);
                 }
 
-                DoOpenClose(id, doOpen, true, ctx);
+                await DoOpenClose(id, doOpen, true, ctx);
             }
         }
     }
 
-    private void ExecuteSelectCase(string script, Context ctx)
+    private async Task ExecuteSelectCase(string script, Context ctx)
     {
         // ScriptLine passed will look like this:
         // select case <whatever> do <!intprocX>
@@ -2863,9 +2864,9 @@ public partial class V4Game : IGame, IGameDebug
             return;
         }
 
-        var blockName = GetParameter(afterLine, ctx);
-        var block = DefineBlockParam("procedure", blockName);
-        var checkValue = GetParameter(script, ctx);
+        var blockName = await GetParameter(afterLine, ctx);
+        var block = await DefineBlockParam("procedure", blockName);
+        var checkValue = await GetParameter(script, ctx);
         var caseMatch = false;
 
         for (int i = block.StartLine + 1, loopTo = block.EndLine - 1; i <= loopTo; i++)
@@ -2888,7 +2889,7 @@ public partial class V4Game : IGame, IGameDebug
                     }
                     else
                     {
-                        var thisCase = GetParameter(_lines[i], ctx);
+                        var thisCase = await GetParameter(_lines[i], ctx);
                         var finished = false;
 
                         do
@@ -2916,7 +2917,7 @@ public partial class V4Game : IGame, IGameDebug
 
                     if (caseMatch)
                     {
-                        ExecuteScript(caseScript, ctx);
+                        await ExecuteScript(caseScript, ctx);
                         return;
                     }
                 }
@@ -2924,7 +2925,7 @@ public partial class V4Game : IGame, IGameDebug
         }
     }
 
-    private bool ExecVerb(string cmd, Context ctx, bool libCommands = false)
+    private async Task<bool> ExecVerb(string cmd, Context ctx, bool libCommands = false)
     {
         DefineBlock gameBlock;
         var foundVerb = false;
@@ -2952,7 +2953,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (BeginsWith(_lines[i], verbTag))
             {
-                verbsList = GetParameter(_lines[i], ctx);
+                verbsList = await GetParameter(_lines[i], ctx);
 
                 // The property or action the verb uses is either after a colon,
                 // or it's the first (or only) verb on the line.
@@ -3010,13 +3011,13 @@ public partial class V4Game : IGame, IGameDebug
 
         if (foundVerb)
         {
-            id = Disambiguate(verbObject, "inventory;" + _currentRoom, ctx);
+            id = await Disambiguate(verbObject, "inventory;" + _currentRoom, ctx);
 
             if (id < 0)
             {
                 if (id != -2)
                 {
-                    PlayerErrorMessage(PlayerError.BadThing, ctx);
+                    await PlayerErrorMessage(PlayerError.BadThing, ctx);
                 }
 
                 _badCmdBefore = thisVerb;
@@ -3042,7 +3043,7 @@ public partial class V4Game : IGame, IGameDebug
                 if (!string.IsNullOrEmpty(thisScript))
                     // Avoid an RTE "this array is fixed or temporarily locked"
                 {
-                    ExecuteScript(thisScript, ctx, id);
+                    await ExecuteScript(thisScript, ctx, id);
                 }
 
                 if (!foundAction)
@@ -3053,7 +3054,7 @@ public partial class V4Game : IGame, IGameDebug
                         if ((Strings.LCase(o.Properties[i].PropertyName) ?? "") == (verbProperty ?? ""))
                         {
                             foundAction = true;
-                            Print(o.Properties[i].PropertyValue, ctx);
+                            await Print(o.Properties[i].PropertyValue, ctx);
                             break;
                         }
                     }
@@ -3062,7 +3063,7 @@ public partial class V4Game : IGame, IGameDebug
                 if (!foundAction)
                     // Execute the default script from the verb definition
                 {
-                    ExecuteScript(script, ctx);
+                    await ExecuteScript(script, ctx);
                 }
             }
         }
@@ -3294,7 +3295,7 @@ public partial class V4Game : IGame, IGameDebug
         return res;
     }
 
-    private string ListContents(int id, Context ctx)
+    private async Task<string> ListContents(int id, Context ctx)
     {
         // Returns a formatted list of the contents of a container.
         // If the list action causes a script to be run instead, ListContents
@@ -3313,7 +3314,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             // Container is closed, so return "list closed" property if there is one.
 
-            if (DoAction(id, "list closed", ctx, false))
+            if (await DoAction(id, "list closed", ctx, false))
             {
                 return "<script>";
             }
@@ -3345,7 +3346,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             // Check if list property is set.
 
-            if (DoAction(id, "list", ctx, false))
+            if (await DoAction(id, "list", ctx, false))
             {
                 return "<script>";
             }
@@ -3422,7 +3423,7 @@ public partial class V4Game : IGame, IGameDebug
 
         // Container is empty, so return "list empty" property if there is one.
 
-        if (DoAction(id, "list empty", ctx, false))
+        if (await DoAction(id, "list empty", ctx, false))
         {
             return "<script>";
         }
@@ -3453,7 +3454,7 @@ public partial class V4Game : IGame, IGameDebug
         return result;
     }
 
-    private void ProcessListInfo(string line, int id)
+    private async Task ProcessListInfo(string line, int id)
     {
         var listInfo = new TextAction();
         var propName = "";
@@ -3461,7 +3462,7 @@ public partial class V4Game : IGame, IGameDebug
         if (BeginsWith(line, "list closed <"))
         {
             listInfo.Type = TextActionType.Text;
-            listInfo.Data = GetParameter(line, _nullContext);
+            listInfo.Data = await GetParameter(line, _nullContext);
             propName = "list closed";
         }
         else if (Strings.Trim(line) == "list closed off")
@@ -3480,7 +3481,7 @@ public partial class V4Game : IGame, IGameDebug
         else if (BeginsWith(line, "list empty <"))
         {
             listInfo.Type = TextActionType.Text;
-            listInfo.Data = GetParameter(line, _nullContext);
+            listInfo.Data = await GetParameter(line, _nullContext);
             propName = "list empty";
         }
         else if (Strings.Trim(line) == "list empty off")
@@ -3504,7 +3505,7 @@ public partial class V4Game : IGame, IGameDebug
         else if (BeginsWith(line, "list <"))
         {
             listInfo.Type = TextActionType.Text;
-            listInfo.Data = GetParameter(line, _nullContext);
+            listInfo.Data = await GetParameter(line, _nullContext);
             propName = "list";
         }
         else if (BeginsWith(line, "list "))
@@ -3522,7 +3523,7 @@ public partial class V4Game : IGame, IGameDebug
             }
             else
             {
-                AddToObjectActions("<" + propName + "> " + listInfo.Data, id, _nullContext);
+                await AddToObjectActions("<" + propName + "> " + listInfo.Data, id, _nullContext);
             }
         }
     }
@@ -3577,7 +3578,7 @@ public partial class V4Game : IGame, IGameDebug
         PrintText?.Invoke(_textFormatter.OutputHTML(text));
     }
 
-    private void DestroyExit(string exitData, Context ctx)
+    private async Task DestroyExit(string exitData, Context ctx)
     {
         var fromRoom = "";
         var toRoom = "";
@@ -3653,7 +3654,7 @@ public partial class V4Game : IGame, IGameDebug
         }
 
         // Update quest.* vars and obj list
-        ShowRoomInfo(_currentRoom, ctx, true);
+        await ShowRoomInfo(_currentRoom, ctx, true);
         UpdateObjectList(ctx);
 
         AddToChangeLog("room " + fromRoom, "destroy exit " + toRoom);
@@ -3664,28 +3665,31 @@ public partial class V4Game : IGame, IGameDebug
         _player.ClearScreen();
     }
 
-    private void DoWait()
+    private void SignalTurnSuspended()
     {
-        _player.DoWait();
-        ChangeState(State.Waiting);
-
-        lock (_waitLock)
-        {
-            Monitor.Wait(_waitLock);
-        }
+        _readyForCommand = true;
+        _turnSuspendedTcs?.TrySetResult();
     }
 
-    private void ExecuteFlag(string line, Context ctx)
+    private async Task DoWaitAsync()
+    {
+        _player.DoWait();
+        _waitTcs = new TaskCompletionSource();
+        SignalTurnSuspended();
+        await _waitTcs.Task;
+    }
+
+    private async Task ExecuteFlag(string line, Context ctx)
     {
         var propertyString = "";
 
         if (BeginsWith(line, "on "))
         {
-            propertyString = GetParameter(line, ctx);
+            propertyString = await GetParameter(line, ctx);
         }
         else if (BeginsWith(line, "off "))
         {
-            propertyString = "not " + GetParameter(line, ctx);
+            propertyString = "not " + await GetParameter(line, ctx);
         }
 
         // Game object always has ObjID 1
@@ -3698,11 +3702,11 @@ public partial class V4Game : IGame, IGameDebug
         return GetObjectProperty(flag, 1, true) == "yes";
     }
 
-    private void ExecuteIncDec(string line, Context ctx)
+    private async Task ExecuteIncDec(string line, Context ctx)
     {
         string variable;
         double change;
-        var param = GetParameter(line, ctx);
+        var param = await GetParameter(line, ctx);
 
         var sc = Strings.InStr(param, ";");
         if (sc == 0)
@@ -3851,7 +3855,7 @@ public partial class V4Game : IGame, IGameDebug
         changeLog.AddItem(ref appliesTo, ref element, ref changeData);
     }
 
-    private void AddToGiveInfo(int id, string giveData)
+    private async Task AddToGiveInfo(int id, string giveData)
     {
         GiveType giveType;
         string actionName;
@@ -3887,7 +3891,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (Strings.Left(Strings.Trim(giveData), 1) == "<")
         {
-            var name = GetParameter(giveData, _nullContext);
+            var name = await GetParameter(giveData, _nullContext);
             var dataId = default(int);
 
             actionName = actionName + "'" + name + "'";
@@ -3922,12 +3926,12 @@ public partial class V4Game : IGame, IGameDebug
         }
     }
 
-    internal void AddToObjectActions(string actionInfo, int id, Context ctx)
+    internal async Task AddToObjectActions(string actionInfo, int id, Context ctx)
     {
         var actionNum = default(int);
         var foundExisting = false;
 
-        var name = Strings.LCase(GetParameter(actionInfo, ctx));
+        var name = Strings.LCase(await GetParameter(actionInfo, ctx));
         var ep = Strings.InStr(actionInfo, ">");
         if (ep == Strings.Len(actionInfo))
         {
@@ -4081,8 +4085,8 @@ public partial class V4Game : IGame, IGameDebug
 
                     if (_gameFullyLoaded)
                     {
-                        UpdateObjectList(ctx);
-                        UpdateItems(ctx);
+                        _ = UpdateObjectList(ctx);
+                        _ = UpdateItems(ctx);
                     }
 
                     break;
@@ -4223,7 +4227,7 @@ public partial class V4Game : IGame, IGameDebug
         } while (Strings.Len(Strings.Trim(propertyInfo)) != 0);
     }
 
-    private void AddToUseInfo(int id, string useData)
+    private async Task AddToUseInfo(int id, string useData)
     {
         UseType useType;
 
@@ -4252,7 +4256,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (Strings.Left(Strings.Trim(useData), 1) == "<")
         {
-            var objectName = GetParameter(useData, _nullContext);
+            var objectName = await GetParameter(useData, _nullContext);
             var dataId = default(int);
             var found = false;
 
@@ -4291,9 +4295,9 @@ public partial class V4Game : IGame, IGameDebug
         return Strings.UCase(Strings.Left(s, 1)) + Strings.Mid(s, 2);
     }
 
-    private string ConvertVarsIn(string s, Context ctx)
+    private async Task<string> ConvertVarsIn(string s, Context ctx)
     {
-        return GetParameter("<" + s + ">", ctx);
+        return await GetParameter("<" + s + ">", ctx);
     }
 
     private bool DisambObjHere(Context ctx, int id, string firstPlace, bool twoPlaces = false, string secondPlace = "",
@@ -4403,22 +4407,22 @@ public partial class V4Game : IGame, IGameDebug
         UpdateObjectList(ctx);
     }
 
-    private void ExecOops(string correction, Context ctx)
+    private async Task ExecOops(string correction, Context ctx)
     {
         if (!string.IsNullOrEmpty(_badCmdBefore))
         {
             if (string.IsNullOrEmpty(_badCmdAfter))
             {
-                ExecCommand(_badCmdBefore + " " + correction, ctx, false);
+                await ExecCommand(_badCmdBefore + " " + correction, ctx, false);
             }
             else
             {
-                ExecCommand(_badCmdBefore + " " + correction + " " + _badCmdAfter, ctx, false);
+                await ExecCommand(_badCmdBefore + " " + correction + " " + _badCmdAfter, ctx, false);
             }
         }
     }
 
-    private void ExecType(string typeData, Context ctx)
+    private async Task ExecType(string typeData, Context ctx)
     {
         var id = default(int);
         var found = default(bool);
@@ -4455,7 +4459,7 @@ public partial class V4Game : IGame, IGameDebug
         Array.Resize(ref o.TypesIncluded, o.NumberTypesIncluded + 1);
         o.TypesIncluded[o.NumberTypesIncluded] = typeName;
 
-        var propertyData = GetPropertiesInType(typeName);
+        var propertyData = await GetPropertiesInType(typeName);
         AddToObjectProperties(propertyData.Properties, id, ctx);
         for (int i = 1, loopTo1 = propertyData.NumberActions; i <= loopTo1; i++)
         {
@@ -4592,7 +4596,7 @@ public partial class V4Game : IGame, IGameDebug
         return result;
     }
 
-    internal int Disambiguate(string name, string containedIn, Context ctx, bool isExit = false)
+    internal async Task<int> Disambiguate(string name, string containedIn, Context ctx, bool isExit = false)
     {
         // Returns object ID being referred to by player.
         // Returns -1 if object doesn't exist, calling function
@@ -4658,7 +4662,7 @@ public partial class V4Game : IGame, IGameDebug
                 return _lastIt;
             }
 
-            PlayerErrorMessage(PlayerError.BadPronoun, ctx);
+            await PlayerErrorMessage(PlayerError.BadPronoun, ctx);
             return -2;
         }
 
@@ -4672,7 +4676,7 @@ public partial class V4Game : IGame, IGameDebug
                 return _lastIt;
             }
 
-            PlayerErrorMessage(PlayerError.BadPronoun, ctx);
+            await PlayerErrorMessage(PlayerError.BadPronoun, ctx);
             return -2;
         }
 
@@ -4686,7 +4690,7 @@ public partial class V4Game : IGame, IGameDebug
                 return _lastIt;
             }
 
-            PlayerErrorMessage(PlayerError.BadPronoun, ctx);
+            await PlayerErrorMessage(PlayerError.BadPronoun, ctx);
             return -2;
         }
 
@@ -4796,7 +4800,7 @@ public partial class V4Game : IGame, IGameDebug
             descriptionText = new string[numberCorresIds + 1];
 
             var question = "Please select which " + name + " you mean:";
-            Print("- |i" + question + "|xi", ctx);
+            await Print("- |i" + question + "|xi", ctx);
 
             var menuItems = new Dictionary<string, string>();
 
@@ -4819,7 +4823,7 @@ public partial class V4Game : IGame, IGameDebug
             }
 
             var mnu = new MenuData(question, menuItems, false);
-            var response = ShowMenu(mnu);
+            var response = await ShowMenuAsync(mnu);
 
             _choiceNumber = Conversions.ToInteger(response);
 
@@ -4847,7 +4851,7 @@ public partial class V4Game : IGame, IGameDebug
                 }
             }
 
-            Print("- " + descriptionText[_choiceNumber] + "|n", ctx);
+            await Print("- " + descriptionText[_choiceNumber] + "|n", ctx);
 
             return idNumbers[_choiceNumber];
         }
@@ -4857,14 +4861,14 @@ public partial class V4Game : IGame, IGameDebug
         return -1;
     }
 
-    private string DisplayStatusVariableInfo(int id, VarType type, Context ctx)
+    private async Task<string> DisplayStatusVariableInfo(int id, VarType type, Context ctx)
     {
         var displayData = "";
         int ep;
 
         if (type == VarType.String)
         {
-            displayData = ConvertVarsIn(_stringVariable[id].DisplayString, ctx);
+            displayData = await ConvertVarsIn(_stringVariable[id].DisplayString, ctx);
             ep = Strings.InStr(displayData, "!");
 
             if (ep != 0)
@@ -4881,7 +4885,7 @@ public partial class V4Game : IGame, IGameDebug
                 return "";
             }
 
-            displayData = ConvertVarsIn(_numericVariable[id].DisplayString, ctx);
+            displayData = await ConvertVarsIn(_numericVariable[id].DisplayString, ctx);
             ep = Strings.InStr(displayData, "!");
 
             if (ep != 0)
@@ -4912,7 +4916,7 @@ public partial class V4Game : IGame, IGameDebug
         return displayData;
     }
 
-    internal bool DoAction(int id, string action, Context ctx, bool logError = true)
+    internal async Task<bool> DoAction(int id, string action, Context ctx, bool logError = true)
     {
         var found = default(bool);
         var script = "";
@@ -4942,7 +4946,7 @@ public partial class V4Game : IGame, IGameDebug
         var newCtx = CopyContext(ctx);
         newCtx.CallingObjectId = id;
 
-        ExecuteScript(script, newCtx, id);
+        await ExecuteScript(script, newCtx, id);
 
         return true;
     }
@@ -4962,7 +4966,7 @@ public partial class V4Game : IGame, IGameDebug
         return false;
     }
 
-    private void ExecForEach(string scriptLine, Context ctx)
+    private async Task ExecForEach(string scriptLine, Context ctx)
     {
         string inLocation, scriptToRun;
         var isExit = default(bool);
@@ -5017,7 +5021,7 @@ public partial class V4Game : IGame, IGameDebug
         }
         else
         {
-            inLocation = Strings.LCase(GetParameter(scriptLine, ctx));
+            inLocation = Strings.LCase(await GetParameter(scriptLine, ctx));
             var bracketPos = Strings.InStr(scriptLine, ">");
             scriptToRun = Strings.Trim(Strings.Mid(scriptLine, bracketPos + 1));
         }
@@ -5030,13 +5034,13 @@ public partial class V4Game : IGame, IGameDebug
                 if ((_objs[i].IsRoom == isRoom) & (_objs[i].IsExit == isExit))
                 {
                     SetStringContents("quest.thing", _objs[i].ObjectName, ctx);
-                    ExecuteScript(scriptToRun, ctx);
+                    await ExecuteScript(scriptToRun, ctx);
                 }
             }
         }
     }
 
-    private void ExecuteAction(string data, Context ctx)
+    private async Task ExecuteAction(string data, Context ctx)
     {
         string actionName;
         string script;
@@ -5045,7 +5049,7 @@ public partial class V4Game : IGame, IGameDebug
         var foundExisting = false;
         var foundObject = false;
 
-        var param = GetParameter(data, ctx);
+        var param = await GetParameter(data, ctx);
         var scp = Strings.InStr(param, ";");
         if (scp == 0)
         {
@@ -5108,7 +5112,7 @@ public partial class V4Game : IGame, IGameDebug
         ObjectActionUpdate(id, actionName, script);
     }
 
-    private bool ExecuteCondition(string condition, Context ctx)
+    private async Task<bool> ExecuteCondition(string condition, Context ctx)
     {
         bool result = default, thisNot;
 
@@ -5124,47 +5128,47 @@ public partial class V4Game : IGame, IGameDebug
 
         if (BeginsWith(condition, "got "))
         {
-            result = ExecuteIfGot(GetParameter(condition, ctx));
+            result = ExecuteIfGot(await GetParameter(condition, ctx));
         }
         else if (BeginsWith(condition, "has "))
         {
-            result = ExecuteIfHas(GetParameter(condition, ctx));
+            result = ExecuteIfHas(await GetParameter(condition, ctx));
         }
         else if (BeginsWith(condition, "ask "))
         {
-            result = ExecuteIfAsk(GetParameter(condition, ctx));
+            result = await ExecuteIfAskAsync(await GetParameter(condition, ctx));
         }
         else if (BeginsWith(condition, "is "))
         {
-            result = ExecuteIfIs(GetParameter(condition, ctx));
+            result = ExecuteIfIs(await GetParameter(condition, ctx));
         }
         else if (BeginsWith(condition, "here "))
         {
-            result = ExecuteIfHere(GetParameter(condition, ctx), ctx);
+            result = ExecuteIfHere(await GetParameter(condition, ctx), ctx);
         }
         else if (BeginsWith(condition, "exists "))
         {
-            result = ExecuteIfExists(GetParameter(condition, ctx), false);
+            result = ExecuteIfExists(await GetParameter(condition, ctx), false);
         }
         else if (BeginsWith(condition, "real "))
         {
-            result = ExecuteIfExists(GetParameter(condition, ctx), true);
+            result = ExecuteIfExists(await GetParameter(condition, ctx), true);
         }
         else if (BeginsWith(condition, "property "))
         {
-            result = ExecuteIfProperty(GetParameter(condition, ctx));
+            result = ExecuteIfProperty(await GetParameter(condition, ctx));
         }
         else if (BeginsWith(condition, "action "))
         {
-            result = ExecuteIfAction(GetParameter(condition, ctx));
+            result = ExecuteIfAction(await GetParameter(condition, ctx));
         }
         else if (BeginsWith(condition, "type "))
         {
-            result = ExecuteIfType(GetParameter(condition, ctx));
+            result = ExecuteIfType(await GetParameter(condition, ctx));
         }
         else if (BeginsWith(condition, "flag "))
         {
-            result = ExecuteIfFlag(GetParameter(condition, ctx));
+            result = ExecuteIfFlag(await GetParameter(condition, ctx));
         }
 
         if (thisNot)
@@ -5175,12 +5179,12 @@ public partial class V4Game : IGame, IGameDebug
         return result;
     }
 
-    private bool ExecuteConditions(string list, Context ctx)
+    private async Task<bool> ExecuteConditions(string list, Context ctx)
     {
         var conditions = default(string[]);
         var numConditions = 0;
         var operations = default(string[]);
-        var obscuredConditionList = ObliterateParameters(list);
+        var obscuredConditionList = await ObliterateParameters(list);
         var pos = 1;
         var isFinalCondition = false;
 
@@ -5218,7 +5222,7 @@ public partial class V4Game : IGame, IGameDebug
 
         for (int i = 1, loopTo = numConditions; i <= loopTo; i++)
         {
-            var thisResult = ExecuteCondition(conditions[i], ctx);
+            var thisResult = await ExecuteCondition(conditions[i], ctx);
 
             if (operations[i - 1] == "AND")
             {
@@ -5233,13 +5237,13 @@ public partial class V4Game : IGame, IGameDebug
         return result;
     }
 
-    private void ExecuteCreate(string data, Context ctx)
+    private async Task ExecuteCreate(string data, Context ctx)
     {
         string newName;
 
         if (BeginsWith(data, "room "))
         {
-            newName = GetParameter(data, ctx);
+            newName = await GetParameter(data, ctx);
             _numberRooms = _numberRooms + 1;
             Array.Resize(ref _rooms, _numberRooms + 1);
             _rooms[_numberRooms] = new RoomType();
@@ -5273,7 +5277,7 @@ public partial class V4Game : IGame, IGameDebug
 
         else if (BeginsWith(data, "object "))
         {
-            var paramData = GetParameter(data, ctx);
+            var paramData = await GetParameter(data, ctx);
             var scp = Strings.InStr(paramData, ";");
             string containerRoom;
 
@@ -5321,17 +5325,17 @@ public partial class V4Game : IGame, IGameDebug
 
         else if (BeginsWith(data, "exit "))
         {
-            ExecuteCreateExit(data, ctx);
+            await ExecuteCreateExit(data, ctx);
         }
     }
 
-    private void ExecuteCreateExit(string data, Context ctx)
+    private async Task ExecuteCreateExit(string data, Context ctx)
     {
         string scrRoom;
         var destRoom = "";
         var destId = default(int);
         var exitData = GetEverythingAfter(data, "exit ");
-        var newName = GetParameter(data, ctx);
+        var newName = await GetParameter(data, ctx);
         var scp = Strings.InStr(newName, ";");
 
         if (ASLVersion < 410)
@@ -5415,7 +5419,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             saveData = Strings.Left(exitData, paramPos - 1);
             // We do this so the changelog doesn't contain unconverted variable names
-            saveData = saveData + "<" + GetParameter(exitData, ctx) + ">";
+            saveData = saveData + "<" + await GetParameter(exitData, ctx) + ">";
         }
 
         AddToChangeLog("room " + _rooms[srcId].RoomName, "exit " + saveData);
@@ -5424,7 +5428,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (ASLVersion >= 410)
         {
-            r.Exits.AddExitFromCreateScript(exitData, ref ctx);
+            await r.Exits.AddExitFromCreateScript(exitData, ctx);
         }
         else if (BeginsWith(exitData, "north "))
         {
@@ -5495,7 +5499,7 @@ public partial class V4Game : IGame, IGameDebug
         if (!_gameLoading)
         {
             // Update quest.doorways variables
-            ShowRoomInfo(_currentRoom, ctx, true);
+           await ShowRoomInfo(_currentRoom, ctx, true);
 
             UpdateObjectList(ctx);
 
@@ -5519,12 +5523,12 @@ public partial class V4Game : IGame, IGameDebug
         }
     }
 
-    private void ExecDrop(string obj, Context ctx)
+    private async Task ExecDrop(string obj, Context ctx)
     {
         bool found;
         int parentId = default, id;
 
-        id = Disambiguate(obj, "inventory", ctx);
+        id = await Disambiguate(obj, "inventory", ctx);
 
         if (id > 0)
         {
@@ -5541,11 +5545,11 @@ public partial class V4Game : IGame, IGameDebug
             {
                 if (ASLVersion >= 391)
                 {
-                    PlayerErrorMessage(PlayerError.NoItem, ctx);
+                    await PlayerErrorMessage(PlayerError.NoItem, ctx);
                 }
                 else
                 {
-                    PlayerErrorMessage(PlayerError.BadDrop, ctx);
+                    await PlayerErrorMessage(PlayerError.BadDrop, ctx);
                 }
             }
 
@@ -5597,11 +5601,11 @@ public partial class V4Game : IGame, IGameDebug
                     parentDisplayName = _objs[parentId].ObjectName;
                 }
 
-                Print("(first removing " + _objs[id].Article + " from " + parentDisplayName + ")", ctx);
+                await Print("(first removing " + _objs[id].Article + " from " + parentDisplayName + ")", ctx);
 
                 // Try to remove the object
                 ctx.AllowRealNamesInCommand = true;
-                ExecCommand("remove " + _objs[id].ObjectName, ctx, false, dontSetIt: true);
+                await ExecCommand("remove " + _objs[id].ObjectName, ctx, false, dontSetIt: true);
 
                 if (!string.IsNullOrEmpty(GetObjectProperty("parent", id, false, false)))
                     // removing the object failed
@@ -5613,56 +5617,56 @@ public partial class V4Game : IGame, IGameDebug
 
         if (!dropFound)
         {
-            PlayerErrorMessage(PlayerError.DefaultDrop, ctx);
-            PlayerItem(_objs[id].ObjectName, false, ctx);
+            await PlayerErrorMessage(PlayerError.DefaultDrop, ctx);
+            await PlayerItem(_objs[id].ObjectName, false, ctx);
         }
         else if (BeginsWith(dropStatement, "everywhere"))
         {
-            PlayerItem(_objs[id].ObjectName, false, ctx);
+            await PlayerItem(_objs[id].ObjectName, false, ctx);
             if (Strings.InStr(dropStatement, "<") != 0)
             {
-                Print(GetParameter(dropStatement, ctx), ctx);
+                await Print(await GetParameter(dropStatement, ctx), ctx);
             }
             else
             {
-                PlayerErrorMessage(PlayerError.DefaultDrop, ctx);
+                await PlayerErrorMessage(PlayerError.DefaultDrop, ctx);
             }
         }
         else if (BeginsWith(dropStatement, "nowhere"))
         {
             if (Strings.InStr(dropStatement, "<") != 0)
             {
-                Print(GetParameter(dropStatement, ctx), ctx);
+                await Print(await GetParameter(dropStatement, ctx), ctx);
             }
             else
             {
-                PlayerErrorMessage(PlayerError.CantDrop, ctx);
+                await PlayerErrorMessage(PlayerError.CantDrop, ctx);
             }
         }
         else
         {
-            ExecuteScript(dropStatement, ctx);
+            await ExecuteScript(dropStatement, ctx);
         }
     }
 
-    private void ExecExamine(string command, Context ctx)
+    private async Task ExecExamine(string command, Context ctx)
     {
         var item = Strings.LCase(Strings.Trim(GetEverythingAfter(command, "examine ")));
 
         if (string.IsNullOrEmpty(item))
         {
-            PlayerErrorMessage(PlayerError.BadExamine, ctx);
+            await PlayerErrorMessage(PlayerError.BadExamine, ctx);
             _badCmdBefore = "examine";
             return;
         }
 
-        var id = Disambiguate(item, _currentRoom + ";inventory", ctx);
+        var id = await Disambiguate(item, _currentRoom + ";inventory", ctx);
 
         if (id <= 0)
         {
             if (id != -2)
             {
-                PlayerErrorMessage(PlayerError.BadThing, ctx);
+                await PlayerErrorMessage(PlayerError.BadThing, ctx);
             }
 
             _badCmdBefore = "examine";
@@ -5676,7 +5680,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (o.Actions[i].ActionName == "examine")
             {
-                ExecuteScript(o.Actions[i].Script, ctx, id);
+                await ExecuteScript(o.Actions[i].Script, ctx, id);
                 return;
             }
         }
@@ -5686,7 +5690,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (o.Properties[i].PropertyName == "examine")
             {
-                Print(o.Properties[i].PropertyValue, ctx);
+                await Print(o.Properties[i].PropertyValue, ctx);
                 return;
             }
         }
@@ -5699,21 +5703,21 @@ public partial class V4Game : IGame, IGameDebug
                 var action = Strings.Trim(GetEverythingAfter(_lines[i], "examine "));
                 if (Strings.Left(action, 1) == "<")
                 {
-                    Print(GetParameter(_lines[i], ctx), ctx);
+                    await Print(await GetParameter(_lines[i], ctx), ctx);
                 }
                 else
                 {
-                    ExecuteScript(action, ctx, id);
+                    await ExecuteScript(action, ctx, id);
                 }
 
                 return;
             }
         }
 
-        DoLook(id, ctx, true);
+        await DoLook(id, ctx, true);
     }
 
-    private void ExecMoveThing(string data, Thing type, Context ctx)
+    private async Task ExecMoveThing(string data, Thing type, Context ctx)
     {
         var scp = Strings.InStr(data, ";");
         var name = Strings.Trim(Strings.Left(data, scp - 1));
@@ -5721,7 +5725,7 @@ public partial class V4Game : IGame, IGameDebug
         MoveThing(name, place, type, ctx);
     }
 
-    private void ExecProperty(string data, Context ctx)
+    private async Task ExecProperty(string data, Context ctx)
     {
         var id = default(int);
         var found = default(bool);
@@ -5755,7 +5759,7 @@ public partial class V4Game : IGame, IGameDebug
         AddToObjectProperties(properties, id, ctx);
     }
 
-    private void ExecuteDo(string procedureName, Context ctx)
+    private async Task ExecuteDo(string procedureName, Context ctx)
     {
         var newCtx = CopyContext(ctx);
         var numParameters = 0;
@@ -5802,7 +5806,7 @@ public partial class V4Game : IGame, IGameDebug
             }
         }
 
-        var block = DefineBlockParam("procedure", procedureName);
+        var block = await DefineBlockParam("procedure", procedureName);
         if ((block.StartLine == 0) & (block.EndLine == 0))
         {
             LogASLError("No such procedure " + procedureName, LogType.WarningError);
@@ -5813,18 +5817,18 @@ public partial class V4Game : IGame, IGameDebug
             {
                 if (!useNewCtx)
                 {
-                    ExecuteScript(_lines[i], ctx);
+                    await ExecuteScript(_lines[i], ctx);
                 }
                 else
                 {
-                    ExecuteScript(_lines[i], newCtx);
+                    await ExecuteScript(_lines[i], newCtx);
                     ctx.DontProcessCommand = newCtx.DontProcessCommand;
                 }
             }
         }
     }
 
-    private void ExecuteDoAction(string data, Context ctx)
+    private async Task ExecuteDoAction(string data, Context ctx)
     {
         var id = default(int);
 
@@ -5855,7 +5859,7 @@ public partial class V4Game : IGame, IGameDebug
             return;
         }
 
-        DoAction(id, actionName, ctx);
+        await DoAction(id, actionName, ctx);
     }
 
     private bool ExecuteIfHere(string obj, Context ctx)
@@ -5987,7 +5991,7 @@ public partial class V4Game : IGame, IGameDebug
         return GetObjectProperty(propertyName, id, true) == "yes";
     }
 
-    private void ExecuteRepeat(string data, Context ctx)
+    private async Task ExecuteRepeat(string data, Context ctx)
     {
         bool repeatWhileTrue;
         var repeatScript = "";
@@ -6032,9 +6036,9 @@ public partial class V4Game : IGame, IGameDebug
 
         do
         {
-            if (ExecuteConditions(conditions, ctx) == repeatWhileTrue)
+            if (await ExecuteConditions(conditions, ctx) == repeatWhileTrue)
             {
-                ExecuteScript(repeatScript, ctx);
+                await ExecuteScript(repeatScript, ctx);
             }
             else
             {
@@ -6093,25 +6097,25 @@ public partial class V4Game : IGame, IGameDebug
         }
 
         CheckCollectable(id);
-        UpdateItems(ctx);
+        _ = UpdateItems(ctx);
     }
 
-    private void ExecuteWait(string waitLine, Context ctx)
+    private async Task ExecuteWaitAsync(string waitLine, Context ctx)
     {
         if (!string.IsNullOrEmpty(waitLine))
         {
-            Print(GetParameter(waitLine, ctx), ctx);
+            await Print(await GetParameter(waitLine, ctx), ctx);
         }
         else if (ASLVersion >= 410)
         {
-            PlayerErrorMessage(PlayerError.DefaultWait, ctx);
+            await PlayerErrorMessage(PlayerError.DefaultWait, ctx);
         }
         else
         {
-            Print("|nPress a key to continue...", ctx);
+            await Print("|nPress a key to continue...", ctx);
         }
 
-        DoWait();
+        await DoWaitAsync();
     }
 
     private void InitFileData(string fileData)
@@ -6140,9 +6144,9 @@ public partial class V4Game : IGame, IGameDebug
         return result;
     }
 
-    private ActionType GetObjectActions(string actionInfo)
+    private async Task<ActionType> GetObjectActions(string actionInfo)
     {
-        var name = Strings.LCase(GetParameter(actionInfo, _nullContext));
+        var name = Strings.LCase(await GetParameter(actionInfo, _nullContext));
         var ep = Strings.InStr(actionInfo, ">");
         if (ep == Strings.Len(actionInfo))
         {
@@ -6157,7 +6161,7 @@ public partial class V4Game : IGame, IGameDebug
         return result;
     }
 
-    private int GetObjectId(string name, Context ctx, string room = "")
+    private async Task<int> GetObjectId(string name, Context ctx, string room = "")
     {
         var id = default(int);
         var found = false;
@@ -6182,7 +6186,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (!found & (ASLVersion >= 280))
         {
-            id = Disambiguate(name, room, ctx);
+            id = await Disambiguate(name, room, ctx);
             if (id > 0)
             {
                 found = true;
@@ -6250,7 +6254,7 @@ public partial class V4Game : IGame, IGameDebug
         return "";
     }
 
-    private PropertiesActions GetPropertiesInType(string type, bool err = true)
+    private async Task<PropertiesActions> GetPropertiesInType(string type, bool err = true)
     {
         var blockId = default(int);
         var propertyList = new PropertiesActions();
@@ -6260,7 +6264,7 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (BeginsWith(_lines[_defineBlocks[i].StartLine], "define type"))
             {
-                if ((Strings.LCase(GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext)) ?? "") ==
+                if ((Strings.LCase(await GetParameter(_lines[_defineBlocks[i].StartLine], _nullContext)) ?? "") ==
                     (Strings.LCase(type) ?? ""))
                 {
                     blockId = i;
@@ -6286,8 +6290,8 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (BeginsWith(_lines[i], "type "))
             {
-                var typeName = Strings.LCase(GetParameter(_lines[i], _nullContext));
-                var newProperties = GetPropertiesInType(typeName);
+                var typeName = Strings.LCase(await GetParameter(_lines[i], _nullContext));
+                var newProperties = await GetPropertiesInType(typeName);
                 propertyList.Properties = propertyList.Properties + newProperties.Properties;
                 Array.Resize(ref propertyList.Actions, propertyList.NumberActions + newProperties.NumberActions + 1);
                 for (int j = propertyList.NumberActions + 1,
@@ -6326,11 +6330,11 @@ public partial class V4Game : IGame, IGameDebug
                 propertyList.NumberActions = propertyList.NumberActions + 1;
                 Array.Resize(ref propertyList.Actions, propertyList.NumberActions + 1);
                 propertyList.Actions[propertyList.NumberActions] =
-                    GetObjectActions(GetEverythingAfter(_lines[i], "action "));
+                    await GetObjectActions(GetEverythingAfter(_lines[i], "action "));
             }
             else if (BeginsWith(_lines[i], "properties "))
             {
-                propertyList.Properties = propertyList.Properties + GetParameter(_lines[i], _nullContext) + ";";
+                propertyList.Properties = propertyList.Properties + await GetParameter(_lines[i], _nullContext) + ";";
             }
             else if (!string.IsNullOrEmpty(Strings.Trim(_lines[i])))
             {
@@ -6360,7 +6364,7 @@ public partial class V4Game : IGame, IGameDebug
         return 0;
     }
 
-    private TextAction GetTextOrScript(string textScript)
+    private async Task<TextAction> GetTextOrScript(string textScript)
     {
         var result = new TextAction();
         textScript = Strings.Trim(textScript);
@@ -6368,7 +6372,7 @@ public partial class V4Game : IGame, IGameDebug
         if (Strings.Left(textScript, 1) == "<")
         {
             result.Type = TextActionType.Text;
-            result.Data = GetParameter(textScript, _nullContext);
+            result.Data = await GetParameter(textScript, _nullContext);
         }
         else
         {
@@ -6648,26 +6652,23 @@ public partial class V4Game : IGame, IGameDebug
             }
         }
 
-        UpdateObjectList(ctx);
+        _ = UpdateObjectList(ctx);
 
         if (BeginsWith(Strings.LCase(room), "inventory") | BeginsWith(Strings.LCase(oldRoom), "inventory"))
         {
-            UpdateItems(ctx);
+            _ = UpdateItems(ctx);
         }
     }
 
-    public void Pause(int duration)
+    public async Task PauseAsync(int duration)
     {
         _player.DoPause(duration);
-        ChangeState(State.Waiting);
-
-        lock (_waitLock)
-        {
-            Monitor.Wait(_waitLock);
-        }
+        _waitTcs = new TaskCompletionSource();
+        SignalTurnSuspended();
+        await _waitTcs.Task;
     }
 
-    private string ConvertParameter(string parameter, string convertChar, ConvertType action, Context ctx)
+    private async Task<string> ConvertParameter(string parameter, string convertChar, ConvertType action, Context ctx)
     {
         // Returns a string with functions, string and
         // numeric variables executed or converted as
@@ -6712,8 +6713,8 @@ public partial class V4Game : IGame, IGameDebug
                 }
                 else if (action == ConvertType.Functions)
                 {
-                    varName = EvaluateInlineExpressions(varName);
-                    result = result + DoFunction(varName, ctx);
+                    varName = await EvaluateInlineExpressions(varName);
+                    result = result + await DoFunction(varName, ctx);
                 }
                 else if (action == ConvertType.Numeric)
                 {
@@ -6731,7 +6732,7 @@ public partial class V4Game : IGame, IGameDebug
         return result;
     }
 
-    private string DoFunction(string data, Context ctx)
+    private async Task<string> DoFunction(string data, Context ctx)
     {
         string name, parameter;
         var intFuncResult = "";
@@ -6757,12 +6758,12 @@ public partial class V4Game : IGame, IGameDebug
         }
 
         DefineBlock block;
-        block = DefineBlockParam("function", name);
+        block = await DefineBlockParam("function", name);
 
         if ((block.StartLine == 0) & (block.EndLine == 0))
         {
             // Function does not exist; try an internal function.
-            intFuncResult = DoInternalFunction(name, parameter, ctx);
+            intFuncResult = await DoInternalFunction(name, parameter, ctx);
             if (intFuncResult == "__NOTDEFINED")
             {
                 LogASLError("No such function '" + name + "'", LogType.WarningError);
@@ -6812,14 +6813,14 @@ public partial class V4Game : IGame, IGameDebug
 
         for (int i = block.StartLine + 1, loopTo = block.EndLine - 1; i <= loopTo; i++)
         {
-            ExecuteScript(_lines[i], newCtx);
+            await ExecuteScript(_lines[i], newCtx);
             result = newCtx.FunctionReturnValue;
         }
 
         return result;
     }
 
-    private string DoInternalFunction(string name, string parameter, Context ctx)
+    private async Task<string> DoInternalFunction(string name, string parameter, Context ctx)
     {
         var parameters = default(string[]);
         var untrimmedParameters = default(string[]);
@@ -6860,14 +6861,14 @@ public partial class V4Game : IGame, IGameDebug
 
         if (name == "displayname")
         {
-            objId = GetObjectId(parameters[1], ctx);
+            objId = await GetObjectId(parameters[1], ctx);
             if (objId == -1)
             {
                 LogASLError("Object '" + parameters[1] + "' does not exist", LogType.WarningError);
                 return "!";
             }
 
-            return _objs[GetObjectId(parameters[1], ctx)].ObjectAlias;
+            return _objs[await GetObjectId(parameters[1], ctx)].ObjectAlias;
         }
 
         if (name == "numberparameters")
@@ -6895,7 +6896,7 @@ public partial class V4Game : IGame, IGameDebug
         if (name == "gettag")
             // Deprecated
         {
-            return FindStatement(DefineBlockParam("room", parameters[1]), parameters[2]);
+            return await FindStatement(await DefineBlockParam("room", parameters[1]), parameters[2]);
         }
 
         if (name == "objectname")
@@ -7156,15 +7157,15 @@ public partial class V4Game : IGame, IGameDebug
         {
             if (numParameters == 3)
             {
-                objId = Disambiguate(parameters[1], parameters[2] + ";" + parameters[3], ctx);
+                objId = await Disambiguate(parameters[1], parameters[2] + ";" + parameters[3], ctx);
             }
             else if (numParameters == 2)
             {
-                objId = Disambiguate(parameters[1], parameters[2], ctx);
+                objId = await Disambiguate(parameters[1], parameters[2], ctx);
             }
             else
             {
-                objId = Disambiguate(parameters[1], _currentRoom + ";inventory", ctx);
+                objId = await Disambiguate(parameters[1], _currentRoom + ";inventory", ctx);
             }
 
             if (objId <= -1)
@@ -7205,12 +7206,12 @@ public partial class V4Game : IGame, IGameDebug
         return "__NOTDEFINED";
     }
 
-    private void ExecFor(string line, Context ctx)
+    private async Task ExecFor(string line, Context ctx)
     {
         // See if this is a "for each" loop:
         if (BeginsWith(line, "each "))
         {
-            ExecForEach(GetEverythingAfter(line, "each "), ctx);
+            await ExecForEach(GetEverythingAfter(line, "each "), ctx);
             return;
         }
 
@@ -7218,7 +7219,7 @@ public partial class V4Game : IGame, IGameDebug
         // for <variable; startvalue; endvalue> script
         int endValue;
         int stepValue;
-        var forData = GetParameter(line, ctx);
+        var forData = await GetParameter(line, ctx);
 
         // Extract individual components:
         var scp1 = Strings.InStr(forData, ";");
@@ -7245,7 +7246,7 @@ public partial class V4Game : IGame, IGameDebug
              i += stepValue)
         {
             SetNumericVariableContents(counterVariable, i, ctx);
-            ExecuteScript(loopScript, ctx);
+            await ExecuteScript(loopScript, ctx);
             i = GetNumericContents(counterVariable, ctx);
         }
     }
@@ -7353,36 +7354,16 @@ public partial class V4Game : IGame, IGameDebug
         }
     }
 
-    private bool ExecuteIfAsk(string question)
+    private async Task<bool> ExecuteIfAskAsync(string question)
     {
         _player.ShowQuestion(question);
-        ChangeState(State.Waiting);
-
-        lock (_waitLock)
-        {
-            Monitor.Wait(_waitLock);
-        }
-
+        _waitTcs = new TaskCompletionSource();
+        SignalTurnSuspended();
+        await _waitTcs.Task;
         return _questionResponse;
     }
 
-    private void SetQuestionResponse(bool response)
-    {
-        var runnerThread = new Thread(SetQuestionResponseInNewThread);
-        ChangeState(State.Working);
-        runnerThread.Start(response);
-        WaitForStateChange(State.Working);
-    }
 
-    private void SetQuestionResponseInNewThread(object response)
-    {
-        _questionResponse = (bool) response;
-
-        lock (_waitLock)
-        {
-            Monitor.PulseAll(_waitLock);
-        }
-    }
 
     private bool ExecuteIfGot(string item)
     {
@@ -7665,14 +7646,14 @@ public partial class V4Game : IGame, IGameDebug
         return Conversion.Val(_numericVariable[numNumber].VariableContents[arrayIndex]);
     }
 
-    internal void PlayerErrorMessage(PlayerError e, Context ctx)
+    internal async Task PlayerErrorMessage(PlayerError e, Context ctx)
     {
-        Print(GetErrorMessage(e, ctx), ctx);
+        await Print(await GetErrorMessage(e, ctx), ctx);
     }
 
-    private void PlayerErrorMessage_ExtendInfo(PlayerError e, Context ctx, string extraInfo)
+    private async Task PlayerErrorMessage_ExtendInfo(PlayerError e, Context ctx, string extraInfo)
     {
-        var message = GetErrorMessage(e, ctx);
+        var message = await GetErrorMessage(e, ctx);
 
         if (!string.IsNullOrEmpty(extraInfo))
         {
@@ -7684,52 +7665,41 @@ public partial class V4Game : IGame, IGameDebug
             message = message + " - " + extraInfo + ".";
         }
 
-        Print(message, ctx);
+        await Print(message, ctx);
     }
 
-    private string GetErrorMessage(PlayerError e, Context ctx)
+    private async Task<string> GetErrorMessage(PlayerError e, Context ctx)
     {
-        return ConvertParameter(
-            ConvertParameter(ConvertParameter(_playerErrorMessageString[(int) e], "%", ConvertType.Numeric, ctx), "$",
+        return await ConvertParameter(
+            await ConvertParameter(await ConvertParameter(_playerErrorMessageString[(int) e], "%", ConvertType.Numeric, ctx), "$",
                 ConvertType.Functions, ctx), "#", ConvertType.Strings, ctx);
     }
 
-    private void PlayMedia(string filename)
+    private async Task PlayMediaAsync(string filename)
     {
-        PlayMedia(filename, false, false);
+        await PlayMediaAsync(filename, false, false);
     }
 
-    private void PlayMedia(string filename, bool sync, bool looped)
+    private async Task PlayMediaAsync(string filename, bool sync, bool looped)
     {
         if (filename.Length == 0)
         {
             _player.StopSound();
+            return;
         }
-        else
+
+        if (looped & sync) sync = false;
+        _player.PlaySound(filename, sync, looped);
+
+        if (sync)
         {
-            if (looped & sync)
-            {
-                sync = false; // Can't loop and sync at the same time, that would just hang!
-            }
-
-            _player.PlaySound(filename, sync, looped);
-
-            if (sync)
-            {
-                ChangeState(State.Waiting);
-            }
-
-            if (sync)
-            {
-                lock (_waitLock)
-                {
-                    Monitor.Wait(_waitLock);
-                }
-            }
+            _waitTcs = new TaskCompletionSource();
+            SignalTurnSuspended();
+            await _waitTcs.Task;
         }
     }
 
-    private void PlayWav(string parameter)
+    private async Task PlayWavAsync(string parameter)
     {
         var sync = false;
         var looped = false;
@@ -7754,7 +7724,7 @@ public partial class V4Game : IGame, IGameDebug
             filename = filename + ".wav";
         }
 
-        PlayMedia(filename, sync, looped);
+        await PlayMediaAsync(filename, sync, looped);
     }
 
     private class ArrayResult

--- a/src/PlayerCore/Player.cs
+++ b/src/PlayerCore/Player.cs
@@ -527,7 +527,7 @@ public class Player : IPlayerHelperUI
 
     public Task<byte[]> UiSaveGameAsync(string html)
     {
-        return Task.FromResult(PlayerHelper.Game.Save(html));
+        return PlayerHelper.Game.SaveAsync(html);
     }
 
     private Task Runner_Output(string text)

--- a/src/PlayerCore/WalkthroughRunner.cs
+++ b/src/PlayerCore/WalkthroughRunner.cs
@@ -45,7 +45,7 @@ internal class WalkthroughRunner(IGameDebug game, string walkthrough)
             {
                 var expr = cmd.Substring(7);
                 WriteLine("<br><b>Assert:</b> " + expr);
-                if (game.Assert(expr))
+                if (await game.AssertAsync(expr))
                 {
                     WriteLine("<br><span style=\"color:green\"><b>Pass</b></span>");
                 }

--- a/tests/EngineTests/SaveTests.cs
+++ b/tests/EngineTests/SaveTests.cs
@@ -41,7 +41,7 @@ public class SaveTests
             if (cmd.StartsWith("assert:"))
             {
                 var expr = cmd.Substring(7);
-                Assert.IsTrue(worldModel.Assert(expr), expr);
+                Assert.IsTrue(await worldModel.AssertAsync(expr), expr);
             }
             else
             {

--- a/tests/EngineTests/Walkthrough.cs
+++ b/tests/EngineTests/Walkthrough.cs
@@ -24,7 +24,7 @@ public class Walkthrough
             if (cmd.StartsWith("assert:"))
             {
                 var expr = cmd.Substring(7);
-                Assert.IsTrue(worldModel.Assert(expr), expr);
+                Assert.IsTrue(await worldModel.AssertAsync(expr), expr);
             }
             else
             {


### PR DESCRIPTION
## Summary

- Makes the Legacy V4 game interpreter (`V4Game`) fully async — no background threads, no blocking waits — so it can run on the browser's single-threaded WASM runtime
- Replaces all `Monitor.Wait/Pulse`, `Task.Run`, and `new Thread()` with `async/await` and a `TaskCompletionSource` trio (`_turnSuspendedTcs`, `_waitTcs`, `_commandTcs`) matching the Engine's Phase 3–4 pattern
- `ExecuteScript` and `ExecCommand` are now `async Task` / `async Task<bool>`, propagating async through 55+ methods across `V4Game.cs`, `V4Game.Part2.cs`, `RoomExit.cs`, and `RoomExits.cs`
- Adds `<SupportedPlatform Include="browser" />` to `Legacy.csproj` so the CA1416 analyser flags any future browser-incompatible API calls — zero such warnings with this change
- Pause points (`DoWaitAsync`, `PauseAsync`, `ShowMenuAsync`, `ExecuteIfAskAsync`, `ExecuteEnterAsync`, etc.) create a `_waitTcs`, call `SignalTurnSuspended()`, then `await _waitTcs.Task`
- `IGame` methods (`SendCommand`, `Tick`, `FinishWait`, `SetMenuResponse`, `SetQuestionResponse`) create `_turnSuspendedTcs`, fire async work, and `await _turnSuspendedTcs.Task`
- `Begin()` stays `void` fire-and-forget (`_ = DoBeginAsync()`) matching WorldModel

## Test plan

- [ ] All 304 tests pass (`dotnet test --configuration Release`)
- [ ] Zero CS4014 warnings (unawaited async calls)
- [ ] Zero CA1416 warnings (browser-incompatible APIs)
- [ ] Zero CS8632 warnings (nullable annotation context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)