### PR TITLE
Legacy: make SetStringContents and SetNumericVariableContents async

### DIFF
--- a/src/Legacy/RoomExits.cs
+++ b/src/Legacy/RoomExits.cs
@@ -301,16 +301,19 @@ internal class RoomExits
         }
     }
 
-    internal void GetAvailableDirectionsDescription(ref string description, ref string list)
+    internal async Task<(string description, string list)> GetAvailableDirectionsDescription()
     {
         RoomExit roomExit;
         int count;
         string descPrefix;
         string orString;
+        string description;
+        string list;
 
         descPrefix = "You can go";
         orString = "or";
 
+        description = "";
         list = "";
         count = 0;
 
@@ -339,12 +342,14 @@ internal class RoomExits
             }
         }
 
-        _game.SetStringContents("quest.doorways", description, _game._nullContext);
+        await _game.SetStringContents("quest.doorways", description, _game._nullContext);
 
         if (count > 0)
         {
             description = descPrefix + " " + description + ".";
         }
+
+        return (description, list);
     }
 
     public string GetDirectionName(ref V4Game.Direction dir)

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -359,14 +359,14 @@ public partial class V4Game
             if (varUbound == 0)
             {
                 data = GetNextChunk();
-                SetStringContents(appliesTo, data, _nullContext);
+                await SetStringContents(appliesTo, data, _nullContext);
             }
             else
             {
                 for (int j = 0, loopTo8 = varUbound; j <= loopTo8; j++)
                 {
                     data = GetNextChunk();
-                    SetStringContents(appliesTo, data, _nullContext, j);
+                    await SetStringContents(appliesTo, data, _nullContext, j);
                 }
             }
         }
@@ -382,14 +382,14 @@ public partial class V4Game
             if (varUbound == 0)
             {
                 data = GetNextChunk();
-                SetNumericVariableContents(appliesTo, Conversion.Val(data), _nullContext);
+                await SetNumericVariableContents(appliesTo, Conversion.Val(data), _nullContext);
             }
             else
             {
                 for (int j = 0, loopTo10 = varUbound; j <= loopTo10; j++)
                 {
                     data = GetNextChunk();
-                    SetNumericVariableContents(appliesTo, Conversion.Val(data), _nullContext, j);
+                    await SetNumericVariableContents(appliesTo, Conversion.Val(data), _nullContext, j);
                 }
             }
         }
@@ -474,7 +474,7 @@ public partial class V4Game
         _player.SetFontSize(size.ToString());
     }
 
-    private void SetNumericVariableContents(string name, double content, Context ctx, int arrayIndex = 0)
+    private async Task SetNumericVariableContents(string name, double content, Context ctx, int arrayIndex = 0)
     {
         var numNumber = default(int);
         var exists = false;
@@ -526,15 +526,12 @@ public partial class V4Game
         if (!string.IsNullOrEmpty(_numericVariable[numNumber].OnChangeScript) & !_gameIsRestoring)
         {
             var script = _numericVariable[numNumber].OnChangeScript;
-            // TODO: SetNumericVariableContents should be async Task so this can be awaited.
-            // Fire-and-forget is wrong if the OnChangeScript contains a pause/wait/menu.
-            // See https://github.com/textadventures/quest/issues/1765
-            _ = ExecuteScript(script, ctx);
+            await ExecuteScript(script, ctx);
         }
 
         if (!string.IsNullOrEmpty(_numericVariable[numNumber].DisplayString))
         {
-            _ = UpdateStatusVars(ctx);
+            await UpdateStatusVars(ctx);
         }
     }
 
@@ -597,7 +594,7 @@ public partial class V4Game
         {
             if ((Strings.LCase(_stringVariable[i].VariableName) ?? "") == (Strings.LCase(name) ?? ""))
             {
-                ExecSetString(variableData, ctx);
+                await ExecSetString(variableData, ctx);
                 return SetResult.Found;
             }
         }
@@ -606,7 +603,7 @@ public partial class V4Game
         {
             if ((Strings.LCase(_numericVariable[i].VariableName) ?? "") == (Strings.LCase(name) ?? ""))
             {
-                ExecSetVar(variableData, ctx);
+                await ExecSetVar(variableData, ctx);
                 return SetResult.Found;
             }
         }
@@ -1806,7 +1803,7 @@ public partial class V4Game
 
         _player.LocationUpdated(prefixAliasNoFormat);
 
-        SetStringContents("quest.formatroom", prefixAliasNoFormat, _nullContext);
+        await SetStringContents("quest.formatroom", prefixAliasNoFormat, _nullContext);
 
         // FIND CHARACTERS ===
 
@@ -1823,13 +1820,13 @@ public partial class V4Game
         if (charsFound == 0)
         {
             charsViewable = "There is nobody here.";
-            SetStringContents("quest.characters", "", _nullContext);
+            await SetStringContents("quest.characters", "", _nullContext);
         }
         else
         {
             // chop off final comma and add full stop (.)
             charList = Strings.Left(charsViewable, Strings.Len(charsViewable) - 2);
-            SetStringContents("quest.characters", charList, _nullContext);
+            await SetStringContents("quest.characters", charList, _nullContext);
 
             // if more than one character, add "and" before
             // last one:
@@ -1902,15 +1899,15 @@ public partial class V4Game
             }
 
             objsViewable = "There is " + objListString + " here.";
-            SetStringContents("quest.objects",
+            await SetStringContents("quest.objects",
                 Strings.Left(noFormatObjsViewable, Strings.Len(noFormatObjsViewable) - 2), _nullContext);
-            SetStringContents("quest.formatobjects", objListString, _nullContext);
+            await SetStringContents("quest.formatobjects", objListString, _nullContext);
             roomDisplayText = roomDisplayText + objsViewable + Constants.vbCrLf;
         }
         else
         {
-            SetStringContents("quest.objects", "", _nullContext);
-            SetStringContents("quest.formatobjects", "", _nullContext);
+            await SetStringContents("quest.objects", "", _nullContext);
+            await SetStringContents("quest.formatobjects", "", _nullContext);
         }
 
         // FIND DOORWAYS
@@ -2008,11 +2005,11 @@ public partial class V4Game
 
             roomDisplayText = roomDisplayText + "You can go out to " + aliasOut + "." + Constants.vbCrLf;
             possDir = possDir + "o";
-            SetStringContents("quest.doorways.out", aliasOut, _nullContext);
+            await SetStringContents("quest.doorways.out", aliasOut, _nullContext);
         }
         else
         {
-            SetStringContents("quest.doorways.out", "", _nullContext);
+            await SetStringContents("quest.doorways.out", "", _nullContext);
         }
 
         bool finished;
@@ -2041,11 +2038,11 @@ public partial class V4Game
             }
 
             roomDisplayText = roomDisplayText + "You can go " + nsew + "." + Constants.vbCrLf;
-            SetStringContents("quest.doorways.dirs", nsew, _nullContext);
+            await SetStringContents("quest.doorways.dirs", nsew, _nullContext);
         }
         else
         {
-            SetStringContents("quest.doorways.dirs", "", _nullContext);
+            await SetStringContents("quest.doorways.dirs", "", _nullContext);
         }
 
         UpdateDirButtons(possDir, _nullContext);
@@ -2077,11 +2074,11 @@ public partial class V4Game
             }
 
             roomDisplayText = roomDisplayText + "You can go to " + places + "." + Constants.vbCrLf;
-            SetStringContents("quest.doorways.places", places, _nullContext);
+            await SetStringContents("quest.doorways.places", places, _nullContext);
         }
         else
         {
-            SetStringContents("quest.doorways.places", "", _nullContext);
+            await SetStringContents("quest.doorways.places", "", _nullContext);
         }
 
         // Print RoomDisplayText if there is no "description" tag,
@@ -2238,7 +2235,7 @@ public partial class V4Game
         }
     }
 
-    private void ExecSetString(string info, Context ctx)
+    private async Task ExecSetString(string info, Context ctx)
     {
         // Sets string contents from a script parameter.
         // Eg <string1;contents> sets string variable string1
@@ -2264,7 +2261,7 @@ public partial class V4Game
         }
 
         var idx = GetArrayIndex(name, ctx);
-        SetStringContents(idx.Name, value, ctx, idx.Index);
+        await SetStringContents(idx.Name, value, ctx, idx.Index);
     }
 
     private async Task<bool> ExecUserCommand(string cmd, Context ctx, bool libCommands = false)
@@ -2501,12 +2498,12 @@ public partial class V4Game
                 }
                 else
                 {
-                    SetStringContents(varName[i], _objs[id].ObjectName, ctx, arrayIndex);
+                    await SetStringContents(varName[i], _objs[id].ObjectName, ctx, arrayIndex);
                 }
             }
             else
             {
-                SetStringContents(varName[i], curChunk, ctx, arrayIndex);
+                await SetStringContents(varName[i], curChunk, ctx, arrayIndex);
             }
         }
 
@@ -2912,7 +2909,7 @@ public partial class V4Game
                     name = Strings.Trim(Strings.Left(data, scp - 1));
                     data = Strings.Right(data, Strings.Len(data) - scp);
 
-                    SetStringContents(name, data, _nullContext);
+                    await SetStringContents(name, data, _nullContext);
                 }
             } while (data != "!n");
 
@@ -2926,7 +2923,7 @@ public partial class V4Game
                     name = Strings.Trim(Strings.Left(data, scp - 1));
                     data = Strings.Right(data, Strings.Len(data) - scp);
 
-                    SetNumericVariableContents(name, Conversion.Val(data), _nullContext);
+                    await SetNumericVariableContents(name, Conversion.Val(data), _nullContext);
                 }
             } while (data != "!e");
         }
@@ -3075,7 +3072,7 @@ public partial class V4Game
         await UpdateObjectList(ctx);
     }
 
-    internal void SetStringContents(string name, string value, Context ctx, int arrayIndex = 0)
+    internal async Task SetStringContents(string name, string value, Context ctx, int arrayIndex = 0)
     {
         var id = default(int);
         var exists = false;
@@ -3143,15 +3140,12 @@ public partial class V4Game
         if (!string.IsNullOrEmpty(_stringVariable[id].OnChangeScript))
         {
             var script = _stringVariable[id].OnChangeScript;
-            // TODO: SetStringContents should be async Task so this can be awaited.
-            // Fire-and-forget is wrong if the OnChangeScript contains a pause/wait/menu.
-            // See https://github.com/textadventures/quest/issues/1765
-            _ = ExecuteScript(script, ctx);
+            await ExecuteScript(script, ctx);
         }
 
         if (!string.IsNullOrEmpty(_stringVariable[id].DisplayString))
         {
-            _ = UpdateStatusVars(ctx);
+            await UpdateStatusVars(ctx);
         }
     }
 
@@ -3756,7 +3750,7 @@ public partial class V4Game
 
         _player.LocationUpdated(Strings.UCase(Strings.Left(roomAlias, 1)) + Strings.Mid(roomAlias, 2));
 
-        SetStringContents("quest.formatroom", roomDisplayNameNoFormat, ctx);
+        await SetStringContents("quest.formatroom", roomDisplayNameNoFormat, ctx);
 
         // SHOW OBJECTS *************************************************************
 
@@ -3810,20 +3804,20 @@ public partial class V4Game
 
         if (visibleObjectsList.Count > 0)
         {
-            SetStringContents("quest.formatobjects", visibleObjects, ctx);
+            await SetStringContents("quest.formatobjects", visibleObjects, ctx);
             visibleObjects = "There is " + visibleObjects + " here.";
-            SetStringContents("quest.objects", visibleObjectsNoFormat, ctx);
+            await SetStringContents("quest.objects", visibleObjectsNoFormat, ctx);
             roomDisplayText = roomDisplayText + visibleObjects + Constants.vbCrLf;
         }
         else
         {
-            SetStringContents("quest.objects", "", ctx);
-            SetStringContents("quest.formatobjects", "", ctx);
+            await SetStringContents("quest.objects", "", ctx);
+            await SetStringContents("quest.formatobjects", "", ctx);
         }
 
         // SHOW EXITS ***************************************************************
 
-        doorwayString = UpdateDoorways(id, ctx);
+        doorwayString = await UpdateDoorways(id, ctx);
 
         if (ASLVersion < 410)
         {
@@ -3856,11 +3850,11 @@ public partial class V4Game
                 }
 
                 roomDisplayText = roomDisplayText + "You can go to " + placeList + "." + Constants.vbCrLf;
-                SetStringContents("quest.doorways.places", placeList, ctx);
+                await SetStringContents("quest.doorways.places", placeList, ctx);
             }
             else
             {
-                SetStringContents("quest.doorways.places", "", ctx);
+                await SetStringContents("quest.doorways.places", "", ctx);
             }
         }
 
@@ -3880,7 +3874,7 @@ public partial class V4Game
             lookDesc = objLook;
         }
 
-        SetStringContents("quest.lookdesc", lookDesc, ctx);
+        await SetStringContents("quest.lookdesc", lookDesc, ctx);
 
 
         // FIND DESCRIPTION TAG, OR ACTION ******************************************
@@ -4134,7 +4128,7 @@ public partial class V4Game
             // so put input into previously specified variable
             // and exit:
 
-            SetStringContents(_commandOverrideVariable, input, ctx);
+            await SetStringContents(_commandOverrideVariable, input, ctx);
             _commandTcs!.TrySetResult();
             return false;
         }
@@ -4148,7 +4142,7 @@ public partial class V4Game
 
         input = Strings.LCase(input);
 
-        SetStringContents("quest.originalcommand", input, ctx);
+        await SetStringContents("quest.originalcommand", input, ctx);
 
         var newCommand = " " + input + " ";
 
@@ -4172,7 +4166,7 @@ public partial class V4Game
         // strip starting and ending spaces
         input = Strings.Mid(newCommand, 2, Strings.Len(newCommand) - 2);
 
-        SetStringContents("quest.command", input, ctx);
+        await SetStringContents("quest.command", input, ctx);
 
         // Execute any "beforeturn" script:
 
@@ -4770,7 +4764,7 @@ public partial class V4Game
                 if (!string.IsNullOrEmpty(script))
                 {
                     foundScript = true;
-                    SetStringContents("quest.give.object.name", _objs[id].ObjectName, ctx);
+                    await SetStringContents("quest.give.object.name", _objs[id].ObjectName, ctx);
                 }
             }
 
@@ -4781,7 +4775,7 @@ public partial class V4Game
                 if (!string.IsNullOrEmpty(script))
                 {
                     foundScript = true;
-                    SetStringContents("quest.give.object.name", _objs[giveToId].ObjectName, ctx);
+                    await SetStringContents("quest.give.object.name", _objs[giveToId].ObjectName, ctx);
                 }
             }
 
@@ -4791,13 +4785,13 @@ public partial class V4Game
             }
             else
             {
-                SetStringContents("quest.error.charactername", _objs[giveToId].ObjectName, ctx);
+                await SetStringContents("quest.error.charactername", _objs[giveToId].ObjectName, ctx);
 
                 var gender = Strings.Trim(_objs[giveToId].Gender);
                 gender = Strings.UCase(Strings.Left(gender, 1)) + Strings.Mid(gender, 2);
-                SetStringContents("quest.error.gender", gender, ctx);
+                await SetStringContents("quest.error.gender", gender, ctx);
 
-                SetStringContents("quest.error.article", article, ctx);
+                await SetStringContents("quest.error.article", article, ctx);
                 await PlayerErrorMessage(PlayerError.ItemUnwanted, ctx);
             }
         }
@@ -4838,9 +4832,9 @@ public partial class V4Game
                     article = "it";
                 }
 
-                SetStringContents("quest.error.charactername", realName, ctx);
-                SetStringContents("quest.error.gender", Strings.Trim(await GetGender(character, true, ctx)), ctx);
-                SetStringContents("quest.error.article", article, ctx);
+                await SetStringContents("quest.error.charactername", realName, ctx);
+                await SetStringContents("quest.error.gender", Strings.Trim(await GetGender(character, true, ctx)), ctx);
+                await SetStringContents("quest.error.article", article, ctx);
                 await PlayerErrorMessage(PlayerError.ItemUnwanted, ctx);
                 return;
             }
@@ -5049,7 +5043,7 @@ public partial class V4Game
 
             if (!foundSpeak)
             {
-                SetStringContents("quest.error.gender",
+                await SetStringContents("quest.error.gender",
                     Strings.UCase(Strings.Left(_objs[ObjID].Gender, 1)) + Strings.Mid(_objs[ObjID].Gender, 2), ctx);
                 await PlayerErrorMessage(PlayerError.DefaultSpeak, ctx);
                 return;
@@ -5097,8 +5091,8 @@ public partial class V4Game
             }
             else if (line == "<unfound>")
             {
-                SetStringContents("quest.error.gender", Strings.Trim(await GetGender(cmd, true, ctx)), ctx);
-                SetStringContents("quest.error.charactername", cmd, ctx);
+                await SetStringContents("quest.error.gender", Strings.Trim(await GetGender(cmd, true, ctx)), ctx);
+                await SetStringContents("quest.error.charactername", cmd, ctx);
                 await PlayerErrorMessage(PlayerError.DefaultSpeak, ctx);
             }
             else if (BeginsWith(data, "<"))
@@ -5161,7 +5155,7 @@ public partial class V4Game
             return;
         }
 
-        SetStringContents("quest.error.article", _objs[id].Article, ctx);
+        await SetStringContents("quest.error.article", _objs[id].Article, ctx);
 
         var isInContainer = false;
 
@@ -5450,7 +5444,7 @@ public partial class V4Game
                     if (!string.IsNullOrEmpty(useScript))
                     {
                         foundUseScript = true;
-                        SetStringContents("quest.use.object.name", _objs[id].ObjectName, ctx);
+                        await SetStringContents("quest.use.object.name", _objs[id].ObjectName, ctx);
                     }
                 }
 
@@ -5461,7 +5455,7 @@ public partial class V4Game
                     if (!string.IsNullOrEmpty(useScript))
                     {
                         foundUseScript = true;
-                        SetStringContents("quest.use.object.name", _objs[useOnObjectId].ObjectName, ctx);
+                        await SetStringContents("quest.use.object.name", _objs[useOnObjectId].ObjectName, ctx);
                     }
                 }
             }
@@ -5929,11 +5923,11 @@ public partial class V4Game
             }
             else if (BeginsWith(scriptLine, "setstring "))
             {
-                ExecSetString(await GetParameter(scriptLine, ctx), ctx);
+                await ExecSetString(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "setvar "))
             {
-                ExecSetVar(await GetParameter(scriptLine, ctx), ctx);
+                await ExecSetVar(await GetParameter(scriptLine, ctx), ctx);
             }
             else if (BeginsWith(scriptLine, "for "))
             {
@@ -6138,11 +6132,11 @@ public partial class V4Game
             }
             else if (BeginsWith(setInstruction, "string "))
             {
-                ExecSetString(await GetParameter(setInstruction, ctx), ctx);
+                await ExecSetString(await GetParameter(setInstruction, ctx), ctx);
             }
             else if (BeginsWith(setInstruction, "numeric "))
             {
-                ExecSetVar(await GetParameter(setInstruction, ctx), ctx);
+                await ExecSetVar(await GetParameter(setInstruction, ctx), ctx);
             }
             else if (BeginsWith(setInstruction, "collectable "))
             {
@@ -6691,7 +6685,7 @@ public partial class V4Game
 
         _currentRoom = room;
 
-        SetStringContents("quest.currentroom", room, ctx);
+        await SetStringContents("quest.currentroom", room, ctx);
 
         if ((ASLVersion >= 391) & (ASLVersion < 410))
         {
@@ -7174,7 +7168,7 @@ public partial class V4Game
         exitList.Add(new ListData(name, _listVerbs[ListType.ExitsList]));
     }
 
-    private string UpdateDoorways(int roomId, Context ctx)
+    private async Task<string> UpdateDoorways(int roomId, Context ctx)
     {
         var roomDisplayText = "";
         var outPlace = "";
@@ -7196,7 +7190,7 @@ public partial class V4Game
 
         if (ASLVersion >= 410)
         {
-            _rooms[roomId].Exits.GetAvailableDirectionsDescription(ref roomDisplayText, ref directions);
+            (roomDisplayText, directions) = await _rooms[roomId].Exits.GetAvailableDirectionsDescription();
         }
         else
         {
@@ -7304,19 +7298,19 @@ public partial class V4Game
                 directions = directions + "o";
                 if (ASLVersion >= 280)
                 {
-                    SetStringContents("quest.doorways.out", outPlaceName, ctx);
+                    await SetStringContents("quest.doorways.out", outPlaceName, ctx);
                 }
                 else
                 {
-                    SetStringContents("quest.doorways.out", outPlaceAlias, ctx);
+                    await SetStringContents("quest.doorways.out", outPlaceAlias, ctx);
                 }
 
-                SetStringContents("quest.doorways.out.display", outPlaceAlias, ctx);
+                await SetStringContents("quest.doorways.out.display", outPlaceAlias, ctx);
             }
             else
             {
-                SetStringContents("quest.doorways.out", "", ctx);
-                SetStringContents("quest.doorways.out.display", "", ctx);
+                await SetStringContents("quest.doorways.out", "", ctx);
+                await SetStringContents("quest.doorways.out.display", "", ctx);
             }
 
             if (!string.IsNullOrEmpty(nsew))
@@ -7344,11 +7338,11 @@ public partial class V4Game
                 }
 
                 roomDisplayText = roomDisplayText + "You can go " + nsew + ".";
-                SetStringContents("quest.doorways.dirs", nsew, ctx);
+                await SetStringContents("quest.doorways.dirs", nsew, ctx);
             }
             else
             {
-                SetStringContents("quest.doorways.dirs", "", ctx);
+                await SetStringContents("quest.doorways.dirs", "", ctx);
             }
         }
 
@@ -7482,13 +7476,13 @@ public partial class V4Game
 
             if (charsFound == 0)
             {
-                SetStringContents("quest.characters", "", ctx);
+                await SetStringContents("quest.characters", "", ctx);
             }
             else
             {
                 // chop off final comma and add full stop (.)
                 charList = Strings.Left(charsViewable, Strings.Len(charsViewable) - 2);
-                SetStringContents("quest.characters", charList, ctx);
+                await SetStringContents("quest.characters", charList, ctx);
             }
         }
 
@@ -7530,14 +7524,14 @@ public partial class V4Game
         {
             objListString = Strings.Left(objsViewable, Strings.Len(objsViewable) - 2);
             noFormatObjListString = Strings.Left(noFormatObjsViewable, Strings.Len(noFormatObjsViewable) - 2);
-            SetStringContents("quest.objects",
+            await SetStringContents("quest.objects",
                 Strings.Left(noFormatObjsViewable, Strings.Len(noFormatObjsViewable) - 2), ctx);
-            SetStringContents("quest.formatobjects", objListString, ctx);
+            await SetStringContents("quest.formatobjects", objListString, ctx);
         }
         else
         {
-            SetStringContents("quest.objects", "", ctx);
-            SetStringContents("quest.formatobjects", "", ctx);
+            await SetStringContents("quest.objects", "", ctx);
+            await SetStringContents("quest.formatobjects", "", ctx);
         }
 
         // FIND DOORWAYS

--- a/src/Legacy/V4Game.cs
+++ b/src/Legacy/V4Game.cs
@@ -2454,7 +2454,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (noParentSpecified & doAdd)
         {
-            SetStringContents("quest.error.article", _objs[childId].Article, ctx);
+            await SetStringContents("quest.error.article", _objs[childId].Article, ctx);
             await PlayerErrorMessage(PlayerError.BadPut, ctx);
             return;
         }
@@ -2593,7 +2593,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (foundAction)
         {
-            SetStringContents("quest." + Strings.LCase(action) + ".object.name", _objs[childId].ObjectName, ctx);
+            await SetStringContents("quest." + Strings.LCase(action) + ".object.name", _objs[childId].ObjectName, ctx);
             await ExecuteScript(actionScript, ctx, parentId);
         }
         else
@@ -3024,7 +3024,7 @@ public partial class V4Game : IGame, IGameDebug
             }
             else
             {
-                SetStringContents("quest.error.article", _objs[id].Article, ctx);
+                await SetStringContents("quest.error.article", _objs[id].Article, ctx);
 
                 var foundAction = false;
 
@@ -3736,7 +3736,7 @@ public partial class V4Game : IGame, IGameDebug
         }
 
         var arrayIndex = GetArrayIndex(variable, ctx);
-        SetNumericVariableContents(arrayIndex.Name, value, ctx, arrayIndex.Index);
+        await SetNumericVariableContents(arrayIndex.Name, value, ctx, arrayIndex.Index);
     }
 
     private Stream ExtractFile(string file)
@@ -4620,7 +4620,7 @@ public partial class V4Game : IGame, IGameDebug
 
         name = Strings.Trim(name);
 
-        SetStringContents("quest.lastobject", "", ctx);
+        await SetStringContents("quest.lastobject", "", ctx);
 
         if (Strings.InStr(containedIn, ";") != 0)
         {
@@ -4643,7 +4643,7 @@ public partial class V4Game : IGame, IGameDebug
                 {
                     if ((Strings.LCase(_objs[i].ObjectName) ?? "") == (Strings.LCase(name) ?? ""))
                     {
-                        SetStringContents("quest.lastobject", _objs[i].ObjectName, ctx);
+                        await SetStringContents("quest.lastobject", _objs[i].ObjectName, ctx);
                         return i;
                     }
                 }
@@ -4654,11 +4654,11 @@ public partial class V4Game : IGame, IGameDebug
         if ((name == "it") | (name == "them") | (name == "this") | (name == "those") | (name == "these") |
             (name == "that"))
         {
-            SetStringContents("quest.error.pronoun", name, ctx);
+            await SetStringContents("quest.error.pronoun", name, ctx);
             if ((_lastIt != 0) & (_lastItMode == ItType.Inanimate) &
                 DisambObjHere(ctx, _lastIt, firstPlace, twoPlaces, secondPlace))
             {
-                SetStringContents("quest.lastobject", _objs[_lastIt].ObjectName, ctx);
+                await SetStringContents("quest.lastobject", _objs[_lastIt].ObjectName, ctx);
                 return _lastIt;
             }
 
@@ -4668,11 +4668,11 @@ public partial class V4Game : IGame, IGameDebug
 
         if (name == "him")
         {
-            SetStringContents("quest.error.pronoun", name, ctx);
+            await SetStringContents("quest.error.pronoun", name, ctx);
             if ((_lastIt != 0) & (_lastItMode == ItType.Male) &
                 DisambObjHere(ctx, _lastIt, firstPlace, twoPlaces, secondPlace))
             {
-                SetStringContents("quest.lastobject", _objs[_lastIt].ObjectName, ctx);
+                await SetStringContents("quest.lastobject", _objs[_lastIt].ObjectName, ctx);
                 return _lastIt;
             }
 
@@ -4682,11 +4682,11 @@ public partial class V4Game : IGame, IGameDebug
 
         if (name == "her")
         {
-            SetStringContents("quest.error.pronoun", name, ctx);
+            await SetStringContents("quest.error.pronoun", name, ctx);
             if ((_lastIt != 0) & (_lastItMode == ItType.Female) &
                 DisambObjHere(ctx, _lastIt, firstPlace, twoPlaces, secondPlace))
             {
-                SetStringContents("quest.lastobject", _objs[_lastIt].ObjectName, ctx);
+                await SetStringContents("quest.lastobject", _objs[_lastIt].ObjectName, ctx);
                 return _lastIt;
             }
 
@@ -4769,7 +4769,7 @@ public partial class V4Game : IGame, IGameDebug
 
         if (numberCorresIds == 1)
         {
-            SetStringContents("quest.lastobject", _objs[idNumbers[1]].ObjectName, ctx);
+            await SetStringContents("quest.lastobject", _objs[idNumbers[1]].ObjectName, ctx);
             _thisTurnIt = idNumbers[1];
 
             switch (_objs[idNumbers[1]].Article ?? "")
@@ -4827,7 +4827,7 @@ public partial class V4Game : IGame, IGameDebug
 
             _choiceNumber = Conversions.ToInteger(response);
 
-            SetStringContents("quest.lastobject", _objs[idNumbers[_choiceNumber]].ObjectName, ctx);
+            await SetStringContents("quest.lastobject", _objs[idNumbers[_choiceNumber]].ObjectName, ctx);
 
             _thisTurnIt = idNumbers[_choiceNumber];
 
@@ -4857,7 +4857,7 @@ public partial class V4Game : IGame, IGameDebug
         }
 
         _thisTurnIt = _lastIt;
-        SetStringContents("quest.error.object", name, ctx);
+        await SetStringContents("quest.error.object", name, ctx);
         return -1;
     }
 
@@ -5033,7 +5033,7 @@ public partial class V4Game : IGame, IGameDebug
             {
                 if ((_objs[i].IsRoom == isRoom) & (_objs[i].IsExit == isExit))
                 {
-                    SetStringContents("quest.thing", _objs[i].ObjectName, ctx);
+                    await SetStringContents("quest.thing", _objs[i].ObjectName, ctx);
                     await ExecuteScript(scriptToRun, ctx);
                 }
             }
@@ -5507,18 +5507,18 @@ public partial class V4Game : IGame, IGameDebug
             {
                 if ((_currentRoom ?? "") == (_rooms[srcId].RoomName ?? ""))
                 {
-                    UpdateDoorways(srcId, ctx);
+                    await UpdateDoorways(srcId, ctx);
                 }
                 else if ((_currentRoom ?? "") == (_rooms[destId].RoomName ?? ""))
                 {
-                    UpdateDoorways(destId, ctx);
+                    await UpdateDoorways(destId, ctx);
                 }
             }
             else
             {
                 // Don't have DestID in ASL410 CreateExit code, so just UpdateDoorways
                 // for current room anyway.
-                UpdateDoorways(GetRoomID(_currentRoom, ctx), ctx);
+                await UpdateDoorways(GetRoomID(_currentRoom, ctx), ctx);
             }
         }
     }
@@ -5582,7 +5582,7 @@ public partial class V4Game : IGame, IGameDebug
             }
         }
 
-        SetStringContents("quest.error.article", _objs[id].Article, ctx);
+        await SetStringContents("quest.error.article", _objs[id].Article, ctx);
 
         if (!dropFound | BeginsWith(dropStatement, "everywhere"))
         {
@@ -6791,7 +6791,7 @@ public partial class V4Game : IGame, IGameDebug
                 var scp = Strings.InStr(pos, parameter, ";");
 
                 var parameterData = Strings.Trim(Strings.Mid(parameter, pos, scp - pos));
-                SetStringContents("quest.function.parameter." + Strings.Trim(Conversion.Str(numParameters)),
+                await SetStringContents("quest.function.parameter." + Strings.Trim(Conversion.Str(numParameters)),
                     parameterData, ctx);
 
                 newCtx.NumParameters = numParameters;
@@ -6801,11 +6801,11 @@ public partial class V4Game : IGame, IGameDebug
                 pos = scp + 1;
             } while (pos < Strings.Len(parameter));
 
-            SetStringContents("quest.function.numparameters", Strings.Trim(Conversion.Str(numParameters)), ctx);
+            await SetStringContents("quest.function.numparameters", Strings.Trim(Conversion.Str(numParameters)), ctx);
         }
         else
         {
-            SetStringContents("quest.function.numparameters", "0", ctx);
+            await SetStringContents("quest.function.numparameters", "0", ctx);
             newCtx.NumParameters = 0;
         }
 
@@ -7245,13 +7245,13 @@ public partial class V4Game : IGame, IGameDebug
              (double) stepValue >= 0 ? i <= loopTo : i >= loopTo;
              i += stepValue)
         {
-            SetNumericVariableContents(counterVariable, i, ctx);
+            await SetNumericVariableContents(counterVariable, i, ctx);
             await ExecuteScript(loopScript, ctx);
             i = GetNumericContents(counterVariable, ctx);
         }
     }
 
-    private void ExecSetVar(string varInfo, Context ctx)
+    private async Task ExecSetVar(string varInfo, Context ctx)
     {
         // Sets variable contents from a script parameter.
         // Eg <var1;7> sets numeric variable var1
@@ -7346,7 +7346,7 @@ public partial class V4Game : IGame, IGameDebug
                 }
             }
 
-            SetNumericVariableContents(idx.Name, Conversion.Val(varCont), ctx, idx.Index);
+            await SetNumericVariableContents(idx.Name, Conversion.Val(varCont), ctx, idx.Index);
         }
         catch
         {


### PR DESCRIPTION
## Summary

Fixes #1765.

- `SetStringContents` and `SetNumericVariableContents` changed from `void` to `async Task`
- Fire-and-forget `_ = ExecuteScript(...)` and `_ = UpdateStatusVars(...)` inside both methods replaced with proper `await`
- `ExecSetString` and `ExecSetVar` made `async Task` (cascade)
- `UpdateDoorways` made `async Task<string>` (cascade)
- `GetAvailableDirectionsDescription` in `RoomExits.cs` converted from `void` with `ref` params to `async Task<(string, string)>` returning a tuple (async methods cannot use `ref` parameters)
- All ~87 call sites across `V4Game.cs`, `V4Game.Part2.cs`, and `RoomExits.cs` updated to `await` the async methods

## Test plan

- [x] `dotnet build --configuration Release` — 0 errors, 0 warnings
- [x] `dotnet test tests/LegacyTests` — 8/8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)