### PR TITLE
Async NCalc: Phase 2 — make IFunction<T> async, eliminate GetAwaiter in expression evaluation

### DIFF
--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -30,17 +30,17 @@ internal class ExpressionOwner(WorldModel worldModel)
         return worldModel.Template.GetText(template);
     }
 
-    public string DynamicTemplate(string? template, params Element[] obj)
+    public Task<string> DynamicTemplate(string? template, params Element[] obj)
     {
         ArgumentNullException.ThrowIfNull(template);
-        return worldModel.Template.GetDynamicText(template, obj);
+        return worldModel.Template.GetDynamicTextAsync(template, obj);
     }
 
-    public string DynamicTemplate(string? template, string? text)
+    public Task<string> DynamicTemplate(string? template, string? text)
     {
         ArgumentNullException.ThrowIfNull(template);
         ArgumentNullException.ThrowIfNull(text);
-        return worldModel.Template.GetDynamicText(template, text);
+        return worldModel.Template.GetDynamicTextAsync(template, text);
     }
 
     public bool HasString( /* Element */ object? obj, string? property)

--- a/src/Engine/Functions/IFunction.cs
+++ b/src/Engine/Functions/IFunction.cs
@@ -2,9 +2,10 @@
 
 namespace QuestViva.Engine.Functions;
 
-public interface IFunction<out T>
+public interface IFunction<T>
 {
     T Execute(Context c);
+    Task<T> ExecuteAsync(Context c);
     string Save();
     IFunction<T> Clone();
 }
@@ -12,6 +13,7 @@ public interface IFunction<out T>
 public interface IFunctionDynamic
 {
     object Execute(Context c);
+    Task<object> ExecuteAsync(Context c);
     string Save();
     IFunctionDynamic Clone();
 }

--- a/src/Engine/Scripts/AskScript.cs
+++ b/src/Engine/Scripts/AskScript.cs
@@ -45,15 +45,14 @@ public class AskScript(
         return new AskScript(scriptContext, scriptFactory, _caption.Clone(), (IScript) callbackScript.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var caption = _caption.Execute(c);
+        var caption = await _caption.ExecuteAsync(c);
         _worldModel.PlayerUi.ShowQuestion(caption);
         _worldModel._questionTcs = new TaskCompletionSource<bool>();
         _worldModel.BeginPendingCallback();
         _worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c);
-        return Task.CompletedTask;
     }
 
     private async Task AwaitResponseAndRunCallbackAsync(Context c)

--- a/src/Engine/Scripts/CreateScript.cs
+++ b/src/Engine/Scripts/CreateScript.cs
@@ -59,18 +59,17 @@ public class CreateScript : ScriptBase
         return new CreateScript(m_scriptContext, m_expr.Clone(), m_type.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
         if (m_type == null)
         {
-            m_worldModel.ObjectFactory.CreateObject(m_expr.Execute(c));
+            m_worldModel.ObjectFactory.CreateObject(await m_expr.ExecuteAsync(c));
         }
         else
         {
-            m_worldModel.ObjectFactory.CreateObject(m_expr.Execute(c), ObjectType.Object, true,
-                new List<string> {m_type.Execute(c)});
+            m_worldModel.ObjectFactory.CreateObject(await m_expr.ExecuteAsync(c), ObjectType.Object, true,
+                new List<string> {await m_type.ExecuteAsync(c)});
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()
@@ -199,11 +198,10 @@ public class CreateExitScript : ScriptBase
             m_initialType.Clone(), m_id.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        m_worldModel.ObjectFactory.CreateExit(m_id == null ? null : m_id.Execute(c), m_name.Execute(c),
-            m_from.Execute(c), m_to.Execute(c), m_initialType == null ? null : m_initialType.Execute(c));
-        return Task.CompletedTask;
+        m_worldModel.ObjectFactory.CreateExit(m_id == null ? null : await m_id.ExecuteAsync(c), await m_name.ExecuteAsync(c),
+            await m_from.ExecuteAsync(c), await m_to.ExecuteAsync(c), m_initialType == null ? null : await m_initialType.ExecuteAsync(c));
     }
 
     public override string Save()
@@ -301,10 +299,9 @@ public class CreateTimerScript : ScriptBase
     }
 
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        m_worldModel.GetElementFactory(ElementType.Timer).Create(m_expr.Execute(c));
-        return Task.CompletedTask;
+        m_worldModel.GetElementFactory(ElementType.Timer).Create(await m_expr.ExecuteAsync(c));
     }
 
     public override string Save()
@@ -358,10 +355,9 @@ public class CreateTurnScript : ScriptBase
         return new CreateTurnScript(m_scriptContext, m_expr.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        m_worldModel.ObjectFactory.CreateTurnScript(m_expr.Execute(c), null);
-        return Task.CompletedTask;
+        m_worldModel.ObjectFactory.CreateTurnScript(await m_expr.ExecuteAsync(c), null);
     }
 
     public override string Save()

--- a/src/Engine/Scripts/DestroyScript.cs
+++ b/src/Engine/Scripts/DestroyScript.cs
@@ -38,9 +38,9 @@ public class DestroyScript : ScriptBase
         return new DestroyScript(m_scriptContext, m_expr.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var elementName = m_expr.Execute(c);
+        var elementName = await m_expr.ExecuteAsync(c);
         var element = m_worldModel.Elements.Get(elementName);
         if (element.ElemType == ElementType.Object || element.ElemType == ElementType.Timer)
         {
@@ -51,7 +51,6 @@ public class DestroyScript : ScriptBase
             throw new InvalidOperationException(
                 string.Format("Unable to destroy element of type {0}", element.ElemType));
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/DictionaryAddScript.cs
+++ b/src/Engine/Scripts/DictionaryAddScript.cs
@@ -47,19 +47,18 @@ public class DictionaryAddScript : ScriptBase
         return new DictionaryAddScript(m_scriptContext, m_dictionary.Clone(), m_key.Clone(), m_value.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var result = m_dictionary.Execute(c) as IDictionary;
+        var result = await m_dictionary.ExecuteAsync(c) as IDictionary;
 
         if (result != null)
         {
-            result.Add(m_key.Execute(c), m_value.Execute(c));
+            result.Add(await m_key.ExecuteAsync(c), await m_value.ExecuteAsync(c));
         }
         else
         {
             throw new Exception("Unrecognised dictionary type");
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()
@@ -140,19 +139,18 @@ public class DictionaryRemoveScript : ScriptBase
         return new DictionaryRemoveScript(m_scriptContext, m_dictionary.Clone(), m_key.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var result = m_dictionary.Execute(c) as IDictionary;
+        var result = await m_dictionary.ExecuteAsync(c) as IDictionary;
 
         if (result != null)
         {
-            result.Remove(m_key.Execute(c));
+            result.Remove(await m_key.ExecuteAsync(c));
         }
         else
         {
             throw new Exception("Unrecognised dictionary type");
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/DoScript.cs
+++ b/src/Engine/Scripts/DoScript.cs
@@ -67,15 +67,15 @@ public class DoActionScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var obj = m_obj.Execute(c);
-        var action = obj.GetAction(m_action.Execute(c));
+        var obj = await m_obj.ExecuteAsync(c);
+        var action = obj.GetAction(await m_action.ExecuteAsync(c));
         if (m_parameters == null)
         {
             await m_worldModel.RunScriptAsync(action, obj);
         }
         else
         {
-            await m_worldModel.RunScriptAsync(action, new Parameters(m_parameters.Execute(c)), obj);
+            await m_worldModel.RunScriptAsync(action, new Parameters(await m_parameters.ExecuteAsync(c)), obj);
         }
     }
 

--- a/src/Engine/Scripts/ErrorScript.cs
+++ b/src/Engine/Scripts/ErrorScript.cs
@@ -42,9 +42,9 @@ public class ErrorScript : ScriptBase
         return new ErrorScript(m_scriptContext, m_function.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var result = m_function.Execute(c);
+        var result = await m_function.ExecuteAsync(c);
         throw new Exception(result.ToString());
     }
 

--- a/src/Engine/Scripts/ForEachScript.cs
+++ b/src/Engine/Scripts/ForEachScript.cs
@@ -55,7 +55,7 @@ public class ForEachScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = m_list.Execute(c);
+        var result = await m_list.ExecuteAsync(c);
         IEnumerable resultList = null;
 
         if (m_scriptContext.WorldModel.Version < WorldModelVersion.v530 || !(result is string))

--- a/src/Engine/Scripts/ForScript.cs
+++ b/src/Engine/Scripts/ForScript.cs
@@ -87,9 +87,9 @@ public class ForScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var from = m_from.Execute(c);
-        var to = m_to.Execute(c);
-        var step = m_step == null ? 1 : m_step.Execute(c);
+        var from = await m_from.ExecuteAsync(c);
+        var to = await m_to.ExecuteAsync(c);
+        var step = m_step == null ? 1 : await m_step.ExecuteAsync(c);
         int count;
         c.Parameters[m_variable] = 0;
 

--- a/src/Engine/Scripts/FunctionCallScript.cs
+++ b/src/Engine/Scripts/FunctionCallScript.cs
@@ -134,7 +134,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
             var cnt = 0;
             foreach (var f in m_parameters.Parameters)
             {
-                paramValues.Add((string) paramNames[cnt], f.Execute(c));
+                paramValues.Add((string) paramNames[cnt], await f.ExecuteAsync(c));
                 cnt++;
             }
 

--- a/src/Engine/Scripts/IfScript.cs
+++ b/src/Engine/Scripts/IfScript.cs
@@ -426,7 +426,7 @@ public class IfScript : ScriptBase, IIfScript
 
     public override async Task ExecuteAsync(Context c)
     {
-        if (Expression.Execute(c))
+        if (await Expression.ExecuteAsync(c))
         {
             await ThenScript.ExecuteAsync(c);
             return;
@@ -436,7 +436,7 @@ public class IfScript : ScriptBase, IIfScript
         {
             foreach (ElseIfScript elseIfScript in m_elseIfScript)
             {
-                if (elseIfScript.Expression.Execute(c))
+                if (await elseIfScript.Expression.ExecuteAsync(c))
                 {
                     await elseIfScript.Script.ExecuteAsync(c);
                     return;

--- a/src/Engine/Scripts/InsertScript.cs
+++ b/src/Engine/Scripts/InsertScript.cs
@@ -38,7 +38,7 @@ public class InsertScript : ScriptBase
         return new InsertScript(m_scriptContext, m_filename.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
         if (m_worldModel.Version >= WorldModelVersion.v540)
         {
@@ -46,27 +46,26 @@ public class InsertScript : ScriptBase
                 "The 'insert' script command is not supported for games written for Quest 5.4 or later. You can output HTML directly using the 'msg' command instead.");
         }
 
-        var filename = m_filename.Execute(c);
+        var filename = await m_filename.ExecuteAsync(c);
         if (m_worldModel.Version == WorldModelVersion.v500)
         {
             // v500 games used Frame.htm for static panel feature. This is now implemented natively
             // in Player and WebPlayer.
             if (filename.ToLower() == "frame.htm")
             {
-                return Task.CompletedTask;
+                return;
             }
         }
 
         var stream = m_worldModel.GetResourceStream(filename);
         if (stream == null)
         {
-            return Task.CompletedTask;
+            return;
         }
 
         using var reader = new StreamReader(stream);
         var html = reader.ReadToEnd();
         m_worldModel.PlayerUi.WriteHTML(html);
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/InvokeScript.cs
+++ b/src/Engine/Scripts/InvokeScript.cs
@@ -57,14 +57,14 @@ public class InvokeScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var script = m_script.Execute(c);
+        var script = await m_script.ExecuteAsync(c);
         if (m_parameters == null)
         {
             await m_worldModel.RunScriptAsync(script);
         }
         else
         {
-            await m_worldModel.RunScriptAsync(script, new Parameters(m_parameters.Execute(c)));
+            await m_worldModel.RunScriptAsync(script, new Parameters(await m_parameters.ExecuteAsync(c)));
         }
     }
 

--- a/src/Engine/Scripts/JSScript.cs
+++ b/src/Engine/Scripts/JSScript.cs
@@ -61,23 +61,22 @@ public class JSScript : ScriptBase
             m_parameters == null ? null : new List<IFunctionDynamic>(m_parameters));
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
         if (string.IsNullOrEmpty(m_function))
         {
-            return Task.CompletedTask;
+            return;
         }
 
         if (m_parameters != null)
         {
-            var paramValues = m_parameters.Select(p => p.Execute(c));
-            m_scriptContext.WorldModel.PlayerUi.RunScript(m_function, paramValues.ToArray());
+            var paramValues = await Task.WhenAll(m_parameters.Select(p => p.ExecuteAsync(c)));
+            m_scriptContext.WorldModel.PlayerUi.RunScript(m_function, paramValues);
         }
         else
         {
             m_scriptContext.WorldModel.PlayerUi.RunScript(m_function, null);
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/ListAddScript.cs
+++ b/src/Engine/Scripts/ListAddScript.cs
@@ -42,19 +42,18 @@ public class ListAddScript : ScriptBase
         return new ListAddScript(m_scriptContext, m_list.Clone(), m_value.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var result = m_list.Execute(c) as IQuestList;
+        var result = await m_list.ExecuteAsync(c) as IQuestList;
 
         if (result != null)
         {
-            result.Add(m_value.Execute(c));
+            result.Add(await m_value.ExecuteAsync(c));
         }
         else
         {
             throw new Exception("Unrecognised list type");
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()
@@ -130,19 +129,18 @@ public class ListRemoveScript : ScriptBase
         return new ListRemoveScript(m_scriptContext, m_list.Clone(), m_value.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var result = m_list.Execute(c) as IQuestList;
+        var result = await m_list.ExecuteAsync(c) as IQuestList;
 
         if (result != null)
         {
-            result.Remove(m_value.Execute(c));
+            result.Remove(await m_value.ExecuteAsync(c));
         }
         else
         {
             throw new Exception("Unrecognised list type");
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/MsgScript.cs
+++ b/src/Engine/Scripts/MsgScript.cs
@@ -42,11 +42,10 @@ public class MsgScript : ScriptBase
         return new MsgScript(m_scriptContext, m_function.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var result = m_function.Execute(c);
+        var result = await m_function.ExecuteAsync(c);
         m_worldModel.Print(result.ToString());
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/PictureScript.cs
+++ b/src/Engine/Scripts/PictureScript.cs
@@ -38,9 +38,9 @@ public class PictureScript : ScriptBase
         return new PictureScript(m_scriptContext, m_filename.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var filename = m_filename.Execute(c);
+        var filename = await m_filename.ExecuteAsync(c);
 
         if (m_worldModel.Version >= WorldModelVersion.v540)
         {
@@ -51,7 +51,6 @@ public class PictureScript : ScriptBase
             m_worldModel.PlayerUi.ShowPicture(filename);
             ((LegacyOutputLogger) m_worldModel.OutputLogger).AddPicture(filename);
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/PlaySoundScript.cs
+++ b/src/Engine/Scripts/PlaySoundScript.cs
@@ -48,9 +48,9 @@ public class PlaySoundScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var filename = m_filename.Execute(c);
-        var synchronous = m_synchronous.Execute(c);
-        var loop = m_loop.Execute(c);
+        var filename = await m_filename.ExecuteAsync(c);
+        var synchronous = await m_synchronous.ExecuteAsync(c);
+        var loop = await m_loop.ExecuteAsync(c);
 
         if (synchronous)
         {

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -71,7 +71,7 @@ public class RequestScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var data = m_data.Execute(c);
+        var data = await m_data.ExecuteAsync(c);
 
         // TO DO: Replace with dictionary mapping the enum to lambda functions
         switch (m_request)

--- a/src/Engine/Scripts/RequestSpeakScript.cs
+++ b/src/Engine/Scripts/RequestSpeakScript.cs
@@ -48,11 +48,10 @@ public class RequestSpeakScript : ScriptBase
         return new RequestSpeakScript(m_scriptContext, m_function.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var result = m_function.Execute(c);
+        var result = await m_function.ExecuteAsync(c);
         m_worldModel.PlayerUi.Speak(result.ToString());
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/ReturnScript.cs
+++ b/src/Engine/Scripts/ReturnScript.cs
@@ -38,16 +38,15 @@ public class ReturnScript : ScriptBase
         return new ReturnScript(m_scriptContext, m_returnValue.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        c.ReturnValue = m_returnValue.Execute(c);
+        c.ReturnValue = await m_returnValue.ExecuteAsync(c);
         // Leaving this set to v550 for backwards compatibility
         // Some things do not work in 550 games when this is changed to 580
         if (m_worldModel.Version >= WorldModelVersion.v550)
         {
             c.IsReturned = true;
         }
-        return Task.CompletedTask;
     }
 
     public override string Save()

--- a/src/Engine/Scripts/RunDelegateScript.cs
+++ b/src/Engine/Scripts/RunDelegateScript.cs
@@ -77,8 +77,8 @@ public class RunDelegateScript : ScriptBase
             throw new NotImplementedException();
         }
 
-        var obj = m_appliesTo.Execute(c);
-        var delName = m_delegate.Execute(c);
+        var obj = await m_appliesTo.ExecuteAsync(c);
+        var delName = await m_delegate.ExecuteAsync(c);
         var impl = obj.Fields.Get(delName) as DelegateImplementation;
 
         if (impl == null)
@@ -92,7 +92,7 @@ public class RunDelegateScript : ScriptBase
         var cnt = 0;
         foreach (var f in m_parameters.Parameters)
         {
-            paramValues.Add((string) impl.Definition.Fields[FieldDefinitions.ParamNames][cnt], f.Execute(c));
+            paramValues.Add((string) impl.Definition.Fields[FieldDefinitions.ParamNames][cnt], await f.ExecuteAsync(c));
             cnt++;
         }
 

--- a/src/Engine/Scripts/SetFieldScript.cs
+++ b/src/Engine/Scripts/SetFieldScript.cs
@@ -46,8 +46,8 @@ public class SetFieldScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var obj = m_obj.Execute(c);
-        await obj.SetFieldAsync(m_field.Execute(c), m_value.Execute(c));
+        var obj = await m_obj.ExecuteAsync(c);
+        await obj.SetFieldAsync(await m_field.ExecuteAsync(c), await m_value.ExecuteAsync(c));
     }
 
     public override string Save()

--- a/src/Engine/Scripts/SetScript.cs
+++ b/src/Engine/Scripts/SetScript.cs
@@ -145,7 +145,7 @@ public abstract class SetScriptBase : ScriptBase
         if (AppliesTo != null)
         {
             // we're setting an object property
-            var obj = AppliesTo.Execute(c);
+            var obj = await AppliesTo.ExecuteAsync(c);
             await obj.SetFieldAsync(Property, result);
         }
         else
@@ -251,7 +251,7 @@ public class SetExpressionScript : SetScriptBase
         var result = await m_expr.ExecuteAsync(c);
         if (AppliesTo != null)
         {
-            var obj = AppliesTo.Execute(c);
+            var obj = await AppliesTo.ExecuteAsync(c);
             await obj.SetFieldAsync(Property, result);
         }
         else

--- a/src/Engine/Scripts/SetScript.cs
+++ b/src/Engine/Scripts/SetScript.cs
@@ -138,23 +138,6 @@ public abstract class SetScriptBase : ScriptBase
         }
     }
 
-    public override async Task ExecuteAsync(Context c)
-    {
-        var result = GetResult(c);
-
-        if (AppliesTo != null)
-        {
-            // we're setting an object property
-            var obj = await AppliesTo.ExecuteAsync(c);
-            await obj.SetFieldAsync(Property, result);
-        }
-        else
-        {
-            // we're setting a local variable
-            c.Parameters[Property] = result;
-        }
-    }
-
     public override string Save()
     {
         string result;
@@ -214,7 +197,6 @@ public abstract class SetScriptBase : ScriptBase
         return base.GetDefinedVariables();
     }
 
-    protected abstract object GetResult(Context c);
     protected abstract string GetSaveString();
     protected abstract object GetValue();
     protected abstract void SetValue(string newValue);
@@ -239,11 +221,6 @@ public class SetExpressionScript : SetScriptBase
     {
         return new SetExpressionScript(Constructor, m_scriptContext, AppliesTo == null ? null : AppliesTo.Clone(),
             Property, (Expression<object>) m_expr.Clone());
-    }
-
-    protected override object GetResult(Context c)
-    {
-        return m_expr.Execute(c);
     }
 
     public override async Task ExecuteAsync(Context c)
@@ -299,9 +276,17 @@ public class SetScriptScript : SetScriptBase
             (IScript) m_script.Clone());
     }
 
-    protected override object GetResult(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        return m_script;
+        if (AppliesTo != null)
+        {
+            var obj = await AppliesTo.ExecuteAsync(c);
+            await obj.SetFieldAsync(Property, m_script);
+        }
+        else
+        {
+            c.Parameters[Property] = m_script;
+        }
     }
 
     protected override string GetSaveString()

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -61,11 +61,11 @@ public class ShowMenuScript : ScriptBase
             m_allowCancel.Clone(), (IScript) m_callbackScript.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        var caption = m_caption.Execute(c);
-        var options = m_options.Execute(c);
-        var allowCancel = m_allowCancel.Execute(c);
+        var caption = await m_caption.ExecuteAsync(c);
+        var options = await m_options.ExecuteAsync(c);
+        var allowCancel = await m_allowCancel.ExecuteAsync(c);
 
         IDictionary<string, string> optionsDictionary;
         if (options is IList<string> stringListOptions)
@@ -91,7 +91,6 @@ public class ShowMenuScript : ScriptBase
         m_worldModel.BeginPendingCallback();
         m_worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c, optionsDictionary);
-        return Task.CompletedTask;
     }
 
     private async Task AwaitResponseAndRunCallbackAsync(Context c, IDictionary<string, string> optionsDictionary)

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -119,7 +119,7 @@ public class SwitchScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = m_expr.Execute(c);
+        var result = await m_expr.ExecuteAsync(c);
         var success = await m_cases.ExecuteAsync(c, result.ToString());
 
         if (!success && m_default != null)
@@ -241,7 +241,7 @@ public class SwitchScript : ScriptBase
             {
                 var expr = m_compiledExpressions[switchCase.Key];
 
-                if (result == expr.Execute(c).ToString())
+                if (result == (await expr.ExecuteAsync(c)).ToString())
                 {
                     await switchCase.Value.ExecuteAsync(c);
                     return true;

--- a/src/Engine/Scripts/UndoScript.cs
+++ b/src/Engine/Scripts/UndoScript.cs
@@ -91,10 +91,9 @@ public class StartTransactionScript : ScriptBase
         return new StartTransactionScript(m_scriptContext, m_command.Clone());
     }
 
-    public override Task ExecuteAsync(Context c)
+    public override async Task ExecuteAsync(Context c)
     {
-        m_worldModel.UndoLogger.RollTransaction(m_command.Execute(c));
-        return Task.CompletedTask;
+        m_worldModel.UndoLogger.RollTransaction(await m_command.ExecuteAsync(c));
     }
 
     public override string Save()

--- a/src/Engine/Scripts/WhileScript.cs
+++ b/src/Engine/Scripts/WhileScript.cs
@@ -54,7 +54,7 @@ public class WhileScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        while (m_expression.Execute(c))
+        while (await m_expression.ExecuteAsync(c))
         {
             await m_loopScript.ExecuteAsync(c);
             if (c.IsReturned)

--- a/src/Engine/Templates.cs
+++ b/src/Engine/Templates.cs
@@ -105,6 +105,42 @@ public partial class Template
         return template.Fields[FieldDefinitions.Function].Execute(c);
     }
 
+    public Task<string> GetDynamicTextAsync(string t, params Element[] obj)
+    {
+        Parameters parameters;
+        if (obj.Length == 1)
+        {
+            parameters = new Parameters("object", obj[0]);
+        }
+        else
+        {
+            parameters = new Parameters();
+            for (var i = 0; i < obj.Length; i++)
+            {
+                parameters.Add("object" + (i + 1), obj[i]);
+            }
+        }
+        return GetDynamicTextInternalAsync(t, parameters);
+    }
+
+    public Task<string> GetDynamicTextAsync(string t, string text)
+    {
+        return GetDynamicTextInternalAsync(t, new Parameters("text", text));
+    }
+
+    private async Task<string> GetDynamicTextInternalAsync(string t, Parameters parameters)
+    {
+        if (!m_worldModel.Elements.ContainsKey(ElementType.DynamicTemplate, t))
+        {
+            return GetText(t);
+        }
+
+        var c = new Context();
+        c.Parameters = parameters;
+        var template = m_worldModel.Elements.Get(ElementType.DynamicTemplate, t);
+        return await template.Fields[FieldDefinitions.Function].ExecuteAsync(c);
+    }
+
     internal Element AddVerbTemplate(string c, string text, string filename)
     {
         Element template;

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -531,7 +531,7 @@ public partial class WorldModel : IGame, IGameDebug
     {
         var expression = new Expression<bool>(expr, new ScriptContext(this));
         var c = new Context();
-        return Task.FromResult(expression.Execute(c));
+        return expression.ExecuteAsync(c);
     }
 
     public event EventHandler<ElementFieldUpdatedEventArgs>? ElementFieldUpdated;


### PR DESCRIPTION
Closes #1769

## Summary

- Adds `Task<T> ExecuteAsync(Context c)` to `IFunction<T>` and `Task<object> ExecuteAsync(Context c)` to `IFunctionDynamic` (removing the `out` variance, which is incompatible with `Task<T>`)
- Migrates all 28 script `ExecuteAsync` methods to `await expr.ExecuteAsync(c)` instead of calling the sync `Execute(c)` (which bottomed out in `GetAwaiter().GetResult()`)
- Removes the dead `GetResult` abstract pattern from `SetScript` — `SetExpressionScript.GetResult` was never reachable since that class fully overrides `ExecuteAsync`
- Adds `GetDynamicTextAsync` / `GetDynamicTextInternalAsync` to `Templates` and makes `ExpressionOwner.DynamicTemplate` return `Task<string>`, so the expression-evaluation path through `DynamicTemplate(...)` is fully async (NCalc's reflective dispatcher already handles `Task`-returning methods)

## Remaining sync path

The sync `GetDynamicText` / `GetDynamicTextInternal` overloads in `Templates` are retained for `UndoLogger.DoUndo`, which is the only remaining caller of `IFunction<T>.Execute` in game-play code. That is tracked in #1771.

## Test plan

- [x] All 313 tests pass
- [x] Full solution builds with 0 warnings