### PR TITLE
Phase 3: Make RunProcedure async — eliminate last GetAwaiter in WorldModel

### DIFF
--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -494,13 +494,13 @@ internal class ExpressionOwner(WorldModel worldModel)
     {
         ArgumentNullException.ThrowIfNull(caption);
         ArgumentNullException.ThrowIfNull(options);
-        worldModel.Print(caption);
+        await worldModel.PrintAsync(caption);
         var menuData = new MenuData(caption, options, allowCancel);
         worldModel.PlayerUi.ShowMenu(menuData);
         worldModel._menuTcs = new TaskCompletionSource<string?>();
         worldModel.SignalTurnSuspended();
         var result = await worldModel._menuTcs.Task;
-        if (result != null) worldModel.Print(" - " + options[result]);
+        if (result != null) await worldModel.PrintAsync(" - " + options[result]);
         return result ?? string.Empty;
     }
 

--- a/src/Engine/Scripts/ForEachScript.cs
+++ b/src/Engine/Scripts/ForEachScript.cs
@@ -58,6 +58,9 @@ public class ForEachScript : ScriptBase
         var result = await m_list.ExecuteAsync(c);
         IEnumerable resultList = null;
 
+        // Cannot foreach over strings as of Quest 5.3, as the Char data type is not supported (retained functionality
+        // for pre-5.3 to prevent breaking existing scripts)
+
         if (m_scriptContext.WorldModel.Version < WorldModelVersion.v530 || !(result is string))
         {
             var resultDictionary = result as IDictionary;

--- a/src/Engine/Scripts/ForScript.cs
+++ b/src/Engine/Scripts/ForScript.cs
@@ -109,6 +109,7 @@ public class ForScript : ScriptBase
             }
             else
             {
+                // The type of the count variable has changed, so abort the loop
                 break;
             }
         }

--- a/src/Engine/Scripts/MsgScript.cs
+++ b/src/Engine/Scripts/MsgScript.cs
@@ -45,7 +45,7 @@ public class MsgScript : ScriptBase
     public override async Task ExecuteAsync(Context c)
     {
         var result = await m_function.ExecuteAsync(c);
-        m_worldModel.Print(result.ToString());
+        await m_worldModel.PrintAsync(result.ToString());
     }
 
     public override string Save()

--- a/src/Engine/Scripts/PictureScript.cs
+++ b/src/Engine/Scripts/PictureScript.cs
@@ -44,7 +44,7 @@ public class PictureScript : ScriptBase
 
         if (m_worldModel.Version >= WorldModelVersion.v540)
         {
-            m_worldModel.Print("<img src=\"" + m_worldModel.ExpressionOwner.GetFileURL(filename) + "\" />");
+            await m_worldModel.PrintAsync("<img src=\"" + m_worldModel.ExpressionOwner.GetFileURL(filename) + "\" />");
         }
         else
         {

--- a/src/Engine/Scripts/SetScript.cs
+++ b/src/Engine/Scripts/SetScript.cs
@@ -228,11 +228,13 @@ public class SetExpressionScript : SetScriptBase
         var result = await m_expr.ExecuteAsync(c);
         if (AppliesTo != null)
         {
+            // we're setting an object property
             var obj = await AppliesTo.ExecuteAsync(c);
             await obj.SetFieldAsync(Property, result);
         }
         else
         {
+            // we're setting a local variable
             c.Parameters[Property] = result;
         }
     }
@@ -280,11 +282,13 @@ public class SetScriptScript : SetScriptBase
     {
         if (AppliesTo != null)
         {
+            // we're setting an object property
             var obj = await AppliesTo.ExecuteAsync(c);
             await obj.SetFieldAsync(Property, m_script);
         }
         else
         {
+            // we're setting a local variable
             c.Parameters[Property] = m_script;
         }
     }

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -83,7 +83,7 @@ public class ShowMenuScript : ScriptBase
             throw new Exception("Unknown menu options type");
         }
 
-        m_worldModel.Print(caption);
+        await m_worldModel.PrintAsync(caption);
         var menuData = new MenuData(caption, optionsDictionary, allowCancel);
         m_worldModel.PlayerUi.ShowMenu(menuData);
 
@@ -99,7 +99,7 @@ public class ShowMenuScript : ScriptBase
         {
             var response = await m_worldModel._menuTcs!.Task;
             if (response != null)
-                m_worldModel.Print(" - " + optionsDictionary[response]);
+                await m_worldModel.PrintAsync(" - " + optionsDictionary[response]);
             c.Parameters["result"] = response;
             await m_worldModel.RunScriptAsync(m_callbackScript, c);
         }

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -120,6 +120,7 @@ public class SwitchScript : ScriptBase
     public override async Task ExecuteAsync(Context c)
     {
         var result = await m_expr.ExecuteAsync(c);
+        // using .ToString() here as an object comparison of ints won't work
         var success = await m_cases.ExecuteAsync(c, result.ToString());
 
         if (!success && m_default != null)

--- a/src/Engine/UndoLogger.cs
+++ b/src/Engine/UndoLogger.cs
@@ -101,7 +101,7 @@ public class UndoLogger
         {
             if (m_worldModel.Template.TemplateExists(NothingToUndoTemplate))
             {
-                m_worldModel.PrintTemplate("NothingToUndo");
+                await m_worldModel.PrintTemplateAsync("NothingToUndo");
             }
             else
             {
@@ -185,7 +185,7 @@ public class UndoLogger
             {
                 if (worldModel.Template.DynamicTemplateExists(undoTurnTemplate))
                 {
-                    worldModel.Print(await worldModel.Template.GetDynamicTextAsync(undoTurnTemplate, Description));
+                    await worldModel.PrintAsync(await worldModel.Template.GetDynamicTextAsync(undoTurnTemplate, Description));
                 }
             }
 

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -1058,6 +1058,10 @@ public partial class WorldModel : IGame, IGameDebug
         {
             var function = Elements.Get(ElementType.Function, name);
 
+            // Only check for too few parameters for games for Quest 5.2 or later, as previous Quest versions
+            // would ignore this (but would usually still fail when the function was run, as the required
+            // variable wouldn't exist). For Quest 5.3, an additional check if parameters is non-null but empty.
+
             var parametersInvalid = false;
             if (Version == WorldModelVersion.v520)
             {

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -221,14 +221,14 @@ public partial class WorldModel : IGame, IGameDebug
             }
 
             await TryRunOnFinallyScriptsAsync();
-            UpdateLists();
+            await UpdateListsAsync();
 
             if (_loadedFromSaved)
             {
                 var output = Elements.GetSingle(ElementType.Output);
                 if (output == null)
                 {
-                    Print("Loaded saved game");
+                    await PrintAsync("Loaded saved game");
                 }
                 else if (Version >= WorldModelVersion.v540)
                 {
@@ -295,8 +295,8 @@ public partial class WorldModel : IGame, IGameDebug
             {
                 if (Version < WorldModelVersion.v520)
                 {
-                    Print("");
-                    Print("> " + Utility.SafeXML(command));
+                    await PrintAsync("");
+                    await PrintAsync("> " + Utility.SafeXML(command));
                 }
 
                 await RunProcedureAsync("HandleCommand", new Parameters(new Dictionary<string, object>
@@ -312,7 +312,7 @@ public partial class WorldModel : IGame, IGameDebug
 
                 if (State != GameState.Finished)
                 {
-                    UpdateLists();
+                    await UpdateListsAsync();
                 }
             }
             else
@@ -347,7 +347,7 @@ public partial class WorldModel : IGame, IGameDebug
 
         if (handler == null)
         {
-            Print($"Error - no handler for event '{eventName}'");
+            await PrintAsync($"Error - no handler for event '{eventName}'");
             return;
         }
 
@@ -366,7 +366,7 @@ public partial class WorldModel : IGame, IGameDebug
 
         if (State != GameState.Finished)
         {
-            UpdateLists();
+            await UpdateListsAsync();
         }
 
         SendNextTimerRequest();
@@ -468,7 +468,7 @@ public partial class WorldModel : IGame, IGameDebug
             {
                 await RunScriptAsync(timerScript.Value, timerScript.Key);
             }
-            UpdateLists();
+            await UpdateListsAsync();
         }
         catch (Exception ex)
         {
@@ -615,18 +615,28 @@ public partial class WorldModel : IGame, IGameDebug
         return _elementFactories[t];
     }
 
-    public void PrintTemplate(string t)
+    public Task PrintTemplateAsync(string t)
     {
-        Print(Template.GetText(t));
+        return PrintAsync(Template.GetText(t));
     }
 
     public void Print(string text, bool linebreak = true)
+    {
+        if (EditMode) return;
+        if (PrintText != null)
+        {
+            PrintText(linebreak ? "<output>" + text + "</output>" : "<output nobr=\"true\">" + text + "</output>");
+        }
+        _legacyOutputLogger?.AddText(text, linebreak);
+    }
+
+    public async Task PrintAsync(string text, bool linebreak = true)
     {
         if (!EditMode && Version >= WorldModelVersion.v540 && Elements.ContainsKey(ElementType.Function, "OutputText"))
         {
             try
             {
-                RunProcedure("OutputText", new Parameters(new Dictionary<string, string> {{"text", text}}), false);
+                await RunProcedureAsync("OutputText", new Parameters(new Dictionary<string, string> {{"text", text}}), false);
             }
             catch (Exception ex)
             {
@@ -656,11 +666,11 @@ public partial class WorldModel : IGame, IGameDebug
         return new QuestList<Element>(Elements.Objects);
     }
 
-    private QuestList<Element> GetObjectsInScope(string scopeFunction)
+    private async Task<QuestList<Element>> GetObjectsInScopeAsync(string scopeFunction)
     {
         if (Elements.ContainsKey(ElementType.Function, scopeFunction))
         {
-            return (QuestList<Element>?) RunProcedure(scopeFunction, true) ?? new QuestList<Element>();
+            return (QuestList<Element>?) await RunProcedureAsync(scopeFunction, null, true) ?? new QuestList<Element>();
         }
 
         throw new Exception($"No function '{scopeFunction}'");
@@ -778,7 +788,7 @@ public partial class WorldModel : IGame, IGameDebug
         _loadedFromSaved = true;
     }
 
-    private void UpdateStatusVariables()
+    private async Task UpdateStatusVariablesAsync()
     {
         if (!Elements.ContainsKey(ElementType.Function, "UpdateStatusAttributes"))
         {
@@ -787,7 +797,7 @@ public partial class WorldModel : IGame, IGameDebug
 
         try
         {
-            RunProcedure("UpdateStatusAttributes");
+            await RunProcedureAsync("UpdateStatusAttributes");
         }
         catch (Exception ex)
         {
@@ -795,20 +805,20 @@ public partial class WorldModel : IGame, IGameDebug
         }
     }
 
-    private void UpdateLists()
+    private async Task UpdateListsAsync()
     {
-        UpdateObjectsList();
-        UpdateExitsList();
-        UpdateStatusVariables();
+        await UpdateObjectsListAsync();
+        await UpdateExitsListAsync();
+        await UpdateStatusVariablesAsync();
     }
 
-    private void UpdateObjectsList()
+    private async Task UpdateObjectsListAsync()
     {
-        UpdateObjectsList("GetPlacesObjectsList", ListType.ObjectsList);
-        UpdateObjectsList("ScopeInventory", ListType.InventoryList);
+        await UpdateObjectsListAsync("GetPlacesObjectsList", ListType.ObjectsList);
+        await UpdateObjectsListAsync("ScopeInventory", ListType.InventoryList);
     }
 
-    private void UpdateObjectsList(string scope, ListType listType)
+    private async Task UpdateObjectsListAsync(string scope, ListType listType)
     {
         if (UpdateList == null)
         {
@@ -816,25 +826,25 @@ public partial class WorldModel : IGame, IGameDebug
         }
 
         var objects = new List<ListData>();
-        foreach (var obj in GetObjectsInScope(scope))
+        foreach (var obj in await GetObjectsInScopeAsync(scope))
         {
             if (Version <= WorldModelVersion.v520 || !Elements.ContainsKey(ElementType.Function, "GetDisplayVerbs"))
             {
                 if (scope == "ScopeInventory")
                 {
-                    objects.Add(new ListData(GetListDisplayAlias(obj), obj.Fields[FieldDefinitions.InventoryVerbs],
-                        obj.Name, GetDisplayAlias(obj)));
+                    objects.Add(new ListData(await GetListDisplayAliasAsync(obj), obj.Fields[FieldDefinitions.InventoryVerbs],
+                        obj.Name, await GetDisplayAliasAsync(obj)));
                 }
                 else
                 {
-                    objects.Add(new ListData(GetListDisplayAlias(obj), obj.Fields[FieldDefinitions.DisplayVerbs],
-                        obj.Name, GetDisplayAlias(obj)));
+                    objects.Add(new ListData(await GetListDisplayAliasAsync(obj), obj.Fields[FieldDefinitions.DisplayVerbs],
+                        obj.Name, await GetDisplayAliasAsync(obj)));
                 }
             }
             else
             {
                 objects.Add(
-                    new ListData(GetListDisplayAlias(obj), GetDisplayVerbs(obj), obj.Name, GetDisplayAlias(obj)));
+                    new ListData(await GetListDisplayAliasAsync(obj), await GetDisplayVerbsAsync(obj), obj.Name, await GetDisplayAliasAsync(obj)));
             }
         }
 
@@ -843,43 +853,46 @@ public partial class WorldModel : IGame, IGameDebug
         // directional exits so they only display in the compass)
         if (scope == "GetPlacesObjectsList")
         {
-            objects.AddRange(GetExitsListData());
+            objects.AddRange(await GetExitsListDataAsync());
         }
 
         UpdateList(listType, objects);
     }
 
-    private void UpdateExitsList()
+    private async Task UpdateExitsListAsync()
     {
-        UpdateList?.Invoke(ListType.ExitsList, GetExitsListData());
+        if (UpdateList != null)
+        {
+            UpdateList(ListType.ExitsList, await GetExitsListDataAsync());
+        }
     }
 
-    private string GetListDisplayAlias(Element obj)
+    private async Task<string> GetListDisplayAliasAsync(Element obj)
     {
         if (Elements.ContainsKey(ElementType.Function, "GetListDisplayAlias"))
         {
-            return (string) RunProcedure("GetListDisplayAlias", new Parameters("obj", obj), true)!;
+            return (string) (await RunProcedureAsync("GetListDisplayAlias", new Parameters("obj", obj), true))!;
         }
 
-        return GetDisplayAlias(obj);
+        return await GetDisplayAliasAsync(obj);
     }
 
-    private string GetDisplayAlias(Element obj)
+    private async Task<string> GetDisplayAliasAsync(Element obj)
     {
         if (Elements.ContainsKey(ElementType.Function, "GetDisplayAlias"))
         {
-            return (string) RunProcedure("GetDisplayAlias", new Parameters("obj", obj), true)!;
+            return (string) (await RunProcedureAsync("GetDisplayAlias", new Parameters("obj", obj), true))!;
         }
 
         return obj.Name;
     }
 
-    private IEnumerable<string> GetDisplayVerbs(Element obj)
+    private async Task<IEnumerable<string>> GetDisplayVerbsAsync(Element obj)
     {
-        return (QuestList<string>) RunProcedure("GetDisplayVerbs", new Parameters("object", obj), true)!;
+        return (QuestList<string>) (await RunProcedureAsync("GetDisplayVerbs", new Parameters("object", obj), true))!;
     }
 
-    private List<ListData> GetExitsListData()
+    private async Task<List<ListData>> GetExitsListDataAsync()
     {
         var exits = new List<ListData>();
         var scopeFunction = "ScopeExits";
@@ -888,7 +901,7 @@ public partial class WorldModel : IGame, IGameDebug
             scopeFunction = "GetExitsList";
         }
 
-        foreach (var exit in GetObjectsInScope(scopeFunction))
+        foreach (var exit in await GetObjectsInScopeAsync(scopeFunction))
         {
             IEnumerable<string> verbs;
             if (Version <= WorldModelVersion.v520 || !Elements.ContainsKey(ElementType.Function, "GetDisplayVerbs"))
@@ -897,10 +910,10 @@ public partial class WorldModel : IGame, IGameDebug
             }
             else
             {
-                verbs = GetDisplayVerbs(exit);
+                verbs = await GetDisplayVerbsAsync(exit);
             }
 
-            exits.Add(new ListData(GetListDisplayAlias(exit), verbs, exit.Name, GetDisplayAlias(exit)));
+            exits.Add(new ListData(await GetListDisplayAliasAsync(exit), verbs, exit.Name, await GetDisplayAliasAsync(exit)));
         }
 
         return exits;
@@ -1007,30 +1020,11 @@ public partial class WorldModel : IGame, IGameDebug
         }
         catch (Exception ex)
         {
-            Print("Error running script: " + Utility.SafeXML(ex.Message));
+            await PrintAsync("Error running script: " + Utility.SafeXML(ex.Message));
             LogException(ex);
         }
 
         return null;
-    }
-
-    private object? RunScript(IScript script, Parameters? parameters, bool expectResult, Element? thisElement)
-    {
-        var c = new Context();
-        parameters ??= new Parameters();
-        if (thisElement != null)
-        {
-            parameters.Add("this", thisElement);
-        }
-
-        c.Parameters = parameters;
-
-        return RunScript(script, c, expectResult);
-    }
-
-    private object? RunScript(IScript script, Context c, bool expectResult)
-    {
-        return RunScriptAsync(script, c, expectResult).GetAwaiter().GetResult();
     }
 
     public Element AddProcedure(string name)
@@ -1053,54 +1047,9 @@ public partial class WorldModel : IGame, IGameDebug
         return del;
     }
 
-    public void RunProcedure(string name)
-    {
-        RunProcedure(name, false);
-    }
-
     public Task RunProcedureAsync(string name)
     {
         return RunProcedureAsync(name, null, false);
-    }
-
-    private object? RunProcedure(string name, bool expectResult)
-    {
-        return RunProcedure(name, null, expectResult);
-    }
-
-    public object? RunProcedure(string name, Parameters? parameters, bool expectResult)
-    {
-        if (Elements.ContainsKey(ElementType.Function, name))
-        {
-            var function = Elements.Get(ElementType.Function, name);
-
-            // Only check for too few parameters for games for Quest 5.2 or later, as previous Quest versions
-            // would ignore this (but would usually still fail when the function was run, as the required
-            // variable wouldn't exist). For Quest 5.3, an additional check if parameters is non-null but empty.
-
-            var parametersInvalid = false;
-            if (Version == WorldModelVersion.v520)
-            {
-                parametersInvalid = parameters == null && function.Fields[FieldDefinitions.ParamNames].Count > 0;
-            }
-            else if (Version >= WorldModelVersion.v530)
-            {
-                parametersInvalid = (parameters == null || parameters.Count == 0) &&
-                                    function.Fields[FieldDefinitions.ParamNames].Count > 0;
-            }
-
-            if (parametersInvalid)
-            {
-                throw new Exception(string.Format("No parameters passed to {0} function - expected {1} parameters",
-                    name,
-                    function.Fields[FieldDefinitions.ParamNames].Count));
-            }
-
-            return RunScript(function.Fields[FieldDefinitions.Script], parameters, expectResult, null);
-        }
-
-        Print($"Error - no such procedure '{name}'");
-        return null;
     }
 
     public async Task<object?> RunProcedureAsync(string name, Parameters? parameters, bool expectResult)
@@ -1130,7 +1079,7 @@ public partial class WorldModel : IGame, IGameDebug
             return await RunScriptAsync(function.Fields[FieldDefinitions.Script], parameters, expectResult);
         }
 
-        Print($"Error - no such procedure '{name}'");
+        await PrintAsync($"Error - no such procedure '{name}'");
         return null;
     }
 


### PR DESCRIPTION
Closes #1770.

## Summary

- Adds `PrintAsync` / `PrintTemplateAsync` to `WorldModel` — the async counterparts that `await RunProcedureAsync("OutputText", ...)` for v540+ games instead of blocking
- Makes the entire `UpdateLists` chain async: `UpdateListsAsync` → `UpdateObjectsListAsync` → `GetObjectsInScopeAsync`, `GetListDisplayAliasAsync`, `GetDisplayAliasAsync`, `GetDisplayVerbsAsync`, `GetExitsListDataAsync`, `UpdateExitsListAsync`, `UpdateStatusVariablesAsync`
- Updates all callers of `UpdateLists` (Begin, HandleCommand, SendEvent, Tick) to `await UpdateListsAsync()`
- Updates `Print` calls in async methods (`RunScriptAsync`, `RunProcedureAsync`, `SendEvent`, `HandleCommandAsyncInternal`, etc.) to `await PrintAsync(...)`
- Updates script `ExecuteAsync` methods (`MsgScript`, `PictureScript`, `ShowMenuScript`) and `ExpressionOwner.ShowMenu` / `UndoLogger.DoUndo` to use `PrintAsync`
- Removes the three sync `RunProcedure` overloads and the two `RunScript` wrappers (including the `GetAwaiter().GetResult()` call)
- Restores five explanatory comments that were dropped when sync methods were removed during the async migration (#1768, #1772, and this PR): `RunProcedureAsync`, `ForEachScript`, `ForScript`, `SetScript` (both subclasses), `SwitchScript`

No `GetAwaiter().GetResult()` remains anywhere in `src/`.

## Test plan

- [x] All 304 tests pass (`dotnet test --configuration Release`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)