### PR TITLE
Publish QuestViva library packages to NuGet.org on release

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,5 +43,11 @@ jobs:
             dotnet pack "$project" --no-build --configuration Release -p:Version=${{ env.VERSION }} --output nupkgs
           done
 
+      - name: Get short-lived NuGet API key
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USERNAME }}
+
       - name: Push to NuGet.org
-        run: dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,45 @@
+name: Publish NuGet packages
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      - name: Verify tag matches VERSION file
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          FILE_VERSION="$(cat VERSION)"
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "❌ Tag $GITHUB_REF_NAME does not match VERSION file ($FILE_VERSION)"
+            exit 1
+          fi
+          echo "VERSION=$FILE_VERSION" >> $GITHUB_ENV
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Pack
+        run: |
+          for project in src/Common src/Utility src/Engine src/Legacy src/PlayerCore; do
+            dotnet pack "$project" --no-build --configuration Release -p:Version=${{ env.VERSION }} --output nupkgs
+          done
+
+      - name: Push to NuGet.org
+        run: dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Quest Viva is an open-source system for creating and playing text adventure games. It's a .NET 9.0 C# application (v6.0.0-beta.9), the modern successor to Quest 5. The main deliverable is a web-based game player built with ASP.NET Core and Blazor.
+Quest Viva is an open-source system for creating and playing text adventure games. It's a .NET 10.0 C# application, the modern successor to Quest 5. The main deliverable is a web-based game player built with ASP.NET Core and Blazor.
 
 ## Build & Test Commands
 
@@ -75,9 +75,9 @@ If you forgot to update `VERSION`, the script will fail locally because the tag 
 
 ## Key Technical Details
 
-- Target framework: .NET 9.0 with nullable reference types enabled
-- Expression evaluation uses `Ciloci.Flee` or `NCalcSync` (migrating from the former to the latter)
+- Target framework: .NET 10.0 with nullable reference types enabled
+- Expression evaluation uses `NCalcAsync`
 - Game files use `.aslx` (XML-based) format; legacy `.asl` format also supported
 - Version is stored in the `VERSION` file and embedded as a resource via Common.csproj
 - CI runs on GitHub Actions (build-and-test on push/PR to main for `src/` and `tests/` changes)
-- The `legacy/` directory contains parts of the Quest 5 codebase (.NET Framework) that haven't yet been migrated to .NET 9 — primarily the desktop apps and ASP.NET web apps. It is not part of the active solution
+- Library packages (`QuestViva.Common`, `QuestViva.Utility`, `QuestViva.Engine`, `QuestViva.Legacy`, `QuestViva.PlayerCore`) are published to NuGet.org on each release tag via the `nuget-publish` workflow

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -6,6 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>default</LangVersion>
         <RootNamespace>QuestViva.Common</RootNamespace>
+        <PackageId>QuestViva.Common</PackageId>
+        <Description>Shared types and interfaces for Quest Viva, an open-source text adventure game engine.</Description>
     </PropertyGroup>
     <ItemGroup>
         <EmbeddedResource Include="..\..\VERSION">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <Authors>Alex Warren</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/textadventures/quest</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/textadventures/quest.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+</Project>

--- a/src/Engine/Engine.csproj
+++ b/src/Engine/Engine.csproj
@@ -3,9 +3,11 @@
         <TargetFramework>net10.0</TargetFramework>
         <OutputType>Library</OutputType>
         <RootNamespace>QuestViva.Engine</RootNamespace>
+        <PackageId>QuestViva.Engine</PackageId>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>default</LangVersion>
         <Nullable>enable</Nullable>
+        <Description>Core game interpreter for Quest Viva — script execution, expression evaluation, game loading, and built-in functions for text adventure games.</Description>
     </PropertyGroup>
     <ItemGroup>
         <None Update="Core\Languages\EditorDeutsch.aslx">

--- a/src/Legacy/Legacy.csproj
+++ b/src/Legacy/Legacy.csproj
@@ -5,7 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <RootNamespace>QuestViva.Legacy</RootNamespace>
+        <PackageId>QuestViva.Legacy</PackageId>
         <LangVersion>default</LangVersion>
+        <Description>Quest 4 and earlier backward-compatibility layer for Quest Viva, an open-source text adventure game engine.</Description>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/PlayerCore/PlayerCore.csproj
+++ b/src/PlayerCore/PlayerCore.csproj
@@ -3,8 +3,10 @@
         <TargetFramework>net10.0</TargetFramework>
         <OutputType>Library</OutputType>
         <RootNamespace>QuestViva.PlayerCore</RootNamespace>
+        <PackageId>QuestViva.PlayerCore</PackageId>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>default</LangVersion>
+        <Description>Game player runtime for Quest Viva — load and query .aslx text adventure game files.</Description>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Legacy\Legacy.csproj"/>

--- a/src/Utility/Utility.csproj
+++ b/src/Utility/Utility.csproj
@@ -3,8 +3,10 @@
         <TargetFramework>net10.0</TargetFramework>
         <OutputType>Library</OutputType>
         <RootNamespace>QuestViva.Utility</RootNamespace>
+        <PackageId>QuestViva.Utility</PackageId>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>default</LangVersion>
+        <Description>Helper functions and language utilities for Quest Viva, an open-source text adventure game engine.</Description>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/nuget-publish.yml` — triggers on `v*` tags (same as Docker publish), verifies tag matches `VERSION`, then packs and pushes all five library packages to NuGet.org
- Adds `src/Directory.Build.props` with shared NuGet metadata (author, MIT license, repo URL, README) inherited by all library projects
- Adds `<PackageId>` and `<Description>` to `Common`, `Utility`, `Engine`, `Legacy`, and `PlayerCore` csproj files
- Updates `CLAUDE.md` to reflect .NET 10, completed NCalcAsync migration, and the new NuGet publishing step

Uses [Trusted Publishing](https://learn.microsoft.com/en-gb/nuget/nuget-org/trusted-publishing) (OIDC) rather than a long-lived API key — no secret rotation needed.

## Pre-requisites before first release

1. On NuGet.org: go to your account → **Trusted Publishing** → add a policy:
   - **Repository Owner:** `textadventures`
   - **Repository:** `quest`
   - **Workflow File:** `nuget-publish.yml`
2. Add a repo secret `NUGET_USERNAME` set to your NuGet.org profile name (not your email)

## Test plan

- [ ] Set up Trusted Publishing policy on NuGet.org
- [ ] Add `NUGET_USERNAME` secret to repo
- [ ] On next release, verify the `nuget-publish` workflow succeeds and packages appear on NuGet.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)