### PR TITLE
Publish AppBundle and WebEditor as GitHub Release assets

### DIFF
--- a/.github/workflows/release-webeditor.yml
+++ b/.github/workflows/release-webeditor.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -30,6 +32,16 @@ jobs:
         working-directory: src/WebEditor
         env:
           PUBLIC_WEBEDITOR_VERSION: ${{ github.ref_name }}
+
+      - name: Package artifacts
+        run: |
+          (cd src/WasmEditor/bin/Release/net10.0/browser-wasm/AppBundle && zip -r $GITHUB_WORKSPACE/AppBundle.zip .)
+          (cd src/WebEditor/build && zip -r $GITHUB_WORKSPACE/WebEditor.zip .)
+
+      - name: Create GitHub Release
+        run: gh release create ${{ github.ref_name }} AppBundle.zip WebEditor.zip --title "${{ github.ref_name }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pin WebEditor version in textadventures.co.uk
         run: |


### PR DESCRIPTION
## Summary

- After building WasmEditor and WebEditor, zips the outputs (`AppBundle.zip`, `WebEditor.zip`) and attaches them to a GitHub Release for the tag
- Adds `permissions: contents: write` needed to create releases
- Keeps the existing steps to pin `WEBEDITOR_VERSION` in textadventures.co.uk and trigger its deployment

## Motivation

Currently, consumers (textadventures.co.uk CI) check out the Quest source and rebuild the WASM editor on every deploy — requiring `dotnet workload install wasm-tools` + a full npm build each time. With pre-built artifacts published to the GitHub Release, any deployment just downloads and extracts the zips instead. This also makes it straightforward to deploy the WebEditor elsewhere (e.g. a future questviva.com subdomain) without needing the Quest build toolchain.

## Test plan

- [ ] Push a `webeditor-v*` tag and verify a GitHub Release is created with `AppBundle.zip` and `WebEditor.zip` attached
- [ ] Verify the textadventures.co.uk deployment (triggered by the dispatch) uses the downloaded artifacts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)