### PR TITLE
Fix WebEditor crash on game open: await async WASM bridge methods

### DIFF
--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -79,10 +79,9 @@
             nextSelection = null;
         }
         if (categories.length === 0) {
-            const cats = getScriptCommandCategories();
-            if (cats) {
-                categories = cats.categories;
-            }
+            void getScriptCommandCategories().then(cats => {
+                if (cats) categories = cats.categories;
+            });
         }
         if (objectNames.length === 0) {
             const names = getObjectNames();

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -55,15 +55,15 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
         refreshUndoRedo();
         scriptClipboardHasContent.set(false);
         const gameNode = nodes.find(n => n.nodeType === "game");
-        if (gameNode) selectNode(gameNode.key);
+        if (gameNode) await selectNode(gameNode.key);
     }
     return ok;
 }
 
-export function selectNode(key: string) {
+export async function selectNode(key: string) {
     if (!_bridge) return;
     selectedKey.set(key);
-    const json = _bridge.GetEditorData(key);
+    const json = await _bridge.GetEditorData(key);
     selectedData.set(json ? JSON.parse(json) : null);
     const attrJson = _bridge.GetFullAttributeData(key);
     fullAttributeData.set(attrJson ? JSON.parse(attrJson) : null);
@@ -122,8 +122,8 @@ export async function saveGameAs(): Promise<void> {
     isDirty.set(false);
 }
 
-export function undo() {
-    _bridge?.Undo();
+export async function undo() {
+    if (_bridge) await _bridge.Undo();
     refreshTree();
     refreshSelectedData();
     refreshUndoRedo();
@@ -403,10 +403,10 @@ export function removeElseIf(elementKey: string, attribute: string, containerPat
     return result;
 }
 
-export function getScriptCommandCategories(): ScriptCommandCategoriesData | null {
+export async function getScriptCommandCategories(): Promise<ScriptCommandCategoriesData | null> {
     if (!_bridge) return null;
-    const json = _bridge.GetScriptCommandCategories();
-    return json ? JSON.parse(json) : null;
+    try { return JSON.parse(await _bridge.GetScriptCommandCategories()); }
+    catch { return null; }
 }
 
 export function getObjectNames(): string[] | null {
@@ -432,9 +432,13 @@ export function getIfExpressionTemplateData(expression: string): IfExpressionTem
 }
 
 function refreshSelectedData() {
+    void refreshSelectedDataAsync();
+}
+
+async function refreshSelectedDataAsync() {
     const key = get(selectedKey);
     if (!_bridge || !key) return;
-    const json = _bridge.GetEditorData(key);
+    const json = await _bridge.GetEditorData(key);
     selectedData.set(json ? JSON.parse(json) : null);
     const attrJson = _bridge.GetFullAttributeData(key);
     fullAttributeData.set(attrJson ? JSON.parse(attrJson) : null);
@@ -458,7 +462,7 @@ export function getUniqueName(baseName: string): string {
 function afterCreate(result: string): string {
     if (result.startsWith("error:")) return result;
     refreshTree();
-    selectNode(result);
+    void selectNode(result);
     refreshUndoRedo();
     return result;
 }

--- a/src/WebEditor/src/lib/wasm.ts
+++ b/src/WebEditor/src/lib/wasm.ts
@@ -1,7 +1,7 @@
 export interface WasmBridge {
   Initialise(bytes: Uint8Array, filename: string): Promise<boolean>
   GetTreeNodes(): string
-  GetEditorData(key: string): string | null
+  GetEditorData(key: string): Promise<string | null>
   SetAttribute(elementKey: string, attribute: string, controlType: string, value: string): string
   SetMultiType(elementKey: string, attribute: string, newType: string): string
   SetObjectReference(elementKey: string, attribute: string, objectName: string): string
@@ -10,7 +10,7 @@ export interface WasmBridge {
   IsDirty(): boolean
   CanUndo(): boolean
   CanRedo(): boolean
-  Undo(): void
+  Undo(): Promise<void>
   Redo(): void
   // Script editor API
   GetScriptCode(elementKey: string, attribute: string): string
@@ -31,7 +31,7 @@ export interface WasmBridge {
   AddElseIf(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string
   RemoveElse(elementKey: string, attribute: string, containerPath: string, scriptIndex: number): string
   RemoveElseIf(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, elseIfIndex: number): string
-  GetScriptCommandCategories(): string
+  GetScriptCommandCategories(): Promise<string>
   GetObjectNames(): string
   GetIfExpressionTemplates(): string
   GetIfExpressionTemplateData(expression: string): string | null


### PR DESCRIPTION
## Summary

- Three `[JSExport]` methods on `WasmEditorBridge` (`GetEditorData`, `GetScriptCommandCategories`, `Undo`) became `async Task<T>` after the recent RunProcedure/UndoLogger async cascade — but the TypeScript `WasmBridge` interface still typed them as synchronous
- Callers received a `Promise` object where they expected a string, then passed it to `JSON.parse()`, producing `SyntaxError: Unexpected token 'o', "[object Promise]" is not valid JSON`
- This manifested as a crash every time you tried to open a game in the WebEditor

## Changes

- Update `WasmBridge` interface types for the three affected methods
- Make `selectNode`, `refreshSelectedData`, `getScriptCommandCategories`, and `undo` properly `await` the bridge calls
- `openGame` now awaits `selectNode` so editor data is populated before the function resolves
- `afterCreate` fires `selectNode` as a void (fire-and-forget) since it must return a sync `string`
- `ScriptEditor.svelte` uses `.then()` for `getScriptCommandCategories` inside the `$effect` block

## Test plan

- [ ] Open a game file in the WebEditor — should load without error and display the game tree/editor panel
- [ ] Select different nodes in the tree — editor panel should update correctly
- [ ] Undo an edit — tree and editor panel should reflect the undone state
- [ ] Open the script editor and add a script — script command categories should load

🤖 Generated with [Claude Code](https://claude.com/claude-code)