### PR TITLE
Remove UseHttpsRedirection

### DIFF
--- a/src/WebPlayer/Program.cs
+++ b/src/WebPlayer/Program.cs
@@ -47,11 +47,8 @@ var app = builder.Build();
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error", true);
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
-
-app.UseHttpsRedirection();
 
 app.UseStaticFiles();
 app.UseAntiforgery();


### PR DESCRIPTION
## Summary

- Removes `app.UseHttpsRedirection()` entirely — the app runs behind a reverse proxy in all environments, so HTTPS enforcement belongs there, not in the app
- This was causing a warning in production logs: `Failed to determine the https port for redirect`
- Also removes the boilerplate HSTS comment (the call itself is unchanged)

## Test plan

- [ ] App starts without the warning in production logs
- [ ] HTTPS continues to work via the reverse proxy as before