### PR TITLE
WasmPlayer: fix paper.js/grid map rendering

### DIFF
--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -118,6 +118,19 @@ function addPaperScript() {
     }
 }
 
+async function setupPaperJs() {
+    if (!window.paper) return;
+    const canvas = document.createElement('canvas');
+    canvas.id = 'gridCanvas';
+    canvas.width = 700;
+    canvas.height = 300;
+    canvas.style.display = 'none';
+    document.body.appendChild(canvas);
+    paper.setup(canvas);
+    const code = await fetch('grid.js').then(r => r.text());
+    paper.PaperScript.evaluate(code, paper);
+}
+
 async function initWasmPlayer(gameFileUrl, filename) {
     const [htmResponse, { dotnet }] = await Promise.all([
         fetch('playercore.htm'),
@@ -185,6 +198,8 @@ async function initWasmPlayer(gameFileUrl, filename) {
         console.error('[Quest] Failed to initialise game');
         return;
     }
+
+    await setupPaperJs();
 
     WebPlayer.gameId = Bridge.GetGameId();
     WebPlayer.initUI();


### PR DESCRIPTION
## Summary

- paper.js initialisation was broken in WasmPlayer because the `<script type="text/paperscript">` approach relies on a DOMContentLoaded hook that fires before `initWasmPlayer` has replaced the body with `playercore.htm`
- Added `setupPaperJs()` which runs after the body replacement and before the game starts: creates the canvas element, calls `paper.setup()` to wire up `paper.view`, then fetches and evaluates `grid.js` as PaperScript so all `gridApi.*` drawing functions are ready before `Bridge.Begin()`

## Test plan

- [ ] Load `examples/map.quest` in WasmPlayer — map should render
- [ ] Confirm no regressions on non-grid games (simple.aslx etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)