### PR TITLE
WasmPlayer: fix game resource images not loading

### DIFF
--- a/src/Engine/GameLoader/PackageReader.cs
+++ b/src/Engine/GameLoader/PackageReader.cs
@@ -22,7 +22,7 @@ internal class PackageReader
 
     public class ReadResult
     {
-        private readonly Dictionary<string, byte[]> _files = new();
+        private readonly Dictionary<string, byte[]> _files = new(StringComparer.OrdinalIgnoreCase);
 
         public readonly Stream GameFile;
 
@@ -33,16 +33,15 @@ internal class PackageReader
                 var entryName = entry.FullName;
                 var memoryStream = new MemoryStream();
                 entry.Open().CopyTo(memoryStream);
-                _files.Add(entryName, memoryStream.ToArray());
+                _files.TryAdd(entryName, memoryStream.ToArray());
             }
 
             GameFile = gameFile;
         }
 
-        public Stream GetFile(string filename)
+        public Stream? GetFile(string filename)
         {
-            var bytes = _files[filename];
-            return new MemoryStream(bytes);
+            return _files.TryGetValue(filename, out var bytes) ? new MemoryStream(bytes) : null;
         }
 
         public IEnumerable<string> GetFileNames()

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -96,7 +96,7 @@ public partial class WorldModel : IGame, IGameDebug
         Game = ObjectFactory.CreateObject("game", ObjectType.Game);
     }
 
-    public Func<string, Stream>? ResourceGetter { get; internal set; }
+    public Func<string, Stream?>? ResourceGetter { get; internal set; }
     public Func<IEnumerable<string>>? GetResourceNames { get; internal set; }
 
     internal static Dictionary<ObjectType, string> DefaultTypeNames { get; } = new()

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -36,7 +36,7 @@ public partial class WasmPlayerBridge
         _game = launcher.GetGame(gameData, null);
         if (_game == null) return false;
 
-        _ui = new WasmPlayerUi(gameData.GameId);
+        _ui = new WasmPlayerUi(gameData.GameId, _game);
         _helper = new PlayerHelper(_game, _ui);
         _ui.SetHelper(_helper);
 
@@ -55,17 +55,6 @@ public partial class WasmPlayerBridge
             _ui.OutputText(string.Join("<br/>", errors) + "<br/>");
             _ui.FlushText();
             return false;
-        }
-
-        foreach (var name in _game.GetResourceNames())
-        {
-            var stream = _game.GetResourceStream(name);
-            if (stream == null) continue;
-            using var ms = new MemoryStream();
-            await stream.CopyToAsync(ms);
-            var mimeType = PlayerHelper.GetContentType(name);
-            var dataUrl = JsRegisterResource(name, mimeType, Convert.ToBase64String(ms.ToArray()));
-            _ui.RegisterResourceUrl(name, dataUrl);
         }
 
         var scripts = _game.GetExternalScripts();
@@ -219,9 +208,6 @@ public partial class WasmPlayerBridge
     [JSImport("requestNextTimerTick", "wasm-player")]
     internal static partial void JsRequestNextTimerTick(int seconds);
 
-    [JSImport("registerResource", "wasm-player")]
-    internal static partial string JsRegisterResource(string filename, string mimeType, string base64);
-
     [JSImport("uiShow", "wasm-player")]
     internal static partial void JsUiShow(string element);
 
@@ -271,14 +257,16 @@ public partial class WasmPlayerBridge
     {
         private readonly Dictionary<string, string> _resourceUrls = new(StringComparer.OrdinalIgnoreCase);
         private readonly ListHandler _listHandler;
+        private readonly IGame _game;
         private PlayerHelper? _helper;
 
         public string GameId { get; }
         public bool IsFinished { get; private set; }
 
-        public WasmPlayerUi(string gameId)
+        public WasmPlayerUi(string gameId, IGame game)
         {
             GameId = gameId;
+            _game = game;
             _listHandler = new ListHandler((identifier, args) =>
             {
                 if (identifier == "updateList"
@@ -299,14 +287,20 @@ public partial class WasmPlayerBridge
 
         public void SetHelper(PlayerHelper helper) => _helper = helper;
 
-        public void RegisterResourceUrl(string filename, string dataUrl) =>
-            _resourceUrls[filename] = dataUrl;
-
         public string GetURL(string filename)
         {
-            var match = _resourceUrls.Keys
-                .FirstOrDefault(k => string.Equals(k, filename, System.StringComparison.OrdinalIgnoreCase));
-            return match != null ? _resourceUrls[match] : filename;
+            if (_resourceUrls.TryGetValue(filename, out var cached))
+                return cached;
+
+            var stream = _game.GetResourceStream(filename);
+            if (stream == null) return filename;
+
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            var mimeType = PlayerHelper.GetContentType(filename);
+            var dataUrl = $"data:{mimeType};base64,{Convert.ToBase64String(ms.ToArray())}";
+            _resourceUrls[filename] = dataUrl;
+            return dataUrl;
         }
 
         public void FlushText()

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -40,17 +40,6 @@ public partial class WasmPlayerBridge
         _helper = new PlayerHelper(_game, _ui);
         _ui.SetHelper(_helper);
 
-        foreach (var name in _game.GetResourceNames())
-        {
-            var stream = _game.GetResourceStream(name);
-            if (stream == null) continue;
-            using var ms = new MemoryStream();
-            await stream.CopyToAsync(ms);
-            var mimeType = PlayerHelper.GetContentType(name);
-            var dataUrl = JsRegisterResource(name, mimeType, Convert.ToBase64String(ms.ToArray()));
-            _ui.RegisterResourceUrl(name, dataUrl);
-        }
-
         _game.LogError += ex =>
         {
             _ui.OutputText("[Sorry, an error occurred]");
@@ -66,6 +55,17 @@ public partial class WasmPlayerBridge
             _ui.OutputText(string.Join("<br/>", errors) + "<br/>");
             _ui.FlushText();
             return false;
+        }
+
+        foreach (var name in _game.GetResourceNames())
+        {
+            var stream = _game.GetResourceStream(name);
+            if (stream == null) continue;
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            var mimeType = PlayerHelper.GetContentType(name);
+            var dataUrl = JsRegisterResource(name, mimeType, Convert.ToBase64String(ms.ToArray()));
+            _ui.RegisterResourceUrl(name, dataUrl);
         }
 
         var scripts = _game.GetExternalScripts();

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -160,9 +160,6 @@ async function initWasmPlayer(gameFileUrl, filename) {
         updateCompass: (data) => updateCompass(data),
         gameFinished: () => gameFinished(),
         requestNextTimerTick: (seconds) => requestNextTimerTick(seconds),
-        registerResource: (filename, mimeType, base64) => {
-            return `data:${mimeType || 'application/octet-stream'};base64,${base64}`;
-        },
         uiShow: (element) => uiShow(element),
         uiHide: (element) => uiHide(element),
         addExternalScript: (url) => addExternalScript(url),


### PR DESCRIPTION
## Summary

- Game resources (images, audio, etc.) were being registered as data URLs **before** `WorldModel.Initialise()` ran — at that point `ResourceGetter`/`GetResourceNames` are still `null`, so nothing was ever registered and images 404'd
- Fixed by moving resource registration to after `_helper.Initialise()`, then improved further with lazy loading:
  - Resources are now converted to base64 data URLs **on demand** the first time `GetURL()` is called, rather than all upfront at startup
  - Games with tens of MB of resources no longer pay the cost of loading everything they may never use
  - Data URLs (not blob URLs) are used so image `src` values embed directly into the saved HTML — save/restore works correctly across page loads
  - Data URL construction moved from JS to C#, removing a JS interop round-trip per resource
- `PackageReader` made case-insensitive and null-safe for resource lookups

## Test plan

- [ ] Load `/examples/images.quest` in WasmPlayer — images should display correctly
- [ ] Verify other game examples still work (no regression in games without resources)
- [ ] Save and restore a game with images — images should still display after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)