### PR TITLE
WasmEditor offline preview: Phase 1 — make GetUrlAsync/PlaySoundAsync/ShowPictureAsync async

### DIFF
--- a/docs/wasmeditor-offline-preview.md
+++ b/docs/wasmeditor-offline-preview.md
@@ -1,0 +1,199 @@
+# WasmEditor: Offline Preview via WasmPlayer
+
+## Motivation
+
+When WasmEditor is used outside of textadventures.co.uk (local files, CDN deployment), the preview button currently shows an informational message because preview previously required a server-side player (WebPlayer). Now that WasmPlayer runs entirely in the browser, it is possible to preview a game without any server — the editor can open WasmPlayer in a new tab and communicate with it directly via the browser's `BroadcastChannel` API.
+
+---
+
+## Architecture
+
+The editor opens WasmPlayer in a new tab and they communicate over a named `BroadcastChannel`. The editor is the authority on game data; the player requests what it needs.
+
+```
+WasmEditor tab                          WasmPlayer tab
+──────────────                          ──────────────
+User clicks "Preview"
+  window.open(playerUrl + '?source=editor')
+  BroadcastChannel('quest-preview')
+                                          registers BroadcastChannel
+                          ←── {type:'ready'} ───
+  sends {type:'game', bytes, filename}
+  ────────────────────────────────────→
+                                          Bridge.Initialise(bytes, filename)
+                                          game loads, game starts
+
+  [during gameplay, as resources are needed]
+
+                          ←── {type:'resource-request', name, id} ───
+  reads file from FSA/OPFS handle
+  sends {type:'resource-response', id, dataUrl}
+  ────────────────────────────────────→
+                                          resolves pending promise → resource displayed
+```
+
+Resource requests are on-demand (lazy): WasmPlayer only asks for a file when the game engine actually needs it, and caches the result so each file is only transferred once per session.
+
+---
+
+## Why on-demand and not batch upfront
+
+Pre-fetching all resources at game start would transfer files the player may never need, and converting every image/sound to a data URL before the game begins would add noticeable startup latency for resource-heavy games. The on-demand proxy sends each resource exactly once, when it is first used.
+
+This requires `GetURL` (the engine's resource URL resolver) to be async. See Phase 1.
+
+---
+
+## Phases
+
+### Phase 1 — Make `GetURL` async
+
+**Goal:** Pure refactor, no behaviour change. Propagate `async`/`Task<string>` through the resource URL resolution stack so that Phase 3's on-demand proxy can await a BroadcastChannel response from inside `GetURL`.
+
+**Files to change:**
+
+| File | Change |
+|------|--------|
+| `src/Common/IGame.cs` | `string GetURL(string)` → `Task<string> GetURL(string)` |
+| `src/Engine/WorldModel.cs` | `GetExternalUrl` → `async Task<string>` |
+| `src/Engine/Functions/ExpressionOwner.cs` | `GetFileURL` → `async Task<string>` |
+| `src/Engine/Scripts/PictureScript.cs` | `await` the now-async `GetFileURL` call (already in `ExecuteAsync`) |
+| `src/PlayerCore/Player.cs` | `GetURL`, `PlaySound`, `ShowPicture` → async |
+| `src/PlayerCore/GameQuery.cs` | `GetURL` → async |
+| `src/WasmPlayer/WasmPlayerBridge.cs` | `WasmPlayerUi.GetURL` → `async Task<string>` |
+| `src/Legacy/V4Game.Part2.cs` | One `GetURL` call site — check whether it is already in an async context |
+
+The `IPlayer.PlaySound` and `IPlayer.ShowPicture` interface methods call `GetURL` in their implementations. These become `Task`-returning; their callers are all in `ExecuteAsync` script methods so no sync-context issues are expected.
+
+**Done when:** All tests pass with no behaviour change.
+
+---
+
+### Phase 2 — WasmPlayer: receive game from BroadcastChannel
+
+**Goal:** WasmPlayer can be opened by the editor and receive the game bytes over the channel, as an alternative to the `?game=url` path.
+
+**`src/WasmPlayer/wasm-player.js`** — add alongside the existing URL-loading path:
+
+```js
+if (params.get('source') === 'editor') {
+    const bc = new BroadcastChannel('quest-preview');
+    bc.postMessage({ type: 'ready' });
+    bc.onmessage = async ({ data }) => {
+        if (data.type === 'game') {
+            bc.onmessage = null;   // hand off to resource handler (Phase 3)
+            await initWasmPlayer(data.bytes, data.filename, bc);
+        }
+    };
+    return;
+}
+```
+
+`initWasmPlayer` gains an optional `bc` parameter used in Phase 3; when null (normal URL mode) behaviour is unchanged.
+
+**Done when:** Opening `player/?source=editor` and manually dispatching a `BroadcastChannel` message with game bytes starts the game correctly.
+
+---
+
+### Phase 3 — WasmPlayer: on-demand resource proxy
+
+**Goal:** When the game engine requests a resource and no local stream is available, WasmPlayer asks the editor for it over the channel and awaits the response.
+
+**`src/WasmPlayer/wasm-player.js`** — expose `getResourceUrl` to C#:
+
+```js
+const pendingResources = new Map();   // requestId → resolve
+
+export function getResourceUrl(name) {
+    return new Promise(resolve => {
+        const id = crypto.randomUUID();
+        pendingResources.set(id, resolve);
+        editorChannel.postMessage({ type: 'resource-request', name, id });
+    });
+}
+
+// In the BroadcastChannel message handler:
+if (data.type === 'resource-response') {
+    pendingResources.get(data.id)?.(data.dataUrl);
+    pendingResources.delete(data.id);
+}
+```
+
+**`src/WasmPlayer/WasmPlayerBridge.cs`** — add JSImport and use it in `GetURL`:
+
+```csharp
+[JSImport("getResourceUrl", "wasm-player")]
+private static partial Task<string> JsGetResourceUrl(string filename);
+
+public async Task<string> GetURL(string filename)
+{
+    if (_resourceUrls.TryGetValue(filename, out var cached))
+        return cached;
+
+    var stream = _game.GetResourceStream(filename);
+    if (stream != null)
+    {
+        // existing data-URL conversion for embedded resources
+        ...
+        _resourceUrls[filename] = dataUrl;
+        return dataUrl;
+    }
+
+    // Fall back to editor proxy (no-op returns filename as-is when not in editor mode)
+    var url = await JsGetResourceUrl(filename);
+    _resourceUrls[filename] = url;
+    return url;
+}
+```
+
+When WasmPlayer is not in editor mode, `getResourceUrl` returns the filename unchanged (current behaviour — the browser attempts to fetch it as a relative URL, which works for URL-loaded games served from a real HTTP server).
+
+**Done when:** A game with local image/sound resources previewed from the editor displays those resources correctly.
+
+---
+
+### Phase 4 — WasmEditor: send game and serve resource requests
+
+**Goal:** The editor's Preview button opens WasmPlayer, sends the current game state, and handles incoming resource requests.
+
+**`src/WebEditor/src/components/Toolbar.svelte`** — replace the info banner with:
+
+```ts
+async function previewInWasmPlayer() {
+    const xml = WasmEditorBridge.Save();           // current game XML from C# bridge
+    const bytes = new TextEncoder().encode(xml);
+
+    const playerTab = window.open(wasmPlayerUrl + '?source=editor', '_blank');
+    const bc = new BroadcastChannel('quest-preview');
+
+    bc.onmessage = async ({ data }) => {
+        if (data.type === 'ready') {
+            bc.postMessage({ type: 'game', bytes, filename: currentFilename });
+        }
+        else if (data.type === 'resource-request') {
+            const fileBytes = await adapter.readFile(data.name);  // reads from FSA/OPFS handle
+            const mimeType = getMimeType(data.name);
+            const dataUrl = await toDataUrl(fileBytes, mimeType);
+            bc.postMessage({ type: 'resource-response', id: data.id, dataUrl });
+        }
+    };
+}
+```
+
+`adapter.readFile(name)` reads from whichever `FileAdapter` is active (FSA directory handle or OPFS). The `BroadcastChannel` stays open for the lifetime of the preview session so late resource requests are served.
+
+**`wasmPlayerUrl`** — needs to resolve to the correct WasmPlayer deployment. Options:
+- Config value set at build time (CDN deployment)
+- Relative path if editor and player are co-deployed (e.g. `/player/`)
+- `window.location.origin + '/player/'` as a convention
+
+**Done when:** Clicking Preview from the editor opens the game in WasmPlayer with images and sounds working, entirely without a server.
+
+---
+
+## Open questions
+
+- **Multiple preview tabs:** If the user clicks Preview again, does it reuse the existing tab or open a new one? `BroadcastChannel` is one-to-many, so multiple player tabs would all receive the game bytes — probably fine for now.
+- **Resource request cancellation / timeout:** If the editor tab is closed while the player is still running, pending resource requests will never resolve. A timeout or an `unload` event on the editor side could post a `{type:'abort'}` message.
+- **Save-before-preview:** Should Preview auto-save, or send the in-memory (possibly unsaved) game state? Sending unsaved state is more useful for a fast edit-preview loop.
+- **`wasmPlayerUrl` for offline/Electron use:** When running offline (PWA or Electron), the player URL needs to be discoverable without a network round-trip. Worth aligning with the Electron architecture doc.

--- a/docs/wasmeditor-offline-preview.md
+++ b/docs/wasmeditor-offline-preview.md
@@ -46,26 +46,19 @@ This requires `GetURL` (the engine's resource URL resolver) to be async. See Pha
 
 ## Phases
 
-### Phase 1 — Make `GetURL` async
+### Phase 1 — Make `GetUrlAsync` async ✅
 
-**Goal:** Pure refactor, no behaviour change. Propagate `async`/`Task<string>` through the resource URL resolution stack so that Phase 3's on-demand proxy can await a BroadcastChannel response from inside `GetURL`.
+**Goal:** Pure refactor, no behaviour change. Propagate `async`/`Task<string>` through the resource URL resolution stack so that Phase 3's on-demand proxy can await a BroadcastChannel response from inside `GetUrlAsync`.
 
-**Files to change:**
+**Changes made:**
 
-| File | Change |
-|------|--------|
-| `src/Common/IGame.cs` | `string GetURL(string)` → `Task<string> GetURL(string)` |
-| `src/Engine/WorldModel.cs` | `GetExternalUrl` → `async Task<string>` |
-| `src/Engine/Functions/ExpressionOwner.cs` | `GetFileURL` → `async Task<string>` |
-| `src/Engine/Scripts/PictureScript.cs` | `await` the now-async `GetFileURL` call (already in `ExecuteAsync`) |
-| `src/PlayerCore/Player.cs` | `GetURL`, `PlaySound`, `ShowPicture` → async |
-| `src/PlayerCore/GameQuery.cs` | `GetURL` → async |
-| `src/WasmPlayer/WasmPlayerBridge.cs` | `WasmPlayerUi.GetURL` → `async Task<string>` |
-| `src/Legacy/V4Game.Part2.cs` | One `GetURL` call site — check whether it is already in an async context |
-
-The `IPlayer.PlaySound` and `IPlayer.ShowPicture` interface methods call `GetURL` in their implementations. These become `Task`-returning; their callers are all in `ExecuteAsync` script methods so no sync-context issues are expected.
-
-**Done when:** All tests pass with no behaviour change.
+- `IPlayer`: `GetURL` → `Task<string> GetUrlAsync`, `PlaySound` → `Task PlaySoundAsync`, `ShowPicture` → `Task ShowPictureAsync`
+- `WorldModel.GetExternalUrlAsync` — async wrapper around `PlayerUi.GetUrlAsync`; path traversal (`..`) guard moved here from `ExpressionOwner`
+- `ExpressionOwner.GetFileURL` — kept as game-facing name (discovered by reflection); delegates to `GetExternalUrlAsync`
+- `PictureScript` — calls `GetExternalUrlAsync` directly (bypasses `ExpressionOwner`)
+- `PlaySoundScript`, `RequestScript`, `OutputLogger.DisplayOutputAsync` — `await` the now-async calls
+- `Player`, `WasmPlayerUi`, `GameQueryUi`, `TestPlayer` — updated implementations
+- `V4Game` / `V4Game.Part2` — `ShowPictureInTextAsync`, `PlaySoundAsync` call sites updated
 
 ---
 

--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -46,14 +46,14 @@ public interface IPlayer
     void DoPause(int ms);
     void ShowQuestion(string caption);
     void SetWindowMenu(MenuData menuData);
-    void PlaySound(string filename, bool synchronous, bool looped);
+    Task PlaySoundAsync(string filename, bool synchronous, bool looped);
     void StopSound();
     void WriteHTML(string html);
-    string GetURL(string filename);
+    Task<string> GetUrlAsync(string filename);
     void LocationUpdated(string location);
     void UpdateGameName(string name);
     void ClearScreen();
-    void ShowPicture(string filename);
+    Task ShowPictureAsync(string filename);
     void SetPanesVisible(string data);
     void SetStatusText(string text);
     void SetBackground(string colour);

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -582,7 +582,7 @@ internal class ExpressionOwner(WorldModel worldModel)
     }
 
     // ReSharper disable once InconsistentNaming
-    public string GetFileURL(string? filename)
+    public async Task<string> GetFileURL(string? filename)
     {
         ArgumentNullException.ThrowIfNull(filename);
         if (filename.Contains(".."))
@@ -590,7 +590,7 @@ internal class ExpressionOwner(WorldModel worldModel)
             throw new Exception("Invalid filename");
         }
 
-        return worldModel.GetExternalUrl(filename);
+        return await worldModel.GetExternalUrlAsync(filename);
     }
 
     public string? GetFileData(string? filename)

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -585,22 +585,12 @@ internal class ExpressionOwner(WorldModel worldModel)
     public async Task<string> GetFileURL(string? filename)
     {
         ArgumentNullException.ThrowIfNull(filename);
-        if (filename.Contains(".."))
-        {
-            throw new Exception("Invalid filename");
-        }
-
         return await worldModel.GetExternalUrlAsync(filename);
     }
 
     public string? GetFileData(string? filename)
     {
         ArgumentNullException.ThrowIfNull(filename);
-        if (filename.Contains(".."))
-        {
-            throw new Exception("Invalid filename");
-        }
-
         return worldModel.GetResourceData(filename);
     }
 

--- a/src/Engine/OutputLogger.cs
+++ b/src/Engine/OutputLogger.cs
@@ -88,7 +88,7 @@ internal class LegacyOutputLogger : IOutputLogger
         m_text.Append(string.Format("<output_setfontsize size=\"{0}\"/>", fontSize));
     }
 
-    public void DisplayOutput(string text)
+    public async Task DisplayOutputAsync(string text)
     {
         text = "<output>" + text + "</output>";
         var output = new StringBuilder();
@@ -115,7 +115,7 @@ internal class LegacyOutputLogger : IOutputLogger
                             var filename = reader.GetAttribute("filename");
                             if (filename != null)
                             {
-                                m_worldModel.PlayerUi.ShowPicture(filename);
+                                await m_worldModel.PlayerUi.ShowPictureAsync(filename);
                             }
 
                             break;

--- a/src/Engine/Scripts/PictureScript.cs
+++ b/src/Engine/Scripts/PictureScript.cs
@@ -44,11 +44,11 @@ public class PictureScript : ScriptBase
 
         if (m_worldModel.Version >= WorldModelVersion.v540)
         {
-            await m_worldModel.PrintAsync("<img src=\"" + m_worldModel.ExpressionOwner.GetFileURL(filename) + "\" />");
+            await m_worldModel.PrintAsync("<img src=\"" + await m_worldModel.ExpressionOwner.GetFileURL(filename) + "\" />");
         }
         else
         {
-            m_worldModel.PlayerUi.ShowPicture(filename);
+            await m_worldModel.PlayerUi.ShowPictureAsync(filename);
             ((LegacyOutputLogger) m_worldModel.OutputLogger).AddPicture(filename);
         }
     }

--- a/src/Engine/Scripts/PictureScript.cs
+++ b/src/Engine/Scripts/PictureScript.cs
@@ -44,7 +44,7 @@ public class PictureScript : ScriptBase
 
         if (m_worldModel.Version >= WorldModelVersion.v540)
         {
-            await m_worldModel.PrintAsync("<img src=\"" + await m_worldModel.ExpressionOwner.GetFileURL(filename) + "\" />");
+            await m_worldModel.PrintAsync("<img src=\"" + await m_worldModel.GetExternalUrlAsync(filename) + "\" />");
         }
         else
         {

--- a/src/Engine/Scripts/PlaySoundScript.cs
+++ b/src/Engine/Scripts/PlaySoundScript.cs
@@ -55,13 +55,13 @@ public class PlaySoundScript : ScriptBase
         if (synchronous)
         {
             m_worldModel._waitTcs = new TaskCompletionSource();
-            m_worldModel.PlayerUi.PlaySound(filename, true, loop);
+            await m_worldModel.PlayerUi.PlaySoundAsync(filename, true, loop);
             m_worldModel.SignalTurnSuspended();
             await m_worldModel._waitTcs.Task;
         }
         else
         {
-            m_worldModel.PlayerUi.PlaySound(filename, false, loop);
+            await m_worldModel.PlayerUi.PlaySoundAsync(filename, false, loop);
         }
     }
 

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -87,7 +87,7 @@ public class RequestScript : ScriptBase
                 m_worldModel.OutputLogger.Clear();
                 break;
             case Request.ShowPicture:
-                m_worldModel.PlayerUi.ShowPicture(data);
+                await m_worldModel.PlayerUi.ShowPictureAsync(data);
                 // TO DO: Picture should be added to the OutputLogger, but the data we
                 // get here includes the full path/URL - we want the original filename
                 // only, so this would be a breaking change.

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -1184,6 +1184,11 @@ public partial class WorldModel : IGame, IGameDebug
 
     internal async Task<string> GetExternalUrlAsync(string file)
     {
+        if (file.Contains(".."))
+        {
+            throw new Exception("Invalid filename");
+        }
+
         return await PlayerUi.GetUrlAsync(file);
     }
 
@@ -1461,6 +1466,11 @@ public partial class WorldModel : IGame, IGameDebug
 
     public string? GetResourceData(string filename)
     {
+        if (filename.Contains(".."))
+        {
+            throw new Exception("Invalid filename");
+        }
+
         var stream = GetResourceStream(filename);
         if (stream == null)
         {

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -240,7 +240,7 @@ public partial class WorldModel : IGame, IGameDebug
                 }
                 else if (_legacyOutputLogger != null)
                 {
-                    _legacyOutputLogger.DisplayOutput(output.Fields.GetString("text"));
+                    await _legacyOutputLogger.DisplayOutputAsync(output.Fields.GetString("text"));
                 }
             }
 
@@ -1182,9 +1182,9 @@ public partial class WorldModel : IGame, IGameDebug
         throw new Exception("Library file not found: " + filename);
     }
 
-    internal string GetExternalUrl(string file)
+    internal async Task<string> GetExternalUrlAsync(string file)
     {
-        return PlayerUi.GetURL(file);
+        return await PlayerUi.GetUrlAsync(file);
     }
 
     public IEnumerable<string> GetAvailableLibraries()

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -1690,17 +1690,17 @@ public partial class V4Game
         await UpdateObjectList(ctx);
     }
 
-    private void ShowPictureInText(string filename)
+    private async Task ShowPictureInTextAsync(string filename)
     {
         if (!_useStaticFrameForPictures)
         {
-            _player.ShowPicture(filename);
+            await _player.ShowPictureAsync(filename);
         }
         else
         {
             // Workaround for a particular game which expects pictures to be in a popup window -
             // use the static picture frame feature so that image is not cleared
-            _player.SetPanelContents("<img src=\"" + _player.GetURL(filename) + "\" onload=\"setPanelHeight()\"/>");
+            _player.SetPanelContents("<img src=\"" + await _player.GetUrlAsync(filename) + "\" onload=\"setPanelHeight()\"/>");
         }
     }
 
@@ -3666,7 +3666,7 @@ public partial class V4Game
             await Print(caption, _nullContext);
         }
 
-        ShowPictureInText(filename);
+        await ShowPictureInTextAsync(filename);
     }
 
     private async Task ShowRoomInfo(string room, Context ctx, bool noPrint = false)
@@ -5823,7 +5823,7 @@ public partial class V4Game
             }
             else if ((ASLVersion >= 390) & BeginsWith(scriptLine, "picture "))
             {
-                ShowPictureInText(await GetParameter(scriptLine, ctx));
+                await ShowPictureInTextAsync(await GetParameter(scriptLine, ctx));
             }
             else if (BeginsWith(scriptLine, "animate persist "))
             {

--- a/src/Legacy/V4Game.cs
+++ b/src/Legacy/V4Game.cs
@@ -7689,7 +7689,7 @@ public partial class V4Game : IGame, IGameDebug
         }
 
         if (looped & sync) sync = false;
-        _player.PlaySound(filename, sync, looped);
+        await _player.PlaySoundAsync(filename, sync, looped);
 
         if (sync)
         {

--- a/src/PlayerCore/GameQuery.cs
+++ b/src/PlayerCore/GameQuery.cs
@@ -282,8 +282,9 @@ public class GameQuery(string filename)
         {
         }
 
-        public void PlaySound(string filename, bool synchronous, bool looped)
+        public Task PlaySoundAsync(string filename, bool synchronous, bool looped)
         {
+            return Task.CompletedTask;
         }
 
         public void StopSound()
@@ -294,7 +295,7 @@ public class GameQuery(string filename)
         {
         }
 
-        public string GetURL(string file)
+        public Task<string> GetUrlAsync(string file)
         {
             throw new NotImplementedException();
         }
@@ -312,8 +313,9 @@ public class GameQuery(string filename)
         {
         }
 
-        public void ShowPicture(string filename)
+        public Task ShowPictureAsync(string filename)
         {
+            return Task.CompletedTask;
         }
 
         public void SetPanesVisible(string data)

--- a/src/PlayerCore/Player.cs
+++ b/src/PlayerCore/Player.cs
@@ -140,7 +140,7 @@ public class Player : IPlayerHelperUI
             Runner.BeginWait();
         }
 
-        var url = await GetURL(filename);
+        var url = await GetUrlAsync(filename);
 
         AddJavaScriptToBuffer(
             "playSound",
@@ -161,7 +161,7 @@ public class Player : IPlayerHelperUI
 
     Task<string> IPlayer.GetUrlAsync(string file)
     {
-        return GetURL(file);
+        return GetUrlAsync(file);
     }
 
     void IPlayer.LocationUpdated(string location)
@@ -183,7 +183,7 @@ public class Player : IPlayerHelperUI
     async Task IPlayer.ShowPictureAsync(string filename)
     {
         OutputText(PlayerHelper.ClearBuffer());
-        var url = await GetURL(filename);
+        var url = await GetUrlAsync(filename);
         OutputText($"<img src=\"{url}\" onload=\"scrollToEnd();\" /><br />");
     }
 
@@ -391,7 +391,7 @@ public class Player : IPlayerHelperUI
         Finished = true;
     }
 
-    private Task<string> GetURL(string file)
+    private Task<string> GetUrlAsync(string file)
     {
         // TODO: Is this only relevant for the local resource provider? If so move the logic there.
         // We might be running on a case-sensitive file system, so look up the correct casing
@@ -428,7 +428,7 @@ public class Player : IPlayerHelperUI
 
         foreach (var script in scripts)
         {
-            var url = await GetURL(script);
+            var url = await GetUrlAsync(script);
             await JSRuntime.InvokeVoidAsync("addExternalScript", url);
         }
     }

--- a/src/PlayerCore/Player.cs
+++ b/src/PlayerCore/Player.cs
@@ -132,7 +132,7 @@ public class Player : IPlayerHelperUI
         // Do nothing - only implemented for desktop player
     }
 
-    void IPlayer.PlaySound(string filename, bool synchronous, bool looped)
+    async Task IPlayer.PlaySoundAsync(string filename, bool synchronous, bool looped)
     {
         if (Runner != null && synchronous)
         {
@@ -140,7 +140,7 @@ public class Player : IPlayerHelperUI
             Runner.BeginWait();
         }
 
-        var url = GetURL(filename);
+        var url = await GetURL(filename);
 
         AddJavaScriptToBuffer(
             "playSound",
@@ -159,7 +159,7 @@ public class Player : IPlayerHelperUI
         OutputText(html);
     }
 
-    string IPlayer.GetURL(string file)
+    Task<string> IPlayer.GetUrlAsync(string file)
     {
         return GetURL(file);
     }
@@ -180,10 +180,10 @@ public class Player : IPlayerHelperUI
         AddJavaScriptToBuffer("clearScreen");
     }
 
-    void IPlayer.ShowPicture(string filename)
+    async Task IPlayer.ShowPictureAsync(string filename)
     {
         OutputText(PlayerHelper.ClearBuffer());
-        var url = GetURL(filename);
+        var url = await GetURL(filename);
         OutputText($"<img src=\"{url}\" onload=\"scrollToEnd();\" /><br />");
     }
 
@@ -391,14 +391,14 @@ public class Player : IPlayerHelperUI
         Finished = true;
     }
 
-    private string GetURL(string file)
+    private Task<string> GetURL(string file)
     {
         // TODO: Is this only relevant for the local resource provider? If so move the logic there.
         // We might be running on a case-sensitive file system, so look up the correct casing
         var resource = PlayerHelper.Game.GetResourceNames()
             .FirstOrDefault(n => string.Equals(n, file, StringComparison.InvariantCultureIgnoreCase));
 
-        return ResourceUrlProvider.GetUrl(resource ?? file);
+        return Task.FromResult(ResourceUrlProvider.GetUrl(resource ?? file));
     }
 
     private static string? GetElementId(string code)
@@ -428,7 +428,7 @@ public class Player : IPlayerHelperUI
 
         foreach (var script in scripts)
         {
-            var url = GetURL(script);
+            var url = await GetURL(script);
             await JSRuntime.InvokeVoidAsync("addExternalScript", url);
         }
     }

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -61,7 +61,7 @@ public partial class WasmPlayerBridge
         if (scripts != null)
         {
             foreach (var script in scripts)
-                JsAddExternalScript(_ui.GetURL(script));
+                JsAddExternalScript(await _ui.GetUrlAsync(script));
         }
 
         var stylesheets = _game.GetExternalStylesheets();
@@ -287,20 +287,20 @@ public partial class WasmPlayerBridge
 
         public void SetHelper(PlayerHelper helper) => _helper = helper;
 
-        public string GetURL(string filename)
+        public Task<string> GetUrlAsync(string filename)
         {
             if (_resourceUrls.TryGetValue(filename, out var cached))
-                return cached;
+                return Task.FromResult(cached);
 
             var stream = _game.GetResourceStream(filename);
-            if (stream == null) return filename;
+            if (stream == null) return Task.FromResult(filename);
 
             using var ms = new MemoryStream();
             stream.CopyTo(ms);
             var mimeType = PlayerHelper.GetContentType(filename);
             var dataUrl = $"data:{mimeType};base64,{Convert.ToBase64String(ms.ToArray())}";
             _resourceUrls[filename] = dataUrl;
-            return dataUrl;
+            return Task.FromResult(dataUrl);
         }
 
         public void FlushText()
@@ -353,14 +353,14 @@ public partial class WasmPlayerBridge
 
         void IPlayer.SetWindowMenu(MenuData menuData) { }
 
-        void IPlayer.PlaySound(string filename, bool synchronous, bool looped) =>
-            JsPlaySound(GetURL(filename), synchronous, looped);
+        async Task IPlayer.PlaySoundAsync(string filename, bool synchronous, bool looped) =>
+            JsPlaySound(await GetUrlAsync(filename), synchronous, looped);
 
         void IPlayer.StopSound() => JsStopSound();
 
         void IPlayer.WriteHTML(string html) => OutputText(html);
 
-        string IPlayer.GetURL(string filename) => GetURL(filename);
+        Task<string> IPlayer.GetUrlAsync(string filename) => GetUrlAsync(filename);
 
         void IPlayer.LocationUpdated(string location) => JsUpdateLocation(location);
 
@@ -372,10 +372,10 @@ public partial class WasmPlayerBridge
             JsClearScreen();
         }
 
-        void IPlayer.ShowPicture(string filename)
+        async Task IPlayer.ShowPictureAsync(string filename)
         {
             FlushText();
-            OutputText($"<img src=\"{GetURL(filename)}\" onload=\"scrollToEnd();\" /><br />");
+            OutputText($"<img src=\"{await GetUrlAsync(filename)}\" onload=\"scrollToEnd();\" /><br />");
         }
 
         void IPlayer.SetPanesVisible(string data) => JsPanesVisible(data == "on");

--- a/tests/LegacyTests/TestPlayer.cs
+++ b/tests/LegacyTests/TestPlayer.cs
@@ -47,8 +47,9 @@ internal class TestPlayer : IPlayer
     {
     }
 
-    public void PlaySound(string filename, bool synchronous, bool looped)
+    public Task PlaySoundAsync(string filename, bool synchronous, bool looped)
     {
+        return Task.CompletedTask;
     }
 
     public void StopSound()
@@ -74,8 +75,9 @@ internal class TestPlayer : IPlayer
     {
     }
 
-    public void ShowPicture(string filename)
+    public Task ShowPictureAsync(string filename)
     {
+        return Task.CompletedTask;
     }
 
     public void SetPanesVisible(string data)
@@ -139,9 +141,9 @@ internal class TestPlayer : IPlayer
     {
     }
 
-    public string GetURL(string file)
+    public Task<string> GetUrlAsync(string file)
     {
-        return file;
+        return Task.FromResult(file);
     }
 
     public void DoPause(int ms)


### PR DESCRIPTION
## Summary

- Makes `IPlayer.GetUrlAsync`, `PlaySoundAsync`, and `ShowPictureAsync` return `Task` throughout the stack — pure refactor, no behaviour change
- Propagates `async`/`Task<string>` through the resource URL resolution stack so Phase 3's on-demand BroadcastChannel proxy can `await` a response from inside `GetUrlAsync`
- Moves the path traversal (`..`) guard from `ExpressionOwner` down into `WorldModel.GetExternalUrlAsync` and `GetResourceData`, where it applies regardless of call path
- `ExpressionOwner` is the game-facing scripting API (method names discovered by reflection); internal callers now call `WorldModel` directly
- Adds the plan doc (`docs/wasmeditor-offline-preview.md`) and marks Phase 1 complete

## Test plan

- [x] All 306 tests pass (`dotnet test --configuration Release`)
- [x] Clean build, zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)