### PR TITLE
WasmEditor: fix preview sending stale game bytes

### DIFF
--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -117,20 +117,26 @@ function blobToDataUrl(blob: Blob): Promise<string> {
     });
 }
 
+let _previewChannel: BroadcastChannel | null = null;
+
 export async function previewInWasmPlayer(wasmPlayerUrl: string): Promise<void> {
     if (!_bridge || !_adapter) return;
 
-    const xml = _bridge.Save();
-    isDirty.set(false);
-    const bytes = new TextEncoder().encode(xml);
+    // Close stale channel so old bytes aren't sent to a new preview window.
+    _previewChannel?.close();
+
     const filename = _adapter.filename;
     const adapter = _adapter;
 
     window.open(wasmPlayerUrl + '?source=editor', '_blank');
     const bc = new BroadcastChannel('quest-preview');
+    _previewChannel = bc;
 
     bc.onmessage = async ({ data }) => {
         if (data.type === 'ready') {
+            // Serialize fresh on every 'ready' so WasmPlayer refreshes also pick up latest edits.
+            if (!_bridge) return;
+            const bytes = new TextEncoder().encode(_bridge.Save());
             bc.postMessage({ type: 'game', bytes, filename });
         } else if (data.type === 'resource-request') {
             const blob = await adapter.getAsset(data.name);


### PR DESCRIPTION
## Summary

- Close the previous `BroadcastChannel` before opening a new preview window, preventing the old handler from racing with the new one and sending outdated bytes to WasmPlayer
- Move `_bridge.Save()` into the `'ready'` handler so game state is serialized fresh on every request — this also fixes refreshing the WasmPlayer tab after making further edits
- Remove the misleading `isDirty.set(false)` from `previewInWasmPlayer` (previewing doesn't save the file)

## Test plan

- [ ] Add an object, click Preview — new object appears in WasmPlayer
- [ ] Make further edits without re-opening the editor, then click Preview again — latest edits appear
- [ ] With a preview window open, make edits and refresh the WasmPlayer tab — latest edits appear (not the state from when Preview was first clicked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)