### PR TITLE
Remove dot encoding now that NCalc handles obj.attr natively (#1754)

### DIFF
--- a/src/EditorCore/EditableScriptFactory.cs
+++ b/src/EditorCore/EditableScriptFactory.cs
@@ -20,7 +20,7 @@ public class EditableScriptData
         var expression = editor.Fields.GetString("onlydisplayif");
         if (expression != null)
         {
-            m_visibilityExpression = new Expression<bool>(Engine.Utility.ConvertVariablesToFleeFormat(expression),
+            m_visibilityExpression = new Expression<bool>(Engine.Utility.EncodeIdentifierSpaces(expression),
                 new ScriptContext(worldModel, true));
         }
     }

--- a/src/EditorCore/EditorVisibilityHelper.cs
+++ b/src/EditorCore/EditorVisibilityHelper.cs
@@ -47,7 +47,7 @@ internal class EditorVisibilityHelper
         var expression = source.Fields.GetString("onlydisplayif");
         if (expression != null)
         {
-            m_visibilityExpression = new Expression<bool>(Engine.Utility.ConvertVariablesToFleeFormat(expression),
+            m_visibilityExpression = new Expression<bool>(Engine.Utility.EncodeIdentifierSpaces(expression),
                 new ScriptContext(worldModel, true));
             m_alwaysVisible = false;
         }

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -22,7 +22,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     {
         _scriptContext = scriptContext;
         _expressionOwner = new ExpressionOwner(scriptContext.WorldModel);
-        _expression = Utility.DecodeIdentifierSpaces(expression);
+        _expression = Utility.ResolveElementName(expression);
 
         _nCalcExpression = new Expression(expression,
             new ExpressionContext { Options = ExpressionOptions.NoStringTypeCoercion },
@@ -404,7 +404,8 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
                 ?? throw new Exception("__Quest_PropertyAccess__ second argument must be a property name string");
             if (receiver is Element element)
             {
-                return element.Fields.Exists(propertyName, true) ? element.Fields.Get(propertyName) : null;
+                var fieldName = Utility.ResolveElementName(propertyName);
+                return element.Fields.Exists(fieldName, true) ? element.Fields.Get(fieldName) : null;
             }
 #pragma warning disable IL2075 // script-accessible types are explicitly rooted in ScriptDispatchRoots.cs
             var prop = receiver?.GetType().GetProperty(propertyName,

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -22,7 +22,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     {
         _scriptContext = scriptContext;
         _expressionOwner = new ExpressionOwner(scriptContext.WorldModel);
-        _expression = Utility.ConvertFleeFormatToVariables(expression);
+        _expression = Utility.DecodeIdentifierSpaces(expression);
 
         _nCalcExpression = new Expression(expression,
             new ExpressionContext { Options = ExpressionOptions.NoStringTypeCoercion },
@@ -92,61 +92,15 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
     private object ResolveVariable(string name)
     {
-        if (name == "null")
-        {
-            return null;
-        }
+        if (name == "null") return null;
 
         if (_context.Parameters?.ContainsKey(name) == true)
-        {
             return _context.Parameters[name];
-        }
 
         if (_scriptContext.WorldModel.TryResolveExpressionElement(Utility.ResolveElementName(name), out var result))
-        {
             return result;
-        }
 
-        ResolveVariableName(name, out var fields, out var variable);
-
-        do
-        {
-            if (!Utility.ContainsUnresolvedDotNotation(variable))
-            {
-                continue;
-            }
-
-            // We may have been passed in something like someobj.parent.someproperty
-            Utility.ResolveVariableName(ref variable, out var nestedObj, out variable);
-            fields = fields.GetObject(nestedObj).Fields;
-        } while (Utility.ContainsUnresolvedDotNotation(variable));
-
-        return !fields.Exists(variable, true) ? null : fields.Get(variable);
-    }
-
-    private void ResolveVariableName(string name, out Fields fields, out string variable)
-    {
-        Utility.ResolveVariableName(ref name, out var obj, out variable);
-
-        if (_scriptContext.WorldModel.TryResolveExpressionElement(name, out var result))
-        {
-            fields = result.Fields;
-        }
-        else
-        {
-            if (obj == null)
-            {
-                throw new Exception($"Unknown object or variable '{name}'");
-            }
-
-            var value = ResolveVariable(obj);
-            if (value is not Element instance)
-            {
-                throw new Exception($"Variable does not refer to an object: '{obj}'");
-            }
-
-            fields = instance.Fields;
-        }
+        throw new Exception($"Unknown object or variable '{name}'");
     }
 
     private async Task EvaluateFunctionAsync(string name, FunctionEventArgs args)

--- a/src/Engine/Functions/Expression.cs
+++ b/src/Engine/Functions/Expression.cs
@@ -16,7 +16,7 @@ public abstract class ExpressionBase
         OriginalExpression = expression;
         if (!scriptContext.WorldModel.EditMode)
         {
-            expression = Utility.ConvertVariablesToFleeFormat(expression);
+            expression = Utility.EncodeIdentifierSpaces(expression);
         }
 
         Expression = expression;

--- a/src/Engine/Scripts/SetScript.cs
+++ b/src/Engine/Scripts/SetScript.cs
@@ -82,10 +82,15 @@ public class SetScriptConstructor : IScriptConstructor
 
     internal IFunction<Element> GetAppliesTo(ScriptContext scriptContext, string value, out string variable)
     {
-        var var = Utility.ConvertVariablesToFleeFormat(value).Trim();
-        string obj;
-        Utility.ResolveObjectDotAttribute(var, out obj, out variable);
-        return obj == null ? null : new Expression<Element>(obj, scriptContext);
+        value = value.Trim();
+        var dotPos = value.LastIndexOf('.');
+        if (dotPos == -1)
+        {
+            variable = Utility.ResolveElementName(value);
+            return null;
+        }
+        variable = value[(dotPos + 1)..];
+        return new Expression<Element>(value[..dotPos], scriptContext);
     }
 }
 

--- a/src/Engine/Utility.cs
+++ b/src/Engine/Utility.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -25,6 +26,7 @@ public static partial class Utility
         {"object", "command", "turnscript", "game", "exit", "type", "finish"};
 
     private static readonly List<string> s_keywords = new() {"and", "or", "xor", "not", "if", "in"};
+    private static readonly HashSet<string> s_keywordsSet = new(s_keywords);
 
     private static readonly string[] s_listSplitDelimiters = new[] {"; ", ";"};
 
@@ -178,7 +180,7 @@ public static partial class Utility
 
                         if (c == ')')
                         {
-                            bracketCount--;
+                            bracketCount = Math.Max(0, bracketCount - 1);
                         }
 
                         if (bracketCount == 0 && c == ',')
@@ -206,11 +208,6 @@ public static partial class Utility
 
     [GeneratedRegex(@"//")]
     private static partial Regex s_detectComments();
-
-    public static string DecodeIdentifierSpaces(string expression)
-    {
-        return expression.Replace(k_spaceReplacementString, " ");
-    }
 
     private static string ReplaceRegexMatchesRespectingQuotes(string input, Regex regex, string replaceWith,
         bool replaceInsideQuote)
@@ -266,23 +263,12 @@ public static partial class Utility
 
     private static bool IsSplitVariableName(string word1, string word2)
     {
-        if (!(s_wordRegex1().IsMatch(word1) && s_wordRegex2().IsMatch(word2)))
-        {
-            return false;
-        }
+        var match1 = s_wordRegex1().Match(word1);
+        var match2 = s_wordRegex2().Match(word2);
 
-        var word1last = s_wordRegex1().Match(word1).Groups[1].Value;
-        var word2first = s_wordRegex2().Match(word2).Groups[1].Value;
-
-        if (s_keywords.Contains(word1last))
-        {
-            return false;
-        }
-
-        if (s_keywords.Contains(word2first))
-        {
-            return false;
-        }
+        if (!match1.Success || !match2.Success) return false;
+        if (s_keywordsSet.Contains(match1.Groups[1].Value)) return false;
+        if (s_keywordsSet.Contains(match2.Groups[1].Value)) return false;
 
         return true;
     }
@@ -485,10 +471,9 @@ public static partial class Utility
 
     private static int GetMatchStrengthInternal(Regex regex, string input)
     {
-        if (!regex.IsMatch(input))
-        {
+        var match = regex.Match(input);
+        if (!match.Success)
             throw new Exception(string.Format("String '{0}' is not a match for Regex '{1}'", input, regex));
-        }
 
         // The idea is that you have a regex like
         //          look at (?<object>.*)
@@ -505,8 +490,7 @@ public static partial class Utility
             // exclude group names like "0", we only want the explicitly named groups
             if (!int.TryParse(groupName, out _))
             {
-                var groupMatch = regex.Match(input).Groups[groupName].Value;
-                lengthOfTextMatchedByGroups += groupMatch.Length;
+                lengthOfTextMatchedByGroups += match.Groups[groupName].Value.Length;
             }
         }
 
@@ -526,10 +510,9 @@ public static partial class Utility
 
     private static QuestDictionary<string> PopulateInternal(Regex regex, string input)
     {
-        if (!regex.IsMatch(input))
-        {
+        var match = regex.Match(input);
+        if (!match.Success)
             throw new Exception(string.Format("String '{0}' is not a match for Regex '{1}'", input, regex));
-        }
 
         var result = new QuestDictionary<string>();
 
@@ -537,8 +520,7 @@ public static partial class Utility
         {
             if (!int.TryParse(groupName, out _))
             {
-                var groupMatch = regex.Match(input).Groups[groupName].Value;
-                result.Add(groupName, groupMatch);
+                result.Add(groupName, match.Groups[groupName].Value);
             }
         }
 
@@ -559,7 +541,7 @@ public static partial class Utility
 
         if (!string.IsNullOrEmpty(separator))
         {
-            separatorRegex = "(" + string.Join("|", separator.Split(';').Select(s => s.Trim())) + ")";
+            separatorRegex = "(" + string.Join("|", separator.Split(';').Select(s => Regex.Escape(s.Trim()))) + ")";
         }
 
         foreach (var verb in verbs)
@@ -574,11 +556,11 @@ public static partial class Utility
             string textToAdd;
             if (verb.Contains("#object#"))
             {
-                textToAdd = "^" + verb.Replace("#object#", objectRegex);
+                textToAdd = "^" + string.Join(objectRegex, verb.Split("#object#").Select(Regex.Escape));
             }
             else
             {
-                textToAdd = "^" + verb + " " + objectRegex;
+                textToAdd = "^" + Regex.Escape(verb) + " " + objectRegex;
             }
 
             if (separatorRegex != null)
@@ -670,61 +652,62 @@ public static partial class Utility
     public static string IndentScript(string script, int indentLevel, string indentChars)
     {
         var lines = SplitIntoLines(script);
-        var result = Environment.NewLine;
+        var sb = new StringBuilder();
+        sb.Append(Environment.NewLine);
 
         foreach (var line in lines)
         {
-            AddLine(ref result, ref indentLevel, line, indentChars);
+            AddLine(sb, ref indentLevel, line, indentChars);
         }
 
-        return result;
+        return sb.ToString();
     }
 
-    private static void AddLine(ref string result, ref int indentLevel, string line, string indentChars)
+    private static void AddLine(StringBuilder result, ref int indentLevel, string line, string indentChars)
     {
-        if (line.Length == 0)
-        {
-            return;
-        }
+        if (line.Length == 0) return;
 
         if (line.StartsWith("}"))
         {
             // if line starts with closing brace, de-indent, put the brace on a line on its own,
             // then resume with the rest of the line.
             indentLevel--;
-            result += GetIndentChars(indentLevel, indentChars) + "}" + Environment.NewLine;
-            AddLine(ref result, ref indentLevel, line[1..], indentChars);
+            result.Append(GetIndentChars(indentLevel, indentChars));
+            result.Append('}');
+            result.Append(Environment.NewLine);
+            AddLine(result, ref indentLevel, line[1..], indentChars);
             return;
         }
 
         // Add this line at the current indent level
-        result += GetIndentChars(indentLevel, indentChars) + line + Environment.NewLine;
+        result.Append(GetIndentChars(indentLevel, indentChars));
+        result.Append(line);
+        result.Append(Environment.NewLine);
 
-        // Now work out the indent level for the following line
-        for (var i = 0; i < line.Length; i++)
+        // Work out the indent level for the following line, ignoring braces inside strings.
+        var inString = false;
+        var i = 0;
+        while (i < line.Length)
         {
-            var curChar = line.Substring(i, 1);
-            if (curChar == "{")
+            var c = line[i];
+            if (inString)
             {
-                indentLevel++;
+                if (c == '\\') i++; // skip escaped character
+                else if (c == '"') inString = false;
             }
-
-            if (curChar == "}")
+            else
             {
-                indentLevel--;
+                if (c == '"') inString = true;
+                else if (c == '{') indentLevel++;
+                else if (c == '}') indentLevel--;
             }
+            i++;
         }
     }
 
     public static string GetIndentChars(int indentLevel, string indentChars)
     {
-        var indentString = string.Empty;
-
-        for (var i = 0; i < indentLevel; i++)
-        {
-            indentString += indentChars;
-        }
-
-        return indentString;
+        if (indentLevel <= 0) return string.Empty;
+        return string.Concat(Enumerable.Repeat(indentChars, indentLevel));
     }
 }

--- a/src/Engine/Utility.cs
+++ b/src/Engine/Utility.cs
@@ -19,7 +19,6 @@ public class MismatchingQuotesException : Exception
 
 public static partial class Utility
 {
-    private const string k_dotReplacementString = "___DOT___";
     private const string k_spaceReplacementString = "___SPACE___";
 
     public static readonly string[] DisallowedAttributes =
@@ -200,84 +199,17 @@ public static partial class Utility
         return result;
     }
 
-    public static void ResolveVariableName(ref string name, out string obj, out string variable)
-    {
-        name = ResolveElementName(name);
-        var eqPos = name.IndexOf(k_dotReplacementString);
-        if (eqPos == -1)
-        {
-            obj = null;
-            variable = name;
-            return;
-        }
-
-        obj = name[..eqPos];
-        variable = name[(eqPos + k_dotReplacementString.Length)..];
-    }
-
-    public static void ResolveObjectDotAttribute(string name, out string obj, out string variable)
-    {
-        variable = ConvertVariablesToFleeFormat(ResolveElementName(name));
-        StringBuilder sb = null;
-
-        do
-        {
-            if (!ContainsUnresolvedDotNotation(variable))
-            {
-                continue;
-            }
-
-            // We may have been passed in something like someobj.parent.someproperty
-            ResolveVariableName(ref variable, out var nestedObj, out variable);
-
-            if (nestedObj == null)
-            {
-                continue;
-            }
-
-            if (sb == null)
-            {
-                sb = new StringBuilder();
-            }
-            else
-            {
-                sb.Append('.');
-            }
-
-            sb.Append(nestedObj);
-        } while (ContainsUnresolvedDotNotation(variable));
-
-        obj = sb?.ToString();
-    }
-
     public static string ResolveElementName(string name)
     {
         return name.Replace(k_spaceReplacementString, " ");
     }
 
-    // private static Regex s_convertVariables = new System.Text.RegularExpressions.Regex(@"(\w)\.([a-zA-Z])");
-    [GeneratedRegex(@"(\w)\.([a-zA-Z])")]
-    private static partial Regex s_convertVariables();
-
     [GeneratedRegex(@"//")]
     private static partial Regex s_detectComments();
 
-    /// <summary>
-    ///     FLEE doesn't allow us to have control over dot notation i.e. "object.property",
-    ///     so instead we handle "object_property". Use this function to convert dot to underscore.
-    /// </summary>
-    /// <param name="expression"></param>
-    /// <returns></returns>
-    public static string ConvertVariablesToFleeFormat(string expression)
+    public static string DecodeIdentifierSpaces(string expression)
     {
-        var result = ReplaceRegexMatchesRespectingQuotes(expression, s_convertVariables(),
-            "$1" + k_dotReplacementString + "$2", false);
-        return ConvertVariableNamesWithSpaces(result);
-    }
-
-    public static string ConvertFleeFormatToVariables(string expression)
-    {
-        return expression.Replace(k_dotReplacementString, ".").Replace(k_spaceReplacementString, " ");
+        return expression.Replace(k_spaceReplacementString, " ");
     }
 
     private static string ReplaceRegexMatchesRespectingQuotes(string input, Regex regex, string replaceWith,
@@ -286,7 +218,7 @@ public static partial class Utility
         return ReplaceRespectingQuotes(input, replaceInsideQuote, text => regex.Replace(text, replaceWith));
     }
 
-    private static string ConvertVariableNamesWithSpaces(string input)
+    public static string EncodeIdentifierSpaces(string input)
     {
         return ReplaceRespectingQuotes(input, false, text =>
         {
@@ -527,11 +459,6 @@ public static partial class Utility
         }
 
         return result.ToString();
-    }
-
-    public static bool ContainsUnresolvedDotNotation(string input)
-    {
-        return input.Contains(k_dotReplacementString);
     }
 
     public static bool IsRegexMatch(string regexPattern, string input)

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -382,7 +382,7 @@ public class ExpressionTests
     {
         // When a method arg is null, NCalc's GetMethod(name, [typeof(object)]) won't find
         // List<Element>.Contains(Element), so the null-arg fallback must kick in.
-        // AllObjects() as receiver avoids the ConvertVariablesToFleeFormat (\w\.\w) mangling.
+        // AllObjects() as receiver avoids dot-notation parsing since the receiver is a function call.
         var expr = new Expression<bool>("AllObjects().Contains(nullobj)", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "nullobj", null } } };
         (await expr.ExecuteAsync(c)).ShouldBeFalse();

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -113,6 +113,14 @@ public class ExpressionTests
         result.ShouldBe(expectedResult);
     }
 
+    [TestMethod]
+    public async Task TestPropertyAccess_AttributeNameWithSpace()
+    {
+        _object.Fields.Set("my attr", "spacedvalue");
+        var result = await RunExpression<string>("object.my attr");
+        result.ShouldBe("spacedvalue");
+    }
+
     [DataTestMethod]
     [DataRow("1", 1)]
     [DataRow("1 + 2", 3)]

--- a/tests/EngineTests/FilesTests.cs
+++ b/tests/EngineTests/FilesTests.cs
@@ -6,21 +6,15 @@ namespace QuestViva.EngineTests;
 public class FilesTests
 {
     [TestMethod]
-    public void TestConvertDottedProperties()
+    public void TestDottedPropertiesNotEncoded()
     {
-        Assert.AreEqual("obj___DOT___prop", Engine.Utility.ConvertVariablesToFleeFormat("obj.prop"));
-        Assert.AreEqual("obj1___DOT___prop, obj2___DOT___prop",
-            Engine.Utility.ConvertVariablesToFleeFormat("obj1.prop, obj2.prop"));
-        Assert.AreEqual("(\"myfile.html\")", Engine.Utility.ConvertVariablesToFleeFormat("(\"myfile.html\")"));
-        Assert.AreEqual("\"myfile.html\"", Engine.Utility.ConvertVariablesToFleeFormat("\"myfile.html\""));
-        Assert.AreEqual("obj1___DOT___prop \"test.html\" obj2___DOT___prop",
-            Engine.Utility.ConvertVariablesToFleeFormat("obj1.prop \"test.html\" obj2.prop"));
-    }
-
-    [TestMethod]
-    public void TestDecimalPointsNotConvertedToDottedProperties()
-    {
-        Assert.AreEqual("3.141", Engine.Utility.ConvertVariablesToFleeFormat("3.141"));
+        // Dots in obj.prop expressions are now handled natively by the NCalc parser postfix rule.
+        Assert.AreEqual("obj.prop", Engine.Utility.EncodeIdentifierSpaces("obj.prop"));
+        Assert.AreEqual("obj1.prop, obj2.prop",
+            Engine.Utility.EncodeIdentifierSpaces("obj1.prop, obj2.prop"));
+        Assert.AreEqual("(\"myfile.html\")", Engine.Utility.EncodeIdentifierSpaces("(\"myfile.html\")"));
+        Assert.AreEqual("\"myfile.html\"", Engine.Utility.EncodeIdentifierSpaces("\"myfile.html\""));
+        Assert.AreEqual("3.141", Engine.Utility.EncodeIdentifierSpaces("3.141"));
     }
 
     [TestMethod]
@@ -103,23 +97,23 @@ public class FilesTests
     [TestMethod]
     public void TestConvertVariableNamesWithSpaces()
     {
-        Assert.AreEqual("my___SPACE___variable", Engine.Utility.ConvertVariablesToFleeFormat("my variable"));
+        Assert.AreEqual("my___SPACE___variable", Engine.Utility.EncodeIdentifierSpaces("my variable"));
         Assert.AreEqual("my___SPACE___variable, other___SPACE___variable",
-            Engine.Utility.ConvertVariablesToFleeFormat("my variable, other variable"));
+            Engine.Utility.EncodeIdentifierSpaces("my variable, other variable"));
         Assert.AreEqual("my___SPACE___variable, \"some text\", other___SPACE___variable",
-            Engine.Utility.ConvertVariablesToFleeFormat("my variable, \"some text\", other variable"));
+            Engine.Utility.EncodeIdentifierSpaces("my variable, \"some text\", other variable"));
         Assert.AreEqual("my___SPACE___long___SPACE___variable___SPACE___name",
-            Engine.Utility.ConvertVariablesToFleeFormat("my long variable name"));
+            Engine.Utility.EncodeIdentifierSpaces("my long variable name"));
     }
 
     [TestMethod]
     public void TestNamesNearKeywordsNotConverted()
     {
-        Assert.AreEqual("not my___SPACE___variable", Engine.Utility.ConvertVariablesToFleeFormat("not my variable"));
+        Assert.AreEqual("not my___SPACE___variable", Engine.Utility.EncodeIdentifierSpaces("not my variable"));
         Assert.AreEqual("my___SPACE___variable or other___SPACE___variable",
-            Engine.Utility.ConvertVariablesToFleeFormat("my variable or other variable"));
+            Engine.Utility.EncodeIdentifierSpaces("my variable or other variable"));
         Assert.AreEqual("(not SomeFunction(\"hello there\"))",
-            Engine.Utility.ConvertVariablesToFleeFormat("(not SomeFunction(\"hello there\"))"));
+            Engine.Utility.EncodeIdentifierSpaces("(not SomeFunction(\"hello there\"))"));
     }
 
     [TestMethod]
@@ -152,58 +146,4 @@ public class FilesTests
             Engine.Utility.GetParameter("msg (\"parameter with a bracket ) in a string\")"));
     }
 
-    [TestMethod]
-    public void TestResolveObjectDotAttribute_Variable()
-    {
-        var name = "somevar";
-        string obj;
-        string variable;
-        Engine.Utility.ResolveObjectDotAttribute(name, out obj, out variable);
-        Assert.AreEqual(null, obj);
-        Assert.AreEqual("somevar", variable);
-    }
-
-    [TestMethod]
-    public void TestResolveObjectDotAttribute_OneObject()
-    {
-        var name = "someobject.somevar";
-        string obj;
-        string variable;
-        Engine.Utility.ResolveObjectDotAttribute(name, out obj, out variable);
-        Assert.AreEqual("someobject", obj);
-        Assert.AreEqual("somevar", variable);
-    }
-
-    [TestMethod]
-    public void TestResolveObjectDotAttribute_TwoObjects()
-    {
-        var name = "someobject.anotherobject.somevar";
-        string obj;
-        string variable;
-        Engine.Utility.ResolveObjectDotAttribute(name, out obj, out variable);
-        Assert.AreEqual("someobject.anotherobject", obj);
-        Assert.AreEqual("somevar", variable);
-    }
-
-    [TestMethod]
-    public void TestResolveObjectDotAttribute_ThreeObjects()
-    {
-        var name = "someobject.anotherobject.thirdobject.somevar";
-        string obj;
-        string variable;
-        Engine.Utility.ResolveObjectDotAttribute(name, out obj, out variable);
-        Assert.AreEqual("someobject.anotherobject.thirdobject", obj);
-        Assert.AreEqual("somevar", variable);
-    }
-
-    [TestMethod]
-    public void TestResolveObjectDotAttribute_ThreeObjectsAndSpaces()
-    {
-        var name = "some object.another object.thirdobject.some var";
-        string obj;
-        string variable;
-        Engine.Utility.ResolveObjectDotAttribute(name, out obj, out variable);
-        Assert.AreEqual("some object.another object.thirdobject", obj);
-        Assert.AreEqual("some var", variable);
-    }
 }

--- a/tests/EngineTests/FilesTests.cs
+++ b/tests/EngineTests/FilesTests.cs
@@ -1,4 +1,6 @@
-﻿using QuestViva.Engine;
+﻿using System.Text.RegularExpressions;
+using QuestViva.Engine;
+using Shouldly;
 
 namespace QuestViva.EngineTests;
 
@@ -144,6 +146,65 @@ public class FilesTests
             Engine.Utility.GetParameter("msg (\"parameter 1\", \"parameter 2\")"));
         Assert.AreEqual("\"parameter with a bracket ) in a string\"",
             Engine.Utility.GetParameter("msg (\"parameter with a bracket ) in a string\")"));
+    }
+
+    [TestMethod]
+    public void TestSplitParameter_UnmatchedClosingBracket()
+    {
+        var result = Engine.Utility.SplitParameter("a), b");
+        result.Count.ShouldBe(2);
+        result[0].ShouldBe("a)");
+        result[1].ShouldBe("b");
+    }
+
+    [TestMethod]
+    public void TestConvertVerbSimplePattern_EscapesVerbMetacharacters()
+    {
+        var pattern = Engine.Utility.ConvertVerbSimplePattern("pick.up", null);
+        var regex = new Regex(pattern, RegexOptions.IgnoreCase);
+        regex.IsMatch("pick.up book").ShouldBeTrue();
+        regex.IsMatch("pickXup book").ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public void TestConvertVerbSimplePattern_EscapesSeparatorMetacharacters()
+    {
+        var pattern = Engine.Utility.ConvertVerbSimplePattern("put", "with;a.k.a.");
+        var regex = new Regex(pattern, RegexOptions.IgnoreCase);
+
+        // Literal separator "a.k.a." should populate object2
+        var literalSep = regex.Match("put book a.k.a. box");
+        literalSep.Success.ShouldBeTrue();
+        literalSep.Groups["object2"].Value.ShouldBe("box");
+
+        // "aXkXaX" should NOT be treated as the separator (dot is not a wildcard)
+        var wildcardSep = regex.Match("put book aXkXaX box");
+        wildcardSep.Success.ShouldBeTrue();
+        wildcardSep.Groups["object2"].Value.ShouldBe(""); // absorbed into object, not a separator match
+    }
+
+    [TestMethod]
+    public void TestIndentScript()
+    {
+        var script = "if (true) {\nmsg(\"hello\")\n}";
+        var result = Engine.Utility.IndentScript(script, 0, "  ");
+        result.ShouldBe(
+            Environment.NewLine +
+            "if (true) {" + Environment.NewLine +
+            "  msg(\"hello\")" + Environment.NewLine +
+            "}" + Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void TestIndentScript_IgnoresBracesInStrings()
+    {
+        // A '{' inside a string literal must not increase the indent level for subsequent lines
+        var script = "msg(\"before { after\")\nmsg(\"end\")";
+        var result = Engine.Utility.IndentScript(script, 0, "  ");
+        result.ShouldBe(
+            Environment.NewLine +
+            "msg(\"before { after\")" + Environment.NewLine +
+            "msg(\"end\")" + Environment.NewLine);
     }
 
 }

--- a/tests/EngineTests/UtilityTests.cs
+++ b/tests/EngineTests/UtilityTests.cs
@@ -5,7 +5,7 @@ using Shouldly;
 namespace QuestViva.EngineTests;
 
 [TestClass]
-public class FilesTests
+public class UtilityTests
 {
     [TestMethod]
     public void TestDottedPropertiesNotEncoded()


### PR DESCRIPTION
## Summary

- Removes `___DOT___` encoding: `obj.attr` expressions are now handled natively by the NCalc postfix rule (`__Quest_PropertyAccess__`), so the old FLEE-era workaround is no longer needed. Verified against 21,704 exported `.aslx` files — none use `___DOT___` manually.
- Renames `ConvertVariablesToFleeFormat` → `EncodeIdentifierSpaces` (and removes the now-redundant wrapper); removes `DecodeIdentifierSpaces`, `ResolveObjectDotAttribute`, `ContainsUnresolvedDotNotation`, and related dead code.
- Fixes several pre-existing bugs found during a code review of `Utility.cs`:
  - `SplitParameter`: clamp `bracketCount` to 0 to prevent undercount on unmatched `)`
  - `IsSplitVariableName`: use pre-built `HashSet` for O(1) keyword lookup; single `Match()` call
  - `GetMatchStrengthInternal` / `PopulateInternal`: store `regex.Match()` result instead of calling twice
  - `ConvertVerbSimplePattern`: `Regex.Escape()` verbs and separators to prevent metacharacter injection
  - `IndentScript`: use `StringBuilder`; track string context so braces inside string literals don't affect indentation
  - `NcalcExpressionEvaluator`: decode `___SPACE___` in property names before `Fields` lookup so attributes with spaces work via dot-notation
- Adds 6 new unit tests covering the above fixes; renames `FilesTests` → `UtilityTests`.

## Test plan

- [x] All 315 tests pass (`dotnet test --configuration Release`)
- [x] No game files in the wild use `___DOT___` manually (grepped 21,704 `.aslx` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)