### PR TITLE
WasmPlayer production entry points and JS execution fix

### DIFF
--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -59,7 +59,7 @@ public interface IPlayer
     void SetBackground(string colour);
     void SetForeground(string colour);
     void SetLinkForeground(string colour);
-    void RunScript(string function, object[]? parameters);
+    Task RunScriptAsync(string function, object[]? parameters);
     void Quit();
     void SetFont(string fontName);
     void SetFontSize(string fontSize);

--- a/src/Engine/Scripts/JSScript.cs
+++ b/src/Engine/Scripts/JSScript.cs
@@ -71,11 +71,11 @@ public class JSScript : ScriptBase
         if (m_parameters != null)
         {
             var paramValues = await Task.WhenAll(m_parameters.Select(p => p.ExecuteAsync(c)));
-            m_scriptContext.WorldModel.PlayerUi.RunScript(m_function, paramValues);
+            await m_scriptContext.WorldModel.PlayerUi.RunScriptAsync(m_function, paramValues);
         }
         else
         {
-            m_scriptContext.WorldModel.PlayerUi.RunScript(m_function, null);
+            await m_scriptContext.WorldModel.PlayerUi.RunScriptAsync(m_function, null);
         }
     }
 

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -129,11 +129,11 @@ public class RequestScript : ScriptBase
                 var functionName = jsArgs[0];
                 if (jsArgs.Length == 0)
                 {
-                    m_worldModel.PlayerUi.RunScript(functionName, null);
+                    await m_worldModel.PlayerUi.RunScriptAsync(functionName, null);
                 }
                 else
                 {
-                    m_worldModel.PlayerUi.RunScript(functionName, jsArgs.Skip(1).ToArray());
+                    await m_worldModel.PlayerUi.RunScriptAsync(functionName, jsArgs.Skip(1).ToArray());
                 }
 
                 break;

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -233,8 +233,8 @@ public partial class WorldModel : IGame, IGameDebug
                 }
                 else if (Version >= WorldModelVersion.v540)
                 {
-                    PlayerUi.RunScript("loadHtml", [output.Fields.GetString("html")]);
-                    PlayerUi.RunScript("markScrollPosition", null);
+                    await PlayerUi.RunScriptAsync("loadHtml", [output.Fields.GetString("html")]);
+                    await PlayerUi.RunScriptAsync("markScrollPosition", null);
                     ScrollToEnd();
                 }
                 else if (_legacyOutputLogger != null)
@@ -1281,7 +1281,7 @@ public partial class WorldModel : IGame, IGameDebug
 
     private void ScrollToEnd()
     {
-        PlayerUi.RunScript("scrollToEnd", null);
+        _ = PlayerUi.RunScriptAsync("scrollToEnd", null);
     }
 
     internal void LogException(Exception ex)

--- a/src/PlayerCore/GameQuery.cs
+++ b/src/PlayerCore/GameQuery.cs
@@ -338,8 +338,9 @@ public class GameQuery(string filename)
         {
         }
 
-        public void RunScript(string function, object[] parameters)
+        public Task RunScriptAsync(string function, object[] parameters)
         {
+            return Task.CompletedTask;
         }
 
         public void Quit()

--- a/src/WasmPlayer/WasmPlayer.csproj
+++ b/src/WasmPlayer/WasmPlayer.csproj
@@ -26,6 +26,7 @@
             <_FlatAssets Include="$(_PCRes)grid.js"/>
             <_FlatAssets Include="$(MSBuildThisFileDirectory)wasm-player.js"/>
             <_FlatAssets Include="$(MSBuildThisFileDirectory)index.html"/>
+            <_FlatAssets Include="$(MSBuildThisFileDirectory)quest-config.js"/>
             <_LibAssets Include="$(_PCRes)lib\jquery-2.1.1.min.js"/>
             <_LibAssets Include="$(_PCRes)lib\jquery-ui.min.js"/>
             <_LibAssets Include="$(_PCRes)lib\jquery-ui.min.css"/>

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -61,7 +61,7 @@ public partial class WasmPlayerBridge
         if (scripts != null)
         {
             foreach (var script in scripts)
-                JsAddExternalScript(await _ui.GetUrlAsync(script));
+                await JsAddExternalScript(await _ui.GetUrlAsync(script));
         }
 
         var stylesheets = _game.GetExternalStylesheets();
@@ -215,7 +215,7 @@ public partial class WasmPlayerBridge
     internal static partial void JsUiHide(string element);
 
     [JSImport("addExternalScript", "wasm-player")]
-    internal static partial void JsAddExternalScript(string url);
+    internal static partial Task JsAddExternalScript(string url);
 
     [JSImport("addExternalStylesheet", "wasm-player")]
     internal static partial void JsAddExternalStylesheet(string url);

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -229,6 +229,9 @@ public partial class WasmPlayerBridge
     [JSImport("runScript", "wasm-player")]
     internal static partial void JsRunScript(string call);
 
+    [JSImport("jsYield", "wasm-player")]
+    internal static partial Task JsYield();
+
     [JSImport("setCompassDirections", "wasm-player")]
     internal static partial void JsSetCompassDirections(string dirsJson);
 
@@ -401,9 +404,10 @@ public partial class WasmPlayerBridge
 
         void IPlayer.SetLinkForeground(string colour) => _helper?.SetLinkForeground(colour);
 
-        void IPlayer.RunScript(string function, object[]? parameters)
+        async Task IPlayer.RunScriptAsync(string function, object[]? parameters)
         {
             FlushText();
+            await JsYield();
             var serializedArgs = string.Join(',',
                 parameters?.Select(SerializeJsArg) ?? System.Array.Empty<string>());
             JsRunScript($"{function}({serializedArgs})");

--- a/src/WasmPlayer/dev-server.mjs
+++ b/src/WasmPlayer/dev-server.mjs
@@ -2,6 +2,11 @@
 // Dev server for WasmPlayer — serves the Debug AppBundle with required COOP/COEP headers.
 // Run: node dev-server.mjs
 // Then open: http://localhost:5175/?game=/examples/simple.aslx
+//
+// Proxy routes (dev only — avoids CORS issues during local development):
+//   /api/                        → https://textadventures.co.uk/api/
+//                                  (rewrites SourceGameUrl in JSON responses)
+//   /game-resource/<encoded-url> → fetches the game file from the encoded URL
 
 import http from 'node:http';
 import fs from 'node:fs';
@@ -45,7 +50,7 @@ function serveFile(res, filePath) {
   });
 }
 
-const server = http.createServer((req, res) => {
+const server = http.createServer(async (req, res) => {
   // Required for SharedArrayBuffer used by the .NET WASM runtime
   res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
   res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
@@ -57,6 +62,62 @@ const server = http.createServer((req, res) => {
     const filePath = path.join(examplesDir, urlPath.slice('/examples/'.length));
     if (!filePath.startsWith(examplesDir)) { res.writeHead(403); res.end(); return; }
     serveFile(res, filePath);
+    return;
+  }
+
+  // Serve quest-config.js with a dev-local API root so requests route through this proxy.
+  // In production the deployed quest-config.js carries the absolute textadventures.co.uk URL.
+  if (urlPath === '/quest-config.js') {
+    const body = `window.QuestVivaConfig = { textAdventuresApiRoot: '/api/' };\n`;
+    res.writeHead(200, { 'Content-Type': 'application/javascript', 'Cache-Control': 'no-cache' });
+    res.end(body);
+    return;
+  }
+
+  // Proxy /api/ → https://textadventures.co.uk/api/.
+  // Rewrites SourceGameUrl in JSON responses so the game file also comes through this proxy.
+  if (urlPath.startsWith('/api/')) {
+    try {
+      const target = `https://textadventures.co.uk${urlPath}`;
+      const apiRes = await fetch(target);
+      const contentType = apiRes.headers.get('content-type') ?? 'application/json';
+      let body = await apiRes.text();
+      if (contentType.includes('application/json')) {
+        try {
+          const json = JSON.parse(body);
+          if (json.sourceGameUrl) {
+            json.sourceGameUrl = `/game-resource/${encodeURIComponent(json.sourceGameUrl)}`;
+          }
+          if (json.resourceRoot) {
+            json.resourceRoot = `/game-resource/${encodeURIComponent(json.resourceRoot)}`;
+          }
+          body = JSON.stringify(json);
+        } catch { /* leave body as-is if JSON parse fails */ }
+      }
+      res.writeHead(apiRes.status, { 'Content-Type': contentType, 'Cache-Control': 'no-cache' });
+      res.end(body);
+    } catch (e) {
+      res.writeHead(502);
+      res.end(`Proxy error: ${e.message}`);
+    }
+    return;
+  }
+
+  // Proxy /game-resource/<encoded-url> → fetch the actual game file.
+  // Used because the direct game file URL may also be blocked by CORS in dev.
+  if (urlPath.startsWith('/game-resource/')) {
+    const targetUrl = decodeURIComponent(urlPath.slice('/game-resource/'.length));
+    try {
+      const gameRes = await fetch(targetUrl);
+      res.writeHead(gameRes.status, {
+        'Content-Type': gameRes.headers.get('content-type') ?? 'application/octet-stream',
+        'Cache-Control': 'no-cache',
+      });
+      res.end(Buffer.from(await gameRes.arrayBuffer()));
+    } catch (e) {
+      res.writeHead(502);
+      res.end(`Proxy error: ${e.message}`);
+    }
     return;
   }
 

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -12,8 +12,168 @@
     <script type="text/javascript" src="playercore.js"></script>
     <script type="text/javascript" src="player.js"></script>
     <script type="text/javascript" src="lib/paper.js"></script>
+    <script type="text/javascript" src="quest-config.js"></script>
     <script type="text/javascript" src="wasm-player.js"></script>
+    <style>
+        #qv-start {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #0a0b12;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            padding: 1rem;
+            box-sizing: border-box;
+        }
+        #qv-card {
+            background: #111220;
+            border: 1px solid rgba(139, 124, 246, 0.25);
+            border-radius: 16px;
+            padding: 2.5rem 2rem;
+            width: 100%;
+            max-width: 440px;
+            box-shadow: 0 0 60px rgba(139, 124, 246, 0.08), 0 8px 40px rgba(0, 0, 0, 0.6);
+        }
+        #qv-card h1 {
+            font-family: Georgia, 'Times New Roman', serif;
+            color: #e2e0ff;
+            font-size: 2rem;
+            margin: 0 0 0.2rem;
+            font-weight: normal;
+            letter-spacing: 0.01em;
+        }
+        #qv-card h1 .gem {
+            color: #8b7cf6;
+            margin-right: 0.3em;
+        }
+        #qv-tagline {
+            color: #5a5b7a;
+            font-size: 0.9rem;
+            margin: 0 0 2rem;
+        }
+        .qv-label {
+            display: block;
+            color: #5a5b7a;
+            font-size: 0.72rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin-bottom: 0.5rem;
+        }
+        #qv-file-btn {
+            width: 100%;
+            padding: 0.8rem 1rem;
+            background: rgba(139, 124, 246, 0.08);
+            border: 1px solid rgba(139, 124, 246, 0.2);
+            border-radius: 10px;
+            color: #b8b4e8;
+            font-size: 0.9rem;
+            font-family: inherit;
+            cursor: pointer;
+            text-align: left;
+            transition: background 0.15s, border-color 0.15s;
+            box-sizing: border-box;
+        }
+        #qv-file-btn:hover {
+            background: rgba(139, 124, 246, 0.14);
+            border-color: rgba(139, 124, 246, 0.4);
+        }
+        #qv-file-input { display: none; }
+        .qv-or {
+            text-align: center;
+            color: #2e2f45;
+            font-size: 0.85rem;
+            margin: 1.25rem 0;
+            position: relative;
+        }
+        .qv-or::before, .qv-or::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            width: 42%;
+            height: 1px;
+            background: #1e1f30;
+        }
+        .qv-or::before { left: 0; }
+        .qv-or::after { right: 0; }
+        #qv-url-row {
+            display: flex;
+            gap: 0.5rem;
+        }
+        #qv-url-input {
+            flex: 1;
+            padding: 0.75rem 0.9rem;
+            background: #0d0e1a;
+            border: 1px solid #1e1f30;
+            border-radius: 10px;
+            color: #c8c6e8;
+            font-size: 0.9rem;
+            font-family: inherit;
+            outline: none;
+            min-width: 0;
+            transition: border-color 0.15s;
+        }
+        #qv-url-input:focus { border-color: rgba(139, 124, 246, 0.5); }
+        #qv-url-input::placeholder { color: #2e2f45; }
+        #qv-url-btn {
+            padding: 0.75rem 1.1rem;
+            background: #8b7cf6;
+            border: none;
+            border-radius: 10px;
+            color: #fff;
+            font-size: 0.9rem;
+            font-family: inherit;
+            font-weight: 600;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: background 0.15s;
+        }
+        #qv-url-btn:hover { background: #7a6ae4; }
+        #qv-error {
+            display: none;
+            background: rgba(220, 60, 60, 0.08);
+            border: 1px solid rgba(220, 60, 60, 0.25);
+            border-radius: 10px;
+            padding: 0.9rem 1rem;
+            margin-bottom: 1.5rem;
+            color: #f87171;
+            font-size: 0.88rem;
+            line-height: 1.6;
+        }
+        #qv-error a { color: #93c5fd; }
+        #qv-loading-msg {
+            display: none;
+            color: #5a5b7a;
+            font-size: 0.88rem;
+            margin-top: 1.25rem;
+            text-align: center;
+        }
+    </style>
 </head>
 <body>
+<div id="qv-start">
+    <div id="qv-card">
+        <h1><span class="gem">&#9672;</span>Quest Viva</h1>
+        <p id="qv-tagline">Play text adventure games</p>
+
+        <div id="qv-error"></div>
+
+        <div id="qv-pickers">
+            <span class="qv-label">Open a game file</span>
+            <button id="qv-file-btn" type="button">&#128193; Choose file (.quest, .aslx, .asl, .cas)</button>
+            <input type="file" id="qv-file-input" accept=".quest,.aslx,.asl,.cas">
+
+            <div class="qv-or">or</div>
+
+            <label class="qv-label" for="qv-url-input">Load from URL</label>
+            <div id="qv-url-row">
+                <input type="url" id="qv-url-input" placeholder="https://&hellip;" autocomplete="off" spellcheck="false">
+                <button id="qv-url-btn" type="button">Load</button>
+            </div>
+        </div>
+
+        <p id="qv-loading-msg">Loading&hellip;</p>
+    </div>
+</div>
 </body>
 </html>

--- a/src/WasmPlayer/quest-config.js
+++ b/src/WasmPlayer/quest-config.js
@@ -1,0 +1,5 @@
+// Quest Viva WasmPlayer configuration.
+// Replace this file (or set window.QuestVivaConfig before wasm-player.js loads) to customise.
+window.QuestVivaConfig = {
+    textAdventuresApiRoot: 'https://textadventures.co.uk/api/'
+};

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -8,8 +8,10 @@ var _audio = null;
 
 const pendingResources = new Map();
 let editorChannel = null;
+let resourceRoot = null;
 
 function getResourceUrl(name) {
+    if (resourceRoot) return Promise.resolve(resourceRoot + name);
     if (!editorChannel) return Promise.resolve(name);
     return new Promise(resolve => {
         const id = crypto.randomUUID();
@@ -221,6 +223,90 @@ async function initWasmPlayer(gameBytes, filename, bc = null) {
     Bridge.Begin();
 }
 
+// ── Start screen helpers ──────────────────────────────────────────────────────
+
+function _esc(str) {
+    return String(str)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function showLoading() {
+    const pickers = document.getElementById('qv-pickers');
+    const msg = document.getElementById('qv-loading-msg');
+    if (pickers) pickers.style.display = 'none';
+    if (msg) msg.style.display = '';
+}
+
+function showError(downloadUrl) {
+    const pickers = document.getElementById('qv-pickers');
+    const msg = document.getElementById('qv-loading-msg');
+    const errorEl = document.getElementById('qv-error');
+    if (msg) msg.style.display = 'none';
+    if (pickers) pickers.style.display = '';
+    if (!errorEl) return;
+    let html = '<strong>Couldn\'t load the game.</strong> '
+        + 'The server may not allow this player to load the file directly (CORS restriction).';
+    if (downloadUrl) {
+        html += ' <a href="' + _esc(downloadUrl) + '" target="_blank" rel="noopener">'
+            + 'Open the file in a new tab</a> to save it, then open it with the file picker below.';
+    } else {
+        html += ' You can try opening a saved copy of the game file instead.';
+    }
+    errorEl.innerHTML = html;
+    errorEl.style.display = '';
+    wireStartScreen();
+}
+
+let _startScreenWired = false;
+function wireStartScreen() {
+    if (_startScreenWired) return;
+    _startScreenWired = true;
+
+    const fileBtn = document.getElementById('qv-file-btn');
+    const fileInput = document.getElementById('qv-file-input');
+    const urlInput = document.getElementById('qv-url-input');
+    const urlBtn = document.getElementById('qv-url-btn');
+    if (!fileBtn) return;
+
+    fileBtn.addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', () => {
+        const file = fileInput.files?.[0];
+        if (!file) return;
+        showLoading();
+        const reader = new FileReader();
+        reader.onload = () => initWasmPlayer(new Uint8Array(reader.result), file.name)
+            .catch(() => showError(null));
+        reader.readAsArrayBuffer(file);
+    });
+
+    async function doLoadUrl() {
+        const url = urlInput.value.trim();
+        if (!url) return;
+        const errorEl = document.getElementById('qv-error');
+        if (errorEl) errorEl.style.display = 'none';
+        showLoading();
+        try {
+            const { bytes, filename } = await fetchGameBytes(url);
+            await initWasmPlayer(bytes, filename);
+        } catch {
+            showError(url);
+        }
+    }
+    urlBtn.addEventListener('click', doLoadUrl);
+    urlInput.addEventListener('keydown', e => { if (e.key === 'Enter') doLoadUrl(); });
+}
+
+async function fetchGameBytes(url) {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const filename = (response.url || url).split('/').pop()?.split('?')[0] || 'game.aslx';
+    return { bytes, filename };
+}
+
+// ── Boot ─────────────────────────────────────────────────────────────────────
+
 (function () {
     const params = new URLSearchParams(window.location.search);
 
@@ -229,28 +315,59 @@ async function initWasmPlayer(gameBytes, filename, bc = null) {
         bc.postMessage({ type: 'ready' });
         bc.onmessage = async ({ data }) => {
             if (data.type === 'game') {
-                bc.onmessage = null;   // hand off to resource handler (Phase 3)
+                bc.onmessage = null;
                 await initWasmPlayer(data.bytes, data.filename, bc);
             }
         };
         return;
     }
 
+    const id = params.get('id');
     const gameUrl = params.get('game');
-    if (!gameUrl) {
-        document.addEventListener('DOMContentLoaded', () => {
-            document.body.innerHTML = '<p style="font-family:sans-serif;padding:2em">No game specified. Add <code>?game=path/to/game.aslx</code> to the URL.</p>';
+
+    if (id) {
+        // Start API fetch immediately; wire DOM once it's ready.
+        let resolvedSourceUrl = null;
+        const gamePromise = (async () => {
+            const apiRoot = window.QuestVivaConfig?.textAdventuresApiRoot
+                ?? 'https://textadventures.co.uk/api/';
+            const apiResponse = await fetch(`${apiRoot}game/${id}`);
+            if (!apiResponse.ok) throw new Error(`API: HTTP ${apiResponse.status}`);
+            const { sourceGameUrl, resourceRoot: resRoot } = await apiResponse.json();
+            resolvedSourceUrl = sourceGameUrl;
+            resourceRoot = resRoot || null;
+            const { bytes, filename } = await fetchGameBytes(sourceGameUrl);
+            return { bytes, filename };
+        })();
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            showLoading();
+            try {
+                const { bytes, filename } = await gamePromise;
+                await initWasmPlayer(bytes, filename);
+            } catch {
+                showError(resolvedSourceUrl);
+            }
         });
         return;
     }
-    const filename = gameUrl.split('/').pop() || 'game.aslx';
-    (async () => {
-        const response = await fetch(gameUrl);
-        if (!response.ok) {
-            document.body.innerHTML = `<p>Failed to load game: ${response.statusText}</p>`;
-            return;
-        }
-        const gameBytes = new Uint8Array(await response.arrayBuffer());
-        await initWasmPlayer(gameBytes, filename);
-    })().catch(e => console.error('[Quest] Init failed:', e));
+
+    if (gameUrl) {
+        // Start fetch immediately; wire DOM once it's ready.
+        const gamePromise = fetchGameBytes(gameUrl);
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            showLoading();
+            try {
+                const { bytes, filename } = await gamePromise;
+                await initWasmPlayer(bytes, filename);
+            } catch {
+                showError(gameUrl);
+            }
+        });
+        return;
+    }
+
+    // No game specified — show start screen and wire up controls.
+    document.addEventListener('DOMContentLoaded', wireStartScreen);
 })();

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -184,6 +184,7 @@ async function initWasmPlayer(gameBytes, filename, bc = null) {
             const globalEval = window.eval;
             try { globalEval(call); } catch (e) { console.error(e); }
         },
+        jsYield: () => new Promise(resolve => setTimeout(resolve, 0)),
         setCompassDirections: (dirsJson) => setCompassDirections(JSON.parse(dirsJson)),
         setInterfaceString: (name, text) => setInterfaceString(name, text),
         setPanelContents: (html) => setPanelContents(html),

--- a/src/WebPlayer/Player.cs
+++ b/src/WebPlayer/Player.cs
@@ -215,12 +215,13 @@ public class Player : IPlayerHelperUI
         PlayerHelper.SetLinkForeground(colour);
     }
 
-    void IPlayer.RunScript(string function, object[]? parameters)
+    Task IPlayer.RunScriptAsync(string function, object[]? parameters)
     {
         // Clear text buffer before running custom JavaScript, otherwise text written
         // before now may appear after inserted HTML.
         OutputText(PlayerHelper.ClearBuffer());
         AddJavaScriptToBuffer(function, parameters);
+        return Task.CompletedTask;
     }
 
     void IPlayer.Quit()

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -10,7 +10,7 @@ namespace QuestViva.EngineTests;
 /// <summary>
 /// Drives a v580+ WorldModel and captures output one interaction step at a time, so tests can
 /// assert that specific text appeared before vs. after a wait / get-input / etc.
-/// For v580+ games, text reaches the player via IPlayer.RunScript("addText", [html]) rather than
+/// For v580+ games, text reaches the player via IPlayer.RunScriptAsync("addText", [html]) rather than
 /// the PrintText event, so we intercept the mock player to capture it.
 /// </summary>
 internal sealed class GameDriver
@@ -25,7 +25,7 @@ internal sealed class GameDriver
     {
         _worldModel = worldModel;
         playerMock
-            .Setup(p => p.RunScript(It.IsAny<string>(), It.IsAny<object[]>()))
+            .Setup(p => p.RunScriptAsync(It.IsAny<string>(), It.IsAny<object[]>()))
             .Callback<string, object[]>((fn, args) =>
             {
                 if (fn == "addText" && args?.Length > 0 && args[0] is string html)
@@ -34,7 +34,8 @@ internal sealed class GameDriver
                     if (!string.IsNullOrEmpty(text))
                         _batch.Add(text);
                 }
-            });
+            })
+            .Returns(Task.CompletedTask);
         worldModel.LogError += ex => _scriptError = ex;
     }
 

--- a/tests/LegacyTests/TestPlayer.cs
+++ b/tests/LegacyTests/TestPlayer.cs
@@ -99,8 +99,9 @@ internal class TestPlayer : IPlayer
         Foreground = colour;
     }
 
-    public void RunScript(string function, object[] parameters)
+    public Task RunScriptAsync(string function, object[] parameters)
     {
+        return Task.CompletedTask;
     }
 
     public void Quit()


### PR DESCRIPTION
## Summary

- **Start screen & entry points**: landing page with file picker and URL input; `?game=<url>` loads a game file directly; `?id=<id>` resolves via the textadventures.co.uk API
- **Dev server proxy**: routes `/api/` and `/game-resource/` locally to avoid CORS/COEP issues; rewrites `sourceGameUrl` and `resourceRoot` in API responses
- **External script loading fix**: `JsAddExternalScript` was `void` so the Promise was never awaited, causing `Begin()` to fire before game scripts loaded — now properly `Task`-returning
- **JS event loop yield fix**: `IPlayer.RunScript` renamed to `RunScriptAsync` (now `Task`-returning); WasmPlayer awaits a `setTimeout(0)` promise before each JS call, matching WebPlayer's per-SignalR-message macrotask behaviour — fixes games like Moquette where CSS transition cleanup was racing with the next JS call and leaving `#divOutput` hidden

## Test plan

- [ ] Load a local `.aslx` file via the file picker on the start screen
- [ ] Load a game via `?game=/examples/simple.aslx` with the dev server
- [ ] Load Moquette via `?id=zbzfpcnknu_vdjog-cbihw` and verify "get on" clears the screen and shows the next section (regression for the `#divOutput` display bug)
- [ ] Verify existing tests pass (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)