### PR TITLE
WasmPlayer: fix SetTimeout timers not firing after commands

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -2,9 +2,10 @@
 # Start the local editor+player dev environment.
 #
 # Usage:
-#   ./dev.sh [--api-proxy <url>]
+#   ./dev.sh [--release] [--api-proxy <url>]
 #
 # Options:
+#   --release           Build in Release mode (AOT-compiled WasmPlayer, ~15s extra)
 #   --api-proxy <url>   Proxy /api requests to <url> (e.g. http://localhost:5043
 #                       for a local textadventures.co.uk instance)
 #
@@ -18,25 +19,39 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 API_PROXY=""
+RELEASE=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --release) RELEASE=true; shift;;
         --api-proxy) API_PROXY="$2"; shift 2;;
         *) echo "Unknown argument: $1" >&2; exit 1;;
     esac
 done
 
 echo "Building WasmEditor..."
-dotnet build src/WasmEditor/WasmEditor.csproj
+if [[ "$RELEASE" == true ]]; then
+    dotnet build src/WasmEditor/WasmEditor.csproj --configuration Release
+else
+    dotnet build src/WasmEditor/WasmEditor.csproj
+fi
 
 echo ""
 echo "Building WasmPlayer..."
-dotnet build src/WasmPlayer/WasmPlayer.csproj
+if [[ "$RELEASE" == true ]]; then
+    dotnet build src/WasmPlayer/WasmPlayer.csproj --configuration Release
+else
+    dotnet build src/WasmPlayer/WasmPlayer.csproj
+fi
 
 echo ""
 echo "Starting dev servers..."
 echo ""
 
-node src/WasmPlayer/dev-server.mjs &
+if [[ "$RELEASE" == true ]]; then
+    node src/WasmPlayer/dev-server.mjs --release &
+else
+    node src/WasmPlayer/dev-server.mjs &
+fi
 PLAYER_PID=$!
 
 VITE_ENV=(

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -334,6 +334,11 @@ public partial class WorldModel : IGame, IGameDebug
             // in its own finally after the callback script runs. Signaling here would complete the
             // turn before the callback output is produced, causing it to appear only on the next turn.
             if (!commandWasOverridden) SignalTurnSuspended();
+            // SendCommand calls SendNextTimerRequest() synchronously before HandleCommandAsyncInternal
+            // has run, so any SetTimeout() registered during the command (e.g. after the first JS yield)
+            // is missed. Calling it here ensures the timer request reflects timers registered by the
+            // command script.
+            SendNextTimerRequest();
         }
     }
 


### PR DESCRIPTION
## Summary

- `SendCommand` fires `HandleCommandAsyncInternal` as fire-and-forget then immediately calls `SendNextTimerRequest()`. The command script typically yields at its first JS call (e.g. `JS.disableAllCommandLinks()`), so any `SetTimeout()` registered later in the same command hasn't been added to the timer runner yet.
- This caused `sendNextGameTickerAfter = 0` in JS, so `timerTick()` never invoked `uiTick()`, and the timeout script was never executed.
- Fix: call `SendNextTimerRequest()` again at the end of `HandleCommandAsyncInternal`'s `finally` block, after the full command has run and all `SetTimeout` registrations are complete.
- Also adds `--release` flag to `dev.sh` for building WasmPlayer in AOT mode locally, with bash 3.2-compatible empty-array handling.

Reproducer: Moquette — getting off the first free-roaming train triggered `SetTimeout(1) { JS.doScreenClear() }` inside the `unboard` command. The blackout animation never ran and the screen stayed blank.

## Test plan

- [ ] Play Moquette in WasmPlayer, ride a train and get off — blackout animation should play and the platform description should appear
- [ ] Verify other timer-based features (e.g. `SetTimeout` calls, recurring `Timer` elements) still work correctly in WasmPlayer
- [ ] Verify WebPlayer is unaffected (change is engine-only, engine behaviour is unchanged since `SendNextTimerRequest` is idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)