### PR TITLE
WasmPlayer: fix RunScript eval and newline handling to match WebPlayer

### DIFF
--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -470,8 +470,21 @@ public partial class WasmPlayerBridge
         {
             FlushBuffer();
             await JsYield();
+
+            // Strip newlines from string parameters — some games depend on this (matching WebPlayer behaviour)
+            var processedParams = parameters?.Select(p =>
+                p is string s ? (object)s.Replace("\r", "").Replace("\n", "") : p).ToArray();
+
+            // When function is "eval", pass the code directly rather than wrapping it in eval(...)
+            // so it runs in global scope (matching WebPlayer behaviour; e.g. spondre defines global functions this way)
+            if (function == "eval" && processedParams is [string evalCode])
+            {
+                JsRunScript(evalCode);
+                return;
+            }
+
             var serializedArgs = string.Join(',',
-                parameters?.Select(SerializeJsArg) ?? System.Array.Empty<string>());
+                processedParams?.Select(SerializeJsArg) ?? System.Array.Empty<string>());
             JsRunScript($"{function}({serializedArgs})");
         }
 


### PR DESCRIPTION
## Summary

- Strip `\r`/`\n` from string parameters in `RunScriptAsync` — WebPlayer does this with the note that \"some existing games depend on this\"
- Special-case `function == "eval"`: pass the code string directly to `JsRunScript` (which calls `globalEval`) rather than wrapping it as `eval("code")`, so game-defined functions land in global scope
- Fixes spondre's custom UI not appearing in WasmPlayer due to `SyntaxError: Invalid or unexpected token` when eval-ing function definitions

## Test plan

- [ ] Load spondre game in WasmPlayer and confirm custom UI appears with no console errors
- [ ] Confirm no regressions in other games that use `request (RunScript, ...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)