### PR TITLE
WasmPlayer: significantly improve performance (~5x on spondre title screen)

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -144,9 +144,9 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         var methods = GetPublicMethodsByName(type, name);
         if (methods == null) return (false, null);
 
-        var evaluatedArgs = await Task.WhenAll(
-            Enumerable.Range(0, parameters.Count)
-                .Select(async i => CoerceLong(await parameters.EvaluateAsync(i))));
+        var evaluatedArgs = new object?[parameters.Count];
+        for (var i = 0; i < parameters.Count; i++)
+            evaluatedArgs[i] = CoerceLong(await parameters.EvaluateAsync(i));
 
         var (handled, result) = DispatchToMethod(methods, instance, name, evaluatedArgs);
         if (handled && result is Task task)
@@ -159,12 +159,20 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         return (handled, result);
     }
 
+    private static readonly Dictionary<(Type, string), MethodBase[]?> s_methodCache = new();
+
     private static MethodBase[]? GetPublicMethodsByName([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string name)
     {
+        var key = (type, name);
+        if (s_methodCache.TryGetValue(key, out var cached))
+            return cached;
+
         var methods = type.GetMethods()
             .Where(m => m.IsPublic && m.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
             .ToArray<MethodBase>();
-        return methods.Length == 0 ? null : methods;
+        var result = methods.Length == 0 ? null : methods;
+        s_methodCache[key] = result;
+        return result;
     }
 
     private static (bool handled, object? result) DispatchToMethod(MethodBase[] methods, object? instance, string name,
@@ -390,8 +398,9 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             var receiver = CoerceLong(await args.Parameters.EvaluateAsync(0));
             var methodName = await args.Parameters.EvaluateAsync(1) as string
                 ?? throw new Exception("__Quest_MethodCall__ second argument must be a string method name");
-            var methodArgs = await Task.WhenAll(Enumerable.Range(2, args.Parameters.Count - 2)
-                .Select(async i => CoerceLong(await args.Parameters.EvaluateAsync(i))));
+            var methodArgs = new object?[args.Parameters.Count - 2];
+            for (var i = 0; i < methodArgs.Length; i++)
+                methodArgs[i] = CoerceLong(await args.Parameters.EvaluateAsync(i + 2));
             return DispatchMethodCall(receiver, methodName, methodArgs);
         }
 

--- a/src/Engine/Scripts/JSScript.cs
+++ b/src/Engine/Scripts/JSScript.cs
@@ -70,7 +70,9 @@ public class JSScript : ScriptBase
 
         if (m_parameters != null)
         {
-            var paramValues = await Task.WhenAll(m_parameters.Select(p => p.ExecuteAsync(c)));
+            var paramValues = new object[m_parameters.Count];
+            for (var i = 0; i < m_parameters.Count; i++)
+                paramValues[i] = await m_parameters[i].ExecuteAsync(c);
             await m_scriptContext.WorldModel.PlayerUi.RunScriptAsync(m_function, paramValues);
         }
         else

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -466,10 +466,17 @@ public partial class WasmPlayerBridge
 
         void IPlayer.SetLinkForeground(string colour) => _helper?.SetLinkForeground(colour);
 
+        private static long _lastYieldMs = 0;
+
         async Task IPlayer.RunScriptAsync(string function, object[]? parameters)
         {
             FlushBuffer();
-            await JsYield();
+            var now = Environment.TickCount64;
+            if (now - _lastYieldMs >= 16)
+            {
+                _lastYieldMs = now;
+                await JsYield();
+            }
 
             // Strip newlines from string parameters — some games depend on this (matching WebPlayer behaviour)
             var processedParams = parameters?.Select(p =>


### PR DESCRIPTION
## Summary

- **Cache reflection results in `NcalcExpressionEvaluator`**: `GetPublicMethodsByName` was calling `type.GetMethods()` on every function invocation (e.g. every call to `Left()`, `Right()`, `Mid()`). Now cached by `(type, name)` after the first lookup — this was the dominant bottleneck.
- **Replace `Task.WhenAll` with sequential `await` loops** in `JSScript` and `NcalcExpressionEvaluator`. In browser-WASM, `Task.WhenAll` dispatches each task through the thread pool emulator (`setTimeout`/`BackgroundJobHandler`), adding a timer round-trip per argument even when evaluation completes synchronously.
- **Throttle `JsYield` in `RunScriptAsync`** to at most ~60Hz rather than yielding on every JS function call.

## Results (spondre title screen, Release/AOT build)

| Event | Before | After | Speedup |
|-------|--------|-------|---------|
| Begin | 12,761ms | 3,174ms | ~4x |
| uiSendEvent "Null" | 5,214ms | 1,145ms | ~4.5x |
| uiSendEvent "TitleText1Done" | 9,679ms | 967ms | ~10x |
| uiSendEvent "TitleText2Done" | 9,616ms | 1,758ms | ~5.5x |
| uiSendEvent "TitleDone" | 5,480ms | 961ms | ~5.7x |

The reflection cache was by far the largest contributor. A remaining opportunity is `DispatchToMethod` which also calls `m.GetParameters()` without caching, but that's left for a follow-up.

## Test plan

- [ ] Play spondre (`?id=yy0qt1xtp0yrrn5tdvdtiq`) in WasmPlayer Release build and verify title screen completes in reasonable time
- [ ] Run engine tests: `dotnet test tests/EngineTests`
- [ ] Verify other games still work correctly in WasmPlayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)