### PR TITLE
Fix Debug build warnings and treat warnings as errors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <Authors>Alex Warren</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -398,7 +398,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             var receiver = CoerceLong(await args.Parameters.EvaluateAsync(0));
             var methodName = await args.Parameters.EvaluateAsync(1) as string
                 ?? throw new Exception("__Quest_MethodCall__ second argument must be a string method name");
-            var methodArgs = new object?[args.Parameters.Count - 2];
+            var methodArgs = new object[args.Parameters.Count - 2];
             for (var i = 0; i < methodArgs.Length; i++)
                 methodArgs[i] = CoerceLong(await args.Parameters.EvaluateAsync(i + 2));
             return DispatchMethodCall(receiver, methodName, methodArgs);

--- a/tests/EngineTests/SaveTests.cs
+++ b/tests/EngineTests/SaveTests.cs
@@ -20,7 +20,7 @@ public class SaveTests
         var success = await worldModel.Initialise(player.Object);
         Assert.IsTrue(success, "Initialisation failed");
 
-        worldModel.Begin();
+        await worldModel.Begin();
 
         await worldModel.SendCommand("update");
 
@@ -34,7 +34,7 @@ public class SaveTests
         success = await savedGameWorldModel.Initialise(player.Object);
         Assert.IsTrue(success, "Initialisation failed");
 
-        savedGameWorldModel.Begin();
+        await savedGameWorldModel.Begin();
 
         foreach (var cmd in worldModel.Walkthroughs.Walkthroughs["verify"].Steps)
         {

--- a/tests/EngineTests/Walkthrough.cs
+++ b/tests/EngineTests/Walkthrough.cs
@@ -17,7 +17,7 @@ public class Walkthrough
 
         var player = new Mock<IPlayer>();
         await worldModel.Initialise(player.Object);
-        worldModel.Begin();
+        await worldModel.Begin();
 
         foreach (var cmd in worldModel.Walkthroughs.Walkthroughs["debug"].Steps)
         {

--- a/tests/LegacyTests/LegacyBlockingTests.cs
+++ b/tests/LegacyTests/LegacyBlockingTests.cs
@@ -23,7 +23,7 @@ public class LegacyBlockingTests
         _game = new V4Game(gameData, null);
         _game.PrintText += _player.PrintText;
         await _game.Initialise(_player);
-        _game.Begin();
+        await _game.Begin();
     }
 
     // wait blocks the script until FinishWait() is called; "Done" must not

--- a/tests/LegacyTests/V4GameTests.cs
+++ b/tests/LegacyTests/V4GameTests.cs
@@ -18,7 +18,7 @@ public class V4GameTests
         m_game = new V4Game(gameData, null);
         m_game.PrintText += m_player.PrintText;
         await m_game.Initialise(m_player);
-        m_game.Begin();
+        await m_game.Begin();
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Fixes the 6 warnings that appeared on a clean Debug build: 5x CS4014 (missing `await` on `Begin()` calls in test setup) and 1x CS8632 (stray nullable annotation inside a `#nullable disable` file).
- Adds a root-level `Directory.Build.props` with `TreatWarningsAsErrors=true` so the build fails fast on new warnings instead of letting them accumulate. `src/Directory.Build.props` now imports the root file so its existing NuGet packaging metadata still applies only to `src/`.

## Test plan
- [x] `dotnet build --configuration Debug --no-incremental` — 0 warnings, 0 errors
- [x] `dotnet build --configuration Release --no-incremental` — 0 warnings, 0 errors (covers WasmPlayer/WasmEditor AOT/trim build path)
- [x] `dotnet test --configuration Debug` — 315/315 tests pass
- [x] Verified the config actually enforces the rule: temporarily introduced an unused-variable warning and confirmed it failed the build as `error CS0219`, then reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)