### PR TITLE
Add deploy pipeline for play.questviva.com

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -1,0 +1,66 @@
+name: Deploy play.questviva.com
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "src/WasmEditor/**"
+      - "src/WebEditor/**"
+      - "src/WasmPlayer/**"
+      - "src/PlayerCore/**"
+      - "src/EditorCore/**"
+      - "src/Engine/**"
+      - "src/Common/**"
+      - "src/Utility/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install .NET WASM workload
+        run: dotnet workload install wasm-tools
+
+      - name: Build WasmEditor
+        run: dotnet build src/WasmEditor/WasmEditor.csproj -c Release
+
+      - name: Build WasmPlayer
+        run: dotnet build src/WasmPlayer/WasmPlayer.csproj -c Release
+
+      - name: Build WebEditor
+        run: npm ci && npm run build
+        working-directory: src/WebEditor
+        env:
+          PUBLIC_WEBEDITOR_VERSION: ${{ github.sha }}
+
+      - name: Assemble deploy directory
+        run: |
+          mkdir -p deploy/AppBundle deploy/player
+          cp -r src/WebEditor/build/. deploy/
+          cp -r src/WasmEditor/bin/Release/net10.0/browser-wasm/AppBundle/. deploy/AppBundle/
+          cp -r src/WasmPlayer/bin/Release/net10.0/browser-wasm/AppBundle/. deploy/player/
+          cat > deploy/_headers <<'EOF'
+          /*
+            Cross-Origin-Opener-Policy: same-origin
+            Cross-Origin-Embedder-Policy: require-corp
+          EOF
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy deploy --project-name=play-questviva --branch=main

--- a/.github/workflows/release-webeditor.yml
+++ b/.github/workflows/release-webeditor.yml
@@ -32,6 +32,7 @@ jobs:
         working-directory: src/WebEditor
         env:
           PUBLIC_WEBEDITOR_VERSION: ${{ github.ref_name }}
+          BASE_PATH: /questviva
 
       - name: Package artifacts
         run: |

--- a/src/WebEditor/svelte.config.js
+++ b/src/WebEditor/svelte.config.js
@@ -5,7 +5,7 @@ export default {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter({ fallback: 'index.html' }),
-    paths: { base: '/questviva' },
+    paths: { base: process.env.BASE_PATH ?? '' },
     alias: {
       $components: 'src/components'
     }


### PR DESCRIPTION
## Summary
- New `deploy-play.yml` workflow builds WasmEditor, WasmPlayer, and WebEditor, then deploys the combined static output to the `play-questviva` Cloudflare Pages project via wrangler.
- `WebEditor`'s SvelteKit base path is now configurable via `BASE_PATH` (defaults to root) instead of hardcoded to `/questviva`, so the same app builds correctly for both `play.questviva.com` (root) and the existing textadventures.co.uk subpath deployment (`release-webeditor.yml` now sets `BASE_PATH: /questviva` explicitly to preserve current behavior).

See `docs/deployment-domains.md` for the overall plan this implements.

## Test plan
- [ ] `build_and_test` CI passes
- [ ] Merge triggers `deploy-play.yml` (touches `src/WebEditor/**`) and it deploys successfully
- [ ] `play.questviva.com` root loads the WebEditor open/create flow; `/player/` loads WasmPlayer and can open+play a local game file