### PR TITLE
Move WebEditor to /editor on play.questviva.com

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -45,11 +45,12 @@ jobs:
         working-directory: src/WebEditor
         env:
           PUBLIC_WEBEDITOR_VERSION: ${{ github.sha }}
+          BASE_PATH: /editor
 
       - name: Assemble deploy directory
         run: |
-          mkdir -p deploy/AppBundle deploy/player
-          cp -r src/WebEditor/build/. deploy/
+          mkdir -p deploy/AppBundle deploy/player deploy/editor
+          cp -r src/WebEditor/build/. deploy/editor/
           cp -r src/WasmEditor/bin/Release/net10.0/browser-wasm/AppBundle/. deploy/AppBundle/
           cp -r src/WasmPlayer/bin/Release/net10.0/browser-wasm/AppBundle/. deploy/player/
           cat > deploy/_headers <<'EOF'


### PR DESCRIPTION
## Summary
- WebEditor now deploys to `/editor` instead of root on play.questviva.com; WasmPlayer stays at `/player`. Root is intentionally empty for now.
- Avoids a double migration: putting WasmPlayer at root as an interim step would mean moving it back to `/player` again once the real Play/Create homepage is built. This way both apps get their final, stable paths now, and root only changes once (when the homepage is added).

## Test plan
- [ ] CI passes
- [ ] Merge triggers deploy-play.yml
- [ ] /editor loads WebEditor, /player loads WasmPlayer, root 404s (expected, no homepage yet)