### PR TITLE
Fix SRI integrity failures on redeploy

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -57,6 +57,12 @@ jobs:
           /*
             Cross-Origin-Opener-Policy: same-origin
             Cross-Origin-Embedder-Policy: require-corp
+
+          /player/_framework/*
+            Cache-Control: no-cache
+
+          /AppBundle/_framework/*
+            Cache-Control: no-cache
           EOF
 
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
## Summary
- Fixes "Failed to find a valid digest in the 'integrity' attribute" errors that block game loading on play.questviva.com after a redeploy.
- Root cause: Cloudflare Pages caches `_framework/*.js` (including `dotnet.boot.js`, the manifest with per-file SHA-256 hashes) for 4 hours by default, while `.wasm` files aren't cached at all. .NET WASM AOT builds aren't byte-reproducible and none of these framework filenames are content-hashed, so a browser holding a cached manifest from one deploy alongside a freshly-fetched binary from a later deploy gets a hash mismatch and the resource is blocked.
- Fix: force revalidation (`Cache-Control: no-cache`) on every load for both `/player/_framework/*` (WasmPlayer) and `/AppBundle/_framework/*` (WasmEditor) via `_headers`, so manifest and binaries always come from the same deployment.

## Test plan
- [ ] CI passes
- [ ] Merge triggers deploy-play.yml
- [ ] Confirm `_framework/*` responses now carry `Cache-Control: no-cache`
- [ ] Load a game at play.questviva.com/player/ and confirm no integrity errors