### PR TITLE
Serve .js with UTF-8 charset on play.questviva.com

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -63,6 +63,9 @@ jobs:
 
           /AppBundle/_framework/*
             Cache-Control: no-cache
+
+          /*.js
+            Content-Type: application/javascript; charset=utf-8
           EOF
 
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
## Summary
- Cloudflare Pages adds `charset=utf-8` to `.css` responses automatically but not `.js`, so JS files with non-ASCII characters (e.g. em dashes in comments) were served as `application/javascript` with no charset, causing View Source to mis-render them. The bytes on disk are correct UTF-8; actual script execution is unaffected (browsers fall back to the document's UTF-8 charset when a script has none declared).
- Adds a `_headers` rule forcing `Content-Type: application/javascript; charset=utf-8` for all `.js` responses.

## Test plan
- [ ] CI passes
- [ ] Merge, then manually trigger deploy-play.yml (workflow-only change won't self-trigger)
- [ ] Confirm `.js` files across /player, /AppBundle, and /editor/_app all return charset=utf-8