### PR TITLE
WasmEditor: enable AOT, fix O(n^2) game-load slowdown

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -57,6 +57,9 @@ PLAYER_PID=$!
 VITE_ENV=(
     "PUBLIC_WASM_PLAYER_URL=http://localhost:5174/player/"
 )
+if [[ "$RELEASE" == true ]]; then
+    VITE_ENV+=("WASM_CONFIG=Release")
+fi
 if [[ -n "$API_PROXY" ]]; then
     VITE_ENV+=("VITE_API_PROXY=$API_PROXY")
 fi

--- a/src/Engine/Element.cs
+++ b/src/Engine/Element.cs
@@ -256,6 +256,7 @@ public class Element : IComparable
             throw new ArgumentException($"Parent of element '{Name}' cannot be set to itself");
         }
 
+        m_worldModel.Elements.UpdateParentIndex(this, _parent, parent);
         _parent = parent;
     }
 

--- a/src/Engine/Elements.cs
+++ b/src/Engine/Elements.cs
@@ -7,6 +7,25 @@ public class Elements
     private readonly Dictionary<ElementType, Dictionary<string, Element>> m_elements = new();
     private readonly Dictionary<ElementType, List<Element>> m_elementsLists = new();
 
+    // Index of parent -> direct children, kept in sync by Add/Remove/UpdateParentIndex so that
+    // GetDirectChildren doesn't need to do a full scan of every element in the game.
+    private readonly List<Element> m_rootElements = new();
+    private readonly Dictionary<Element, List<Element>> m_childrenByParent = new();
+
+    // Elements that have completed at least one Add() call, and so are eligible to have their
+    // parent-index entry moved by UpdateParentIndex. Elements being cloned have "parent" copied
+    // onto them (via Fields.Clone) before they've been added, so that early parent assignment
+    // must not touch the index - Add() below performs the baseline registration instead.
+    private readonly HashSet<Element> m_indexedElements = new();
+
+    // Per-parent counters backing UpdateElementSortOrder, so assigning a new child's SortIndex
+    // doesn't need to scan all existing siblings to find the current max. SortIndex is only ever
+    // used for relative ordering (OrderBy) or pairwise swapping of two already-issued values, so
+    // a monotonically increasing counter per parent is safe even though it doesn't reclaim gaps
+    // left by removed elements.
+    private readonly Dictionary<Element, int> m_nextSortIndexByParent = new();
+    private int m_nextRootSortIndex;
+
     internal Elements()
     {
         foreach (ElementType t in Enum.GetValues<ElementType>())
@@ -42,15 +61,26 @@ public class Elements
             }
 
             // element is being overridden, so detach the event handler
-            m_allElements[key].Fields.NameChanged -= ElementNameChanged;
+            var oldElement = m_allElements[key];
+            oldElement.Fields.NameChanged -= ElementNameChanged;
 
             // remove old element from ordered elements list
             m_elementsLists[t].Remove(m_elements[t][key]);
+
+            // and from the parent index, since it's being displaced from the live element graph
+            RemoveFromParentIndex(oldElement, oldElement.Parent);
+            m_indexedElements.Remove(oldElement);
         }
 
         m_allElements[key] = e;
         m_elements[t][key] = e;
         m_elementsLists[t].Add(e);
+
+        // Baseline parent-index registration. Covers both fresh elements (Parent is still null
+        // at this point) and clones (Parent may already be set, copied from the clone source by
+        // Fields.Clone before Add() ran) and undo/redo re-creation of a previously-removed element.
+        AddToParentIndex(e, e.Parent);
+        m_indexedElements.Add(e);
 
         e.Fields.NameChanged += ElementNameChanged;
     }
@@ -76,9 +106,61 @@ public class Elements
 
     internal void Remove(ElementType t, string key)
     {
+        if (m_allElements.TryGetValue(key, out var element))
+        {
+            RemoveFromParentIndex(element, element.Parent);
+            m_indexedElements.Remove(element);
+        }
+
         m_allElements.Remove(key);
         m_elementsLists[t].Remove(m_elements[t][key]);
         m_elements[t].Remove(key);
+    }
+
+    // Called by Element.SetParentFromFields whenever an element's parent changes, so the
+    // parent -> children index stays in sync without needing a full rescan of all elements.
+    internal void UpdateParentIndex(Element child, Element oldParent, Element newParent)
+    {
+        if (!m_indexedElements.Contains(child))
+        {
+            // Still under construction (e.g. Fields.Clone copying "parent" before the clone has
+            // been added) - Add() will perform the baseline registration once it's added.
+            return;
+        }
+
+        RemoveFromParentIndex(child, oldParent);
+        AddToParentIndex(child, newParent);
+    }
+
+    private void AddToParentIndex(Element child, Element parent)
+    {
+        if (parent == null)
+        {
+            m_rootElements.Add(child);
+            return;
+        }
+
+        if (!m_childrenByParent.TryGetValue(parent, out var children))
+        {
+            children = new List<Element>();
+            m_childrenByParent[parent] = children;
+        }
+
+        children.Add(child);
+    }
+
+    private void RemoveFromParentIndex(Element child, Element parent)
+    {
+        if (parent == null)
+        {
+            m_rootElements.Remove(child);
+            return;
+        }
+
+        if (m_childrenByParent.TryGetValue(parent, out var children))
+        {
+            children.Remove(child);
+        }
     }
 
     public Element Get(string key)
@@ -169,7 +251,7 @@ public class Elements
 
     private IEnumerable<Element> CollectChildElements(Element parent, HashSet<Element> visited)
     {
-        foreach (var e in m_allElements.Values.Where(e => e.Parent == parent))
+        foreach (var e in GetDirectChildren(parent))
         {
             if (!visited.Add(e)) continue;
             yield return e;
@@ -182,6 +264,23 @@ public class Elements
 
     public IEnumerable<Element> GetDirectChildren(Element parent)
     {
-        return from element in m_allElements.Values where element.Parent == parent select element;
+        if (parent == null)
+        {
+            return m_rootElements;
+        }
+
+        return m_childrenByParent.TryGetValue(parent, out var children) ? children : [];
+    }
+
+    internal int GetNextSortIndex(Element parent)
+    {
+        if (parent == null)
+        {
+            return m_nextRootSortIndex++;
+        }
+
+        var next = m_nextSortIndexByParent.GetValueOrDefault(parent);
+        m_nextSortIndexByParent[parent] = next + 1;
+        return next;
     }
 }

--- a/src/Engine/GameLoader/GameLoader.cs
+++ b/src/Engine/GameLoader/GameLoader.cs
@@ -166,8 +166,6 @@ internal partial class GameLoader
 
     private void LoadXml(Stream scanStream, XmlReader reader)
     {
-        var timer = Stopwatch.StartNew();
-
         Element? current = null;
         IXmlLoader? currentLoader = null;
 

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -1442,10 +1442,7 @@ public partial class WorldModel : IGame, IGameDebug
         // When this happens, its SortIndex MetaField must be updated so that it
         // is at the end of the list of children.
 
-        var maxIndex = Elements.GetDirectChildren(movedElement.Parent)
-            .Select(sibling => sibling.MetaFields[MetaFieldDefinitions.SortIndex]).Prepend(-1).Max();
-
-        movedElement.MetaFields[MetaFieldDefinitions.SortIndex] = maxIndex + 1;
+        movedElement.MetaFields[MetaFieldDefinitions.SortIndex] = Elements.GetNextSortIndex(movedElement.Parent);
     }
 
     internal async Task AddOnReady(IScript callback, Context c)

--- a/src/WasmEditor/WasmEditor.csproj
+++ b/src/WasmEditor/WasmEditor.csproj
@@ -7,6 +7,8 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
+        <RunAOTCompilation>true</RunAOTCompilation>
+        <WasmEmitSymbolMap>true</WasmEmitSymbolMap>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\EditorCore\EditorCore.csproj"/>

--- a/src/WebEditor/vite.config.ts
+++ b/src/WebEditor/vite.config.ts
@@ -5,8 +5,11 @@ import { fileURLToPath } from 'node:url'
 import { join, extname } from 'node:path'
 import { readFile } from 'node:fs/promises'
 
+// Set WASM_CONFIG=Release to serve the AOT-compiled AppBundle instead of the Debug/interpreter one
+// (e.g. for profiling, where AOT gives per-method native frames instead of one opaque interpreter loop).
+const wasmConfig = process.env.WASM_CONFIG === 'Release' ? 'Release' : 'Debug'
 const appBundleDir = fileURLToPath(
-  new URL('../WasmEditor/bin/Debug/net10.0/browser-wasm/AppBundle', import.meta.url)
+  new URL(`../WasmEditor/bin/${wasmConfig}/net10.0/browser-wasm/AppBundle`, import.meta.url)
 )
 
 const mimeTypes: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Enable AOT compilation for WasmEditor (matches WasmPlayer), plus a symbol map for future wasm profiling and a `WASM_CONFIG=Release` toggle for the WebEditor dev server.
- Fix an O(n^2) bug in `Elements`/`WorldModel` where every element created while in edit mode triggered a full scan of every element in the game (via `GetDirectChildren`) to compute its sort order. With ~3000 elements created per load (mostly Quest's own built-in editor/language libraries, parsed fresh every time), this made loading a game in the WasmEditor take 12-17 seconds. Fixed by maintaining an incremental parent → children index and a per-parent sort-index counter instead of rescanning. Not AOT/WASM-specific — the same bug applied to the old desktop editor too, since it's gated on `EditMode` rather than player type.
- Wire `WASM_CONFIG=Release` through `dev.sh --release`, which built WasmEditor in Release/AOT but wasn't telling the Vite dev server to actually serve that bundle.

Net effect: editor game-load time drops from ~12-17s to ~4s.

## Test plan
- [x] `dotnet test` — full solution (315 tests) passes
- [x] `dotnet build --configuration Release src/WasmEditor/WasmEditor.csproj` — clean build
- [x] Manually verified via `./dev.sh --release`: game load time and "create new object" responsiveness both confirmed faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)