### PR TITLE
v5: fix O(n^2) element lookups slowing down game loads in the editor

### DIFF
--- a/WorldModel/WorldModel/Elements.cs
+++ b/WorldModel/WorldModel/Elements.cs
@@ -11,6 +11,25 @@ namespace TextAdventures.Quest
         private Dictionary<ElementType, Dictionary<string, Element>> m_elements = new Dictionary<ElementType, Dictionary<string, Element>>();
         private Dictionary<ElementType, List<Element>> m_elementsLists = new Dictionary<ElementType, List<Element>>();
 
+        // Index of parent -> direct children, kept in sync by Add/Remove/UpdateParentIndex so that
+        // GetDirectChildren doesn't need to do a full scan of every element in the game.
+        private List<Element> m_rootElements = new List<Element>();
+        private Dictionary<Element, List<Element>> m_childrenByParent = new Dictionary<Element, List<Element>>();
+
+        // Elements that have completed at least one Add() call, and so are eligible to have their
+        // parent-index entry moved by UpdateParentIndex. Elements being cloned have "parent" copied
+        // onto them (via Fields.Clone) before they've been added, so that early parent assignment
+        // must not touch the index - Add() below performs the baseline registration instead.
+        private HashSet<Element> m_indexedElements = new HashSet<Element>();
+
+        // Per-parent counters backing UpdateElementSortOrder, so assigning a new child's SortIndex
+        // doesn't need to scan all existing siblings to find the current max. SortIndex is only ever
+        // used for relative ordering or pairwise swapping of two already-issued values, so a
+        // monotonically increasing counter per parent is safe even though it doesn't reclaim gaps
+        // left by removed elements.
+        private Dictionary<Element, int> m_nextSortIndexByParent = new Dictionary<Element, int>();
+        private int m_nextRootSortIndex;
+
         public event EventHandler<NameChangedEventArgs> ElementRenamed;
 
         internal Elements()
@@ -44,15 +63,26 @@ namespace TextAdventures.Quest
                 }
 
                 // element is being overridden, so detach the event handler
-                m_allElements[key].Fields.NameChanged -= ElementNameChanged;
+                Element oldElement = m_allElements[key];
+                oldElement.Fields.NameChanged -= ElementNameChanged;
 
                 // remove old element from ordered elements list
                 m_elementsLists[t].Remove(m_elements[t][key]);
+
+                // and from the parent index, since it's being displaced from the live element graph
+                RemoveFromParentIndex(oldElement, oldElement.Parent);
+                m_indexedElements.Remove(oldElement);
             }
 
             m_allElements[key] = e;
             m_elements[t][key] = e;
             m_elementsLists[t].Add(e);
+
+            // Baseline parent-index registration. Covers both fresh elements (Parent is still null
+            // at this point) and clones (Parent may already be set, copied from the clone source by
+            // Fields.Clone before Add() ran) and undo/redo re-creation of a previously-removed element.
+            AddToParentIndex(e, e.Parent);
+            m_indexedElements.Add(e);
 
             e.Fields.NameChanged += ElementNameChanged;
         }
@@ -75,9 +105,64 @@ namespace TextAdventures.Quest
 
         internal void Remove(ElementType t, string key)
         {
+            Element element;
+            if (m_allElements.TryGetValue(key, out element))
+            {
+                RemoveFromParentIndex(element, element.Parent);
+                m_indexedElements.Remove(element);
+            }
+
             m_allElements.Remove(key);
             m_elementsLists[t].Remove(m_elements[t][key]);
             m_elements[t].Remove(key);
+        }
+
+        // Called by Fields.Set whenever an element's "parent" field changes, so the
+        // parent -> children index stays in sync without needing a full rescan of all elements.
+        internal void UpdateParentIndex(Element child, Element oldParent, Element newParent)
+        {
+            if (!m_indexedElements.Contains(child))
+            {
+                // Still under construction (e.g. Fields.Clone copying "parent" before the clone has
+                // been added) - Add() will perform the baseline registration once it's added.
+                return;
+            }
+
+            RemoveFromParentIndex(child, oldParent);
+            AddToParentIndex(child, newParent);
+        }
+
+        private void AddToParentIndex(Element child, Element parent)
+        {
+            if (parent == null)
+            {
+                m_rootElements.Add(child);
+                return;
+            }
+
+            List<Element> children;
+            if (!m_childrenByParent.TryGetValue(parent, out children))
+            {
+                children = new List<Element>();
+                m_childrenByParent[parent] = children;
+            }
+
+            children.Add(child);
+        }
+
+        private void RemoveFromParentIndex(Element child, Element parent)
+        {
+            if (parent == null)
+            {
+                m_rootElements.Remove(child);
+                return;
+            }
+
+            List<Element> children;
+            if (m_childrenByParent.TryGetValue(parent, out children))
+            {
+                children.Remove(child);
+            }
         }
 
         public Element Get(string key)
@@ -160,24 +245,47 @@ namespace TextAdventures.Quest
 
         public IEnumerable<Element> GetChildElements(Element parent)
         {
-            foreach (Element e in m_allElements.Values)
+            foreach (Element e in GetDirectChildren(parent))
             {
-                if (e.Parent == parent)
+                if (e == parent) throw new InvalidOperationException("Object's parent is set to self");
+                yield return e;
+                foreach (Element child in GetChildElements(e))
                 {
-                    if (e == parent) throw new InvalidOperationException("Object's parent is set to self");
-                    yield return e;
-                    foreach (Element child in GetChildElements(e))
-                    {
-                        if (child == parent) throw new InvalidOperationException("Circular parent");
-                        yield return child;
-                    }
+                    if (child == parent) throw new InvalidOperationException("Circular parent");
+                    yield return child;
                 }
             }
         }
 
         public IEnumerable<Element> GetDirectChildren(Element parent)
         {
-            return from element in m_allElements.Values where element.Parent == parent select element;
+            if (parent == null)
+            {
+                return m_rootElements;
+            }
+
+            List<Element> children;
+            if (m_childrenByParent.TryGetValue(parent, out children))
+            {
+                return children;
+            }
+            return Enumerable.Empty<Element>();
+        }
+
+        internal int GetNextSortIndex(Element parent)
+        {
+            if (parent == null)
+            {
+                return m_nextRootSortIndex++;
+            }
+
+            int next;
+            if (!m_nextSortIndexByParent.TryGetValue(parent, out next))
+            {
+                next = 0;
+            }
+            m_nextSortIndexByParent[parent] = next + 1;
+            return next;
         }
     }
 }

--- a/WorldModel/WorldModel/Fields.cs
+++ b/WorldModel/WorldModel/Fields.cs
@@ -412,6 +412,13 @@ namespace TextAdventures.Quest
                 throw new ArgumentException(string.Format("Parent of element '{0}' cannot be set to itself", m_element.Name));
             }
 
+            if (changed && name == "parent")
+            {
+                // Keep Elements' parent -> children index in sync with every parent reassignment,
+                // not just the ones that also update sort order below.
+                m_worldModel.Elements.UpdateParentIndex(m_element, oldValue as Element, value as Element);
+            }
+
             if (m_worldModel.Version >= WorldModelVersion.v530 && value == null)
             {
                 m_attributes.Remove(name);

--- a/WorldModel/WorldModel/WorldModel.cs
+++ b/WorldModel/WorldModel/WorldModel.cs
@@ -1731,15 +1731,7 @@ namespace TextAdventures.Quest
             // When this happens, its SortIndex MetaField must be updated so that it
             // is at the end of the list of children.
 
-            int maxIndex = -1;
-
-            foreach (Element sibling in m_elements.GetDirectChildren(movedElement.Parent))
-            {
-                int thisSortIndex = sibling.MetaFields[MetaFieldDefinitions.SortIndex];
-                if (thisSortIndex > maxIndex) maxIndex = thisSortIndex;
-            }
-
-            movedElement.MetaFields[MetaFieldDefinitions.SortIndex] = maxIndex + 1;
+            movedElement.MetaFields[MetaFieldDefinitions.SortIndex] = m_elements.GetNextSortIndex(movedElement.Parent);
         }
 
         public bool Assert(string expr)


### PR DESCRIPTION
## Summary
Port of the same fix from the Quest Viva (.NET 10) repo, applied to this v5 (.NET Framework 4.8) codebase.

`WorldModel.UpdateElementSortOrder` ran on every element created while in edit mode, and called `Elements.GetDirectChildren`, which did a full scan of every element in the game to find siblings. With thousands of elements created per load (mostly the engine's own built-in editor/language libraries, loaded fresh every time), this made loading a game in the editor take many seconds longer than necessary.

`Elements` now maintains an incrementally-updated parent → children index instead of scanning on every lookup, and `UpdateElementSortOrder` uses a per-parent counter instead of rescanning siblings to find the current max `SortIndex` — safe since `SortIndex` is only ever used for relative ordering (`OrderBy`) or pairwise swapping of two already-issued values, never read as an absolute value.

## ⚠️ Not yet built or tested
I don't have `msbuild`/`mono` available in the environment this was written in, and this branch has no CI configured. I hand-traced `WorldModelTests/ElementsTests.cs`'s four existing tests (`TestGetChildrenOfA`, `TestGetChildrenOfF`, `TestSortIndexes`, `TestSortIndexesOnMove`) against the new logic and they check out on paper, but **this has not actually been compiled or executed**. Please build and run `WorldModelTests` locally before merging.

One thing worth a second look during review: the new `GetDirectChildren` returns children in "order last assigned to this parent" rather than the old dictionary-scan's "global creation order." These match for the common case (element created and parented once, as happens during game loading), but could theoretically differ if an element is reparented late, after its new siblings already exist (e.g. drag-and-drop in the editor). Everywhere that cares about a specific order already explicitly sorts by `SortIndex` afterward, so this shouldn't be user-visible, but flagging it since it's a genuine (if narrow) behavioral difference from the old scan-based approach.

## Test plan
- [ ] Build `WorldModel`/`WorldModelTests` locally
- [ ] Run `WorldModelTests`, particularly `ElementsTests`
- [ ] Manually verify game loading in the editor is faster and object tree ordering still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)