### PR TITLE
WasmPlayer: rename ?game= to ?url=, fix error-message link and copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ dotnet build --configuration Release src/WasmPlayer/WasmPlayer.csproj
 # Run WasmPlayer dev server (requires COOP/COEP headers for SharedArrayBuffer)
 node src/WasmPlayer/dev-server.mjs              # Debug build
 node src/WasmPlayer/dev-server.mjs --release    # Release/AOT build
-# Open: http://localhost:5175/?game=/examples/simple.aslx
+# Open: http://localhost:5175/?url=/examples/simple.aslx
 ```
 
 Tests use MSTest with Moq (mocking) and Shouldly (assertions).

--- a/docs/deployment-domains.md
+++ b/docs/deployment-domains.md
@@ -54,5 +54,5 @@ Subdomain name: settled on `play.questviva.com` (favoured over `app.questviva.co
 
 ## Follow-ups (not in this pass)
 
-- **Play/Create homepage at root** — a small standalone page (no WASM needed) linking to `/player` and `/editor`, desktop-app style. Shared game links (`?game=<url>`) should route straight to `/player` rather than through the splash.
+- **Play/Create homepage at root** — a small standalone page (no WASM needed) linking to `/player` and `/editor`, desktop-app style. Shared game links (`?url=<url>`) should route straight to `/player` rather than through the splash.
 - **Template list needs a WASM export** — `/editor/open`'s "create new game from template" calls `getGameTemplates()` → `/api/editor/games` on textadventures.co.uk (`src/WebEditor/src/lib/filesystem/server-adapter.ts`), which isn't reachable cross-origin from play.questviva.com. "Open existing file/folder" is unaffected. Fix: add a `GetGameTemplates()` WASM bridge export (mirroring the existing `CreateGameFromTemplate`) so template listing needs no server round-trip.

--- a/src/WasmPlayer/dev-server.mjs
+++ b/src/WasmPlayer/dev-server.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Dev server for WasmPlayer — serves the Debug AppBundle with required COOP/COEP headers.
 // Run: node dev-server.mjs
-// Then open: http://localhost:5175/?game=/examples/simple.aslx
+// Then open: http://localhost:5175/?url=/examples/simple.aslx
 //
 // Proxy routes (dev only — avoids CORS issues during local development):
 //   /api/                        → https://textadventures.co.uk/api/
@@ -130,6 +130,6 @@ const server = http.createServer(async (req, res) => {
 server.listen(port, () => {
   console.log(`WasmPlayer dev server (${config}) running at http://localhost:${port}/`);
   console.log(`Serving: ${appBundleDir}`);
-  console.log(`Try: http://localhost:${port}/?game=/examples/simple.aslx`);
+  console.log(`Try: http://localhost:${port}/?url=/examples/simple.aslx`);
   console.log('Press Ctrl+C to stop.');
 });

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -11,7 +11,7 @@
         // pickers render for a frame before showLoading() gets a chance to hide them.
         (function () {
             var params = new URLSearchParams(location.search);
-            if (params.get('id') || params.get('game') || params.get('source') === 'editor') {
+            if (params.get('id') || params.get('url') || params.get('source') === 'editor') {
                 document.documentElement.classList.add('qv-booting');
             }
         })();

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -275,6 +275,19 @@ function showError(downloadUrl, isLocalFile) {
     wireStartScreen();
 }
 
+// Keeps the address bar in sync with the game that's actually loaded (or being
+// attempted), so a refresh reproduces it. `name`/`value` set the active source
+// param; both `id` and `url` are cleared first since only one can be current.
+function setLocationParam(name, value) {
+    const params = new URLSearchParams(window.location.search);
+    params.delete('id');
+    params.delete('url');
+    if (name) params.set(name, value);
+    const query = params.toString();
+    const newUrl = window.location.pathname + (query ? `?${query}` : '') + window.location.hash;
+    history.replaceState(null, '', newUrl);
+}
+
 let _startScreenWired = false;
 function wireStartScreen() {
     if (_startScreenWired) return;
@@ -290,6 +303,7 @@ function wireStartScreen() {
     fileInput.addEventListener('change', () => {
         const file = fileInput.files?.[0];
         if (!file) return;
+        setLocationParam(null);
         showLoading();
         const reader = new FileReader();
         reader.onload = () => initWasmPlayer(new Uint8Array(reader.result), file.name)
@@ -306,6 +320,7 @@ function wireStartScreen() {
         try {
             const { bytes, filename } = await fetchGameBytes(url);
             await initWasmPlayer(bytes, filename);
+            setLocationParam('url', url);
         } catch {
             showError(url);
         }

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -244,7 +244,7 @@ function showLoading() {
     if (msg) msg.style.display = 'flex';
 }
 
-function showError(downloadUrl) {
+function showError(downloadUrl, isLocalFile) {
     const pickers = document.getElementById('qv-pickers');
     const msg = document.getElementById('qv-loading-msg');
     const errorEl = document.getElementById('qv-error');
@@ -254,13 +254,19 @@ function showError(downloadUrl) {
     // inline style always beats an external stylesheet rule, cleared or not.
     if (pickers) pickers.style.display = 'block';
     if (!errorEl) return;
-    let html = '<strong>Couldn\'t load the game.</strong> '
-        + 'The server may not allow this player to load the file directly (CORS restriction).';
-    if (downloadUrl) {
-        html += ' <a href="' + _esc(downloadUrl) + '" target="_blank" rel="noopener">'
-            + 'Open the file in a new tab</a> to save it, then open it with the file picker below.';
+    let html;
+    if (isLocalFile) {
+        html = '<strong>Couldn\'t open that file.</strong> '
+            + 'It doesn\'t look like a Quest game file (.quest, .aslx, .asl or .cas). Choose a different file below.';
+    } else if (downloadUrl) {
+        html = '<strong>Couldn\'t load the game from that URL.</strong> '
+            + 'The site hosting it likely isn\'t configured to allow other sites to fetch the file directly '
+            + '(a CORS restriction) &mdash; this is a limitation of the hosting site, not something wrong with your download. '
+            + '<a class="anchor" href="' + _esc(downloadUrl) + '" target="_blank" rel="noopener">'
+            + 'Open the file in a new tab</a>, save it to your computer, then load it with the file picker below.';
     } else {
-        html += ' You can try opening a saved copy of the game file instead.';
+        html = '<strong>Couldn\'t load the game.</strong> '
+            + 'Try opening a saved copy of the game file instead, using the file picker below.';
     }
     errorEl.innerHTML = html;
     // 'block', not '' — errorEl carries the .hidden class, so clearing the
@@ -287,7 +293,7 @@ function wireStartScreen() {
         showLoading();
         const reader = new FileReader();
         reader.onload = () => initWasmPlayer(new Uint8Array(reader.result), file.name)
-            .catch(() => showError(null));
+            .catch(() => showError(null, true));
         reader.readAsArrayBuffer(file);
     });
 
@@ -334,7 +340,7 @@ async function fetchGameBytes(url) {
     }
 
     const id = params.get('id');
-    const gameUrl = params.get('game');
+    const gameUrl = params.get('url');
 
     if (id) {
         // Start API fetch immediately; wire DOM once it's ready.


### PR DESCRIPTION
## Summary
- Renamed the WasmPlayer query param from `?game=<url>` to `?url=<url>` (updated docs/dev-server references accordingly).
- Fixed the load-failure error message: the "Open the file in a new tab" link was invisible (Tailwind's preflight reset stripped default anchor styling) — now uses Skeleton's `anchor` utility so it's visibly styled.
- Split the error copy by actual cause: a bad local file no longer shows the "server... CORS restriction" wording, since no network request was involved for that path.
- The address bar now stays in sync with the active source: loading a URL via the text box updates it to `?url=<url>` (so refresh reproduces the same game), and falling back to a local file after a failed `?url=` load clears the stale param.

## Test plan
- [x] `dotnet build src/WasmPlayer/WasmPlayer.csproj` succeeds
- [x] Verified in a real (headless Chromium) browser via the dev server:
  - `?url=<bad-url>` shows the CORS-style message with a visibly styled link
  - Picking an invalid local file shows the "doesn't look like a Quest game file" message, not the CORS wording
  - `?url=/examples/simple.aslx` loads the game normally
  - Typing a URL into the box and loading it updates the address bar to `?url=<url>`, and reload reproduces the same game
  - Boot with a failing `?url=`, then picking a local file, clears `?url=` from the address bar