### PR TITLE
Fix inline object links losing display verbs after a wait

### DIFF
--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -78,7 +78,8 @@ public enum ListType
 {
     InventoryList,
     ExitsList,
-    ObjectsList
+    ObjectsList,
+    ElementMenuVerbs
 }
 
 public enum UIOption

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -170,6 +170,7 @@ public partial class WorldModel : IGame, IGameDebug
         _turnSuspendedTcs = new();
         tcs?.TrySetResult(response);
         await _turnSuspendedTcs.Task;
+        if (State != GameState.Finished) await UpdateListsAsync();
     }
 
     public async Task<bool> Initialise(IPlayer player)
@@ -389,6 +390,7 @@ public partial class WorldModel : IGame, IGameDebug
         _turnSuspendedTcs = new();
         tcs?.TrySetResult();
         await _turnSuspendedTcs.Task;
+        if (State != GameState.Finished) await UpdateListsAsync();
     }
 
     public async Task FinishPause()
@@ -397,6 +399,7 @@ public partial class WorldModel : IGame, IGameDebug
         _turnSuspendedTcs = new();
         tcs?.TrySetResult();
         await _turnSuspendedTcs.Task;
+        if (State != GameState.Finished) await UpdateListsAsync();
     }
 
     public IEnumerable<string> GetExternalScripts()
@@ -487,6 +490,7 @@ public partial class WorldModel : IGame, IGameDebug
         _turnSuspendedTcs = new();
         tcs?.TrySetResult(response);
         await _turnSuspendedTcs.Task;
+        if (State != GameState.Finished) await UpdateListsAsync();
     }
 
     public Stream? GetResourceStream(string filename)
@@ -836,6 +840,49 @@ public partial class WorldModel : IGame, IGameDebug
     {
         await UpdateObjectsListAsync("GetPlacesObjectsList", ListType.ObjectsList);
         await UpdateObjectsListAsync("ScopeInventory", ListType.InventoryList);
+        await UpdateElementMenuVerbsAsync();
+    }
+
+    // Unlike GetPlacesObjectsList (which excludes scenery so it isn't double-listed in the
+    // room's auto-generated object list), this covers every object the player can currently
+    // see or is carrying - including scenery - so that inline {object:} links in output text
+    // always have "live" display verbs available for their pop-up menu, regardless of whether
+    // the object also appears in the room's object list.
+    private async Task UpdateElementMenuVerbsAsync()
+    {
+        if (UpdateList == null)
+        {
+            return;
+        }
+
+        var heldObjects = await GetObjectsInScopeAsync("ScopeInventory");
+        var held = new HashSet<Element>(heldObjects);
+
+        var objects = new List<ListData>();
+        var seen = new HashSet<Element>();
+        foreach (var obj in heldObjects.Concat(await GetObjectsInScopeAsync("ScopeVisibleNotHeld")))
+        {
+            if (!seen.Add(obj))
+            {
+                continue;
+            }
+
+            IEnumerable<string> verbs;
+            if (Version <= WorldModelVersion.v520 || !Elements.ContainsKey(ElementType.Function, "GetDisplayVerbs"))
+            {
+                verbs = held.Contains(obj)
+                    ? obj.Fields[FieldDefinitions.InventoryVerbs]
+                    : obj.Fields[FieldDefinitions.DisplayVerbs];
+            }
+            else
+            {
+                verbs = await GetDisplayVerbsAsync(obj);
+            }
+
+            objects.Add(new ListData(await GetListDisplayAliasAsync(obj), verbs, obj.Name, await GetDisplayAliasAsync(obj)));
+        }
+
+        UpdateList(ListType.ElementMenuVerbs, objects);
     }
 
     private async Task UpdateObjectsListAsync(string scope, ListType listType)

--- a/src/PlayerCore/ListHandler.cs
+++ b/src/PlayerCore/ListHandler.cs
@@ -11,6 +11,18 @@ public class ListHandler(Action<string, object?[]?> addJavaScriptToBuffer)
 
     public void UpdateList(ListType listType, List<ListData> items)
     {
+        // ElementMenuVerbs isn't cached/deduplicated like the other lists: it exists to sync
+        // data-verbs onto whichever inline {object:} links currently exist in the DOM, and new
+        // links can appear (e.g. after a "wait" block reveals text) even when the underlying
+        // verb data hasn't changed since the last push - a no-op push would then wrongly get
+        // suppressed and the newly-added link would never receive its verbs.
+        if (listType == ListType.ElementMenuVerbs)
+        {
+            _lists[listType] = items;
+            SendUpdatedList(listType);
+            return;
+        }
+
         bool listChanged;
         if (!_lists.TryGetValue(listType, out var list))
         {
@@ -38,6 +50,12 @@ public class ListHandler(Action<string, object?[]?> addJavaScriptToBuffer)
             return;
         }
 
+        if (listType == ListType.ElementMenuVerbs)
+        {
+            SendElementMenuVerbs(_lists[ListType.ElementMenuVerbs]);
+            return;
+        }
+
         var listName = listType switch
         {
             ListType.InventoryList => "inventory",
@@ -57,6 +75,20 @@ public class ListHandler(Action<string, object?[]?> addJavaScriptToBuffer)
     {
         var data = string.Join("/", list.Select(l => l.Text));
         AddJavaScriptToBuffer("updateCompass", [data]);
+    }
+
+    private void SendElementMenuVerbs(List<ListData> list)
+    {
+        var data = new Dictionary<string, string>();
+        foreach (var item in list)
+        {
+            if (item.ElementId != null)
+            {
+                data[item.ElementId] = PlayerHelper.VerbString(item.Verbs);
+            }
+        }
+
+        AddJavaScriptToBuffer("updateObjectLinks", [data]);
     }
 
     private class ListDataComparer : IEqualityComparer<ListData>

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -743,7 +743,7 @@ function bindMenu(linkid, verbs, text, elementId) {
 }
 
 function buildMenuOptions(verbs, text, elementId) {
-    var verbsList = verbs.split("/");
+    var verbsList = verbs ? verbs.split("/") : [];
     var options = [];
     var metadata = {};
     metadata[text] = elementId;
@@ -2106,6 +2106,19 @@ function Grid_DrawShape(id, border, fill, opacity) {
     $.fn.jjmenu_popup = function (param) {
         var el = this;
 
+        if (typeof param === "undefined") {
+            var verbs = el.data("verbs");
+            if (!verbs) {
+                // No live verb data for this element yet (or it was never made
+                // available server-side) - nothing to show, so bail out rather
+                // than crashing on an undefined verb list.
+                return;
+            }
+            var text = el.html();
+            var elementId = el.data("elementid");
+            param = buildMenuOptions(verbs, text, elementId);
+        }
+
         $("div[id^=jjmenu_main]").remove();
 
         var m = document.createElement('div');
@@ -2118,13 +2131,6 @@ function Grid_DrawShape(id, border, fill, opacity) {
         $(document.body).append(m);
 
         positionMenu();
-
-        if (typeof param === "undefined") {
-            var verbs = el.data("verbs");
-            var text = el.html();
-            var elementId = el.data("elementid");
-            param = buildMenuOptions(verbs, text, elementId);
-        }
 
         for (var i in param) {
             putItem(param[i]);

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -200,6 +200,9 @@ public partial class WasmPlayerBridge
     [JSImport("updateList", "wasm-player")]
     internal static partial void JsUpdateList(string listName, string itemsJson);
 
+    [JSImport("updateObjectLinks", "wasm-player")]
+    internal static partial void JsUpdateObjectLinks(string verbsJson);
+
     [JSImport("updateCompass", "wasm-player")]
     internal static partial void JsUpdateCompass(string data);
 
@@ -294,6 +297,13 @@ public partial class WasmPlayerBridge
                          && args[0] is string compassData)
                 {
                     _uiBuffer.Add(() => JsUpdateCompass(compassData));
+                }
+                else if (identifier == "updateObjectLinks"
+                         && args?.Length == 1
+                         && args[0] is Dictionary<string, string> verbsData)
+                {
+                    var json = JsonSerializer.Serialize(verbsData, WasmJsonContext.Default.DictionaryStringString);
+                    _uiBuffer.Add(() => JsUpdateObjectLinks(json));
                 }
             });
         }

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -172,6 +172,7 @@ async function initWasmPlayer(gameBytes, filename, bc = null) {
         setForeground: (colour) => setForeground(colour),
         updateList: (listName, itemsJson) => updateList(listName, JSON.parse(itemsJson)),
         updateCompass: (data) => updateCompass(data),
+        updateObjectLinks: (verbsJson) => updateObjectLinks(JSON.parse(verbsJson)),
         gameFinished: () => gameFinished(),
         requestNextTimerTick: (seconds) => requestNextTimerTick(seconds),
         uiShow: (element) => uiShow(element),


### PR DESCRIPTION
## Summary
- Objects revealed inside a `wait { }` continuation (e.g. a scenery object referenced via `{object:name}` in a `firstenter` script) never got live display-verb data pushed to the client, so clicking their popup menu threw `Cannot read properties of undefined (reading 'split')`.
- `FinishWait`/`FinishPause`/`SetQuestionResponse`/`SetMenuResponse` never refreshed the client-side object/verb lists after resuming a suspended script, unlike `SendCommand`/`SendEvent`/`Begin`/`Tick` which all do.
- The existing `ObjectsList`/`InventoryList` push (sidebar "Places and objects" panel) deliberately excludes scenery, so inline `{object:}` links to scenery objects had no source of verb data at all - added a separate `ElementMenuVerbs` list (`ScopeVisibleNotHeld` + `ScopeInventory`) that wires up the previously-unused `updateObjectLinks()` JS function without touching the sidebar list.
- `ListHandler`'s change-detection cache suppressed re-sending `ElementMenuVerbs` when the underlying verb data hadn't changed, even though a brand-new DOM link (added by the wait's continuation) had never received it - `ElementMenuVerbs` now always pushes.
- Hardened `playercore.js`'s `jjmenu_popup`/`buildMenuOptions` to disable the menu instead of throwing when verb data is genuinely missing.

## Test plan
- [x] `dotnet build --configuration Release` - full solution builds clean
- [x] `dotnet test --configuration Release` - all 315 existing tests pass
- [x] Verified end-to-end against a real reported game (scenery object with custom display verbs revealed inside a `firstenter` → `wait` block): menu now shows the correct verbs after a full WebPlayer rebuild/retest by the reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)