### PR TITLE
Fix release CI: remove stale src/Utility references

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -11,7 +11,6 @@ on:
       - "src/EditorCore/**"
       - "src/Engine/**"
       - "src/Common/**"
-      - "src/Utility/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Pack
         run: |
-          for project in src/Common src/Utility src/Engine src/Legacy src/PlayerCore; do
+          for project in src/Common src/Engine src/Legacy src/PlayerCore; do
             dotnet pack "$project" --no-build --configuration Release -p:Version=${{ env.VERSION }} --output nupkgs
           done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The solution (`QuestViva.sln`) has a layered architecture:
 ```
 WebPlayer (ASP.NET Core + Blazor Server)  ─┐
 WasmPlayer (browser-wasm, AOT)             ─┤
-                                            ├─► PlayerCore ─► Engine ─► Utility ─► Common
+                                            ├─► PlayerCore ─► Engine ─► Common
 EditorCore ─────────────────────────────────┘        │
                                                      └─► Legacy
 ```
@@ -65,7 +65,6 @@ EditorCore ───────────────────────
 **Key projects in `src/`:**
 
 - **Common** — Shared types and interfaces used across all projects
-- **Utility** — Helper functions and language utilities
 - **Engine** — Core game interpreter: script execution, expression evaluation, game loading, built-in functions. Contains embedded `.aslx` files (game templates, language definitions) in `Core/`
 - **PlayerCore** — Game player runtime that wraps Engine. Contains embedded UI resources (HTML, CSS, JS including jQuery UI, jPlayer)
 - **EditorCore** — Game editor logic (non-UI)
@@ -91,4 +90,4 @@ If you forgot to update `VERSION`, the script will fail locally because the tag 
 - Game files use `.aslx` (XML-based) format; legacy `.asl` format also supported
 - Version is stored in the `VERSION` file and embedded as a resource via Common.csproj
 - CI runs on GitHub Actions (build-and-test on push/PR to main for `src/` and `tests/` changes)
-- Library packages (`QuestViva.Common`, `QuestViva.Utility`, `QuestViva.Engine`, `QuestViva.Legacy`, `QuestViva.PlayerCore`) are published to NuGet.org on each release tag via the `nuget-publish` workflow
+- Library packages (`QuestViva.Common`, `QuestViva.Engine`, `QuestViva.Legacy`, `QuestViva.PlayerCore`) are published to NuGet.org on each release tag via the `nuget-publish` workflow

--- a/src/WebPlayer/Dockerfile
+++ b/src/WebPlayer/Dockerfile
@@ -8,7 +8,6 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["src/WebPlayer/WebPlayer.csproj", "src/WebPlayer/"]
-COPY ["src/Utility/Utility.csproj", "src/Utility/"]
 COPY ["src/Legacy/Legacy.csproj", "src/Legacy/"]
 COPY ["src/Common/Common.csproj", "src/Common/"]
 COPY ["src/Engine/Engine.csproj", "src/Engine/"]


### PR DESCRIPTION
## Summary
- The `docker-publish` and `nuget-publish` workflows failed on the `v6.0.0-beta.27` tag because both still referenced `src/Utility`, which was deleted in #1790 (folded into Engine).
- Removes the stale `COPY` line in `src/WebPlayer/Dockerfile` and the stale entry in the `nuget-publish.yml` pack loop.
- Also cleans up the stale `src/Utility/**` path filter in `deploy-play.yml` and stale `Utility` references in `CLAUDE.md`.

## Test plan
- [x] Built the Docker image locally with the fixed Dockerfile — succeeds
- [x] Ran the fixed `dotnet pack` loop locally for Common/Engine/Legacy/PlayerCore — all packages built successfully
- [ ] CI (build-and-test) passes on this PR
- [ ] After merge, retag `v6.0.0-beta.27` to trigger `docker-publish` and `nuget-publish` again

🤖 Generated with [Claude Code](https://claude.com/claude-code)