### PR TITLE
Add WasmPlayer restart button and unsaved-progress warning

### DIFF
--- a/src/PlayerCore/Resources/player.js
+++ b/src/PlayerCore/Resources/player.js
@@ -29,6 +29,7 @@ function setUpSessionLog() {
 var _waitingForSoundToFinish = false;
 
 function msgboxSubmit(response) {
+    markUnsavedProgress();
     $("#msgbox").dialog("close");
     window.setTimeout(async function () {
         await WebPlayer.uiSetQuestionResponse(response);
@@ -84,6 +85,7 @@ function showMenu(title, options, allowCancel) {
 function dialogSelect() {
     _menuSelection = $("#dialogOptions").val();
     if (_menuSelection.length > 0) {
+        markUnsavedProgress();
         $("#dialog").dialog("close");
         window.setTimeout(function () {
             WebPlayer.uiChoice(_menuSelection);
@@ -111,6 +113,7 @@ function sendCommand(text, metadata) {
     if (_pauseMode || _waitingForSoundToFinish || _waitMode || !canSendCommand) return;
     canSendCommand = false;
     markScrollPosition();
+    markUnsavedProgress();
 
     window.setTimeout(function () {
         WebPlayer.sendCommand(text, getTickCountAndStopTimer(), metadata);
@@ -118,6 +121,7 @@ function sendCommand(text, metadata) {
 }
 
 function ASLEvent(event, parameter) {
+    markUnsavedProgress();
     window.setTimeout(async function () {
         await WebPlayer.uiSendEvent(event, "" + parameter);
     }, 1);

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -12,12 +12,15 @@ var beginningOfCurrentTurnScrollPosition = 0;
 // Tracks whether the player has made progress since the game started/loaded
 // that hasn't been saved anywhere (slot or file) yet, so an accidental
 // refresh/close can warn before silently discarding it (see beforeunload
-// listener below). suppressUnsavedProgressWarning lets WasmPlayer's
-// editor-preview mode (which relies on manual reloads to pick up new edits —
-// see wasm-player.js) opt out, since every reload there would otherwise
-// trigger the native "leave site?" prompt.
+// listener below). canSave mirrors the last value passed to
+// WebPlayer.setCanSave (both playerweb.js's and wasm-player.js's versions
+// keep this in sync) — if saving isn't even offered, there's nothing the
+// player could do about unsaved progress, so the warning is pointless. This
+// is what keeps the legacy editor's preview page (Editor.razor's
+// EnableSave="false") and WasmPlayer's editor-preview mode — both of which
+// reload on every edit — from being nagged by the warning on every reload.
 var hasUnsavedProgress = false;
-var suppressUnsavedProgressWarning = false;
+var canSave = true;
 
 function markUnsavedProgress() {
     hasUnsavedProgress = true;
@@ -28,7 +31,7 @@ function clearUnsavedProgress() {
 }
 
 window.addEventListener("beforeunload", function (e) {
-    if (!hasUnsavedProgress || suppressUnsavedProgressWarning) return;
+    if (!hasUnsavedProgress || !canSave) return;
     e.preventDefault();
     e.returnValue = "";
 });

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -9,6 +9,30 @@ var placesObjectsVerbs = null;
 var verbButtonCount = 9;
 var beginningOfCurrentTurnScrollPosition = 0;
 
+// Tracks whether the player has made progress since the game started/loaded
+// that hasn't been saved anywhere (slot or file) yet, so an accidental
+// refresh/close can warn before silently discarding it (see beforeunload
+// listener below). suppressUnsavedProgressWarning lets WasmPlayer's
+// editor-preview mode (which relies on manual reloads to pick up new edits —
+// see wasm-player.js) opt out, since every reload there would otherwise
+// trigger the native "leave site?" prompt.
+var hasUnsavedProgress = false;
+var suppressUnsavedProgressWarning = false;
+
+function markUnsavedProgress() {
+    hasUnsavedProgress = true;
+}
+
+function clearUnsavedProgress() {
+    hasUnsavedProgress = false;
+}
+
+window.addEventListener("beforeunload", function (e) {
+    if (!hasUnsavedProgress || suppressUnsavedProgressWarning) return;
+    e.preventDefault();
+    e.returnValue = "";
+});
+
 function initPlayerUI() {
     const gameBorder = document.getElementById("gameBorder");
     gameBorder.style.display = "block";
@@ -856,6 +880,7 @@ function resetGameOutput() {
     beginningOfCurrentTurnScrollPosition = 0;
     $("#divOutput").css("min-height", 0).html("");
     createNewDiv("left");
+    clearUnsavedProgress();
 }
 
 // Scrollback functions added by KV
@@ -2373,6 +2398,7 @@ const GameSaver = (() => {
             const label = name || "Saved game — " + new Date().toLocaleString();
             await saveGame(gameId, slotIndex, result, label);
             addText("Game saved.<br>");
+            clearUnsavedProgress();
             if (!persistenceRequested) {
                 await ensurePersistentStorage();
                 persistenceRequested = true;

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -98,7 +98,7 @@
 
         <div id="qv-saves-error" class="hidden card preset-tonal-error p-3 text-sm"></div>
 
-        <button id="qv-saves-start-new" type="button" class="qv-boot-only btn preset-tonal-primary w-full justify-start">
+        <button id="qv-saves-start-new" type="button" class="btn preset-tonal-primary w-full justify-start">
             Start from the beginning
         </button>
 

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -74,8 +74,7 @@
     display: none;
 }
 
-:scope#qv-saves[data-mode="manage"] [data-mode-text="boot"],
-:scope#qv-saves[data-mode="manage"] .qv-boot-only {
+:scope#qv-saves[data-mode="manage"] [data-mode-text="boot"] {
     display: none;
 }
 

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -88,6 +88,7 @@ window.WebPlayer = {
     setCanSave(value) {
         const cmdSave = document.getElementById("cmdSave");
         if (cmdSave) cmdSave.style.display = value ? "initial" : "none";
+        canSave = value;
         if (!value) window.saveGame = () => addText("Disabled");
     },
 
@@ -250,7 +251,10 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
         ? () => GameSaver.save()
         : () => openSavesDialog('manage');
     WebPlayer.initUI();
-    WebPlayer.setCanSave(true);
+    // Editor-preview sessions (bc) don't offer saving at all — see the
+    // "Editor-preview sessions" comment in startGame() for why a churny,
+    // per-edit-reused filename can't safely back a save slot.
+    WebPlayer.setCanSave(!bc);
 
     await Bridge.Begin();
 }
@@ -283,10 +287,6 @@ async function startGame(bytes, filename, bc = null, gameIdOverride = null) {
     originalGameBytes = bytes;
     originalGameFilename = filename;
     isLegacyGame = /\.(asl|cas)$/i.test(filename);
-    // Editor-preview authors reload the preview tab to pick up every edit
-    // (see the comment below) — without this, the beforeunload warning added
-    // for issue #1741 would nag on every single one of those reloads.
-    if (bc) suppressUnsavedProgressWarning = true;
     // gameIdOverride lets callers with a stronger identity than the filename
     // (e.g. the Text Adventures API's stable game id) use it instead.
     const gameId = gameIdOverride || computeGameId(filename);

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -251,9 +251,12 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
         ? () => GameSaver.save()
         : () => openSavesDialog('manage');
     WebPlayer.initUI();
-    // Editor-preview sessions (bc) don't offer saving at all — see the
-    // "Editor-preview sessions" comment in startGame() for why a churny,
-    // per-edit-reused filename can't safely back a save slot.
+    // Editor-preview sessions (bc) don't offer saving at all — these are
+    // transient test runs launched from the game editor, not real play
+    // sessions worth persisting. The boot-time Continue/Load prompt is
+    // skipped for bc sessions for a related but narrower reason (a churny,
+    // per-edit-reused filename can't safely identify a save slot) — see the
+    // "Editor-preview sessions" comment in startGame() below.
     WebPlayer.setCanSave(!bc);
 
     await Bridge.Begin();

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -255,8 +255,9 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
     await Bridge.Begin();
 }
 
-// Reloads a save on top of the already-booted WASM runtime — used for
-// in-game Load, so it must NOT repeat WebPlayer.initUI()/setupPaperJs():
+// Reloads a save (or, with saveBytes null, the fresh original game) on top
+// of the already-booted WASM runtime — used for in-game Load and "Start
+// from the beginning", so it must NOT repeat WebPlayer.initUI()/setupPaperJs():
 // those rebind #cmdSave/#cmdDebug click handlers, jQuery-UI widgets, etc.
 // unconditionally, and doing that twice on the same live DOM would
 // double-bind every one of them.
@@ -264,7 +265,9 @@ async function restartGame(saveBytes) {
     document.getElementById('qv-saves')?.close();
     resetGameOutput();
 
-    const ok = await Bridge.InitialiseWithSave(originalGameBytes, originalGameFilename, saveBytes);
+    const ok = saveBytes
+        ? await Bridge.InitialiseWithSave(originalGameBytes, originalGameFilename, saveBytes)
+        : await Bridge.Initialise(originalGameBytes, originalGameFilename);
     if (!ok) {
         showSavesError('Failed to load that save.');
         return;
@@ -280,6 +283,10 @@ async function startGame(bytes, filename, bc = null, gameIdOverride = null) {
     originalGameBytes = bytes;
     originalGameFilename = filename;
     isLegacyGame = /\.(asl|cas)$/i.test(filename);
+    // Editor-preview authors reload the preview tab to pick up every edit
+    // (see the comment below) — without this, the beforeunload warning added
+    // for issue #1741 would nag on every single one of those reloads.
+    if (bc) suppressUnsavedProgressWarning = true;
     // gameIdOverride lets callers with a stronger identity than the filename
     // (e.g. the Text Adventures API's stable game id) use it instead.
     const gameId = gameIdOverride || computeGameId(filename);
@@ -364,6 +371,7 @@ async function downloadSaveToFile() {
     a.download = WebPlayer.gameId.replace(/\.[^.]+$/, '') + '.quest-save';
     a.click();
     URL.revokeObjectURL(url);
+    clearUnsavedProgress();
 }
 
 // A .quest-save only carries state, not resources — it must be paired with
@@ -415,11 +423,16 @@ function ensureSavesDialogWired() {
     });
 
     document.getElementById('qv-saves-start-new').addEventListener('click', () => {
-        if (!bootChoiceResolve) return;
-        const resolve = bootChoiceResolve;
-        bootChoiceResolve = null;
-        dlg.close();
-        resolve({ type: 'new' });
+        if (bootChoiceResolve) {
+            const resolve = bootChoiceResolve;
+            bootChoiceResolve = null;
+            dlg.close();
+            resolve({ type: 'new' });
+            return;
+        }
+        // Manage mode: restarting mid-session, matches WebPlayer's Slots
+        // "Start from the beginning" button (no confirm() there either).
+        restartGame(null);
     });
 
     document.getElementById('qv-saves-list').addEventListener('click', async (e) => {

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -253,10 +253,7 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
     WebPlayer.initUI();
     // Editor-preview sessions (bc) don't offer saving at all — these are
     // transient test runs launched from the game editor, not real play
-    // sessions worth persisting. The boot-time Continue/Load prompt is
-    // skipped for bc sessions for a related but narrower reason (a churny,
-    // per-edit-reused filename can't safely identify a save slot) — see the
-    // "Editor-preview sessions" comment in startGame() below.
+    // sessions worth persisting.
     WebPlayer.setCanSave(!bc);
 
     await Bridge.Begin();

--- a/src/WebPlayer/wwwroot/playerweb.js
+++ b/src/WebPlayer/wwwroot/playerweb.js
@@ -58,6 +58,7 @@ class WebPlayer {
         a.download = filename;
         a.click();
         URL.revokeObjectURL(url);
+        clearUnsavedProgress();
     }
 
     static initSlotsDialog() {

--- a/src/WebPlayer/wwwroot/playerweb.js
+++ b/src/WebPlayer/wwwroot/playerweb.js
@@ -108,14 +108,9 @@ class WebPlayer {
     static setCanSave(value) {
         const cmdSave = document.getElementById("cmdSave");
         cmdSave.style.display = value ? "initial" : "none";
+        canSave = value;
         if (!value) {
             window.saveGame = () => addText("Disabled");
-            // Saving disabled means this is the legacy editor's preview page
-            // (Editor.razor sets EnableSave="false"), which the editor reloads
-            // on every edit — without this, that reload would trigger the
-            // beforeunload warning added for issue #1741 on every single one.
-            // Matches WasmPlayer's editor-preview suppression in wasm-player.js.
-            suppressUnsavedProgressWarning = true;
         }
     }
 

--- a/src/WebPlayer/wwwroot/playerweb.js
+++ b/src/WebPlayer/wwwroot/playerweb.js
@@ -110,6 +110,12 @@ class WebPlayer {
         cmdSave.style.display = value ? "initial" : "none";
         if (!value) {
             window.saveGame = () => addText("Disabled");
+            // Saving disabled means this is the legacy editor's preview page
+            // (Editor.razor sets EnableSave="false"), which the editor reloads
+            // on every edit — without this, that reload would trigger the
+            // beforeunload warning added for issue #1741 on every single one.
+            // Matches WasmPlayer's editor-preview suppression in wasm-player.js.
+            suppressUnsavedProgressWarning = true;
         }
     }
 


### PR DESCRIPTION
## Summary
- WasmPlayer's Save/Load manager now shows "Start from the beginning" in manage mode too (previously boot-prompt only), matching WebPlayer's `Slots.razor` — restarts the current game fresh via `Bridge.Initialise`.
- Fixes #1741: warn before a browser refresh/close silently discards unsaved progress. A shared `hasUnsavedProgress` flag (in `playercore.js`, used by both WebPlayer and WasmPlayer) is set on any player action (typed command, object/menu link, question response) and cleared on save, save-to-file, or restart/load — a `beforeunload` prompt only fires when it's dirty.
- The warning is gated behind a shared `canSave` flag, kept in sync by `WebPlayer.setCanSave` on both players: if saving isn't offered, there's nothing the player could do about unsaved progress anyway. WasmPlayer's editor-preview sessions now disable saving entirely (`setCanSave(false)`, matching the legacy editor's `Editor.razor` `EnableSave="false"`), so both editor preview paths get the warning suppression for free with no separate opt-out flag needed.

## Test plan
- [x] `dotnet build --configuration Release` for WasmPlayer and WebPlayer
- [x] `dotnet test tests/PlayerCoreTests`
- [x] Manually verified in real browsers via Playwright:
  - Normal play sessions (WebPlayer and WasmPlayer): no `beforeunload` dialog before any action, dialog appears after a command, suppressed again after save/save-to-file/restart
  - "Start from the beginning" button visible in manage mode, closes the dialog, and restarts with a clean transcript
  - WasmPlayer editor-preview (driven through the real `quest-preview` BroadcastChannel with `?source=editor`): Save button hidden, `canSave` false, no warning dialog on reload despite unsaved progress
  - Legacy editor preview (`EnableSave="false"` path): same suppression via `canSave`
  - No console/page errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)