### PR TITLE
Bring legacy .asl/.cas games to full save/load parity in WasmPlayer

### DIFF
--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -17,7 +17,6 @@ let resourceRoot = null;
 // and never reassigned by a slot/file load.
 let originalGameBytes = null;
 let originalGameFilename = null;
-let isLegacyGame = false;
 
 function computeGameId(filename) {
     return filename.split('/').pop();
@@ -247,9 +246,7 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
 
     await setupPaperJs();
 
-    WebPlayer.onSaveClick = isLegacyGame
-        ? () => GameSaver.save()
-        : () => openSavesDialog('manage');
+    WebPlayer.onSaveClick = () => openSavesDialog('manage');
     WebPlayer.initUI();
     // Editor-preview sessions (bc) don't offer saving at all — these are
     // transient test runs launched from the game editor, not real play
@@ -286,18 +283,16 @@ async function restartGame(saveBytes) {
 async function startGame(bytes, filename, bc = null, gameIdOverride = null) {
     originalGameBytes = bytes;
     originalGameFilename = filename;
-    isLegacyGame = /\.(asl|cas)$/i.test(filename);
     // gameIdOverride lets callers with a stronger identity than the filename
     // (e.g. the Text Adventures API's stable game id) use it instead.
     const gameId = gameIdOverride || computeGameId(filename);
     WebPlayer.gameId = gameId;
 
     let saveBytes = null;
-    // Editor-preview sessions (bc) and legacy games are excluded: a preview's
-    // filename is transient/reused per edit (prompting every reload would be
-    // noisy and would fragment saves under a churny id), and legacy .asl/.cas
-    // saves aren't self-contained enough for the full slot manager (see plan).
-    if (!bc && !isLegacyGame) {
+    // Editor-preview sessions (bc) are excluded: a preview's filename is
+    // transient/reused per edit, so prompting every reload would be noisy
+    // and would fragment saves under a churny id.
+    if (!bc) {
         let saves = [];
         try { saves = await GameSaver.listSaves(gameId); } catch { saves = []; }
         if (saves.length > 0) {
@@ -384,10 +379,23 @@ async function downloadSaveToFile() {
 // "different game entirely" apart reliably. IFID is stable regardless of
 // how/where the game was loaded from, so it also makes a save downloaded
 // from WebPlayer for a textadventures.co.uk game load correctly here. Only
-// falls back to the filename if either side lacks an ifid (shouldn't happen
-// for modern games — legacy .asl/.cas are excluded from this whole feature).
+// falls back to the filename if either side lacks an ifid (rare for modern
+// games). Legacy .asl/.cas games skip the check altogether: V4Game.GameID is
+// hardcoded null (no ifid concept) *and* their save data is raw restore-data
+// text, not XML, so it carries no "original"/gameid to fall back to either —
+// there's simply nothing reliable to cross-check. The engine's own
+// save-format validation (V4Game's "QUEST300"/"QUEST200.1" header check) is
+// the safety net there instead, same tradeoff WebPlayer's equivalent check
+// already makes.
 async function loadSaveFromFile(file) {
     const bytes = new Uint8Array(await file.arrayBuffer());
+
+    if (/\.(asl|cas)$/i.test(originalGameFilename)) {
+        hideSavesError();
+        await restartGame(bytes);
+        return;
+    }
+
     let originalAttr = null;
     let uploadedIfid = null;
     try {

--- a/src/WebPlayer/Components/Game.razor
+++ b/src/WebPlayer/Components/Game.razor
@@ -167,10 +167,17 @@
     // game was loaded) over the loading filename: filename is often
     // generic/shared (e.g. always "game.aslx" for every
     // textadventures.co.uk game), so it can neither confirm a same-game
-    // match nor tell different games apart reliably in that case. GameID is
-    // null for legacy .asl/.cas games (V4Game has no IFID concept), so fall
-    // back to filename there — unlike WasmPlayer, WebPlayer's manager isn't
-    // restricted to modern games.
+    // match nor tell different games apart reliably in that case.
+    //
+    // Legacy .asl/.cas games skip this check entirely: GameID is hardcoded
+    // null for V4Game (no IFID concept), *and* their save data is raw
+    // Quest-4 restore-data text (V4Game.SaveAsync -> MakeRestoreData(),
+    // header "QUEST300"/"QUEST200.1"), not XML at all — XDocument.LoadAsync
+    // throws on it, so originalAttr/uploadedIfid always end up null and the
+    // mismatch error would fire even for a genuinely matching save. There's
+    // nothing reliable to cross-check for those, so trust the upload and let
+    // V4Game.OpenGame's own header-version check reject anything that isn't
+    // actually a legacy save (surfaced as a StartGame failure) instead.
     private async Task LoadSaveFromFile(IBrowserFile file)
     {
         if (gameData == null) return;
@@ -182,32 +189,38 @@
         }
         ms.Position = 0;
 
-        string? originalAttr = null;
-        string? uploadedIfid = null;
-        try
+        var isLegacyGame = gameData.Filename.EndsWith(".asl", StringComparison.OrdinalIgnoreCase)
+            || gameData.Filename.EndsWith(".cas", StringComparison.OrdinalIgnoreCase);
+        if (!isLegacyGame)
         {
-            var doc = await XDocument.LoadAsync(ms, LoadOptions.None, CancellationToken.None);
-            originalAttr = doc.Root?.Attribute("original")?.Value;
-            uploadedIfid = doc.Root?.Element("game")?.Element("gameid")?.Value;
-        }
-        catch
-        {
-            // falls through to the mismatch error below
-        }
+            string? originalAttr = null;
+            string? uploadedIfid = null;
+            try
+            {
+                var doc = await XDocument.LoadAsync(ms, LoadOptions.None, CancellationToken.None);
+                originalAttr = doc.Root?.Attribute("original")?.Value;
+                uploadedIfid = doc.Root?.Element("game")?.Element("gameid")?.Value;
+            }
+            catch
+            {
+                // falls through to the mismatch error below
+            }
 
-        var currentIdentity = !string.IsNullOrEmpty(game?.GameID) ? game.GameID : Path.GetFileName(gameData.Filename);
-        var uploadedIdentity = !string.IsNullOrEmpty(uploadedIfid) ? uploadedIfid
-            : !string.IsNullOrEmpty(originalAttr) ? Path.GetFileName(originalAttr) : null;
+            var currentIdentity = !string.IsNullOrEmpty(game?.GameID) ? game.GameID : Path.GetFileName(gameData.Filename);
+            var uploadedIdentity = !string.IsNullOrEmpty(uploadedIfid) ? uploadedIfid
+                : !string.IsNullOrEmpty(originalAttr) ? Path.GetFileName(originalAttr) : null;
 
-        if (uploadedIdentity == null || !string.Equals(currentIdentity, uploadedIdentity, StringComparison.OrdinalIgnoreCase))
-        {
-            saveManagerError = "This save is for a different game — open that game first, then try again.";
-            StateHasChanged();
-            return;
+            if (uploadedIdentity == null || !string.Equals(currentIdentity, uploadedIdentity, StringComparison.OrdinalIgnoreCase))
+            {
+                saveManagerError = "This save is for a different game — open that game first, then try again.";
+                StateHasChanged();
+                return;
+            }
+
+            ms.Position = 0;
         }
 
         saveManagerError = null;
-        ms.Position = 0;
         await StartGame(ms);
     }
 

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "quest-e2e",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "quest-e2e",
+      "version": "0.0.1",
+      "devDependencies": {
+        "playwright": "^1.55.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "quest-e2e",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Playwright browser-driven verification scripts for WebPlayer/WasmPlayer manual QA — not part of the dotnet test suite.",
+  "devDependencies": {
+    "playwright": "^1.55.0"
+  }
+}

--- a/tests/e2e/verify-webplayer-legacy-save.mjs
+++ b/tests/e2e/verify-webplayer-legacy-save.mjs
@@ -1,0 +1,64 @@
+// Ad-hoc manual verification: legacy (.asl) save/load parity fix on
+// WebPlayer's LoadSaveFromFile (Game.razor) — confirms downloading a legacy
+// save then re-uploading it is accepted (no longer always rejected as
+// "different game"). Requires WebPlayer running locally in Development mode
+// with Dev:Enabled (see CLAUDE.md / dotnet run --configuration Release
+// --no-launch-profile --urls http://localhost:5099, ASPNETCORE_ENVIRONMENT=Development).
+import { chromium } from 'playwright';
+import path from 'node:path';
+
+const baseUrl = process.argv[2] || 'http://localhost:5099';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('console', msg => console.log('[console]', msg.type(), msg.text()));
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+await page.goto(`${baseUrl}/dev/open`);
+await page.waitForTimeout(1000);
+const fileInput = await page.$('input[type=file]');
+await fileInput.setInputFiles(path.resolve('../../examples/test.asl'));
+
+await page.waitForSelector('#txtCommand', { timeout: 30000 });
+console.log('Legacy game booted via /dev/open.');
+
+await page.fill('#txtCommand', 'look');
+await page.press('#txtCommand', 'Enter');
+await page.waitForTimeout(500);
+
+await page.click('#cmdSave');
+await page.waitForTimeout(500);
+
+await page.fill('input[placeholder="Save name"]', 'legacy-slot-1');
+await page.click('button:has-text("Save new")');
+await page.waitForTimeout(500);
+console.log('Slot saved (sanity check for existing slot-based flow).');
+
+const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('button:has-text("Save to file")'),
+]);
+const savedPath = await download.path();
+console.log('Downloaded legacy save to', savedPath, 'suggested name:', download.suggestedFilename());
+
+const loadFileInput = await page.$('input[type=file][accept=".quest-save"]');
+await loadFileInput.setInputFiles(savedPath);
+await page.waitForTimeout(1000);
+
+const errorEl = await page.$('.alert-danger');
+const errorText = errorEl ? await errorEl.textContent() : null;
+console.log('Mismatch error shown after re-upload (expect null):', errorText);
+
+await page.fill('#txtCommand', 'look');
+await page.press('#txtCommand', 'Enter');
+await page.waitForTimeout(500);
+const outputText = await page.$eval('#divOutput', el => el.textContent).catch(() => null);
+console.log('Output tail after reload+command:', outputText?.slice(-300));
+
+await browser.close();
+
+if (errorText) {
+    console.error('FAIL: mismatch error was shown for a legitimate same-game legacy save re-upload.');
+    process.exit(1);
+}
+console.log('PASS');


### PR DESCRIPTION
## Summary
- WasmPlayer previously excluded legacy `.asl`/`.cas` games from the boot-time Continue/New-Game prompt and the multi-slot save manager dialog — saves were created via `GameSaver.save()` but there was no way to load one. The same `InitialiseWithSave` mechanism already worked for `V4Game`, so this was a scope gap, not a technical limitation — removed the `isLegacyGame` gating.
- Fixed a save-file upload/download bug this surfaced in both `wasm-player.js` and its WebPlayer equivalent (`Game.razor`): the cross-game identity check parses uploaded saves as XML to compare an embedded IFID/`original` attribute, but legacy saves are raw Quest-4 restore-data text with no embedded identity at all — so the check always rejected a legitimate re-upload as "a different game." Both now skip the check for `.asl`/`.cas` and rely on the engine's own save-format header validation (`V4Game.OpenGame`) instead.
- Added `tests/e2e` with Playwright as a devDependency for browser-driven verification of WebPlayer/WasmPlayer changes going forward (not part of the `dotnet test` suite).

## Test plan
- [x] `dotnet build` for WasmPlayer and WebPlayer
- [x] Playwright verification against a locally-run WasmPlayer + `examples/test.asl`: save-to-slot, boot-time Continue/New-Game prompt on reload, loading a slot to resume state
- [x] Playwright verification against a locally-run WebPlayer (`/dev/open` + `examples/test.asl`): save-to-slot, download save-to-file, re-upload the same file — no mismatch error, game correctly restores ("Restored saved game")

🤖 Generated with [Claude Code](https://claude.com/claude-code)