### PR TITLE
Tie WasmPlayer deploys to release.sh, print version on load

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -1,26 +1,30 @@
 name: Deploy play.questviva.com
 
+# Runs when release.sh tags a version (e.g. v6.0.0-beta.30), keeping
+# play.questviva.com on the same release cadence as the WebPlayer Docker image.
 on:
   push:
-    branches: [ "main" ]
-    paths:
-      - "src/WasmEditor/**"
-      - "src/WebEditor/**"
-      - "src/WasmPlayer/**"
-      - "src/PlayerCore/**"
-      - "src/EditorCore/**"
-      - "src/Engine/**"
-      - "src/Common/**"
+    tags: ['v*']
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       deployments: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify tag matches VERSION file
+        if: github.ref_type == 'tag'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          FILE_VERSION="$(cat VERSION)"
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "❌ Tag $GITHUB_REF_NAME does not match VERSION file ($FILE_VERSION)"
+            exit 1
+          fi
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -73,3 +77,12 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy deploy --project-name=play-questviva --branch=main
+
+      - name: Package WasmPlayer artifact
+        run: (cd src/WasmPlayer/bin/Release/net10.0/browser-wasm/AppBundle && zip -r $GITHUB_WORKSPACE/WasmPlayer.zip .)
+
+      - name: Attach WasmPlayer build to GitHub Release
+        if: github.ref_type == 'tag'
+        run: gh release create ${{ github.ref_name }} WasmPlayer.zip --title "${{ github.ref_name }}" --notes "Quest Viva ${{ github.ref_name }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -34,6 +34,9 @@
     <script type="text/javascript" src="player.js"></script>
     <script type="text/javascript" src="lib/paper.js"></script>
     <script type="text/javascript" src="quest-config.js"></script>
+    <!-- VERSION_SCRIPT: spliced in at build time by scripts/inject-version.mjs
+         (into generated/index.html) — sets window.QuestVivaVersion from the
+         repo-root VERSION file before wasm-player.js runs. -->
     <script type="text/javascript" src="wasm-player.js"></script>
 </head>
 <body>

--- a/src/WasmPlayer/package.json
+++ b/src/WasmPlayer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tailwindcss -i styles/chrome.css -o generated/chrome.css --minify && node scripts/scope-css.mjs generated/chrome.css && node scripts/build-icons.mjs"
+    "build": "tailwindcss -i styles/chrome.css -o generated/chrome.css --minify && node scripts/scope-css.mjs generated/chrome.css && node scripts/build-icons.mjs && node scripts/inject-version.mjs"
   },
   "devDependencies": {
     "@skeletonlabs/skeleton": "^4.15.2",

--- a/src/WasmPlayer/scripts/inject-version.mjs
+++ b/src/WasmPlayer/scripts/inject-version.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Splices the repo-root VERSION string into generated/index.html, replacing
+// the VERSION_SCRIPT placeholder comment in index.html, so wasm-player.js can
+// print its startup banner immediately on page load — without waiting for the
+// WASM runtime to boot (which only happens once a game starts loading).
+//
+// Run via `npm run build`, after build-icons.mjs has produced generated/index.html.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(root, '..', '..');
+
+const version = fs.readFileSync(path.join(repoRoot, 'VERSION'), 'utf8').trim();
+
+const target = path.join(root, 'generated', 'index.html');
+const html = fs.readFileSync(target, 'utf8');
+
+const placeholder = '<!-- VERSION_SCRIPT';
+const start = html.indexOf(placeholder);
+if (start === -1) throw new Error('generated/index.html is missing the VERSION_SCRIPT placeholder');
+const end = html.indexOf('-->', start);
+if (end === -1) throw new Error('VERSION_SCRIPT placeholder comment is not closed with -->');
+
+const output = html.slice(0, start)
+    + `<script>window.QuestVivaVersion = ${JSON.stringify(version)};</script>`
+    + html.slice(end + '-->'.length);
+fs.writeFileSync(target, output);
+console.log(`Wrote generated/index.html with version ${version}`);

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -2,6 +2,17 @@
 // Defines the WebPlayer object surface that playercore.js / player.js call into,
 // then initialises the .NET WASM runtime and wires up [JSImport] callbacks.
 
+// Printed as soon as this script runs (i.e. as the start screen appears) —
+// window.QuestVivaVersion comes from the repo-root VERSION file, spliced in
+// at build time by scripts/inject-version.mjs, so this doesn't need to wait
+// for the WASM runtime to boot (which only happens once a game loads).
+console.log(
+    '%cQuest Viva %c' + (window.QuestVivaVersion || 'dev') + '\n%chttps://questviva.com',
+    'font-weight:700;font-size:14px;color:#0ea5e9',
+    'font-weight:400;color:#64748b',
+    'color:#64748b'
+);
+
 var platform = "wasmplayer";
 
 var _audio = null;


### PR DESCRIPTION
## Summary
- `deploy-play.yml` now triggers on version tags (`v*`, pushed by `release.sh`) instead of every push to `main`, keeping play.questviva.com on the same release cadence as the WebPlayer Docker image, and verifies the tag matches the `VERSION` file.
- The same workflow zips the built WasmPlayer `AppBundle` and attaches it to the GitHub Release for that tag, so it can be downloaded and self-hosted.
- WasmPlayer now prints a styled version banner to the browser console as soon as the start screen appears (not gated on the WASM runtime booting), sourced from the repo-root `VERSION` file at build time via a new `scripts/inject-version.mjs` step in the existing `npm run build` pipeline.

## Test plan
- [x] `dotnet build -c Release src/WasmPlayer/WasmPlayer.csproj` succeeds and `generated/index.html` contains the injected `window.QuestVivaVersion`
- [x] Verified in a real headless browser (Playwright) that the console banner appears on the bare start screen (no game loaded yet) and exactly once when a game does load
- [ ] Workflow YAML validated for syntax/pattern consistency with `docker-publish.yml` / `release-webeditor.yml`, but not run live (requires pushing a `v*` tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)