### PR TITLE
WasmPlayer: clear file:// error, drop unneeded COOP/COEP headers

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -57,10 +57,6 @@ jobs:
           cp -r src/WasmEditor/bin/Release/net10.0/browser-wasm/AppBundle/. deploy/AppBundle/
           cp -r src/WasmPlayer/bin/Release/net10.0/browser-wasm/AppBundle/. deploy/player/
           cat > deploy/_headers <<'EOF'
-          /*
-            Cross-Origin-Opener-Policy: same-origin
-            Cross-Origin-Embedder-Policy: require-corp
-
           /player/_framework/*
             Cache-Control: no-cache
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ dotnet build src/WasmPlayer/WasmPlayer.csproj
 # Build WasmPlayer (Release — AOT compiled, ~15s)
 dotnet build --configuration Release src/WasmPlayer/WasmPlayer.csproj
 
-# Run WasmPlayer dev server (requires COOP/COEP headers for SharedArrayBuffer)
+# Run WasmPlayer dev server
 node src/WasmPlayer/dev-server.mjs              # Debug build
 node src/WasmPlayer/dev-server.mjs --release    # Release/AOT build
 # Open: http://localhost:5175/?url=/examples/simple.aslx

--- a/docs/webeditor-wasm-svelte.md
+++ b/docs/webeditor-wasm-svelte.md
@@ -107,7 +107,7 @@ Output lands in `src/WasmEditor/bin/Debug/net10.0/browser-wasm/AppBundle/`. The 
 src/WebEditor/
 ├── eslint.config.mjs
 ├── svelte.config.js        # adapter-static, $components alias
-├── vite.config.ts          # AppBundle middleware, COOP/COEP headers
+├── vite.config.ts          # AppBundle middleware
 ├── src/
 │   ├── app.css             # @import tailwindcss + skeleton + cerberus theme
 │   ├── app.html            # data-theme="cerberus"
@@ -137,8 +137,6 @@ Requires a WasmEditor Debug build first (see above), then:
 cd src/WebEditor
 npm run dev     # http://localhost:5174
 ```
-
-The Vite dev server sets `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers, which are required for the .NET WASM runtime's use of `SharedArrayBuffer`.
 
 ### WASM loading
 

--- a/src/WasmPlayer/dev-server.mjs
+++ b/src/WasmPlayer/dev-server.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Dev server for WasmPlayer — serves the Debug AppBundle with required COOP/COEP headers.
+// Dev server for WasmPlayer — serves the Debug AppBundle.
 // Run: node dev-server.mjs
 // Then open: http://localhost:5175/?url=/examples/simple.aslx
 //
@@ -52,10 +52,6 @@ function serveFile(res, filePath) {
 }
 
 const server = http.createServer(async (req, res) => {
-  // Required for SharedArrayBuffer used by the .NET WASM runtime
-  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
-
   let urlPath = req.url?.split('?')[0] ?? '/';
   if (urlPath === '/') urlPath = '/index.html';
 

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -519,6 +519,30 @@ async function openSavesDialog(mode, gameId = WebPlayer.gameId) {
     dlg.showModal();
 }
 
+// Nothing here can ever work over file:// — the runtime fetches its own
+// resources (playercore.htm, the dotnet WASM runtime) via relative URLs,
+// and browsers refuse those fetches from a file: origin (each file: URL is
+// treated as a unique, opaque origin with no ability to fetch even its own
+// sibling files). Caught up front, before any load is attempted, so the
+// user gets an accurate explanation instead of the generic "not a valid
+// game file" message that fetch failures would otherwise produce.
+function showFileProtocolError() {
+    document.documentElement.classList.remove('qv-booting');
+    const pickers = document.getElementById('qv-pickers');
+    const msg = document.getElementById('qv-loading-msg');
+    const errorEl = document.getElementById('qv-error');
+    if (msg) msg.style.display = 'none';
+    if (pickers) pickers.style.display = 'none';
+    if (!errorEl) return;
+    errorEl.innerHTML = '<strong>This can\'t run from a local file.</strong> '
+        + 'You\'ve opened index.html directly from disk (a file:// address). Browsers block the web features this '
+        + 'player needs &mdash; fetching its own files and running WebAssembly &mdash; when a page is loaded that way, '
+        + 'so no game will load no matter which one you pick. '
+        + 'Serve this folder over http(s) instead: for example, run <code>npx serve</code> in this folder and open '
+        + 'the http://localhost address it prints, or upload the files to any web host.';
+    errorEl.style.display = 'block';
+}
+
 function showLoading() {
     const pickers = document.getElementById('qv-pickers');
     const msg = document.getElementById('qv-loading-msg');
@@ -664,6 +688,11 @@ async function fetchGameBytes(url) {
 // ── Boot ─────────────────────────────────────────────────────────────────────
 
 (function () {
+    if (window.location.protocol === 'file:') {
+        document.addEventListener('DOMContentLoaded', showFileProtocolError);
+        return;
+    }
+
     const params = new URLSearchParams(window.location.search);
 
     if (params.get('source') === 'editor') {

--- a/src/WebEditor/vite.config.ts
+++ b/src/WebEditor/vite.config.ts
@@ -39,9 +39,6 @@ export default defineConfig({
             const data = await readFile(filePath)
             const ext = extname(filePath)
             res.setHeader('Content-Type', mimeTypes[ext] ?? 'application/octet-stream')
-            // Required for SharedArrayBuffer used by the .NET WASM runtime
-            res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
-            res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
             res.end(data)
           } catch {
             next()
@@ -52,10 +49,6 @@ export default defineConfig({
   ],
   server: {
     port: 5174,
-    headers: {
-      'Cross-Origin-Opener-Policy': 'same-origin',
-      'Cross-Origin-Embedder-Policy': 'require-corp',
-    },
     proxy: {
       // Proxy WasmPlayer through the same origin so BroadcastChannel works between editor and player tabs.
       '/player': {


### PR DESCRIPTION
## Summary
- Opening `index.html` directly from disk (`file://`) always fails — the runtime needs to fetch its own sibling files (`playercore.htm`, the dotnet WASM runtime), which browsers block from a `file:` origin. Previously this surfaced as the generic "doesn't look like a Quest game file" message. Now detected up front and reported with a clear, accurate explanation.
- Removed COOP/COEP headers from the WasmPlayer/WebEditor dev servers and the `play.questviva.com` Cloudflare Pages deploy — confirmed via `grep`/build inspection that no WASM project here enables threading, so `SharedArrayBuffer` (the only reason those headers are needed) is never used. This means a plain `WasmPlayer.zip` uploaded to arbitrary webspace now works over plain HTTP(S) without needing any special header configuration.

## Test plan
- [x] Built WasmPlayer and opened the AppBundle's `index.html` via `file://` in Chrome — confirmed the new clear error shows instead of the old misleading one
- [x] Rebuilt WasmPlayer, ran `dev-server.mjs` (now sending no COOP/COEP headers), confirmed via `curl -I` no such headers are sent and `dotnet.js` still loads
- [x] Loaded a real game (`?url=/examples/simple.aslx`) in Chrome against the header-less dev server — game played normally with a clean console
- [x] `tsc --noEmit` on WebEditor after the `vite.config.ts` edit — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)