### PR TITLE
Add defaultGameUrl config option to WasmPlayer

### DIFF
--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -5,13 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quest Viva</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <script type="text/javascript" src="quest-config.js"></script>
     <script type="text/javascript">
         // Runs before the start screen is parsed, so when a game is specified via the
-        // URL we paint straight into the loading state — otherwise the file/URL
-        // pickers render for a frame before showLoading() gets a chance to hide them.
+        // URL (or a defaultGameUrl is configured) we paint straight into the loading
+        // state — otherwise the file/URL pickers render for a frame before
+        // showLoading() gets a chance to hide them.
         (function () {
             var params = new URLSearchParams(location.search);
-            if (params.get('id') || params.get('url') || params.get('source') === 'editor') {
+            if (params.get('id') || params.get('url') || params.get('source') === 'editor'
+                || window.QuestVivaConfig?.defaultGameUrl) {
                 document.documentElement.classList.add('qv-booting');
             }
         })();
@@ -33,7 +36,6 @@
     <script type="text/javascript" src="playercore.js"></script>
     <script type="text/javascript" src="player.js"></script>
     <script type="text/javascript" src="lib/paper.js"></script>
-    <script type="text/javascript" src="quest-config.js"></script>
     <!-- VERSION_SCRIPT: spliced in at build time by scripts/inject-version.mjs
          (into generated/index.html) — sets window.QuestVivaVersion from the
          repo-root VERSION file before wasm-player.js runs. -->

--- a/src/WasmPlayer/quest-config.js
+++ b/src/WasmPlayer/quest-config.js
@@ -1,5 +1,13 @@
 // Quest Viva WasmPlayer configuration.
 // Replace this file (or set window.QuestVivaConfig before wasm-player.js loads) to customise.
 window.QuestVivaConfig = {
-    textAdventuresApiRoot: 'https://textadventures.co.uk/api/'
+    textAdventuresApiRoot: 'https://textadventures.co.uk/api/',
+
+    // Set this to always load a specific game, e.g. when self-hosting WasmPlayer
+    // alongside a single .quest/.aslx file. Visitors land straight in the game
+    // instead of seeing the file/URL picker. Can be a relative path (resolved
+    // against this site) or an absolute URL to a file hosted elsewhere (subject
+    // to that host's CORS policy). A ?url= or ?id= query param still overrides
+    // this, so links to other games keep working.
+    // defaultGameUrl: 'my-game.quest',
 };

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -708,7 +708,9 @@ async function fetchGameBytes(url) {
     }
 
     const id = params.get('id');
-    const gameUrl = params.get('url');
+    // A URL-supplied game always wins over the configured default, so authors
+    // testing/sharing a specific ?url= link aren't stuck on their own game.
+    const gameUrl = params.get('url') || window.QuestVivaConfig?.defaultGameUrl;
 
     if (id) {
         // Start API fetch immediately; wire DOM once it's ready.


### PR DESCRIPTION
## Summary
- Adds a `defaultGameUrl` option to `quest-config.js` so an author can self-host WasmPlayer alongside a single `.quest`/`.aslx` file and have visitors land straight in the game, without needing a `?url=` link.
- An explicit `?url=`/`?id=` query param still takes priority, so shared links to other games keep working.
- Moved the `quest-config.js` `<script>` tag earlier in `index.html` so the config is available to the early "booting" check that avoids a flash of the file/URL picker.

## Test plan
- [x] `dotnet build src/WasmPlayer/WasmPlayer.csproj`
- [x] Set `defaultGameUrl` in the built AppBundle's `quest-config.js`, served it with a plain static server (simulating self-hosting), and confirmed via headless Chrome that it loads straight into the game with no query params, no console errors, and the picker UI hidden.
- [x] Confirmed `?url=`/`?id=` still override the configured default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)