### PR TITLE
WasmPlayer: fix startup race and DOM-ordering bugs breaking custom games

### DIFF
--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -50,6 +50,20 @@ public partial class WorldModel : IGame, IGameDebug
     private GameSaver? _saver;
     private TimerRunner? _timerRunner;
 
+    // Guards against re-entering the engine while the initial InitInterface/
+    // StartGame sequence (kicked off by BeginAsync but not yet complete) is
+    // still running. Games can trigger this via a JS-raised event mid-startup
+    // (e.g. a device-detection script that calls ASLEvent(...), which schedules
+    // a real `setTimeout` a few ms out) — WasmPlayer's cooperative single-
+    // threaded scheduling lets that fire and call back into SendEvent/Tick
+    // while, say, InitVerbsList hasn't run yet. Blazor Server's synchronization
+    // context doesn't allow that interleaving, which is why this only bites
+    // WasmPlayer. Tick can just be dropped (Begin() reschedules the next one
+    // itself); SendEvent has real one-time semantics so it's queued in
+    // _deferredEvents and replayed once Begin() completes instead.
+    private bool _beginInProgress;
+    private readonly Queue<(string eventName, string param)> _deferredEvents = new();
+
     internal TaskCompletionSource? _waitTcs;
     internal TaskCompletionSource<string?>? _menuTcs;
     internal TaskCompletionSource<bool>? _questionTcs;
@@ -199,6 +213,7 @@ public partial class WorldModel : IGame, IGameDebug
     private async Task BeginInternalAsync()
     {
         _turnSuspendedTcs = new();
+        _beginInProgress = true;
         try
         {
             _timerRunner = new TimerRunner(this, !_loadedFromSaved);
@@ -253,6 +268,13 @@ public partial class WorldModel : IGame, IGameDebug
         }
         finally
         {
+            _beginInProgress = false;
+            while (_deferredEvents.Count > 0)
+            {
+                var (eventName, param) = _deferredEvents.Dequeue();
+                await SendEventCore(eventName, param);
+            }
+
             SignalTurnSuspended();
         }
     }
@@ -347,7 +369,18 @@ public partial class WorldModel : IGame, IGameDebug
         return SendCommand(command, 0, ReadOnlyDictionary<string, string>.Empty);
     }
 
-    public async Task SendEvent(string eventName, string param)
+    public Task SendEvent(string eventName, string param)
+    {
+        if (_beginInProgress)
+        {
+            _deferredEvents.Enqueue((eventName, param));
+            return Task.CompletedTask;
+        }
+
+        return SendEventCore(eventName, param);
+    }
+
+    private async Task SendEventCore(string eventName, string param)
     {
         Elements.TryGetValue(ElementType.Function, eventName, out var handler);
 
@@ -459,6 +492,15 @@ public partial class WorldModel : IGame, IGameDebug
 
         if (State == GameState.Finished)
         {
+            return Task.CompletedTask;
+        }
+
+        if (_beginInProgress)
+        {
+            // A stale/early tick raced the still-running Begin() sequence (see
+            // _beginInProgress). Drop it — BeginInternalAsync calls
+            // SendNextTimerRequest() itself once it completes, so the next tick
+            // gets scheduled correctly from actual post-startup state.
             return Task.CompletedTask;
         }
 

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -232,6 +232,32 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
         };
     }
 
+    // Swap in the game UI *before* Initialise/Begin run, not after. Initialise
+    // registers the game's external <javascript> resources (RegisterExternalScripts),
+    // and games commonly use those to manipulate the game UI's own DOM (e.g.
+    // inserting a custom pane next to the built-in Inventory/Status panes). If
+    // the swap happens later, those scripts execute while the start screen is
+    // still showing, find none of the elements they're looking for, and
+    // silently no-op — a real game, "A Stranger Unregarded", does exactly this
+    // with a custom Inventory2 pane that never appeared because of this
+    // ordering.
+    //
+    // #qv-start is a fixed, full-viewport overlay (see chrome.css), so keeping
+    // it in the DOM on top of the freshly-swapped-in game UI still covers the
+    // screen exactly as before — the loading spinner/error UI's visible
+    // behaviour is unchanged. #qv-saves is a sibling of #qv-start in the
+    // static markup, so it'd also be destroyed by the innerHTML swap —
+    // detach both first and re-append them right after.
+    const startScreenEl = document.getElementById('qv-start');
+    const savesDialogEl = document.getElementById('qv-saves');
+    startScreenEl?.remove();
+    savesDialogEl?.remove();
+
+    document.body.innerHTML = playerHtml;
+
+    if (startScreenEl) document.body.appendChild(startScreenEl);
+    if (savesDialogEl) document.body.appendChild(savesDialogEl);
+
     const ok = saveBytes
         ? await Bridge.InitialiseWithSave(gameBytes, filename, saveBytes)
         : await Bridge.Initialise(gameBytes, filename);
@@ -240,20 +266,9 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
         throw new Error('Failed to initialise game');
     }
 
-    // #qv-saves is a sibling of #qv-start in the static markup, so it would
-    // otherwise be destroyed by the innerHTML swap below along with the rest
-    // of the start screen — detach it first and re-append it right after, so
-    // a failure in between (nothing throws here today, but keep the window
-    // tight) can't strand it permanently out of the DOM.
-    const savesDialogEl = document.getElementById('qv-saves');
-    savesDialogEl?.remove();
-
-    // Only swap in the game UI once everything has succeeded — keeps the start
-    // screen's loading spinner on screen for the whole WASM boot + game-parse
-    // sequence instead of cutting to a blank page while that runs.
-    document.body.innerHTML = playerHtml;
-
-    if (savesDialogEl) document.body.appendChild(savesDialogEl);
+    // Now that startup has actually succeeded, remove the start screen overlay
+    // to reveal the game UI underneath.
+    startScreenEl?.remove();
 
     await setupPaperJs();
 


### PR DESCRIPTION
## Summary

Investigated why [A Stranger Unregarded](https://textadventures.co.uk/games/view/vh_rnrkiqeshmt4zzmbmzg/a-stranger-unregarded) works in WebPlayer but not WasmPlayer. Two distinct WasmPlayer-only bugs:

- **Startup race in the engine**: the game raises a JS event mid-startup (a device-detection script calling `ASLEvent`, which schedules a real `setTimeout` a few ms out) before `InitVerbsList` has run. WasmPlayer's cooperative single-threaded scheduling lets that event reenter `SendEvent`/`Tick` against a half-initialized game, throwing `ArgumentNullException` on null `game.verbattributes` and flooding the output with "[Sorry, an error occurred]". Blazor Server's synchronization context never allows this interleaving, which is why WebPlayer was unaffected. Fixed with a `_beginInProgress` guard: a stale reentrant `Tick` is dropped (`Begin()` reschedules the next one itself), and a reentrant `SendEvent` is queued and replayed once `Begin()` completes.
- **DOM-ordering bug in WasmPlayer's JS bootstrap**: `wasm-player.js` swapped the real game DOM in only *after* `Bridge.Initialise()` succeeded, but `Initialise()` is what runs the game's external `<javascript>` resources. Games that manipulate the game UI's own DOM from custom JS (this one inserts a second "Magic Spells" inventory pane) ran against the still-showing start screen and silently found nothing to attach to. Fixed by swapping the DOM in first, keeping the (already full-screen) start-screen overlay on top until startup actually succeeds — same visible loading behavior, but external scripts now see the real game DOM.

## Test plan

- [x] `dotnet test tests/EngineTests` — 269 passed
- [x] `dotnet test tests/PlayerCoreTests` — 8 passed
- [x] Verified against the real game (`?id=vh_rnrkiqeshmt4zzmbmzg`) via Playwright: clean console output through character creation, custom "Magic Spells" pane now renders
- [x] Regression check: `simple.aslx` (basic commands) and `timer.aslx` (normal timer firing) still behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)