### PR TITLE
WasmPlayer: speed up saves and show progress feedback

### DIFF
--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -175,13 +175,20 @@ public partial class WasmPlayerBridge
         _ui.FlushBuffer();
     }
 
+    // Split in two because the JS interop source generator doesn't support
+    // Task<byte[]> as a JSExport return type (only plain, synchronous byte[]
+    // — see SYSLIB1072). PrepareSaveGame does the (possibly awaited) work and
+    // stashes the result; GetSaveGameBytes hands it back synchronously.
+    private static byte[]? _pendingSaveBytes;
+
     [JSExport]
-    public static async Task<string> SaveGame(string html)
+    public static async Task PrepareSaveGame(string html)
     {
-        if (_game == null) return string.Empty;
-        var bytes = await _game.SaveAsync(html);
-        return Convert.ToBase64String(bytes);
+        _pendingSaveBytes = _game == null ? [] : await _game.SaveAsync(html);
     }
+
+    [JSExport]
+    public static byte[] GetSaveGameBytes() => _pendingSaveBytes ?? [];
 
     // ── C# → JS imports ─────────────────────────────────────────────────────
 

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -130,11 +130,8 @@ window.WebPlayer = {
     },
 
     async uiSaveGame(html) {
-        const base64 = await Bridge.SaveGame(html);
-        const binary = atob(base64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-        return bytes;
+        await Bridge.PrepareSaveGame(html);
+        return Bridge.GetSaveGameBytes();
     },
 
 };
@@ -348,6 +345,38 @@ function _esc(str) {
 let savesDialogWired = false;
 let bootChoiceResolve = null;
 
+// Waits for the browser to actually paint the current frame. WasmPlayer's
+// WASM runtime is single-threaded and the engine's SaveAsync does its work
+// synchronously (no genuine await inside it) — so a DOM update made right
+// before calling into it sits queued but unpainted for the entire blocking
+// call, since the one JS/UI thread has no chance to render until that call
+// returns. Awaiting two animation frames forces a real yield back to the
+// browser first, so a "Saving…" label actually reaches the screen before the
+// blocking work starts, instead of only flashing briefly at the very end.
+function nextPaint() {
+    return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+
+// Disables a button and (if given) swaps its label for the duration of an
+// async op, so slower saves (a big transcript, IndexedDB contention, low-end
+// devices) read as "working" rather than an unresponsive click — there was
+// previously no feedback at all between clicking Save and the list
+// refreshing. busyText is omitted for icon-only buttons (e.g. delete), whose
+// content is an <svg>, not text — overwriting textContent would destroy it.
+async function withBusyButton(button, busyText, fn) {
+    const originalText = button.textContent;
+    const wasDisabled = button.disabled;
+    button.disabled = true;
+    if (busyText) button.textContent = busyText;
+    await nextPaint();
+    try {
+        return await fn();
+    } finally {
+        button.disabled = wasDisabled;
+        if (busyText) button.textContent = originalText;
+    }
+}
+
 function showSavesError(message) {
     const el = document.getElementById('qv-saves-error');
     if (!el) return;
@@ -488,19 +517,24 @@ function ensureSavesDialogWired() {
         if (delBtn) {
             const name = delBtn.closest('li')?.querySelector('[data-slot]')?.textContent ?? 'this save';
             if (!confirm(`Delete "${name}"? This can't be undone.`)) return;
-            await GameSaver.deleteSlot(Number(delBtn.dataset.deleteSlot), WebPlayer.gameId);
+            await withBusyButton(delBtn, '', async () => {
+                await GameSaver.deleteSlot(Number(delBtn.dataset.deleteSlot), WebPlayer.gameId);
+            });
             renderSavesList(await GameSaver.listSaves(WebPlayer.gameId), 'manage');
         }
     });
 
-    document.getElementById('qv-saves-save-new').addEventListener('click', async () => {
+    document.getElementById('qv-saves-save-new').addEventListener('click', async (e) => {
         const input = document.getElementById('qv-saves-name-input');
-        await GameSaver.save(input.value.trim() || undefined);
+        await withBusyButton(e.currentTarget, 'Saving…', async () => {
+            await GameSaver.save(input.value.trim() || undefined);
+        });
         input.value = '';
         renderSavesList(await GameSaver.listSaves(WebPlayer.gameId), 'manage');
     });
 
-    document.getElementById('qv-saves-download').addEventListener('click', downloadSaveToFile);
+    document.getElementById('qv-saves-download').addEventListener('click', (e) =>
+        withBusyButton(e.currentTarget, 'Saving…', downloadSaveToFile));
 
     const uploadBtn = document.getElementById('qv-saves-upload-btn');
     const fileInput = document.getElementById('qv-saves-file-input');


### PR DESCRIPTION
## Summary
- Removes a base64 encode/decode round-trip between the WASM save call and JS — bytes now cross the JS/WASM boundary directly as a `Uint8Array` instead of a base64 string decoded byte-by-byte via `atob()`/`charCodeAt`.
- Adds a "Saving…" busy state to the Save new / Save to file / delete-slot buttons in the Save/Load dialog, which previously gave no feedback at all during a save.
- The busy label needed an explicit paint yield (two `requestAnimationFrame` round-trips) before calling into the blocking WASM save work — the engine's save is fully synchronous, so without the yield the label was set but never actually painted until the whole (multi-second, for larger saves) blocking call finished.

## Test plan
- [x] `dotnet build --configuration Release` (full solution, including WasmPlayer AOT) succeeds
- [x] Verified via Playwright against the dev server (`examples/simple.aslx`): save completes and appears in the list, delete button's icon survives a full click cycle (caught a bug pre-fix where clearing `textContent` on an icon-only button would have destroyed its `<svg>`), zero console errors
- [x] Verified with a rAF frame-sampler that "Saving…" is now actually painted across ~1433ms of a ~1463ms save round-trip, rather than flashing only at the very end

🤖 Generated with [Claude Code](https://claude.com/claude-code)