### PR TITLE
Automate release tagging and notes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,33 @@
+name: Auto-tag release
+
+# Runs whenever the VERSION file changes on main. Creates and pushes the git
+# tag that docker-publish.yml, nuget-publish.yml, and deploy-play.yml key off
+# of, so merging a VERSION-bump PR is the release — no manual release.sh run
+# needed.
+on:
+  push:
+    branches: [main]
+    paths: ['VERSION']
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Create and push tag if it doesn't exist yet
+        run: |
+          VERSION="$(cat VERSION)"
+          TAG="v$VERSION"
+          if git ls-remote --tags origin | grep -q "refs/tags/$TAG\$"; then
+            echo "Tag $TAG already exists, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Pushed $TAG"

--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -79,6 +79,6 @@ jobs:
 
       - name: Attach WasmPlayer build to GitHub Release
         if: github.ref_type == 'tag'
-        run: gh release create ${{ github.ref_name }} WasmPlayer.zip --title "${{ github.ref_name }}" --notes "Quest Viva ${{ github.ref_name }}"
+        run: gh release create ${{ github.ref_name }} WasmPlayer.zip --title "${{ github.ref_name }}" --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,12 +76,14 @@ EditorCore ───────────────────────
 
 ## Releasing
 
-1. Update the `VERSION` file on `main` and push
-2. Run `./release.sh`
+1. Open a PR that updates the `VERSION` file
+2. Merge it to `main`
 
-This creates and pushes a git tag (e.g. `v6.0.0-beta.12`) which triggers the `docker-publish` GitHub Actions workflow. That workflow verifies the tag matches the `VERSION` file, then builds and pushes the Docker image tagged with that version. The version is also embedded in the binary at build time and displayed at `/about`.
+Merging a `VERSION` change to `main` triggers the `auto-tag` GitHub Actions workflow, which creates and pushes a git tag (e.g. `v6.0.0-beta.12`) if one doesn't already exist for that version. The tag push in turn triggers `docker-publish`, `nuget-publish`, and `deploy-play`, which build/push the Docker image, publish NuGet packages, deploy play.questviva.com, and attach a GitHub Release with auto-generated notes. The version is also embedded in the binary at build time and displayed at `/about`.
 
-If you forgot to update `VERSION`, the script will fail locally because the tag for the old version already exists.
+`auto-tag` pushes using the `RELEASE_PAT` repo secret (a PAT with Contents read/write), not the default `GITHUB_TOKEN` — tags pushed with `GITHUB_TOKEN` don't trigger other workflows, so a PAT is required for the tag-triggered workflows to fire.
+
+`./release.sh` still works as a manual fallback if you need to tag from a clean local `main` directly (e.g. if `auto-tag` is broken). If you forgot to update `VERSION` before running it, the script will fail locally because the tag for the old version already exists.
 
 ## Key Technical Details
 


### PR DESCRIPTION
## Summary
- Add `auto-tag.yml`: watches pushes to `main` for `VERSION` changes and creates/pushes the corresponding git tag automatically, using the new `RELEASE_PAT` secret so the tag push still triggers `docker-publish`, `nuget-publish`, and `deploy-play` (a tag pushed with the default `GITHUB_TOKEN` would not).
- Update `deploy-play.yml` to create the GitHub Release with `--generate-notes` instead of a static notes string, so it matches the "Generate release notes" button.
- Update `CLAUDE.md`'s Releasing section to describe the new flow (`release.sh` remains as a manual fallback).

## Test plan
- [ ] Merge this PR, then merge a follow-up PR that bumps `VERSION`, and confirm `auto-tag` creates the tag and the downstream workflows (docker-publish, nuget-publish, deploy-play) all fire and the GitHub Release gets auto-generated notes.