### PR TITLE
Fix duplicate DOM elements from custom game JS on restart

### DIFF
--- a/src/PlayerCore/Resources/player.js
+++ b/src/PlayerCore/Resources/player.js
@@ -176,12 +176,28 @@ function saveGame() {
     }, 100);
 }
 
+// A restart (Start from the beginning / Load) re-runs Initialise() on the
+// same live document rather than a fresh page load, and Initialise()
+// unconditionally re-registers the game's external scripts. A real <script
+// src> only ever runs once per document, so re-adding the same URL here would
+// re-execute the game's setup code against DOM it already set up on the
+// previous run (e.g. a custom sidebar pane), producing duplicates. Dedupe by
+// URL so each script tag still only truly executes once per document, same
+// as normal page-load semantics.
+var _loadedExternalScripts = new Set();
+
 function addExternalScript(url) {
+    if (_loadedExternalScripts.has(url)) return Promise.resolve();
+    _loadedExternalScripts.add(url);
+
     return new Promise((resolve, reject) => {
         const script = document.createElement("script");
         script.src = url;
         script.onload = () => resolve();
-        script.onerror = () => reject(new Error(`Failed to load script: ${url}`));
+        script.onerror = () => {
+            _loadedExternalScripts.delete(url);
+            reject(new Error(`Failed to load script: ${url}`));
+        };
         document.head.appendChild(script);
     });
 }

--- a/src/WasmPlayer/dev-server.mjs
+++ b/src/WasmPlayer/dev-server.mjs
@@ -18,6 +18,7 @@ const isRelease = process.argv.includes('--release');
 const config = isRelease ? 'Release' : 'Debug';
 const appBundleDir = path.resolve(__dirname, `bin/${config}/net10.0/browser-wasm/AppBundle`);
 const examplesDir = path.resolve(__dirname, '../../examples');
+const e2eFixturesDir = path.resolve(__dirname, '../../tests/e2e/fixtures');
 const port = 5175;
 
 const mimeTypes = {
@@ -58,6 +59,18 @@ const server = http.createServer(async (req, res) => {
   if (urlPath.startsWith('/examples/')) {
     const filePath = path.join(examplesDir, urlPath.slice('/examples/'.length));
     if (!filePath.startsWith(examplesDir)) { res.writeHead(403); res.end(); return; }
+    serveFile(res, filePath);
+    return;
+  }
+
+  // Serves e2e regression-test fixture games (tests/e2e/fixtures/*.aslx) the
+  // same way /examples/ does. Also checked as a fallback for bare resource
+  // requests below (e.g. a fixture's <javascript src="foo.js">) — the
+  // ?url= boot path never sets a resourceRoot, so those resolve relative to
+  // this server's own origin rather than alongside the .aslx file.
+  if (urlPath.startsWith('/e2e-fixtures/')) {
+    const filePath = path.join(e2eFixturesDir, urlPath.slice('/e2e-fixtures/'.length));
+    if (!filePath.startsWith(e2eFixturesDir)) { res.writeHead(403); res.end(); return; }
     serveFile(res, filePath);
     return;
   }
@@ -115,6 +128,15 @@ const server = http.createServer(async (req, res) => {
       res.writeHead(502);
       res.end(`Proxy error: ${e.message}`);
     }
+    return;
+  }
+
+  // A fixture's own external resources (e.g. restart-test.js) are requested
+  // bare, relative to this server's origin — see the /e2e-fixtures/ comment
+  // above. Check there before falling back to the AppBundle.
+  const fixtureFilePath = path.join(e2eFixturesDir, urlPath);
+  if (fixtureFilePath.startsWith(e2eFixturesDir) && fs.existsSync(fixtureFilePath)) {
+    serveFile(res, fixtureFilePath);
     return;
   }
 

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -28,6 +28,11 @@ let resourceRoot = null;
 // and never reassigned by a slot/file load.
 let originalGameBytes = null;
 let originalGameFilename = null;
+// The pristine player chrome markup (playercore.htm), fetched once at boot
+// and reused verbatim by restartGame() so a mid-session restart gets exactly
+// the same clean slate as the initial boot, instead of the previous game's
+// live DOM (see swapInPlayerUi()).
+let originalPlayerHtml = null;
 
 function computeGameId(filename) {
     return filename.split('/').pop();
@@ -164,12 +169,36 @@ async function setupPaperJs() {
     paper.PaperScript.evaluate(code, paper);
 }
 
+// Replaces document.body with a fresh copy of the player chrome, preserving
+// #qv-start/#qv-saves (the static markup's overlays, which live outside the
+// swapped-in playerHtml and would otherwise be destroyed by the innerHTML
+// assignment). Used both for the initial boot and for a mid-session restart
+// ("Start from the beginning" / Load) — a restart must get a genuinely new
+// DOM, not just a cleared output pane, because games commonly use their
+// external <javascript> resources to inject their own elements elsewhere in
+// the chrome (e.g. a custom sidebar pane). Those run again on every restart
+// (RegisterExternalScripts fires on every Initialise call), so anything short
+// of a full DOM reset here leaves the previous run's injected elements in
+// place for the new run to duplicate.
+function swapInPlayerUi() {
+    const startScreenEl = document.getElementById('qv-start');
+    const savesDialogEl = document.getElementById('qv-saves');
+    startScreenEl?.remove();
+    savesDialogEl?.remove();
+
+    document.body.innerHTML = originalPlayerHtml;
+
+    if (startScreenEl) document.body.appendChild(startScreenEl);
+    if (savesDialogEl) document.body.appendChild(savesDialogEl);
+    return startScreenEl;
+}
+
 async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) {
     const [htmResponse, { dotnet }] = await Promise.all([
         fetch('playercore.htm'),
         import('./_framework/dotnet.js'),
     ]);
-    const playerHtml = await htmResponse.text();
+    originalPlayerHtml = await htmResponse.text();
 
     const runtime = await dotnet.create();
     const { setModuleImports, getAssemblyExports, getConfig } = runtime;
@@ -242,18 +271,8 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
     // #qv-start is a fixed, full-viewport overlay (see chrome.css), so keeping
     // it in the DOM on top of the freshly-swapped-in game UI still covers the
     // screen exactly as before — the loading spinner/error UI's visible
-    // behaviour is unchanged. #qv-saves is a sibling of #qv-start in the
-    // static markup, so it'd also be destroyed by the innerHTML swap —
-    // detach both first and re-append them right after.
-    const startScreenEl = document.getElementById('qv-start');
-    const savesDialogEl = document.getElementById('qv-saves');
-    startScreenEl?.remove();
-    savesDialogEl?.remove();
-
-    document.body.innerHTML = playerHtml;
-
-    if (startScreenEl) document.body.appendChild(startScreenEl);
-    if (savesDialogEl) document.body.appendChild(savesDialogEl);
+    // behaviour is unchanged.
+    const startScreenEl = swapInPlayerUi();
 
     const ok = saveBytes
         ? await Bridge.InitialiseWithSave(gameBytes, filename, saveBytes)
@@ -281,12 +300,19 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
 
 // Reloads a save (or, with saveBytes null, the fresh original game) on top
 // of the already-booted WASM runtime — used for in-game Load and "Start
-// from the beginning", so it must NOT repeat WebPlayer.initUI()/setupPaperJs():
-// those rebind #cmdSave/#cmdDebug click handlers, jQuery-UI widgets, etc.
-// unconditionally, and doing that twice on the same live DOM would
-// double-bind every one of them.
+// from the beginning". Rebuilds the player chrome from scratch via
+// swapInPlayerUi() (same as the initial boot) rather than just clearing the
+// output pane: RegisterExternalScripts fires again on every Initialise call,
+// and games commonly use their external <javascript> resources to inject
+// their own elements into the chrome (e.g. a custom sidebar pane) — without a
+// full DOM reset here, that injected element from the previous run is still
+// sitting in the (undisturbed) sidebar when the script re-runs and adds
+// another one. A fresh DOM means initUI()/setupPaperJs() are being bound to
+// brand-new elements each time, not the same live ones, so this isn't the
+// double-binding repeat-init the old comment here used to warn about.
 async function restartGame(saveBytes) {
     document.getElementById('qv-saves')?.close();
+    swapInPlayerUi();
     resetGameOutput();
 
     const ok = saveBytes
@@ -296,6 +322,9 @@ async function restartGame(saveBytes) {
         showSavesError('Failed to load that save.');
         return;
     }
+
+    await setupPaperJs();
+    WebPlayer.initUI();
     WebPlayer.setCanSave(true);
     await Bridge.Begin();
 }

--- a/src/WebPlayer/Components/Game.razor
+++ b/src/WebPlayer/Components/Game.razor
@@ -41,7 +41,7 @@
     <Debugger Game="@gameDebug" OnRunWalkthrough="RunWalkthrough"></Debugger>
 }
 
-@UiHtml
+<div id="qv-player-chrome">@UiHtml</div>
 
 <Slots Saves="@saves" ManageMode="@manageMode" ErrorMessage="@saveManagerError"
        OnStart="() => StartGame(null)" OnLoad="@LoadGame"
@@ -237,11 +237,19 @@
 
         if (game != null)
         {
-            // Clear the previous game's transcript before swapping it out —
-            // a no-op on the very first call (the div is already empty then),
-            // but essential for a mid-session restart (Start from the
-            // beginning / Load), or the new game's output gets appended
-            // after the old one instead of replacing it.
+            // A mid-session restart (Start from the beginning / Load) reuses
+            // this same live DOM — Blazor's diff never touches @UiHtml again
+            // once rendered once, since its content is a constant string, so
+            // nothing here resets it for us. Without resetPlayerUi, whatever
+            // the previous game's own <javascript> resources injected
+            // elsewhere in the chrome (e.g. a custom sidebar pane) survives
+            // into the new session, and since RegisterExternalScripts runs
+            // again on every Initialise, the game re-adds another one on top
+            // of it. Reset the whole chrome to a pristine copy first, then
+            // resetOutput to clear the JS-side output-tracking state
+            // (_currentDiv/_divCount in playercore.js) that innerHTML alone
+            // doesn't touch.
+            await JS.InvokeVoidAsync("WebPlayer.resetPlayerUi", PlayerHelper.GetUiResourceString("playercore.htm"));
             await JS.InvokeVoidAsync("WebPlayer.resetOutput");
             game.Finish();
             GameSessionTracker.GameEnded();

--- a/src/WebPlayer/wwwroot/playerweb.js
+++ b/src/WebPlayer/wwwroot/playerweb.js
@@ -49,6 +49,19 @@ class WebPlayer {
         resetGameOutput();
     }
 
+    // Replaces the #qv-player-chrome container (everything Game.razor's
+    // @UiHtml renders — #gameBorder, #dialog, #msgbox) with a fresh copy of
+    // playercore.htm, ahead of a mid-session restart. Blazor never re-renders
+    // this content itself (the underlying string is a constant, so its diff
+    // sees no change across renders), so anything a game's own <javascript>
+    // resources injected into the chrome during the previous session (e.g. a
+    // custom sidebar pane) would otherwise still be sitting there when
+    // RegisterExternalScripts re-runs the game's setup code on the new
+    // session and it adds another one.
+    static resetPlayerUi(html) {
+        document.getElementById("qv-player-chrome").innerHTML = html;
+    }
+
     static async downloadSaveAsFile(filename) {
         const bytes = await WebPlayer.uiSaveGame($("#divOutput").html());
         const blob = new Blob([bytes], {type: 'application/xml'});

--- a/tests/e2e/fixtures/restart-test.aslx
+++ b/tests/e2e/fixtures/restart-test.aslx
@@ -1,0 +1,20 @@
+<asl version="580">
+
+  <include ref="English.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <game name="Simple">
+  </game>
+
+  <javascript src="restart-test.js"/>
+
+  <function name="StartGame">
+    JS.addSidebarPane()
+  </function>
+
+  <object name="room">
+    <object name="player">
+    </object>
+  </object>
+
+</asl>

--- a/tests/e2e/fixtures/restart-test.js
+++ b/tests/e2e/fixtures/restart-test.js
@@ -1,0 +1,10 @@
+window.__restartTestScriptRuns = (window.__restartTestScriptRuns || 0) + 1;
+
+function addSidebarPane() {
+    var sidebar = document.getElementById('sidebar');
+    if (!sidebar) return;
+    var div = document.createElement('div');
+    div.className = 'newwindow-test-pane';
+    div.textContent = 'pane';
+    sidebar.appendChild(div);
+}

--- a/tests/e2e/verify-wasmplayer-restart-sidebar-dup.mjs
+++ b/tests/e2e/verify-wasmplayer-restart-sidebar-dup.mjs
@@ -1,0 +1,48 @@
+// Ad-hoc manual verification: WasmPlayer's "Start from the beginning" used to
+// duplicate DOM elements a game's custom JS injects into the chrome (e.g. a
+// custom sidebar pane), because restartGame() only cleared #divOutput while
+// leaving the rest of the live DOM (and the game's <javascript> resources,
+// which re-run their setup on every restart) untouched. Fixed by having
+// restartGame() rebuild the whole player chrome via swapInPlayerUi(), same as
+// the initial boot. Requires the WasmPlayer dev server running locally:
+//   node ../../src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+await page.goto(`${baseUrl}/?url=/e2e-fixtures/restart-test.aslx`);
+await page.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+await page.waitForTimeout(500);
+
+const countPanes = () => page.$$eval('.newwindow-test-pane', els => els.length);
+
+const restart = async () => {
+    await page.click('#cmdSave');
+    await page.waitForSelector('#qv-saves', { state: 'visible', timeout: 10000 });
+    await page.click('#qv-saves-start-new');
+    await page.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+    await page.waitForTimeout(500);
+};
+
+const initial = await countPanes();
+console.log('panes after initial start:', initial);
+
+await restart();
+const after1 = await countPanes();
+console.log('panes after 1st restart:', after1);
+
+await restart();
+const after2 = await countPanes();
+console.log('panes after 2nd restart:', after2);
+
+await browser.close();
+
+if (initial !== 1 || after1 !== 1 || after2 !== 1) {
+    console.error('FAIL: expected exactly 1 pane at every step (no duplication, no loss).');
+    process.exit(1);
+}
+console.log('PASS');

--- a/tests/e2e/verify-webplayer-restart-chrome-reset.mjs
+++ b/tests/e2e/verify-webplayer-restart-chrome-reset.mjs
@@ -1,0 +1,76 @@
+// Ad-hoc manual verification: mirrors verify-wasmplayer-restart-sidebar-dup.mjs
+// for WebPlayer. WebPlayer's Game.razor renders the player chrome
+// (#qv-player-chrome, wrapping playercore.htm) once via Blazor; Blazor never
+// re-diffs it afterwards since the underlying string never changes, so a
+// mid-session restart (Start from the beginning / Load) needs to reset that
+// DOM itself. Fixed via WebPlayer.resetPlayerUi(html), called before
+// resetOutput/initUI on every restart.
+//
+// Doesn't wire up a real game with a custom <javascript> resource (WebPlayer's
+// /dev/open + FileGameDataProvider flow has no adjacent-resource support to
+// serve one locally) — instead manually injects a marker element into
+// #sidebar to stand in for "a game's custom JS added something to the
+// chrome", then confirms restart wipes it, and that basic gameplay (typing a
+// command) still works afterwards (proving initUI/Player wiring survived the
+// DOM reset). Requires WebPlayer running locally in Development mode:
+//   ASPNETCORE_ENVIRONMENT=Development dotnet run --configuration Release \
+//     --no-launch-profile --urls http://localhost:5099 --project src/WebPlayer
+import { chromium } from 'playwright';
+import path from 'node:path';
+
+const baseUrl = process.argv[2] || 'http://localhost:5099';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console error]', msg.text()); });
+
+await page.goto(`${baseUrl}/dev/open`);
+await page.waitForTimeout(1000);
+const fileInput = await page.$('input[type=file]');
+await fileInput.setInputFiles(path.resolve('../../examples/blank.aslx'));
+
+await page.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+console.log('Game booted via /dev/open.');
+
+const injectMarker = () => page.evaluate(() => {
+    const sidebar = document.getElementById('sidebar');
+    const div = document.createElement('div');
+    div.className = 'newwindow-test-pane';
+    div.textContent = 'pane';
+    sidebar.appendChild(div);
+});
+const countMarkers = () => page.$$eval('.newwindow-test-pane', els => els.length);
+
+await injectMarker();
+console.log('markers before restart (expect 1):', await countMarkers());
+
+await page.click('#cmdSave');
+await page.waitForSelector('#questVivaSlots', { state: 'visible', timeout: 10000 });
+await page.click('button:has-text("Start from the beginning")');
+
+await page.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+await page.waitForTimeout(500);
+
+const markersAfterRestart = await countMarkers();
+console.log('markers after restart (expect 0 — resetPlayerUi wiped the chrome):', markersAfterRestart);
+
+// Confirm the fresh chrome is actually wired up (initUI/Player.Initialise ran
+// correctly against it, not just visually present).
+await page.fill('#txtCommand', 'look');
+await page.press('#txtCommand', 'Enter');
+await page.waitForTimeout(500);
+const outputText = await page.$eval('#divOutput', el => el.textContent).catch(() => null);
+console.log('output after restart + "look" command:', outputText?.slice(-200));
+
+await browser.close();
+
+if (markersAfterRestart !== 0) {
+    console.error('FAIL: expected the manually-injected chrome marker to be gone after restart.');
+    process.exit(1);
+}
+if (!outputText || !outputText.toLowerCase().includes('room')) {
+    console.error('FAIL: game did not respond to a command after restart — chrome reset likely broke wiring.');
+    process.exit(1);
+}
+console.log('PASS');


### PR DESCRIPTION
## Summary
- "Start from the beginning" / Load reuses the live DOM instead of doing a fresh page load, but previously only ever cleared the output pane. Games commonly use their external `<javascript>` resources to inject elements elsewhere in the chrome (e.g. a custom sidebar pane), and that setup code re-runs on every restart (`RegisterExternalScripts` fires on every `Initialise` call, and a game's `StartGame` function can call `JS.*` directly too) — so anything the previous run injected was still there when the new run added another one.
- **WasmPlayer**: `restartGame()` now rebuilds the whole player chrome via a new `swapInPlayerUi()` helper, same as the initial boot, instead of only resetting `#divOutput`. Also dedupes `addExternalScript()` by URL in the shared `player.js` so a script's top-level setup code doesn't re-execute across restarts.
- **WebPlayer**: mirrors the same fix — `Game.razor` wraps its rendered chrome in `#qv-player-chrome` (Blazor never re-diffs it once rendered, since the underlying string is constant) and resets it via `WebPlayer.resetPlayerUi()` before a restart.

## Test plan
- [x] `dotnet build --configuration Release` (full solution)
- [x] `dotnet test --configuration Release` (all projects pass)
- [x] Playwright regression test against WasmPlayer dev server (`tests/e2e/verify-wasmplayer-restart-sidebar-dup.mjs` + fixture game `tests/e2e/fixtures/restart-test.aslx`): confirms exactly 1 injected pane survives repeated restarts; confirmed the old code duplicates it (1 → 2 → 3) to validate the test is meaningful
- [x] Playwright regression test against a locally-run WebPlayer (`tests/e2e/verify-webplayer-restart-chrome-reset.mjs`): confirms a manually-injected chrome marker is wiped on restart and gameplay still works afterwards; confirmed the old code leaves the marker in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)