### PR TITLE
Fix: timer created inside wait/pause/ask/menu callback never fires

### DIFF
--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -185,6 +185,7 @@ public partial class WorldModel : IGame, IGameDebug
         tcs?.TrySetResult(response);
         await _turnSuspendedTcs.Task;
         if (State != GameState.Finished) await UpdateListsAsync();
+        SendNextTimerRequest();
     }
 
     public async Task<bool> Initialise(IPlayer player)
@@ -424,6 +425,7 @@ public partial class WorldModel : IGame, IGameDebug
         tcs?.TrySetResult();
         await _turnSuspendedTcs.Task;
         if (State != GameState.Finished) await UpdateListsAsync();
+        SendNextTimerRequest();
     }
 
     public async Task FinishPause()
@@ -433,6 +435,7 @@ public partial class WorldModel : IGame, IGameDebug
         tcs?.TrySetResult();
         await _turnSuspendedTcs.Task;
         if (State != GameState.Finished) await UpdateListsAsync();
+        SendNextTimerRequest();
     }
 
     public IEnumerable<string> GetExternalScripts()
@@ -533,6 +536,7 @@ public partial class WorldModel : IGame, IGameDebug
         tcs?.TrySetResult(response);
         await _turnSuspendedTcs.Task;
         if (State != GameState.Finished) await UpdateListsAsync();
+        SendNextTimerRequest();
     }
 
     public Stream? GetResourceStream(string filename)

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -18,6 +18,7 @@ internal sealed class GameDriver
     private readonly WorldModel _worldModel;
     private List<string> _batch = [];
     private Exception _scriptError;
+    public List<int> RequestedTimerTicks { get; } = [];
 
     private static readonly Regex StripTags = new(@"<[^>]+>", RegexOptions.Compiled);
 
@@ -37,6 +38,7 @@ internal sealed class GameDriver
             })
             .Returns(Task.CompletedTask);
         worldModel.LogError += ex => _scriptError = ex;
+        worldModel.RequestNextTimerTick += seconds => RequestedTimerTicks.Add(seconds);
     }
 
     public static async Task<GameDriver> LoadAsync(string filename)
@@ -71,6 +73,7 @@ internal sealed class GameDriver
     {
         _batch = [];
         _scriptError = null;
+        RequestedTimerTicks.Clear();
         await _worldModel.SendCommand(command);
         return TakeBatch();
     }
@@ -79,6 +82,7 @@ internal sealed class GameDriver
     {
         _batch = [];
         _scriptError = null;
+        RequestedTimerTicks.Clear();
         await _worldModel.FinishWait();
         return TakeBatch();
     }
@@ -134,6 +138,23 @@ public class CallbackTests
         var phase2 = await driver.FinishWaitAsync();
         phase2.ShouldContain("wait done");
         phase2.ShouldContain("on ready");
+    }
+
+    // A timer created inside a wait callback (e.g. via SetTimeout) must cause the host
+    // to be told when to next call Tick(), otherwise the timer never fires. Regression
+    // test for a bug where FinishWait didn't re-request the next timer tick after running
+    // its callback, so a timer created there would silently never run on WebPlayer/WasmPlayer
+    // (which rely on the RequestNextTimerTick event, unlike a desktop player polling a clock).
+    [TestMethod]
+    public async Task Wait_CallbackCreatesTimer_RequestsNextTimerTick()
+    {
+        var driver = await GameDriver.LoadAsync("callbacktest.aslx");
+
+        await driver.SendCommandAsync("testwaittimer");
+
+        var phase2 = await driver.FinishWaitAsync();
+        phase2.ShouldContain("wait done");
+        driver.RequestedTimerTicks.ShouldContain(5);
     }
 
     // An 'on ready' encountered inside another 'on ready' callback should be queued

--- a/tests/EngineTests/callbacktest.aslx
+++ b/tests/EngineTests/callbacktest.aslx
@@ -45,6 +45,23 @@
     </script>
   </command>
 
+  <!-- wait callback creates a timer via SetTimeout: after FinishWait resolves the outer
+       wait, the newly-created/enabled timer must be picked up so the host is told when
+       to next call Tick(). Regression test for a bug where FinishWait/FinishPause/
+       SetQuestionResponse/SetMenuResponse didn't re-request the next timer tick. -->
+  <command name="cmd_wait_timer">
+    <pattern>testwaittimer</pattern>
+    <script>
+      msg ("before wait")
+      wait {
+        msg ("wait done")
+        SetTimeout (5) {
+          msg ("timer fired")
+        }
+      }
+    </script>
+  </command>
+
   <!-- nested on ready: inner on ready should queue and run after the outer callback
        completes, not nested inside it. Before the AddOnReady fix this would either
        produce the wrong order (inner before "outer after") or stack-overflow when


### PR DESCRIPTION
## Summary

- A user reported a game (using a `wait { SetTimeout(8) { wait { Ask(...) } } }` pattern) that works on the Quest 5 desktop player but hangs forever on WebPlayer and WasmPlayer after the initial "Continue" prompt.
- Root cause: `FinishWait`, `FinishPause`, `SetQuestionResponse`, and `SetMenuResponse` in `WorldModel` never called `SendNextTimerRequest()` after running their callback script, unlike every other turn-ending path (`SendCommand`, `Tick`, `SendEventCore`, `BeginInternalAsync`). WebPlayer/WasmPlayer rely on the `RequestNextTimerTick` event to know when to next poll the engine for elapsed timers — a timer created *during* one of these callbacks (e.g. via the `SetTimeout` core function) was never scheduled, so it silently never ran. The desktop player isn't affected because it polls its own clock instead of relying on this push event.
- Fix: call `SendNextTimerRequest()` at the end of all four methods, matching the existing pattern elsewhere in the file.

## Test plan

- [x] Added `Wait_CallbackCreatesTimer_RequestsNextTimerTick` regression test (`tests/EngineTests/CallbackTests.cs`) plus a `testwaittimer` fixture command, asserting the host is notified via `RequestNextTimerTick` after a wait callback creates a timer.
- [x] Verified the new test fails without the fix and passes with it.
- [x] `dotnet test` — all 318 tests across every test project pass.
- [x] Full solution build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)