### PR TITLE
Guard against unbounded script recursion causing a StackOverflowException

### DIFF
--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -78,6 +78,12 @@ public partial class WorldModel : IGame, IGameDebug
 
     private bool _reportingScriptError;
 
+    // Guards against unbounded script recursion (e.g. a "changed<field>" script that sets the
+    // field it's watching) blowing the stack with a StackOverflowException, which cannot be
+    // caught and kills the whole process/all connected players in WebPlayer.
+    private const int MaxScriptExecutionDepth = 200;
+    private int _scriptExecutionDepth;
+
     private Walkthroughs? _walkthroughs;
 
     static WorldModel()
@@ -1127,6 +1133,13 @@ public partial class WorldModel : IGame, IGameDebug
 
     private async Task<object?> RunScriptAsync(IScript script, Context c, bool expectResult)
     {
+        if (_scriptExecutionDepth >= MaxScriptExecutionDepth)
+        {
+            throw new Exception(
+                $"Script execution depth exceeded {MaxScriptExecutionDepth} - this usually means a script is recursing infinitely (e.g. a \"changed<field>\" script that sets the field it's watching)");
+        }
+
+        _scriptExecutionDepth++;
         try
         {
             await script.ExecuteAsync(c);
@@ -1152,6 +1165,10 @@ public partial class WorldModel : IGame, IGameDebug
                 }
             }
             LogException(ex);
+        }
+        finally
+        {
+            _scriptExecutionDepth--;
         }
 
         return null;

--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -34,6 +34,9 @@
         <None Update="callbacktest.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="recursiontest.aslx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="v500test.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>

--- a/tests/EngineTests/RecursionGuardTests.cs
+++ b/tests/EngineTests/RecursionGuardTests.cs
@@ -1,0 +1,24 @@
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+// Regression test for a production incident: a "changed<field>" script that sets the field
+// it's watching recurses through WorldModel.RunScriptAsync with no base case, eventually
+// throwing a StackOverflowException. That exception can't be caught, so it killed the whole
+// WebPlayer process - and every other player connected to it - instead of just failing the
+// one script. WorldModel.RunScriptAsync now caps recursion depth and throws a normal,
+// catchable exception once it's exceeded.
+[TestClass]
+public class RecursionGuardTests
+{
+    [TestMethod]
+    public async Task ChangedFieldScript_SetsSameField_FailsGracefullyInsteadOfCrashing()
+    {
+        var driver = await GameDriver.LoadAsync("recursiontest.aslx");
+
+        var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("triggerrecursion"));
+
+        ex.InnerException.ShouldNotBeNull();
+        ex.InnerException.Message.ShouldContain("Script execution depth exceeded");
+    }
+}

--- a/tests/EngineTests/recursiontest.aslx
+++ b/tests/EngineTests/recursiontest.aslx
@@ -1,0 +1,29 @@
+<asl version="580">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="recursiontest"/>
+  <object name="start">
+    <object name="player">
+      <inherit name="defaultplayer" />
+    </object>
+  </object>
+
+  <!-- A changed<field> script that sets the field it's watching recurses into itself
+       every time, with no base case. Regression test for the WorldModel.RunScriptAsync
+       depth guard: this must fail with a catchable script error instead of overflowing
+       the stack and crashing the whole process. -->
+  <object name="widget">
+    <counter type="int">0</counter>
+    <changedcounter type="script">
+      this.counter = this.counter + 1
+    </changedcounter>
+  </object>
+
+  <command name="cmd_trigger_recursion">
+    <pattern>triggerrecursion</pattern>
+    <script>
+      widget.counter = 1
+      msg ("after trigger")
+    </script>
+  </command>
+</asl>


### PR DESCRIPTION
## Summary
- A `changed<field>` script that sets the field it's watching (or a mutual chain across fields) recurses through `WorldModel.RunScriptAsync` with no base case. `StackOverflowException` can't be caught, so it killed the whole WebPlayer process — and every other player connected to it — instead of just failing the one script. This caused a production outage on play.textadventures.co.uk on 2026-07-09.
- `RunScriptAsync` now caps recursion depth at 200 and throws a normal, catchable exception once exceeded, which flows through the existing "Error running script" reporting path.
- 200 was chosen empirically: the deepest call chain anywhere across the whole test suite (which exercises Core.aslx's own type-inheritance and `changed<field>` machinery, e.g. `changedhealth`) is 21.

## Test plan
- [x] `dotnet test --configuration Release` — all 320 tests pass (272 in EngineTests, incl. the new one)
- [x] New regression test `tests/EngineTests/RecursionGuardTests.cs` + `recursiontest.aslx`: a `changed<field>` script that sets its own field fails with a catchable "Script execution depth exceeded" error instead of crashing