### PR TITLE
Fix WasmPlayer sound playback: bad mp3 MIME type and lost autoplay activation

### DIFF
--- a/src/PlayerCore/PlayerHelper.cs
+++ b/src/PlayerCore/PlayerHelper.cs
@@ -41,7 +41,7 @@ public class PlayerHelper
         s_mimeTypes.Add(".bmp", "image/bmp");
         s_mimeTypes.Add(".png", "image/png");
         s_mimeTypes.Add(".wav", "audio/wav");
-        s_mimeTypes.Add(".mp3", "audio/mpeg3");
+        s_mimeTypes.Add(".mp3", "audio/mpeg");
         s_mimeTypes.Add(".ogg", "audio/ogg");
         s_mimeTypes.Add(".js", "application/javascript");
         s_mimeTypes.Add(".ttf", "application/font-woff");

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -49,6 +49,44 @@ public partial class WasmPlayerBridge
         return await InitialiseCore(gameData, saveStream);
     }
 
+    private static readonly string[] AudioExtensions = [".mp3", ".wav", ".ogg"];
+
+    // Heuristic used to decide whether to gate the boot-time autoplay
+    // permission check on a click (see wasm-player.js's maybeGateOnActivation) —
+    // does this game plausibly play a sound before the player has had a
+    // chance to interact with the page? Not a proof of reachability from
+    // start/beforeenter specifically vs. only from a player command; a
+    // false positive just costs one extra click, a false negative silently
+    // breaks the game's audio, so this deliberately rounds towards
+    // over-detecting.
+    [JSExport]
+    public static bool GameLikelyPlaysSound(byte[] gameFileBytes)
+    {
+        if (_game == null) return true; // conservative default
+
+        // Primary signal: any bundled audio resource, regardless of format.
+        // Works for .quest zip packages and Legacy .asl/.cas alike, since
+        // both populate GetResourceNames() from their own self-contained
+        // archive — no script-syntax assumptions needed here at all.
+        var resourceNames = _game.GetResourceNames();
+        if (resourceNames.Any(name =>
+                AudioExtensions.Contains(Path.GetExtension(name), StringComparer.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        // Fallback: GetResourceNames() is only empty when the game was
+        // loaded as plain aslx text with no local resource archive at all —
+        // a bare .aslx file, or textadventures.co.uk's remote-resource-mode
+        // (resourceRoot) API path. Both are guaranteed modern aslx script
+        // text (Legacy games are always self-contained archives, so they
+        // never reach here), so searching for the literal "play sound"
+        // script keyword (PlaySoundScriptConstructor.Keyword) is reliable
+        // in this branch only.
+        var source = System.Text.Encoding.UTF8.GetString(gameFileBytes);
+        return source.Contains("play sound", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static async Task<bool> InitialiseCore(GameData gameData, Stream? saveData)
     {
         _game?.Finish();

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -84,8 +84,7 @@
         </div>
 
         <div id="qv-clicktobegin" class="hidden flex-col items-center gap-3 text-surface-500 text-sm text-center">
-            <span>This game plays sound as soon as it starts &mdash; click below to allow it.</span>
-            <button id="qv-clicktobegin-btn" type="button" class="btn preset-filled-primary-500">Click to begin</button>
+            <button id="qv-clicktobegin-btn" type="button" class="btn preset-filled-primary-500">Begin</button>
         </div>
     </div>
 </div>

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -82,6 +82,11 @@
             <div class="animate-spin rounded-full h-8 w-8 border-2 border-surface-400-600 border-t-transparent" aria-hidden="true"></div>
             <span>Loading&hellip;</span>
         </div>
+
+        <div id="qv-clicktobegin" class="hidden flex-col items-center gap-3 text-surface-500 text-sm text-center">
+            <span>This game plays sound as soon as it starts &mdash; click below to allow it.</span>
+            <button id="qv-clicktobegin-btn" type="button" class="btn preset-filled-primary-500">Click to begin</button>
+        </div>
     </div>
 </div>
 

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -88,6 +88,46 @@ function finishSync(showCommandDiv) {
     }, 100);
 }
 
+// Chrome (and others) block unmuted audio until the page has "user
+// activation". A click through to this page (e.g. a target=_blank Play
+// button) does transfer that activation across the navigation, but it
+// doesn't reliably survive WasmPlayer's boot sequence (fetching the game,
+// booting the AOT WASM runtime) for a slow-enough load — by the time the
+// game's start logic tries to play a sound, the activation can already be
+// gone, and the browser silently rejects it. Only relevant for games that
+// might play a sound before the player has had any chance to interact with
+// the page themselves (typing a command is itself a fresh activation).
+function activationLikelyGranted() {
+    return !('userActivation' in navigator) || navigator.userActivation.hasBeenActive;
+}
+
+// Shows a "click to begin" prompt in the still-visible start screen and
+// waits for it, so the resulting click is a fresh, same-page activation —
+// but only when it's actually needed (see activationLikelyGranted) and only
+// for games that could plausibly play a sound before the player interacts
+// (see Bridge.GameLikelyPlaysSound). Call before Bridge.Begin() and before
+// the start screen overlay is removed.
+async function maybeGateOnActivation(gameBytes) {
+    if (activationLikelyGranted()) return;
+
+    let usesSound = true;
+    try { usesSound = Bridge.GameLikelyPlaysSound(gameBytes); } catch { /* don't block boot on detection failure */ }
+    if (!usesSound) return;
+
+    const pickers = document.getElementById('qv-pickers');
+    const msg = document.getElementById('qv-loading-msg');
+    const gate = document.getElementById('qv-clicktobegin');
+    if (pickers) pickers.style.display = 'none';
+    if (msg) msg.style.display = 'none';
+    if (gate) gate.style.display = 'flex';
+
+    await new Promise(resolve => {
+        document.getElementById('qv-clicktobegin-btn')?.addEventListener('click', resolve, { once: true });
+    });
+
+    if (gate) gate.style.display = 'none';
+}
+
 // The WebPlayer object — same surface API as playerweb.js so that playercore.js
 // and player.js can call into it without modification.
 window.WebPlayer = {
@@ -282,6 +322,8 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null) 
         throw new Error('Failed to initialise game');
     }
 
+    await maybeGateOnActivation(gameBytes);
+
     // Now that startup has actually succeeded, remove the start screen overlay
     // to reveal the game UI underneath.
     startScreenEl?.remove();
@@ -322,6 +364,8 @@ async function restartGame(saveBytes) {
         showSavesError('Failed to load that save.');
         return;
     }
+
+    await maybeGateOnActivation(originalGameBytes);
 
     await setupPaperJs();
     WebPlayer.initUI();


### PR DESCRIPTION
## Summary
- Fixed the `.mp3` MIME type in `PlayerHelper` (`audio/mpeg3` → `audio/mpeg`), which broke data-URL playback of embedded mp3 resources with `NotSupportedError`.
- Fixed silently-dropped intro sound in WasmPlayer: a game that plays sound as soon as it starts can hit Chrome's autoplay block even when reached via a genuine click-through (e.g. the "Try the new player (beta)" button on textadventures.co.uk) — the click transfers user activation across the navigation, but it doesn't reliably survive WasmPlayer's WASM boot sequence, so the sound is silently rejected (`NotAllowedError`) by the time it plays. Now, right before running the game's start logic, WasmPlayer checks `navigator.userActivation` and — only if activation looks lost and the game plausibly plays sound (bundled audio resource, or a `play sound` script call for games without a local resource archive) — shows a "Begin" prompt so the resulting click is a fresh, same-page gesture. Skipped entirely for the common case (fast boot, local file picker, non-audio games), so no behavior change there.

Root-caused with a Playwright repro against the live site (hooking `HTMLMediaElement.prototype.play` and `navigator.userActivation` at the exact call time) — full details in the commit messages.

## Test plan
- [x] `dotnet build --configuration Release` (full solution)
- [x] `dotnet test --configuration Release` (320 tests, all passing)
- [x] Playwright-verified against Debug and Release/AOT WasmPlayer builds: no-sound game (no gate), sound game via `.aslx` text fallback, sound game via Legacy `.cas` resource-name path, and a real cross-origin `target="_blank"` click-through — all show zero `NotAllowedError`, gate shows/dismisses correctly, no gate for non-sound games

🤖 Generated with [Claude Code](https://claude.com/claude-code)