### PR TITLE
Fix: restored-save output silently written to a detached div

### DIFF
--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -269,6 +269,23 @@ function initPlayerUI() {
 
 function loadHtml(html) {
     $("#divOutput").html(html);
+    // The injected HTML carries its own divOutputAlign<N> ids from whenever the
+    // game was saved, but _currentDiv/_divCount (used by addText/createNewDiv)
+    // are untouched by the line above. If a div was already created before this
+    // ran (e.g. WasmPlayer's in-session restore resets output and creates div 1
+    // before loadHtml overwrites #divOutput with the restored transcript),
+    // _currentDiv keeps pointing at that now-detached node — every future
+    // addText() call then silently appends to an invisible div instead of the
+    // page, even though the command that produced it succeeded. Resetting here
+    // makes the next addText() start a fresh div (via its getCurrentDiv()==null
+    // check), numbered past whatever the restored transcript already used.
+    _currentDiv = null;
+    var maxDivId = 0;
+    $("#divOutput [id^='divOutputAlign']").each(function () {
+        var n = parseInt(this.id.slice("divOutputAlign".length), 10);
+        if (n > maxDivId) maxDivId = n;
+    });
+    setDivCount(maxDivId);
 }
 
 function showStatusVisible(visible) {


### PR DESCRIPTION
## Summary
- Bug report: after importing a `.quest-save` in WasmPlayer via "Load from file", clicking an object's context-menu verb (e.g. "Untersuche"/Examine) sent the command to the engine successfully — but no text ever appeared. "Nimm" (take) moved the item into the inventory panel correctly, but likewise showed no confirmation text.
- Root cause: `restartGame()` creates a fresh output `<div>` (`_currentDiv` points at it, attached) before applying the save. `Begin()` then calls `loadHtml()` to inject the saved transcript by replacing `#divOutput`'s entire innerHTML — detaching the div `_currentDiv` was pointing at, without updating `_currentDiv`/`_divCount`. Every later `addText()` call kept silently appending into that now-invisible, detached div.
- Fix: `loadHtml()` now resets `_currentDiv` and resyncs `_divCount` to the highest `divOutputAlign<N>` id actually present after the injected HTML, so the next `addText()` starts a fresh, attached div.

## Test plan
- [x] Reproduced with the reporter's attached `.quest-save`, driving the actual published game (`?id=eod-od2dpkwlt0nglpztug`) in a local WasmPlayer dev server via Playwright, confirming "Untersuche"/"Nimm" produced no output before the fix.
- [x] Confirmed the fix: after the same repro, "Untersuche" and a follow-up "Nimm" both correctly append visible output with no div-id collisions.
- [x] `dotnet test --configuration Release tests/PlayerCoreTests` passes.
- [x] Existing `tests/e2e/verify-wasmplayer-restart-sidebar-dup.mjs` still passes (no regression in the related restart flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)