### PR TITLE
Fix: base .aslx file's own duplicate template names lose to the first, not the last

### DIFF
--- a/src/Engine/Templates.cs
+++ b/src/Engine/Templates.cs
@@ -18,11 +18,14 @@ public partial class Template
     internal Element AddTemplate(string templateName, string text, bool isCommandTemplate, bool isBaseTemplate = false)
     {
         // if a template is marked as IsBaseTemplate, it's from the base .aslx file so shouldn't be overwritten
-        // by an equivalent library definition
+        // by an equivalent library definition. But a later base-template definition (e.g. a second
+        // <template> for the same name further down the same base file, as produced by old Quest 5.8
+        // exports that inline a full library per language one after another) must still win over an
+        // earlier one from the same scan - only non-base (library) definitions are blocked here.
         Element existingTemplate;
         if (m_templateLookup.TryGetValue(templateName, out existingTemplate))
         {
-            if (existingTemplate.Fields[FieldDefinitions.IsBaseTemplate])
+            if (existingTemplate.Fields[FieldDefinitions.IsBaseTemplate] && !isBaseTemplate)
             {
                 return null;
             }

--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -37,6 +37,9 @@
         <None Update="recursiontest.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="duplicatetemplatetest.aslx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="v500test.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>

--- a/tests/EngineTests/TemplateTests.cs
+++ b/tests/EngineTests/TemplateTests.cs
@@ -1,4 +1,6 @@
-﻿using QuestViva.Engine;
+﻿using QuestViva.Common;
+using QuestViva.Engine;
+using Moq;
 
 namespace QuestViva.EngineTests;
 
@@ -38,5 +40,31 @@ public class TemplateTests
         Assert.AreEqual("other text and [unknown]", m_worldModel.Template.ReplaceTemplateText("[Test2] and [unknown]"));
         Assert.AreEqual("[unknown1], my text, [unknown2], other text",
             m_worldModel.Template.ReplaceTemplateText("[unknown1], [Test1], [unknown2], [Test2]"));
+    }
+
+    // Regression test for a bug affecting games loaded as a bare .aslx (not a compiled .quest
+    // package - e.g. WasmPlayer's ?id= route, which fetches an unpacked .aslx via the
+    // textadventures.co.uk API rather than a .quest zip). Loading a bare .aslx runs
+    // GameLoader.ScanForTemplates as a preliminary pass over the base file, which locks in
+    // the *first* value it sees for each template name as an unoverridable "base template" so
+    // that a later library file can't clobber a game's own override. Old Quest 5.8 desktop
+    // exports inline a full language pack directly in the base file instead of as a separate
+    // library (e.g. an English block followed by a German block, both defining the same
+    // template names) - and the base-template guard was blocking the second, later
+    // definition from winning even though both come from the base file itself, silently
+    // keeping the first (English) text. duplicatetemplatetest.aslx reproduces that shape:
+    // the same template name defined twice with no <include>d libraries at all, so the only
+    // way "German value" can win is if later-in-file redefinitions of a base file's own
+    // templates are honoured, matching ordinary top-to-bottom XML semantics.
+    [TestMethod]
+    public async Task DuplicateTemplateInBaseAslxFile_LaterDefinitionWins()
+    {
+        var data = await new FileGameDataProvider("duplicatetemplatetest.aslx").GetData();
+        var model = new WorldModel(data, null);
+
+        var success = await model.Initialise(new Mock<IPlayer>().Object);
+
+        Assert.IsTrue(success, string.Join("; ", model.Errors));
+        Assert.AreEqual("German value", model.Template.GetText("DupeTemplate"));
     }
 }

--- a/tests/EngineTests/duplicatetemplatetest.aslx
+++ b/tests/EngineTests/duplicatetemplatetest.aslx
@@ -1,0 +1,5 @@
+<asl version="580">
+  <template name="DupeTemplate">English value</template>
+  <game name="duplicatetemplatetest"/>
+  <template name="DupeTemplate">German value</template>
+</asl>


### PR DESCRIPTION
## Summary
- Loading a bare `.aslx` (not a compiled `.quest` package — e.g. WasmPlayer's `?id=` route, which fetches an unpacked `.aslx` via the textadventures.co.uk API instead of a `.quest` zip) runs `GameLoader.ScanForTemplates`, a preliminary pass that locks in the *first* value seen for each template name as an unoverridable "base template", so a later library file can't clobber a game's own override.
- Old Quest 5.8 desktop exports inline a full language pack directly in the base file instead of as a separate library (e.g. an English block followed by a German block, both defining the same template names). The guard was blocking the later, correct definition from winning even though both come from the base file itself — silently keeping the earlier English text (e.g. `You are carrying` instead of `Du trägst`).
- `Template.AddTemplate`'s guard now only blocks a *non-base* (library) definition from overwriting a locked base template — a later base-template definition (still within the same base-file scan) is allowed to win, matching ordinary top-to-bottom XML semantics. This doesn't change the original protection (a library trying to override a game-defined template is still blocked).

## Test plan
- [x] Added `tests/EngineTests/duplicatetemplatetest.aslx`, a minimal bare `.aslx` fixture (no `<include>`d libraries) defining the same template name twice.
- [x] Added `TemplateTests.DuplicateTemplateInBaseAslxFile_LaterDefinitionWins`, which loads that fixture and asserts the later definition wins.
- [x] Verified the new test fails against the pre-fix code (`Expected: German value. Actual: English value`) and passes with the fix.
- [x] Full `EngineTests` suite passes (273/273).
- [x] Reproduced the original bug end-to-end against a real reported game file by serving its raw `.aslx` the same way WasmPlayer's `?id=` route does, confirmed the fix resolves it there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)