### PR TITLE
Fix: wedged script session could OOM-crash the shared WebPlayer process

### DIFF
--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -497,9 +497,9 @@ internal class ExpressionOwner(WorldModel worldModel)
         await worldModel.PrintAsync(caption);
         var menuData = new MenuData(caption, options, allowCancel);
         worldModel.PlayerUi.ShowMenu(menuData);
-        worldModel._menuTcs = new TaskCompletionSource<string?>();
+        var tcs = WorldModel.BeginPrompt(ref worldModel._menuTcs);
         worldModel.SignalTurnSuspended();
-        var result = await worldModel._menuTcs.Task;
+        var result = await tcs.Task;
         if (result != null) await worldModel.PrintAsync(" - " + options[result]);
         return result ?? string.Empty;
     }
@@ -574,9 +574,9 @@ internal class ExpressionOwner(WorldModel worldModel)
     public async Task<string> GetInput()
     {
         worldModel._commandOverride = true;
-        worldModel._commandInputTcs = new TaskCompletionSource<string>();
+        var tcs = WorldModel.BeginPrompt(ref worldModel._commandInputTcs);
         worldModel.SignalTurnSuspended();
-        var result = await worldModel._commandInputTcs.Task;
+        var result = await tcs.Task;
         worldModel._commandOverride = false;
         return result;
     }
@@ -616,9 +616,9 @@ internal class ExpressionOwner(WorldModel worldModel)
     {
         ArgumentNullException.ThrowIfNull(caption);
         worldModel.PlayerUi.ShowQuestion(caption);
-        worldModel._questionTcs = new TaskCompletionSource<bool>();
+        var tcs = WorldModel.BeginPrompt(ref worldModel._questionTcs);
         worldModel.SignalTurnSuspended();
-        return await worldModel._questionTcs.Task;
+        return await tcs.Task;
     }
 
     public int GetRandomInt(int min, int max)

--- a/src/Engine/Scripts/AskScript.cs
+++ b/src/Engine/Scripts/AskScript.cs
@@ -49,7 +49,7 @@ public class AskScript(
     {
         var caption = await _caption.ExecuteAsync(c);
         _worldModel.PlayerUi.ShowQuestion(caption);
-        _worldModel._questionTcs = new TaskCompletionSource<bool>();
+        WorldModel.BeginPrompt(ref _worldModel._questionTcs);
         _worldModel.BeginPendingCallback();
         _worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c);

--- a/src/Engine/Scripts/GetInputScript.cs
+++ b/src/Engine/Scripts/GetInputScript.cs
@@ -42,7 +42,7 @@ public class GetInputScript : ScriptBase
     public override Task ExecuteAsync(Context c)
     {
         m_worldModel._commandOverride = true;
-        m_worldModel._commandInputTcs = new TaskCompletionSource<string>();
+        WorldModel.BeginPrompt(ref m_worldModel._commandInputTcs);
         m_worldModel.BeginPendingCallback();
         m_worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c);

--- a/src/Engine/Scripts/PlaySoundScript.cs
+++ b/src/Engine/Scripts/PlaySoundScript.cs
@@ -54,10 +54,14 @@ public class PlaySoundScript : ScriptBase
 
         if (synchronous)
         {
-            m_worldModel._waitTcs = new TaskCompletionSource();
+            var tcs = WorldModel.BeginPrompt(ref m_worldModel._waitTcs);
             await m_worldModel.PlayerUi.PlaySoundAsync(filename, true, loop);
             m_worldModel.SignalTurnSuspended();
-            await m_worldModel._waitTcs.Task;
+            try
+            {
+                await tcs.Task;
+            }
+            catch (OperationCanceledException) { }
         }
         else
         {

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -87,7 +87,7 @@ public class ShowMenuScript : ScriptBase
         var menuData = new MenuData(caption, optionsDictionary, allowCancel);
         m_worldModel.PlayerUi.ShowMenu(menuData);
 
-        m_worldModel._menuTcs = new TaskCompletionSource<string?>();
+        WorldModel.BeginPrompt(ref m_worldModel._menuTcs);
         m_worldModel.BeginPendingCallback();
         m_worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c, optionsDictionary);

--- a/src/Engine/Scripts/WaitScript.cs
+++ b/src/Engine/Scripts/WaitScript.cs
@@ -41,7 +41,7 @@ public class WaitScript : ScriptBase
     public override Task ExecuteAsync(Context c)
     {
         m_worldModel.PlayerUi.DoWait();
-        m_worldModel._waitTcs = new TaskCompletionSource();
+        WorldModel.BeginPrompt(ref m_worldModel._waitTcs);
         m_worldModel.BeginPendingCallback();
         m_worldModel.SignalTurnSuspended();
         _ = AwaitWaitAndRunCallbackAsync(c);

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -71,6 +71,25 @@ public partial class WorldModel : IGame, IGameDebug
     internal TaskCompletionSource? _pauseTcs;
     private TaskCompletionSource _turnSuspendedTcs = new();
 
+    // Every prompt (wait/menu/ask/get input) reuses a single TCS field, replacing it each time
+    // it's shown. If a new prompt is triggered before a previous one resolves (e.g. via 'on ready'
+    // reentrancy), the old field gets silently overwritten and whatever was awaiting it - along
+    // with its _scriptExecutionDepth increment - is orphaned forever, permanently wedging the
+    // depth guard for the rest of the session. Cancelling the outgoing TCS before replacing it
+    // ensures every prompt is resolved one way or another; callers already handle
+    // OperationCanceledException from these awaits (see FinishGame, which does the same thing).
+    internal static TaskCompletionSource BeginPrompt(ref TaskCompletionSource? field)
+    {
+        field?.TrySetCanceled();
+        return field = new TaskCompletionSource();
+    }
+
+    internal static TaskCompletionSource<T> BeginPrompt<T>(ref TaskCompletionSource<T>? field)
+    {
+        field?.TrySetCanceled();
+        return field = new TaskCompletionSource<T>();
+    }
+
     // Tracks show menu / ask / get input callbacks that fire-and-forget their response handling.
     // on ready defers until this reaches zero.
     private int _pendingCallbackCount;
@@ -83,6 +102,20 @@ public partial class WorldModel : IGame, IGameDebug
     // caught and kills the whole process/all connected players in WebPlayer.
     private const int MaxScriptExecutionDepth = 200;
     private int _scriptExecutionDepth;
+
+    // If something has left the game in a state where a script fails the same way every time it
+    // runs (e.g. the depth guard above is permanently tripped by corrupted game state), the catch
+    // block that reports each failure runs again on every subsequent turn forever, with nothing to
+    // stop it. That's cheap per call, but with no upper bound on how many turns get attempted,
+    // output/log buffers that are only cleared after a *successful* turn (see WebPlayer's
+    // Player.ClearJavaScriptBuffer) grow without limit. This is a session-lifetime total, not a
+    // consecutive/streak count that resets on the next unrelated successful script call (which
+    // happens constantly during ordinary turns) - a genuinely wedged session fails this many times
+    // in short order regardless, while a normal session with the odd one-off script bug never gets
+    // close.
+    private const int MaxScriptErrors = 20;
+    private int _scriptErrorCount;
+    private bool _scriptErrorsFatal;
 
     private Walkthroughs? _walkthroughs;
 
@@ -1071,17 +1104,17 @@ public partial class WorldModel : IGame, IGameDebug
     internal async Task DoWaitAsync()
     {
         PlayerUi.DoWait();
-        _waitTcs = new TaskCompletionSource();
+        var tcs = BeginPrompt(ref _waitTcs);
         SignalTurnSuspended();
-        await _waitTcs.Task;
+        await tcs.Task;
     }
 
     internal async Task DoPauseAsync(int ms)
     {
         PlayerUi.DoPause(ms);
-        _pauseTcs = new TaskCompletionSource();
+        var tcs = BeginPrompt(ref _pauseTcs);
         SignalTurnSuspended();
-        await _pauseTcs.Task;
+        await tcs.Task;
     }
 
     public Task RunScriptAsync(IScript script)
@@ -1133,6 +1166,11 @@ public partial class WorldModel : IGame, IGameDebug
 
     private async Task<object?> RunScriptAsync(IScript script, Context c, bool expectResult)
     {
+        if (_scriptErrorsFatal)
+        {
+            return null;
+        }
+
         if (_scriptExecutionDepth >= MaxScriptExecutionDepth)
         {
             throw new Exception(
@@ -1152,7 +1190,17 @@ public partial class WorldModel : IGame, IGameDebug
         }
         catch (Exception ex)
         {
-            if (!_reportingScriptError)
+            LogException(ex);
+
+            if (++_scriptErrorCount >= MaxScriptErrors)
+            {
+                // The session is unrecoverably wedged (every script execution is failing the
+                // same way). Stop here rather than let it keep failing forever: end the game so
+                // WebPlayer/WasmPlayer stop sending it any further work.
+                _scriptErrorsFatal = true;
+                FinishGame();
+            }
+            else if (!_reportingScriptError)
             {
                 _reportingScriptError = true;
                 try
@@ -1164,7 +1212,6 @@ public partial class WorldModel : IGame, IGameDebug
                     _reportingScriptError = false;
                 }
             }
-            LogException(ex);
         }
         finally
         {

--- a/src/WebPlayer/Player.cs
+++ b/src/WebPlayer/Player.cs
@@ -323,8 +323,19 @@ public class Player : IPlayerHelperUI
         return PlayerHelper.Game.GetResourceStream(filename);
     }
 
+    // JavaScriptBuffer is only flushed after a *successful* turn (see ClearBuffer/UiActionAsync
+    // below). If a game session gets stuck retrying failed turns indefinitely, this buffer would
+    // otherwise grow without bound and eventually OOM the whole (shared, multi-tenant) process.
+    // This is a backstop, not the main fix - see WorldModel's script-error circuit breaker.
+    private const int MaxJavaScriptBufferSize = 10_000;
+
     private void AddJavaScriptToBuffer(string identifier, params object?[]? args)
     {
+        if (JavaScriptBuffer.Count >= MaxJavaScriptBufferSize)
+        {
+            return;
+        }
+
         if (args != null)
         {
             for (var i = 0; i < args.Length; i++)

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -19,6 +19,7 @@ internal sealed class GameDriver
     private List<string> _batch = [];
     private Exception _scriptError;
     public List<int> RequestedTimerTicks { get; } = [];
+    public GameState State => _worldModel.State;
 
     private static readonly Regex StripTags = new(@"<[^>]+>", RegexOptions.Compiled);
 

--- a/tests/EngineTests/RecursionGuardTests.cs
+++ b/tests/EngineTests/RecursionGuardTests.cs
@@ -1,3 +1,4 @@
+using QuestViva.Engine;
 using Shouldly;
 
 namespace QuestViva.EngineTests;
@@ -20,5 +21,42 @@ public class RecursionGuardTests
 
         ex.InnerException.ShouldNotBeNull();
         ex.InnerException.Message.ShouldContain("Script execution depth exceeded");
+    }
+
+    // Regression test for a follow-up production incident: once the depth guard above trips,
+    // the *same* recursing script keeps getting invoked on every subsequent command (e.g. because
+    // the corrupted state persists for the rest of the session), so it fails identically forever.
+    // Nothing stopped that from repeating indefinitely, and each failed attempt appends to
+    // output/log buffers that are only ever cleared after a successful turn - so the session
+    // just grew memory without bound until the shared WebPlayer process OOMed, taking every
+    // other connected player down with it. WorldModel now trips a circuit breaker once a session
+    // accumulates too many script failures and ends the game instead of retrying forever.
+    [TestMethod]
+    public async Task ChangedFieldScript_RepeatedlyTriggered_TripsCircuitBreakerInsteadOfRetryingForever()
+    {
+        var driver = await GameDriver.LoadAsync("recursiontest.aslx");
+
+        var failureCount = 0;
+        for (var i = 0; i < 30; i++)
+        {
+            try
+            {
+                await driver.SendCommandAsync("triggerrecursion");
+            }
+            catch (Exception ex)
+            {
+                failureCount++;
+                ex.InnerException.ShouldNotBeNull();
+                ex.InnerException.Message.ShouldContain("Script execution depth exceeded");
+            }
+        }
+
+        // A bounded number of attempts are reported as failures before the breaker trips ...
+        failureCount.ShouldBeInRange(1, 29);
+        // ... after which the game ends instead of continuing to retry the same broken script.
+        driver.State.ShouldBe(GameState.Finished);
+
+        // Further commands after the game has ended must be safe no-ops, not more failures.
+        await Should.NotThrowAsync(() => driver.SendCommandAsync("triggerrecursion"));
     }
 }


### PR DESCRIPTION
## Summary

A production WebPlayer crash was traced back to a session whose script-execution depth guard (`MaxScriptExecutionDepth`, added for an earlier StackOverflow fix) got permanently wedged. Once wedged, every subsequent script execution in that session failed identically, forever - including the error-reporting path itself, which had no circuit breaker and kept retrying on every turn. Each failed attempt appended to WebPlayer's output/JS buffer, which is only ever flushed after a *successful* turn, so it grew without bound until `OutOfMemoryException` crashed the whole shared, multi-tenant process - taking down every connected player, not just the broken session.

Most likely trigger for the wedge: several prompt mechanisms (`wait`/`show menu`/`ask`/`get input`) each reuse a single `TaskCompletionSource` field that gets unconditionally overwritten each time a new prompt is shown. If a second prompt fires before the first resolves, the first awaiting call - and whatever depth-guard state it was holding - is silently orphaned forever with no way to recover.

- `WorldModel.BeginPrompt` cancels an outgoing prompt `TaskCompletionSource` before replacing it, so a superseded prompt can no longer be silently orphaned. Applied at all 9 call sites (`WorldModel`, `WaitScript`, `PlaySoundScript`, `GetInputScript`, `AskScript`, `ShowMenuScript`, `ExpressionOwner`).
- `RunScriptAsync` now trips a session-lifetime circuit breaker after repeated script failures (not a "consecutive" count, since ordinary turns contain plenty of unrelated successful script calls that would reset a streak counter before it could ever accumulate) and ends the game instead of retrying forever.
- WebPlayer's `JavaScriptBuffer` gets a hard size cap as a defense-in-depth backstop, independent of the root-cause fix above.

## Test plan
- [x] `dotnet build --configuration Release` - clean build, 0 warnings/errors
- [x] `dotnet test --configuration Release` - all 322 tests pass across the solution
- [x] Added `RecursionGuardTests.ChangedFieldScript_RepeatedlyTriggered_TripsCircuitBreakerInsteadOfRetryingForever`, which repeatedly triggers the existing infinite-recursion regression fixture and asserts the circuit breaker trips (game ends cleanly) instead of failing forever, and that further commands afterward are safe no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)