### PR TITLE
fix: keep newest release marked "Latest" despite perpetual-beta prerelease flag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,5 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.RELEASE_PAT }}
+
+      # release-please-config.json sets prerelease: true so the "prerelease"
+      # versioning strategy keeps bumping the trailing beta.N instead of
+      # graduating out of it (that config key drives both the version-bump
+      # logic and the GitHub Release's prerelease flag). Un-flag the release
+      # itself here so it isn't excluded from "Latest" — GitHub structurally
+      # never lets a prerelease-flagged release hold that badge.
+      - name: Mark release as latest
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: gh release edit "${{ steps.release.outputs.tag_name }}" --prerelease=false --latest --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
After merging the release-please migration, the newly created `v6.0.0-beta.36` release came out flagged as a GitHub "Pre-release" and `v6.0.0-beta.35` (the last release created the old way) stayed as "Latest" — GitHub structurally excludes prerelease/draft releases from ever holding the "Latest" badge.

Traced the config through release-please's source rather than just flipping `prerelease: false`: `packages["."].prerelease` in `release-please-config.json` is a single field that feeds into **both** the GitHub Release's `prerelease` flag **and** the `prerelease` versioning strategy's decision to keep bumping the trailing `beta.N` vs. stripping it and graduating to a bare `major.minor.patch` (confirmed in `versioning-strategies/prerelease.ts`'s `determineReleaseType`). Setting it to `false` would fix the badge but also mean the *next* release jumps straight to a real `6.0.0` instead of `6.0.0-beta.37` — not what we want.

Instead, this keeps `prerelease: true` in the config (so versioning keeps working) and adds a follow-up step to `release-please.yml` that un-flags the just-created *GitHub Release object* specifically via `gh release edit --prerelease=false --latest`, decoupling "how the version is computed" from "what the Releases page shows". This restores the pre-migration behavior where every new release becomes Latest.

Also manually ran the same `gh release edit` against the already-published `v6.0.0-beta.36` so it's fixed immediately rather than waiting for the next release.

## Test plan
- [x] Manually verified `v6.0.0-beta.36` is now `isPrerelease: false` and `/releases/latest` resolves to it
- [ ] On the next real release-please PR merge, confirm the new release comes out already marked Latest (not prerelease) without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)