### PR TITLE
fix: deploy-play uploads to the release-please-created Release instead of recreating it

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -1,11 +1,12 @@
 name: Deploy play.questviva.com and WebEditor
 
-# Runs when release.sh tags a version (e.g. v6.0.0-beta.30), keeping
-# play.questviva.com on the same release cadence as the WebPlayer Docker image.
-# Tag pushes also attach WasmPlayer/AppBundle/WebEditor build artifacts to the
-# GitHub Release and dispatch a deploy to textadventures.co.uk, so a single
-# release cadence drives both play.questviva.com and the WebEditor on
-# textadventures.co.uk.
+# Runs when a version tag is pushed (e.g. v6.0.0-beta.30, normally via
+# release-please merging its release PR), keeping play.questviva.com on the
+# same release cadence as the WebPlayer Docker image. Tag pushes also attach
+# WasmPlayer/AppBundle/WebEditor build artifacts to the GitHub Release
+# release-please already created and dispatch a deploy to
+# textadventures.co.uk, so a single release cadence drives both
+# play.questviva.com and the WebEditor on textadventures.co.uk.
 on:
   push:
     tags: ['v*']
@@ -99,8 +100,11 @@ jobs:
           (cd src/WebEditor/build && zip -r $GITHUB_WORKSPACE/WebEditor.zip .)
 
       - name: Attach player and editor builds to GitHub Release
+        # release-please creates the GitHub Release itself (with changelog-based
+        # notes) before pushing the tag that triggers this workflow, so just
+        # upload assets to it rather than creating a new one.
         if: github.ref_type == 'tag'
-        run: gh release create ${{ github.ref_name }} WasmPlayer.zip AppBundle.zip WebEditor.zip --title "${{ github.ref_name }}" --generate-notes
+        run: gh release upload ${{ github.ref_name }} WasmPlayer.zip AppBundle.zip WebEditor.zip --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
`deploy-play.yml`'s "Attach player and editor builds to GitHub Release" step called `gh release create ... --generate-notes`, which assumed no Release existed yet for the pushed tag. That was true under the old flow (`auto-tag.yml` just pushed a bare git tag, and this step was what actually created the Release). Now release-please creates the Release itself — with changelog-based notes — as part of merging its release PR, before it pushes the tag that triggers this workflow. So the two collided:

```
a release with the same tag name already exists: v6.0.0-beta.36
```

(https://github.com/textadventures/quest/actions/runs/29191911924)

Fix: switch to `gh release upload ... --clobber`, which attaches assets to the already-existing release instead of trying to create a new one.

## Test plan
- [ ] On the next tag push, confirm "Attach player and editor builds to GitHub Release" succeeds and `WasmPlayer.zip`/`AppBundle.zip`/`WebEditor.zip` show up on the release release-please created
- [ ] Confirm the subsequent "Pin WebEditor version" and "Trigger textadventures.co.uk deployment" steps run too (they were skipped this time as a knock-on effect of the earlier failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)