### PR TITLE
feat: preview server-backed editor games in WasmPlayer instead of WebPlayer

### DIFF
--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -2,7 +2,7 @@
     import { AppBar } from "@skeletonlabs/skeleton-svelte";
     import { PUBLIC_WEBEDITOR_VERSION, PUBLIC_WASM_PLAYER_URL } from "$env/static/public";
     import {
-        gameFilename, isDirty, saveGame, saveGameAs, canSaveAs, previewUrl,
+        gameFilename, isDirty, saveGame, saveGameAs, canSaveAs,
         previewInWasmPlayer,
         undo, redo, canUndo, canRedo,
         treeNodes, selectedKey, openAddModal,
@@ -27,12 +27,7 @@
     }
 
     async function handlePreview() {
-        if ($previewUrl) {
-            await saveGame();
-            window.open($previewUrl, "_blank");
-        } else {
-            await previewInWasmPlayer(wasmPlayerUrl);
-        }
+        await previewInWasmPlayer(wasmPlayerUrl);
     }
 
     // Derive the currently selected tree node

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -18,7 +18,6 @@ export function openAddModal(type: "room" | "object" | "function" | "timer" | "w
 }
 export const gameFilename = writable<string | null>(null);
 export const canSaveAs = writable(false);
-export const previewUrl = writable<string | null>(null);
 export const treeNodes = writable<TreeNode[]>([]);
 export const selectedKey = writable<string | null>(null);
 export const selectedData = writable<EditorDataResponse | null>(null);
@@ -40,7 +39,6 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
     _bridge = await loadWasm();
     _adapter = adapter;
     canSaveAs.set(adapter.canSaveAs);
-    previewUrl.set(adapter.previewUrl);
     loadingStatus.set("Loading game…");
     // Double rAF ensures the browser actually paints the status update before
     // Initialise blocks the JS thread (C# WASM calls are synchronous).

--- a/src/WebEditor/src/lib/filesystem/browser-adapter.ts
+++ b/src/WebEditor/src/lib/filesystem/browser-adapter.ts
@@ -122,7 +122,6 @@ export class BrowserFileAdapter implements FileAdapter {
     ) {}
 
     get filename() { return this._filename; }
-    readonly previewUrl: string | null = null;
 
     // Save As is only meaningful in directory mode — in fallback mode both save paths trigger a download.
     get canSaveAs(): boolean { return this._mode.kind === "directory"; }

--- a/src/WebEditor/src/lib/filesystem/server-adapter.ts
+++ b/src/WebEditor/src/lib/filesystem/server-adapter.ts
@@ -30,7 +30,6 @@ export class ServerFileAdapter implements FileAdapter {
     constructor(
         private readonly _gameId: string,
         private readonly _filename: string,
-        readonly previewUrl: string | null,
     ) {}
 
     get filename() { return this._filename; }
@@ -90,7 +89,6 @@ export async function loadFromServer(gameId: string): Promise<LoadedFile> {
     const disposition = resp.headers.get("Content-Disposition") ?? "";
     const match = /filename[^;=\n]*=['"]?([^'";\n]+)['"]?/.exec(disposition);
     const filename = match?.[1]?.trim() ?? `${gameId}.aslx`;
-    const previewUrl = resp.headers.get("X-Preview-Url");
     const bytes = new Uint8Array(await resp.arrayBuffer());
-    return { bytes, adapter: new ServerFileAdapter(gameId, filename, previewUrl) };
+    return { bytes, adapter: new ServerFileAdapter(gameId, filename) };
 }

--- a/src/WebEditor/src/lib/filesystem/types.ts
+++ b/src/WebEditor/src/lib/filesystem/types.ts
@@ -6,7 +6,6 @@ export interface AssetInfo {
 export interface FileAdapter {
     readonly filename: string;
     readonly canSaveAs: boolean;
-    readonly previewUrl: string | null;
     saveFile(data: Uint8Array | string): Promise<void>;
     // Returns the filename that was saved to, or null if the user cancelled.
     saveFileAs(data: Uint8Array | string, suggestedName?: string): Promise<string | null>;


### PR DESCRIPTION
## Summary
- Removes the `X-Preview-Url`/`previewUrl` plumbing that opened server-backed editor previews in a new tab pointed at WebPlayer's legacy `/editor/{Id}/{File}` route.
- `handlePreview()` now always goes through `previewInWasmPlayer()`, the same `BroadcastChannel`-based bridge already used for local browser editing — so preview stays behind auth (assets are fetched via the adapter's existing cookie-authenticated API calls) instead of relying on public blob storage or a new API surface.
- Requires WasmPlayer to be deployed same-origin with the WebEditor instance (see companion PR in textadventures.co.uk).

## Test plan
- [x] `svelte-check` — 0 errors
- [x] `npm run build` in `src/WebEditor` — succeeds
- [x] Verified end-to-end locally against a `textadventures.co.uk` checkout serving both WebEditor and WasmPlayer same-origin: opening a saved game via `?game={id}` and clicking Preview opens WasmPlayer and loads the game

🤖 Generated with [Claude Code](https://claude.com/claude-code)