### PR TITLE
feat: add asset picker UI for WebEditor file controls

### DIFF
--- a/docs/webeditor-wasm-svelte.md
+++ b/docs/webeditor-wasm-svelte.md
@@ -1,22 +1,31 @@
 # WebEditor: EditorCore WASM + SvelteKit
 
+## Status
+
+Core editing is done and in daily use: open/create a game, browse and edit the tree, edit
+attributes and scripts (visual + code view), add/delete every element type, undo/redo, save
+locally (File System Access API, with an `<input>`/download fallback) or to
+textadventures.co.uk, upload/browse/delete image and sound assets, and preview in WasmPlayer.
+See [Remaining work](#remaining-work) below for what's left.
+
 ## Architecture
 
 ```
 Browser
 ├── SvelteKit frontend  (src/WebEditor/)
-│   ├── TreePanel       — game object hierarchy (Skeleton TreeView)
-│   ├── PropertyEditor  — attribute display with typed controls and tab navigation
-│   ├── ScriptEditor    — visual script editor with code view and copy/paste
-│   ├── AddScriptModal  — categorised command picker
-│   └── Toolbar         — save, undo/redo (Skeleton AppBar)
+│   ├── TreePanel        — game object hierarchy (Skeleton TreeView)
+│   ├── PropertyEditor   — attribute display with typed controls and tab navigation
+│   ├── ScriptEditor      — visual script editor with code view and copy/paste
+│   ├── AddScriptModal    — categorised command picker
+│   ├── AddElementModal   — new room/object/function/timer/template/etc.
+│   └── Toolbar           — save, undo/redo, preview (Skeleton AppBar)
 │
 └── .NET WASM module  (src/WasmEditor/)
     ├── WasmEditorBridge  — thin JSExport interop layer
     └── EditorCore → Engine / Utility / Common
 ```
 
-All data crossing the JS/WASM boundary is JSON. The Svelte layer calls `[JSExport]` methods on the bridge; events fire back synchronously during `Initialise` and are collected in C# lists before being returned via `GetTreeNodes()`.
+All data crossing the JS/WASM boundary is JSON. The Svelte layer calls `[JSExport]` methods on the bridge; events fire back synchronously during `Initialise` and are collected in C# lists/flags before being returned or polled (`GetTreeNodes()`, `IsDirty()`, etc.) — see [Not yet implemented](#not-yet-implemented).
 
 ---
 
@@ -24,29 +33,17 @@ All data crossing the JS/WASM boundary is JSON. The Svelte layer calls `[JSExpor
 
 `src/WasmEditor/` targets `net10.0` with `<RuntimeIdentifier>browser-wasm</RuntimeIdentifier>`. It depends on `EditorCore` and `Common`.
 
-### Implemented bridge API (`WasmEditorBridge.cs`)
+### Bridge API (`WasmEditorBridge.cs`)
 
-```csharp
-[JSExport] Task<bool> Initialise(byte[] gameFileBytes, string filename)
-[JSExport] string     GetTreeNodes()           // JSON: List<{key, text, parent}>
-[JSExport] string?    GetEditorData(string key) // JSON: EditorDataResponse (see below)
-[JSExport] string     SetAttribute(string elementKey, string attribute, string controlType, string value)
-[JSExport] string     Save()                   // returns XML
-[JSExport] void       Undo()
-[JSExport] void       Redo()
-// Element creation — returns new element key on success, "error:..." on failure
-[JSExport] string     ValidateName(string name)
-[JSExport] string     GetUniqueName(string baseName)
-[JSExport] string     CreateRoom(string name, string? parent)    // parent="" means top-level
-[JSExport] string     CreateObject(string name, string? parent)
-[JSExport] string     CreateFunction(string name)
-[JSExport] string     CreateTimer(string name)
-[JSExport] string     CreateExit(string parent)       // anonymous; navigate to it to edit destination
-[JSExport] string     CreateTurnScript(string parent) // anonymous
-[JSExport] string     CreateCommand(string? parent)   // anonymous; parent="" means global
-[JSExport] string     CreateVerb(string? parent)      // anonymous; parent="" means global
-[JSExport] void       DeleteElement(string key)
-```
+The bridge now exposes ~65 `[JSExport]` methods and has grown well past what's practical to hand-maintain as a list here — `WasmEditorBridge.cs` is the source of truth. Broad categories:
+
+- **Lifecycle**: `Initialise`, `Save`, `IsDirty`, `CanUndo`/`CanRedo`, `Undo`/`Redo`
+- **Tree / attributes**: `GetTreeNodes`, `GetEditorData`, `GetFullAttributeData`, `SetAttribute`, `RemoveAttribute`, `ChangeAttributeType`, `SetMultiType`, `SetObjectReference`, `SetDropdownType`, `SetPatternAttribute`
+- **Lists / dictionaries**: `AddListItem`/`RemoveListItem`/`UpdateListItem`, `AddDictionaryItem`/`RemoveDictionaryItem`/`UpdateDictionaryItem`, `MakeScriptEditable`, `MakeScriptDictEditable`, `AddScriptDictionaryItem`/`RemoveScriptDictionaryItem`
+- **Scripts**: `GetScriptData`, `SetScriptParameter`, `SetIfExpression`/`SetElseIfExpression`, `AddScript`/`DeleteScript`/`DeleteScripts`/`MoveScript`, `AddElse`/`AddElseIf`/`RemoveElse`/`RemoveElseIf`, `GetScriptCode`/`SetScriptCode`, `CopyScripts`/`CutScripts`/`PasteScripts`/`CanPasteScript`, `GetScriptCommandCategories`, `GetObjectNames`, `GetIfExpressionTemplates`/`GetIfExpressionTemplateData`
+- **Element creation/deletion**: `ValidateName`, `GetUniqueName`, `CreateRoom`/`CreateObject`/`CreateFunction`/`CreateTimer`/`CreateExit`/`CreateTurnScript`/`CreateCommand`/`CreateVerb`/`CreateWalkthrough`/`CreateTemplate`/`CreateDynamicTemplate`/`CreateObjectType`/`CreateIncludedLibrary`/`CreateJavascript`, `DeleteElement`, `SwapElements`
+- **Types**: `AddInheritedType`/`RemoveInheritedType`, `GetTypeNames`
+- **Templates**: `GetGameTemplates`, `CreateGameFromTemplate`
 
 `GetEditorData` returns an `EditorDataResponse`:
 ```json
@@ -59,7 +56,9 @@ All data crossing the JS/WASM boundary is JSON. The Svelte layer calls `[JSExpor
         { "attribute": "name", "controlType": "textbox", "caption": "Name", "options": null },
         { "attribute": "enabled", "controlType": "checkbox", "caption": "Enabled", "options": null },
         { "attribute": "direction", "controlType": "dropdown", "caption": "Direction",
-          "options": [{ "value": "north", "label": "north" }, ...] }
+          "options": [{ "value": "north", "label": "north" }, ...] },
+        { "attribute": "cover", "controlType": "file", "caption": "Cover art",
+          "source": "*.jpg;*.jpeg;*.png;*.gif" }
       ]
     }
   ],
@@ -69,11 +68,13 @@ All data crossing the JS/WASM boundary is JSON. The Svelte layer calls `[JSExpor
 
 `SetAttribute` converts `value` (always a string) to the correct .NET type based on `controlType` (`checkbox` → `bool`, `number` → `int`, `numberdouble` → `double`, otherwise `string`), wraps in a transaction for undo support, and returns `"ok"` or an error message.
 
+Both `ControlInfo` and `ScriptControlData` (the latter used for `simpleeditor="file"` script parameters like "Play sound"/"Show picture", not just attribute-level `file` controls) carry a `source` field — the control's `<source>` filter (e.g. `*.jpg;*.jpeg;*.png;*.gif` or `*.wav;*.mp3`), resolved from any `[TemplateName]` reference (e.g. `[EditorImageFormats]`) by `EditorControl.GetString` before it reaches JS. The frontend's `AssetPicker.svelte` parses this into an upload `accept` filter, a dropdown filter, and an image/non-image thumbnail decision — confirmed empirically that the template resolution happens correctly rather than passing through as a literal bracketed string.
+
 Tree nodes are collected during `Initialise` by subscribing to `EditorController.AddedNode`, then returned as a flat list via `GetTreeNodes()`.
 
 ### Not yet implemented
 
-- Live JS callbacks (JSImport) — events currently captured into C# state at init time rather than pushed to JS as they occur
+- Live JS callbacks (`[JSImport]`) — events are still captured into C# state (flags, lists) and polled/re-fetched from JS rather than pushed as they occur. Fine for single-user editing; would matter for any future collaborative or long-running-background-task scenario.
 
 ### Supporting types
 
@@ -86,7 +87,7 @@ Tree nodes are collected during `Initialise` by subscribing to `EditorController
 dotnet build src/WasmEditor --configuration Debug
 ```
 
-Output lands in `src/WasmEditor/bin/Debug/net10.0/browser-wasm/AppBundle/`. The Vite dev server serves this directory at `/AppBundle/` (see `vite.config.ts`).
+Output lands in `src/WasmEditor/bin/Debug/net10.0/browser-wasm/AppBundle/`. The Vite dev server serves this directory at `/AppBundle/` (see `vite.config.ts`). Set `WASM_CONFIG=Release` to serve the AOT-compiled build instead (e.g. for profiling).
 
 ---
 
@@ -107,26 +108,36 @@ Output lands in `src/WasmEditor/bin/Debug/net10.0/browser-wasm/AppBundle/`. The 
 src/WebEditor/
 ├── eslint.config.mjs
 ├── svelte.config.js        # adapter-static, $components alias
-├── vite.config.ts          # AppBundle middleware
+├── vite.config.ts          # AppBundle middleware, WasmPlayer proxy for preview
 ├── src/
 │   ├── app.css             # @import tailwindcss + skeleton + cerberus theme
-│   ├── app.html            # data-theme="cerberus"
+│   ├── app.html             # data-theme="cerberus"
 │   ├── lib/
-│   │   ├── wasm.ts         # loads dotnet.js, exposes WasmBridge
-│   │   ├── editor-store.ts # Svelte stores + wrappers for all WASM calls
-│   │   └── types.ts        # TreeNode, ControlInfo, TabInfo, EditorDataResponse, ScriptNodeData, …
+│   │   ├── wasm.ts          # loads dotnet.js, exposes WasmBridge
+│   │   ├── editor-store.ts  # Svelte stores + wrappers for all WASM calls
+│   │   ├── types.ts         # TreeNode, ControlInfo, TabInfo, EditorDataResponse, ScriptNodeData, …
+│   │   └── filesystem/      # FileAdapter interface + browser/server implementations
 │   ├── components/
-│   │   ├── Toolbar.svelte         # AppBar: title, filename, undo/redo/save/preview
-│   │   ├── TreePanel.svelte       # Skeleton TreeView (flat→hierarchy conversion)
-│   │   ├── PropertyEditor.svelte  # Typed controls with tab navigation
-│   │   ├── ScriptEditor.svelte    # Visual script editor (recursive); code view; copy/paste
-│   │   └── AddScriptModal.svelte  # Categorised command picker modal
+│   │   ├── Toolbar.svelte             # AppBar: title, filename, undo/redo/save/preview
+│   │   ├── TreePanel.svelte           # Skeleton TreeView (flat→hierarchy conversion)
+│   │   ├── PropertyEditor.svelte      # Typed controls with tab navigation
+│   │   ├── AttributesEditor.svelte    # Raw attribute list editor
+│   │   ├── ScriptEditor.svelte        # Visual script editor (recursive); code view; copy/paste
+│   │   ├── ScriptDictionaryEditor.svelte
+│   │   ├── AddScriptModal.svelte      # Categorised command picker modal
+│   │   ├── AddElementModal.svelte     # New room/object/function/.../template modal
+│   │   ├── ElementsList.svelte        # Objects/Verbs/Commands/Functions/Timers list views
+│   │   ├── AssetPicker.svelte         # Image/sound picker for "file" attribute & script controls
+│   │   ├── AssetManagerModal.svelte   # Standalone browse/upload/delete assets modal
+│   │   ├── ListEditor.svelte
+│   │   ├── DictionaryEditor.svelte
+│   │   └── Combobox.svelte
 │   └── routes/
 │       ├── +layout.svelte  # imports app.css
 │       ├── +layout.ts      # prerendering config
-│       ├── +page.svelte    # Welcome: file picker → openGame() → /editor
-│       └── editor/
-│           └── +page.svelte  # Editor layout: Toolbar + TreePanel + PropertyEditor
+│       ├── +page.svelte    # Editor layout (Toolbar + TreePanel + PropertyEditor), or redirect to /open if no game loaded
+│       └── open/
+│           └── +page.svelte  # File picker / create-new-game / server load
 ```
 
 ### Running the dev server
@@ -152,6 +163,7 @@ The browser cannot read files from the local filesystem directly.
 - User opens a file via `<input type="file">`
 - JS reads it as `ArrayBuffer`, converts to `Uint8Array`, passes to `Initialise`
 - Save triggers a download via a temporary `<a>` with an object URL
+- Still used as the fallback path for browsers without the File System Access API (Firefox)
 
 **Option B (implemented)** — File System Access API (`showDirectoryPicker`)
 - The user opens a **game folder**, not just a single file. `openDirectory()` calls `showDirectoryPicker({ mode: "readwrite" })` and scans for `.aslx` files inside. If exactly one is found it auto-loads; if multiple (split-file games, custom libraries) the open page shows a file picker within the folder.
@@ -159,11 +171,12 @@ The browser cannot read files from the local filesystem directly.
 - The directory model is necessary because the FSA API deliberately provides no path from a `FileSystemFileHandle` to its parent — you cannot reach sibling asset files from a file handle alone.
 - Non-FSA browsers (Firefox): `loadLocalFile()` falls back to `<input type="file">` + download save. A clear notice directs users to a supported browser for full asset support.
 
-**Option C (partially implemented)** — Asset storage
+**Option C (implemented)** — Asset storage
 - **Directory mode** (`BrowserFileAdapter`): `putAsset` / `getAsset` / `listAssets` / `deleteAsset` are real sibling files on disk inside the game folder. Assets persist across sessions, are portable (the desktop editor and other tools find them), and require no upload to any server.
-- **Fallback mode** (`BrowserFileAdapter`): assets go to OPFS under a per-session UUID. They survive the session but cannot be extracted or used outside the browser. Asset upload is disabled in this mode — there is nowhere persistent to put them that the user can retrieve later.
-- **Server mode** (`ServerFileAdapter`): asset operations hit `/api/editor/games/{gameId}/assets` REST endpoints (see `docs/textadventures-api.md`). This is a transitional path for games already hosted on textadventures.co.uk; the intent is that local directory mode becomes the primary workflow.
-- Service Worker to intercept asset URL requests during game preview is **not yet implemented** — assets are stored correctly but are not yet resolvable as URLs inside the player preview.
+- **Fallback mode** (`BrowserFileAdapter`): assets go to OPFS under a per-session UUID. They survive the session but cannot be extracted or used outside the browser. Upload works the same as directory mode — there was never an adapter-level restriction here, an earlier version of this doc claimed otherwise.
+- **Server mode** (`ServerFileAdapter`): asset operations hit `/api/editor/games/{gameId}/assets` REST endpoints (see `docs/textadventures-api.md`).
+- `AssetPicker.svelte` (used by both `file`-type attribute controls and `simpleeditor="file"` script parameters, e.g. "Play sound"/"Show picture") and the standalone `AssetManagerModal.svelte` (opened from the toolbar's "Assets" button) both consume these adapter methods via a shared `assets` store in `editor-store.ts`. Pickers filter the asset list and restrict uploads by the control's `<source>` extension filter (resolved server-side by `WasmEditorBridge` — see the `Source` field below) — an image control won't offer a `.wav` file and vice versa; unknown control kinds fall back to showing every asset with no thumbnail.
+- Asset URL resolution inside the WasmPlayer preview does **not** need a Service Worker — an earlier version of this doc said one was required and that assets weren't resolvable in preview. That was already wrong by the time it was written: `previewInWasmPlayer()` in `editor-store.ts` implements a `resource-request`/`resource-response` protocol over a `BroadcastChannel`, and `getResourceUrl()` in `wasm-player.js` (registered as the Engine's resource-lookup callback) already consumes it, for both editor-preview and normal server-hosted play.
 
 **Option D (future)** — Electron wrapper
 - Electron exposes Node.js `fs` to the renderer via `contextBridge` + IPC handlers in the main process — do **not** attempt to use the File System Access API inside Electron, which has known parity bugs (missing persistent permissions, broken directory iteration)
@@ -187,7 +200,6 @@ loadFromServer(gameId: string): Promise<LoadedFile>  // fetches from /api/editor
 interface FileAdapter {
   readonly filename: string
   readonly canSaveAs: boolean
-  readonly previewUrl: string | null   // null for local mode; server-provided URL for online mode
   saveFile(data: Uint8Array | string): Promise<void>
   saveFileAs(data: Uint8Array | string, suggestedName?: string): Promise<string | null>  // returns new filename or null if cancelled
   putAsset(key: string, data: Blob): Promise<void>
@@ -199,10 +211,9 @@ interface FileAdapter {
 
 `saveFileAs` returns the filename that was saved to (so the toolbar can update), or `null` if the user cancelled.
 
-`previewUrl` is exposed as a Svelte store and drives the Preview button in the toolbar:
+### Preview
 
-- **Server mode**: the server returns the player URL in the `X-Preview-Url` response header when loading the game. Clicking Preview saves the game then opens the URL in a new tab (the existing WebPlayer handles rendering).
-- **Local mode**: `previewUrl` is `null`. Clicking Preview shows an inline banner explaining that local games must be tested in the Quest desktop app. The WebEditor cannot run a local game preview in the browser because the WASM player was removed — the Engine uses OS threads (via `Task.Run`) that are incompatible with the browser's no-shared-memory WASM model. Fixing this requires migrating the expression evaluator from Ciloci.Flee to NCalc (async-safe), which is still in progress.
+The toolbar's Preview button opens WasmPlayer (`previewInWasmPlayer` in `editor-store.ts`) in a new tab, passing the current in-memory game bytes via `BroadcastChannel` — this works the same way for local and server-backed games, since WasmPlayer itself now handles both local files and server-backed games (see `#1852`). There is no more local/server split for preview.
 
 ### Unsaved changes
 
@@ -214,94 +225,54 @@ interface FileAdapter {
 
 `ServerFileAdapter` expects the API described in `docs/textadventures-api.md`. When the editor is opened with `?game={guid}`, it auto-loads via `loadFromServer` and uses `ServerFileAdapter` for all subsequent saves and asset operations. The server API uses the user's existing session cookie — no token exchange needed.
 
+`docs/textadventures-api.md` is slightly behind the real implementation in the sibling `textadventures.co.uk` repo (`TextAdventures.Web/Controllers/EditorApiController.cs`) — that repo also has `POST /api/editor/games` (create a new server-side game from name + `.aslx`) which isn't documented yet. Worth reconciling when picking up the Export/Publish work below, since it touches the same controller.
+
 ---
 
-## Phased delivery
+## Export & Publish
 
-### Phase 1 — WASM proof of concept ✅
-- Removed `System.Data.DataSetExtensions` from `EditorCore.csproj`
-- Changed `EditorController.Initialise` to accept `IGameDataProvider` instead of a filename string
-- Created `WasmEditor` project, compiles to WASM with zero warnings
-- Exported minimal API: init, get tree, get element data, save, undo, redo
-- `ByteArrayGameDataProvider` in `Common` wraps `byte[]` from JS
-- Source-generated JSON serialisation (`JsonSerializerContext`) throughout
+Both features hinge on one missing piece: producing a `.quest` package (a zip with `game.aslx` + asset files, the format v5's desktop editor called "Publish to file"). The **read** side already fully supports this — `PackageReader.cs` in Engine loads `.quest` files today using plain `System.IO.Compression.ZipArchive` (pure BCL, works fine under `browser-wasm`). The **write** side, `Packager.CreatePackage`, is a stub (`throw new NotImplementedException()`) with the old Quest 5 implementation commented out, written against a legacy Ionic Zip library and local-disk scanning that don't apply in a browser.
 
-### Phase 2 — SvelteKit skeleton ✅
-- SvelteKit SPA at `src/WebEditor/`; Vite AppBundle middleware for WASM serving
-- File picker → bytes → `Initialise` → tree rendered with Skeleton `TreeView`
-- Click a tree node → attribute list in `PropertyEditor`
-- Toolbar: save (file download), undo, redo
-- Skeleton UI v4 + Tailwind CSS 4 + ESLint configured
+`EditorController.Publish(filename, includeWalkthrough, includeFiles, outputStream)` already has the right shape for this — it accepts an explicit `IEnumerable<PackageIncludeFile>` and bypasses disk scanning entirely when one is supplied. `WorldModel.Save(SaveMode.Package, includeWalkthrough)` already produces a correct, self-contained `game.aslx` (inlines included-library content, strips editor-only elements) — the only thing the zip needs beyond that is the asset bytes the `FileAdapter` already knows about.
 
-### Phase 3 — Property editors ✅
+### Export (this repo)
 
-`PropertyEditor` replaced with typed controls and tab navigation:
+1. **Engine**: implement `Packager.CreatePackage` for real using `ZipArchive` in write mode. Delete the old disk-scanning branch (`GetAvailableExternalFiles`/`AddLibraryResources`) rather than porting it — the browser caller will always pass `includeFiles` explicitly, so that code path is dead on arrival.
+   - `game.aslx` entry ← `_worldModel.Save(SaveMode.Package, includeWalkthrough)`
+   - One zip entry per `PackageIncludeFile` (filename + stream)
+2. **`WasmEditorBridge`**: `[JSExport]` doesn't cleanly marshal an array of blobs in one call, so follow the bridge's existing stage-then-consume pattern (same shape as the dirty-flag polling): `AddPackageAsset(string filename, byte[] data)` to stage assets one at a time, then `ExportPackage(bool includeWalkthrough)` → `byte[]` that consumes the staged list, calls `EditorController.Publish(null, includeWalkthrough, staged, memoryStream)`, and returns the zip bytes.
+3. **WebEditor UI**: "Export…" toolbar action → small modal with an "Include walkthrough" checkbox (mirrors v5's Publish dialog) → `editor-store.ts` calls `adapter.listAssets()` + `getAsset()` per file, stages them via the bridge, calls `ExportPackage`, then triggers a browser download of `{gameName}.quest`. This is adapter-agnostic — identical code path for local and server-mode games, since it only touches the `FileAdapter` interface.
+4. **Known gap, deferred deliberately**: multi-file/library games (a `.aslx` that itself includes sibling library files on disk) are rare in WebEditor today and out of scope for v1 — only assets the `FileAdapter` knows about get bundled.
+5. Natural to pair with a round-trip test (export → reload the zip via `Initialise` or through WasmPlayer) — fits alongside the already-planned WASM bridge test suite.
 
-1. `SetAttribute(elementKey, attribute, controlType, value)` added to `WasmEditorBridge` — type-converts `value` based on `controlType`, wraps in undo transaction
-2. `GetEditorData` extended to return `EditorDataResponse` with `attributes`, `tabs`, and `controls` — each control carries `controlType`, `caption`, and `options` (for dropdowns)
-3. `PropertyEditor.svelte` maps `controlType` to inputs: `textbox`/`richtext` → text input, `checkbox` → checkbox, `number`/`numberdouble` → number input, `dropdown` → select with options, `script` → Phase 4 placeholder, others → read-only display
-4. Tab navigation: tabs from the EditorDefinition are rendered as a tab bar; clicking a tab switches the visible controls
-5. `editor-store.ts` now exports `selectedData` (replacing `selectedAttributes`) and `setAttribute`
+### Publish (cross-repo: quest + textadventures.co.uk)
 
-Known limitations for this phase: live C#→JS events not yet implemented.
+Unlike Export, this isn't a file-format problem — it's textadventures.co.uk's existing public-listing/submission flow, and most of it is **already built and wired, just waiting for a `.quest` file that nothing currently produces**:
 
-### Phase 4 — Script editor ✅
+- `TextAdventures.Web/Controllers/CreateController.cs` has `Publish(int id)`, whose comment reads *"Used only by Quest WebEditor, which redirects here after publishing game output to Azure"* — it forwards to `SubmitController.QuestWebEditor(id)`.
+- `Views/Submit/Quest.razor` downloads `{editorGameDir}/Output/{gamename}.quest` from blob storage, parses it via the existing `GameQuery` reader (same one used by the classic manual-upload flow), and either shows the `GameDetails` submission form (title/description/category/cover/visibility) for a first publish, or calls `SubmitService.UpdateGameFile` to update an already-published listing (tracked via `EditorGame.PublishId`).
+- Category, tags, and visibility (`Game.IsVisible`) all reuse the same infrastructure as the classic upload and old v5-desktop-editor publish paths — no new data model needed.
+- **The one missing piece is server-side**: `EditorApiController.cs` has no endpoint to accept an uploaded compiled package. It needs something like `POST /api/editor/games/{gameId}/publish` that stores the uploaded bytes at the blob path `Quest.razor` already reads from (`{editorGameDir}/Output/{gamename}.quest`).
+- **quest (this repo)**: add a "Publish" toolbar action, shown only when `ServerFileAdapter` is active (local-mode games have no `gameId` to attach a listing to). It reuses Export's `ExportPackage()` output, POSTs the zip to the new endpoint above, then navigates to `/create/publish/{gameId}` on textadventures.co.uk.
+- Local-mode users aren't blocked by any of this: they can already Export a `.quest` file and use the site's existing classic manual "submit a game" upload page.
 
-Visual script editor, code view, and copy/paste — full feature parity with the v5 web editor for script editing.
+Since the counterpart repo lives outside this one, this section should be treated as the plan of record for both sides — update it here if the shape changes, since `docs/textadventures-api.md` in this repo is the only place that spec is written down for someone working purely in `quest`.
 
-**Visual editor** (`ScriptEditor.svelte`)
-- Script commands render as inline rows: labels + textboxes/dropdowns/expression inputs interleaved in a sentence-like layout (`Print [textbox]`, `Set [dropdown] of [dropdown] to [expression]`)
-- Nested scripts (if/then/else, for, foreach) recurse into child `ScriptEditor` instances with their own Add/Delete buttons
-- `if` blocks special-cased: condition + Then block, with Add Else If / Add Else buttons
-- Expression parameters offer a simple/expression toggle: friendly widget (dropdown, number, object picker) when the value matches a simple form; raw text input for arbitrary expressions
-- `if` condition additionally offers a template picker (36 predefined patterns from `usetemplates="if"`) for the most common conditions
-- Move up/down and delete via hover action buttons on each row
+---
 
-**Add script** (`AddScriptModal.svelte`)
-- Categorised command picker with quick-add shortcuts for common commands
-- Keyboard: Escape cancels, Enter confirms, double-click adds immediately
+## Remaining work
 
-**Code view**
-- Toggle button switches the block between the visual editor and a monospace textarea showing the raw Quest script text
-- Round-trips through `EditableScripts.Code` (`Save()` / `LoadCode()`); works correctly on empty attributes by auto-creating the container
+Core editing, element CRUD, script editing, save/load (local + server), new-game-from-template, preview, and asset management (upload/browse/delete, plus pickers for both attribute-level and script-level file controls) are all done. What's left, roughly in the order it'll likely get tackled:
 
-**Copy / cut / paste**
-- Checkbox on each root-level row; checking any shows a selection toolbar with Cut, Copy, Delete, and (single selection) Move Up / Move Down
-- Cut/Copy use `IEditableScripts.Cut/Copy` — clipboard lives in `EditorController.m_clipboardScripts`
-- Paste appends clipboard scripts at the end of the container; handles empty (unset) attributes by creating the container first
-- `scriptClipboardHasContent` Svelte store controls Paste button visibility
-
-**Bridge additions** (all `[JSExport]` on `WasmEditorBridge`):
-`GetScriptData`, `SetScriptParameter`, `SetIfExpression`, `SetElseIfExpression`, `AddScript`, `DeleteScript`, `DeleteScripts`, `MoveScript`, `AddElse`, `AddElseIf`, `RemoveElse`, `RemoveElseIf`, `GetScriptCommandCategories`, `GetObjectNames`, `GetIfExpressionTemplates`, `GetIfExpressionTemplateData`, `GetScriptCode`, `SetScriptCode`, `CopyScripts`, `CutScripts`, `PasteScripts`, `CanPasteScript`
-
-### Phase 5 — Add / delete elements ✅
-
-Tree panel and WASM bridge support creating and deleting all element types:
-
-- **Rooms and Objects** — named, via `AddElementModal` (live name validation, unique-name suggestion)
-- **Functions and Timers** — named, same modal flow
-- **Exits, Commands, Verbs, Turn Scripts** — anonymous (auto-named), created immediately and selected for editing
-- **Delete** — any non-header element; confirm dialog; tree and undo/redo update immediately
-- Tree nodes now carry `nodeIcon` so the UI knows element type without a round-trip
-- `RemovedNode`, `RenamedNode`, `RetitledNode` events now kept live in C# so `GetTreeNodes()` always returns current state
-
-UX: hovering a tree node reveals "+" (add child) and "×" (delete) action buttons. Header nodes get a single-click "+". The Rooms exits tab with a richer exit dialog is a separate future phase.
-
-### Phase 6 — Remaining full feature parity
-- New game (from templates)
-- Publish/export
-- File System Access API + OPFS persistence (see File handling section)
-- Asset storage for images via OPFS + Service Worker
-- Test suite for the WASM bridge
-
-### Phase 6 — Raw ASLX editor
-
-The desktop editor (to be replaced by this WebEditor wrapped in Electron) includes a full raw-file code view. Required for parity.
-
-- A CodeMirror 6 XML editor surfaced as a top-level toggle (whole-file view, not per-script)
-- XML syntax highlighting is built into CM6 — no custom grammar needed
-- Round-trips through save/reload; needs a clear "you are editing raw XML" warning since changes bypass all validation
-- Natural fit for CodeMirror 6 given bundle size and the availability of the XML language package; Monaco is an alternative if a more VS Code–like experience is wanted at the cost of a much larger bundle
+1. **Export & Publish** — not started. Fully scoped now, see [Export & Publish](#export--publish) above: Export means finishing the stubbed `Packager.CreatePackage` (Engine) plus a small bridge/UI layer; Publish is a small cross-repo addition since textadventures.co.uk's submission flow already exists and is just waiting on the `.quest` file Export produces. Export should land first since Publish depends on it. Export's actual risky logic (`Packager.CreatePackage` — the zip writing, round-tripping through `PackageReader`) lives in `Engine`, a normal `net10.0` project, so it should get ordinary `EditorCoreTests`/`EngineTests`-style unit tests as part of that same PR — no new test infrastructure needed, this isn't gated on item 8 below.
+2. **Raw ASLX (whole-file) editor** — a CodeMirror 6 XML view as a top-level toggle, for parity with the v5 desktop editor's raw code view. Round-trips through save/reload; needs a clear "you are editing raw XML, this bypasses validation" warning. CodeMirror 6 has built-in XML highlighting, so no custom grammar is needed; Monaco is the alternative if a more VS Code–like experience is wanted at the cost of bundle size.
+3. **Dirty flag doesn't clear on undo to saved state** — see [Unsaved changes](#unsaved-changes) above.
+4. **Richer room-exits dialog** — deferred from the add/delete-elements work; exits are currently created anonymously and edited like any other element rather than through a dedicated exits tab.
+5. **`EditorController.AddControlType`/`GetControlType`** — dead code now the only consumer is Svelte (the `EditorMode` Desktop/Web split itself was already removed). Cleanup, not urgent.
+6. **Live JS push events** (`[JSImport]`) — see [Not yet implemented](#not-yet-implemented). Only matters if/when the editor needs push-based updates (e.g. background operations, collaboration); not needed for anything currently planned.
+7. **Electron wrapper** — future; see Option D above and [Open questions](#open-questions).
+8. **WebEditor e2e coverage** (Playwright, `tests/e2e`) — this is the real gap, not a "WasmEditorBridge unit test project". `WasmEditor.csproj` targets `<RuntimeIdentifier>browser-wasm</RuntimeIdentifier>` with `OutputType>Exe`, which a normal MSTest project can't reference the way `EditorCoreTests` references `EditorCore.csproj` — there's no in-process host to unit-test the `[JSExport]` boundary itself. Most of the ~65 bridge methods are thin pass-throughs to `EditorController`, which already has decent coverage (`EditableListTests`, `EditableScriptTests`, `EditorControllerTests`, etc.); what's actually untested is the JS↔WASM marshaling boundary and end-to-end UI wiring, which only a real browser driving the built `AppBundle` can exercise — i.e. Playwright, extending the existing pattern in `tests/e2e` (currently WebPlayer/WasmPlayer verification scripts only). Independent of item 1; not a prerequisite for it. (The Asset UI work verified this approach informally — a throwaway Playwright script driving the built AppBundle via the non-FSA `<input type="file">` fallback path worked well for exercising the picker/upload/preview flow end-to-end; formalizing that into `tests/e2e` is what this item is.)
+9. **Blockly** — future; see [Blockly (future)](#blockly-future) below.
 
 ---
 
@@ -351,9 +322,6 @@ Blockly is ~800KB and requires a TypeScript bridge layer to synchronise the bloc
 
 ## Open questions
 
-- **EditorCore API cleanup**: `EditorMode` (Desktop/Web distinction) and `AddControlType`/`GetControlType` (.NET UI control registration) are dead weight now the only consumer is Svelte. Remove in a future cleanup pass.
-- **Live C# → JS events**: Currently tree state is snapshot-based (collected at init). As editing adds/removes/renames nodes, the bridge will need to push updates to JS rather than relying on a full re-fetch.
-- **Build integration**: Should `WasmEditor` output be served by `WebPlayer` (embedded SPA) or deployed separately? — resolved, see [deployment-domains.md](./deployment-domains.md): deployed separately, own subdomain (`play.questviva.com`).
-- **Auth / server-side storage**: Is cloud save in scope? Affects whether the editor stays purely client-side. — resolved, see [deployment-domains.md](./deployment-domains.md): cloud sync stays in scope, but only on textadventures.co.uk (same-origin with existing auth); `play.questviva.com` stays local-only.
-- **Shared filesystem adapter**: Implement `src/lib/filesystem/` here first (see File handling section and [squiffy#215](https://github.com/textadventures/squiffy/issues/215)); extract into a published package when Squiffy becomes the second consumer.
+- **Live C# → JS events**: Currently tree/dirty state is snapshot- or poll-based. As editing adds/removes/renames nodes, would the bridge ever need to push updates to JS rather than relying on re-fetch? Not needed for anything currently planned (see Remaining work item 6).
+- **Shared filesystem adapter**: `src/lib/filesystem/` has no Svelte/Quest-specific imports by design (see File handling section and [squiffy#215](https://github.com/textadventures/squiffy/issues/215)); extract into a published package when Squiffy becomes a second consumer.
 - **Electron wrapper**: Both Quest and Squiffy editors are candidates for an Electron app. The `FileAdapter` interface is the seam; `createElectronAdapter()` bridges to Node.js `fs` via `contextBridge` IPC. Decide whether to build one Electron shell that hosts both, or separate apps.

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -32,7 +32,8 @@ internal record ControlInfo(
     string? AddPrompt = null,
     string? ElementType = null,
     string? ObjectType = null,
-    string? ListFilter = null);
+    string? ListFilter = null,
+    string? Source = null);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -48,6 +49,7 @@ internal record ScriptControlData(
     string? Value,
     string? SimpleEditor,
     string? SimpleLabel,
+    string? Source,
     List<ControlOption>? Options,
     List<ScriptNodeData>? Scripts
 );
@@ -2503,6 +2505,7 @@ public partial class WasmEditorBridge
         }
 
         string? simpleLabel = null;
+        string? source = null;
 
         if (ctrl.ControlType == "expression")
         {
@@ -2510,6 +2513,7 @@ public partial class WasmEditorBridge
             var simpleEditorTag = ctrl.GetString("simpleeditor");
             // If <simpleeditor> is absent but <simple> is set, default simple editor is a textbox
             simpleEditor = simpleEditorTag ?? (simpleLabel != null ? "textbox" : null);
+            source = ctrl.GetString("source");
 
             if (simpleEditor == "dropdown")
             {
@@ -2552,6 +2556,7 @@ public partial class WasmEditorBridge
             value,
             simpleEditor,
             simpleLabel,
+            source,
             options,
             nestedScripts
         );
@@ -2708,9 +2713,10 @@ public partial class WasmEditorBridge
         }
 
         var addPrompt = ctrl.ControlType == "list" ? ctrl.GetString("editprompt") : null;
+        var source = ctrl.ControlType == "file" ? ctrl.GetString("source") : null;
 
         return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
-            null, null, textProcessorCommands, addPrompt);
+            null, null, textProcessorCommands, addPrompt, Source: source);
     }
 
     [JSExport]

--- a/src/WebEditor/src/components/AssetManagerModal.svelte
+++ b/src/WebEditor/src/components/AssetManagerModal.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+    import { assets, uploadAsset, deleteAssetByKey, resolveAssetUrl, isImageAsset } from "$lib/editor-store";
+
+    interface Props {
+        oncancel: () => void;
+    }
+    const { oncancel }: Props = $props();
+
+    let thumbUrls = $state<Record<string, string>>({});
+
+    $effect(() => {
+        for (const asset of $assets) {
+            if (isImageAsset(asset.key) && !(asset.key in thumbUrls)) {
+                resolveAssetUrl(asset.key).then((url) => {
+                    if (url) thumbUrls = { ...thumbUrls, [asset.key]: url };
+                });
+            }
+        }
+    });
+
+    let inputEl: HTMLInputElement;
+    let uploading = $state(false);
+    let error = $state("");
+
+    async function handleUpload(e: Event) {
+        const target = e.target as HTMLInputElement;
+        const file = target.files?.[0];
+        target.value = "";
+        if (!file) return;
+        uploading = true;
+        error = "";
+        try {
+            await uploadAsset(file);
+        } catch (err) {
+            error = String(err);
+        } finally {
+            uploading = false;
+        }
+    }
+
+    async function handleDelete(key: string) {
+        await deleteAssetByKey(key);
+        if (key in thumbUrls) {
+            const rest = { ...thumbUrls };
+            delete rest[key];
+            thumbUrls = rest;
+        }
+    }
+
+    function onBackdropClick(e: MouseEvent) {
+        if (e.target === e.currentTarget) oncancel();
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") oncancel();
+    }
+</script>
+
+<div
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+    onclick={onBackdropClick}
+    onkeydown={handleKeydown}
+>
+    <div class="card bg-white rounded-xl shadow-xl w-[32rem] max-h-[80vh] p-6 flex flex-col gap-4">
+        <div class="flex items-center justify-between">
+            <h2 class="text-base font-semibold">Assets</h2>
+            <button class="btn btn-sm preset-tonal" onclick={oncancel}>Close</button>
+        </div>
+
+        <div class="flex items-center gap-2">
+            <button
+                type="button"
+                class="btn btn-sm preset-filled-primary-500"
+                onclick={() => inputEl.click()}
+                disabled={uploading}
+            >{uploading ? "Uploading…" : "Upload…"}</button>
+            <input bind:this={inputEl} type="file" class="hidden" onchange={handleUpload} />
+            {#if error}<p class="text-xs text-error-500">{error}</p>{/if}
+        </div>
+
+        <div class="flex-1 overflow-y-auto flex flex-col gap-1">
+            {#if $assets.length === 0}
+                <p class="text-xs text-surface-400-500">No assets yet.</p>
+            {/if}
+            {#each $assets as asset (asset.key)}
+                <div class="flex items-center gap-2 px-1.5 py-1 rounded hover:bg-surface-100-900">
+                    {#if thumbUrls[asset.key]}
+                        <img src={thumbUrls[asset.key]} alt="" class="h-8 w-8 object-cover rounded border border-surface-200-800 shrink-0" />
+                    {:else}
+                        <span class="h-8 w-8 rounded border border-surface-200-800 shrink-0 flex items-center justify-center text-sm">📄</span>
+                    {/if}
+                    <span class="text-xs flex-1 truncate" title={asset.key}>{asset.key}</span>
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-error-500 text-xs px-2 py-0.5"
+                        onclick={() => handleDelete(asset.key)}
+                    >Delete</button>
+                </div>
+            {/each}
+        </div>
+    </div>
+</div>

--- a/src/WebEditor/src/components/AssetPicker.svelte
+++ b/src/WebEditor/src/components/AssetPicker.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+    import { assets, uploadAsset, resolveAssetUrl, parseAssetSource } from "$lib/editor-store";
+    import Combobox from "./Combobox.svelte";
+
+    let { value, source = null, onchange, class: className = "input text-xs py-0.5 px-1.5 w-auto min-w-24" }: {
+        value: string;
+        source?: string | null;
+        onchange: (value: string) => void;
+        class?: string;
+    } = $props();
+
+    let filter = $derived(parseAssetSource(source));
+    let options = $derived(
+        $assets.filter(a => filter.matches(a.key)).map(a => ({ value: a.key, label: a.key }))
+    );
+
+    let thumbUrl = $state<string | null>(null);
+
+    $effect(() => {
+        const key = value;
+        if (!key || filter.kind !== "image") {
+            thumbUrl = null;
+            return;
+        }
+        resolveAssetUrl(key).then((url) => {
+            if (value === key) thumbUrl = url;
+        });
+    });
+
+    let inputEl: HTMLInputElement;
+    let uploading = $state(false);
+
+    async function handleUpload(e: Event) {
+        const target = e.target as HTMLInputElement;
+        const file = target.files?.[0];
+        target.value = "";
+        if (!file) return;
+        uploading = true;
+        try {
+            await uploadAsset(file);
+            onchange(file.name);
+        } finally {
+            uploading = false;
+        }
+    }
+</script>
+
+<div class="flex items-center gap-1.5">
+    {#if filter.kind === "image" && value}
+        {#if thumbUrl}
+            <img src={thumbUrl} alt="" class="h-6 w-6 object-cover rounded border border-surface-200-800 shrink-0" />
+        {:else}
+            <span class="h-6 w-6 rounded border border-surface-200-800 shrink-0"></span>
+        {/if}
+    {:else if value}
+        <span class="text-xs shrink-0" title={value}>📄</span>
+    {/if}
+    <Combobox {value} {options} {onchange} class={className} />
+    <button
+        type="button"
+        class="btn btn-sm preset-outlined-primary-500 text-xs px-1.5 py-0.5 whitespace-nowrap shrink-0"
+        onclick={() => inputEl.click()}
+        disabled={uploading}
+        title="Upload a new file"
+    >{uploading ? "Uploading…" : "Upload…"}</button>
+    <input bind:this={inputEl} type="file" accept={filter.accept} class="hidden" onchange={handleUpload} />
+</div>

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -6,6 +6,7 @@
     import AttributesEditor from "./AttributesEditor.svelte";
     import ListEditor from "./ListEditor.svelte";
     import ElementsList from "./ElementsList.svelte";
+    import AssetPicker from "./AssetPicker.svelte";
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
@@ -217,7 +218,11 @@
             >Generate</button>
         </div>
     {:else if ctrl.controlType === "file"}
-        <em class="text-xs text-surface-400-500">File picker not yet implemented</em>
+        <AssetPicker
+            value={attrValue(ctrl.attribute!) ?? ""}
+            source={ctrl.source}
+            onchange={(v) => onTextChange(ctrl.attribute!, ctrl.controlType, v)}
+        />
     {:else if ctrl.controlType === "list" && ctrl.attribute && $selectedKey}
         <ListEditor elementKey={$selectedKey} attribute={ctrl.attribute} value={attrValue(ctrl.attribute)} addPrompt={ctrl.addPrompt ?? undefined} />
     {:else if ctrl.controlType === "stringdictionary" && ctrl.attribute}

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import ScriptEditor from "./ScriptEditor.svelte";
     import AddScriptModal from "./AddScriptModal.svelte";
+    import AssetPicker from "./AssetPicker.svelte";
     import {
         scriptVersion,
         scriptClipboardHasContent,
@@ -598,6 +599,13 @@
                         class="input text-xs py-0 px-1 min-w-12 max-w-24"
                         value={ctrl.value ?? "0"}
                         onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
+                    />
+                {:else if ctrl.simpleEditor === "file"}
+                    <AssetPicker
+                        value={toSimpleDisplay(ctrl)}
+                        source={ctrl.source}
+                        onchange={(v) => onSimpleValueChange(scriptIndex, ctrl, v)}
+                        class="input text-xs py-0 px-1 min-w-16 max-w-48"
                     />
                 {:else}
                     <!-- textbox (default for message, text, colour, etc.) -->

--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -9,6 +9,7 @@
         createExit, createTurnScript, createCommand, createVerb,
         createIncludedLibrary, createJavascript,
         deleteElement,
+        assetManagerOpen,
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
 
@@ -125,6 +126,7 @@
                             title={"Delete " + (selectedNode?.text ?? "")}
                         >Delete</button>
                     {/if}
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => assetManagerOpen.set(true)} title="Manage assets">🖼 Assets</button>
                     <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
                     <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
                     <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleSave} disabled={saving} title="Save">💾 Save</button>

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -1,7 +1,7 @@
 import { writable, get } from "svelte/store";
 import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
-import type { FileAdapter } from "./filesystem/types";
+import type { AssetInfo, FileAdapter } from "./filesystem/types";
 import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData } from "./types";
 
 export type AddElementModalState = { type: "room" | "object" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
@@ -27,6 +27,8 @@ export const canRedo = writable(false);
 export const isDirty = writable(false);
 export const scriptVersion = writable(0);
 export const scriptClipboardHasContent = writable(false);
+export const assets = writable<AssetInfo[]>([]);
+export const assetManagerOpen = writable(false);
 
 function refreshUndoRedo() {
     canUndo.set(_bridge?.CanUndo() ?? false);
@@ -45,6 +47,7 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
     await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
     const ok = await _bridge.Initialise(bytes, filename);
     loadingStatus.set(null);
+    clearAssetUrlCache();
     if (ok) {
         const nodes: TreeNode[] = JSON.parse(_bridge.GetTreeNodes());
         treeNodes.set(nodes);
@@ -52,6 +55,7 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
         gameFilename.set(filename);
         refreshUndoRedo();
         scriptClipboardHasContent.set(false);
+        await refreshAssets();
         const gameNode = nodes.find(n => n.nodeType === "game");
         if (gameNode) await selectNode(gameNode.key);
     }
@@ -173,6 +177,99 @@ export function redo() {
     refreshSelectedData();
     refreshUndoRedo();
     scriptVersion.update(n => n + 1);
+}
+
+// ── Assets ───────────────────────────────────────────────────────────────────
+
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg"]);
+
+// Unscoped classification (no <source> filter in play) — used by the standalone
+// asset manager, which lists everything rather than filtering to one control's kind.
+export function isImageAsset(filename: string): boolean {
+    const dot = filename.lastIndexOf(".");
+    return dot >= 0 && IMAGE_EXTENSIONS.has(filename.slice(dot + 1).toLowerCase());
+}
+
+export interface AssetFilter {
+    // For the upload <input accept="...">. Empty string means no restriction.
+    accept: string;
+    kind: "image" | "other";
+    matches(filename: string): boolean;
+}
+
+// Parses a Quest editor <source> filter like "*.jpg;*.jpeg;*.png;*.gif" or
+// "*.wav;*.mp3" (already resolved from any [TemplateName] reference by the
+// bridge) into something usable for filtering the asset list and restricting
+// uploads. A missing/empty source (shouldn't happen for the known "file"
+// controls, but defensive) falls back to permissive: show everything, no
+// thumbnail.
+export function parseAssetSource(source: string | null | undefined): AssetFilter {
+    const exts = (source ?? "")
+        .split(";")
+        .map(s => s.trim().replace(/^\*/, "").replace(/^\./, "").toLowerCase())
+        .filter(s => s.length > 0);
+    if (exts.length === 0) {
+        return { accept: "", kind: "other", matches: () => true };
+    }
+    const extSet = new Set(exts);
+    return {
+        accept: exts.map(e => `.${e}`).join(","),
+        kind: exts.every(e => IMAGE_EXTENSIONS.has(e)) ? "image" : "other",
+        matches: (filename: string) => {
+            const dot = filename.lastIndexOf(".");
+            return dot >= 0 && extSet.has(filename.slice(dot + 1).toLowerCase());
+        },
+    };
+}
+
+export async function refreshAssets(): Promise<void> {
+    assets.set(_adapter ? await _adapter.listAssets() : []);
+}
+
+export async function uploadAsset(file: File): Promise<void> {
+    if (!_adapter) return;
+    await _adapter.putAsset(file.name, file);
+    releaseAssetUrl(file.name); // in case this overwrote an asset with a cached object URL
+    await refreshAssets();
+}
+
+export async function deleteAssetByKey(key: string): Promise<void> {
+    if (!_adapter) return;
+    await _adapter.deleteAsset(key);
+    releaseAssetUrl(key);
+    await refreshAssets();
+}
+
+const assetUrlCache = new Map<string, string>();
+
+function releaseAssetUrl(key: string) {
+    const cached = assetUrlCache.get(key);
+    if (cached) {
+        URL.revokeObjectURL(cached);
+        assetUrlCache.delete(key);
+    }
+}
+
+function clearAssetUrlCache() {
+    for (const url of assetUrlCache.values()) URL.revokeObjectURL(url);
+    assetUrlCache.clear();
+}
+
+// Resolves an asset key to something usable as an <img src>. Server-mode
+// assets already have a fetchable url from listAssets(); local-mode assets
+// are read as a Blob and turned into a cached object URL (released when the
+// asset changes or a new game is opened).
+export async function resolveAssetUrl(key: string): Promise<string | null> {
+    if (!key || !_adapter) return null;
+    const info = get(assets).find(a => a.key === key);
+    if (info?.url) return info.url;
+    const cached = assetUrlCache.get(key);
+    if (cached) return cached;
+    const blob = await _adapter.getAsset(key);
+    if (!blob) return null;
+    const url = URL.createObjectURL(blob);
+    assetUrlCache.set(key, url);
+    return url;
 }
 
 // ── List editor functions ────────────────────────────────────────────────────

--- a/src/WebEditor/src/lib/types.ts
+++ b/src/WebEditor/src/lib/types.ts
@@ -30,6 +30,7 @@ export interface ControlInfo {
   elementType?: string | null
   objectType?: string | null
   listFilter?: string | null
+  source?: string | null
 }
 
 export interface TabInfo {
@@ -50,6 +51,7 @@ export interface ScriptControlData {
   value: string | null
   simpleEditor: string | null
   simpleLabel: string | null
+  source: string | null
   options: ControlOption[] | null
   scripts: ScriptNodeData[] | null
 }

--- a/src/WebEditor/src/routes/+page.svelte
+++ b/src/WebEditor/src/routes/+page.svelte
@@ -4,12 +4,13 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { get } from "svelte/store";
-    import { isLoaded, isDirty, loadingStatus, addElementModal, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType } from "$lib/editor-store";
+    import { isLoaded, isDirty, loadingStatus, addElementModal, assetManagerOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType } from "$lib/editor-store";
     import { loadFromServer } from "$lib/filesystem/server-adapter";
     import Toolbar from "$components/Toolbar.svelte";
     import TreePanel from "$components/TreePanel.svelte";
     import PropertyEditor from "$components/PropertyEditor.svelte";
     import AddElementModal from "$components/AddElementModal.svelte";
+    import AssetManagerModal from "$components/AssetManagerModal.svelte";
 
     let serverLoadError = $state<string | null>(null);
 
@@ -80,5 +81,9 @@
             onconfirm={handleAddConfirm}
             oncancel={() => addElementModal.set(null)}
         />
+    {/if}
+
+    {#if $assetManagerOpen}
+        <AssetManagerModal oncancel={() => assetManagerOpen.set(false)} />
     {/if}
 {/if}


### PR DESCRIPTION
## Summary
- Replaces the "File picker not yet implemented" placeholder with a working upload/browse picker (`AssetPicker.svelte`), wired into both attribute-level file controls (game cover art, background images) and script-level file params (Play sound, Show picture)
- Pickers filter by file kind via a new `Source` field threaded from the control's `<source>` extension filter through `WasmEditorBridge`, so an image control won't offer a `.wav` and vice versa
- Adds a standalone Assets modal (`AssetManagerModal.svelte`) for browsing/deleting all uploaded assets, opened from a new toolbar button
- Corrects two stale claims in `docs/webeditor-wasm-svelte.md`: preview already resolves asset URLs via an existing `BroadcastChannel` protocol (no Service Worker needed), and OPFS fallback-mode asset upload was never actually disabled

## Test plan
- [x] `dotnet build src/WasmEditor --configuration Debug` — 0 warnings
- [x] `npm run lint` / `npm run check` in `src/WebEditor` — no new errors introduced (verified against pre-existing baseline)
- [x] Manually verified in a real browser (Playwright-driven): uploaded an image via the Cover art picker, confirmed thumbnail + dropdown; confirmed the same image was offered (with thumbnail) in a "Show picture" script picker but correctly filtered out of "Play sound"'s picker, which only offered the uploaded `.wav`; confirmed the Assets modal lists/deletes correctly; confirmed Preview still boots WasmPlayer cleanly with no console errors
- [x] User confirmed working after manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)