### PR TITLE
fix: regenerate WebEditor lockfile and harden CI against lockfile drift

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,34 @@ jobs:
         run: npm run build
         working-directory: site
 
+  build_webeditor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      # Matches the node-version deploy-play.yml uses to build WebEditor for
+      # release, so a lockfile that only resolves cleanly on a contributor's
+      # local platform gets caught here instead of on release day.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: src/WebEditor/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: src/WebEditor
+
+      - name: Build
+        run: npm run build
+        working-directory: src/WebEditor
+        env:
+          PUBLIC_WEBEDITOR_VERSION: ${{ github.sha }}
+          BASE_PATH: /editor
+
   build_and_test:
     runs-on: ubuntu-latest
 

--- a/src/WasmPlayer/WasmPlayer.csproj
+++ b/src/WasmPlayer/WasmPlayer.csproj
@@ -18,7 +18,7 @@
          scripts/build-icons.mjs) into generated/index.html, before either gets copied into
          the AppBundle. -->
     <Target Name="BuildChromeCss" BeforeTargets="CopyPlayerAssetsToAppBundle">
-        <Exec Command="npm install" WorkingDirectory="$(MSBuildThisFileDirectory)" Condition="!Exists('$(MSBuildThisFileDirectory)node_modules')"/>
+        <Exec Command="npm ci" WorkingDirectory="$(MSBuildThisFileDirectory)" Condition="!Exists('$(MSBuildThisFileDirectory)node_modules')"/>
         <Exec Command="npm run build" WorkingDirectory="$(MSBuildThisFileDirectory)"/>
     </Target>
 

--- a/src/WebEditor/package-lock.json
+++ b/src/WebEditor/package-lock.json
@@ -30,6 +30,31 @@
         "vite": "^8.0.16"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -37,6 +62,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -290,7 +316,6 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -770,7 +795,6 @@
       "integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -813,7 +837,6 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -1219,7 +1242,6 @@
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1276,7 +1298,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1384,7 +1405,6 @@
       "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2080,7 +2100,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2314,7 +2333,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3263,7 +3281,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3291,7 +3308,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -3571,7 +3587,6 @@
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3702,8 +3717,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -3785,7 +3799,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3848,7 +3861,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",


### PR DESCRIPTION
## Summary
- `src/WebEditor/package-lock.json` was last regenerated on macOS (arm64) in #1855, which didn't capture `@emnapi/core@1.11.2` / `@emnapi/runtime@1.11.2` — peer deps of a Linux-specific vite/rolldown WASM binding. On the `ubuntu-latest` `deploy-play` runner, `npm ci` failed with `EUSAGE` ("Missing ... from lock file"), breaking the `v6.0.0-beta.37` deploy (Docker + NuGet publish succeeded, `deploy-play` failed). Regenerated the lockfile inside a `linux/amd64` `node:22` container to match CI exactly. `package.json` is untouched.
- **CI gap**: `build-and-test.yml` never built WebEditor at all — it's a standalone SvelteKit app with no `.csproj`, unlike WasmEditor/WasmPlayer which get their npm steps exercised via MSBuild targets during the solution's `dotnet build`. Only `deploy-play.yml` (tag-push only) ever ran `npm ci` for WebEditor, so this class of break only surfaces after a release tag is already cut. Added a `build_webeditor` job mirroring deploy-play's node version and build invocation, so it runs on every PR.
- **WasmPlayer hardening**: its MSBuild target ran `npm install`, which silently re-resolves and heals a stale lockfile instead of failing — so it wouldn't have caught this same class of drift. Swapped to `npm ci` (kept inside the existing "only when `node_modules` is missing" guard, so local dev speed is unaffected). Verified WasmPlayer's own lockfile is already in sync for Linux.

## Test plan
- [x] Reproduced the exact CI failure locally via `docker run --platform linux/amd64 node:22 npm ci`
- [x] Regenerated the WebEditor lockfile in the same container via `npm install`; verified `npm ci && npm run build` succeed there
- [x] Verified WasmPlayer's lockfile passes `npm ci` on `linux/amd64` node:22, and `dotnet build src/WasmPlayer/WasmPlayer.csproj -c Release` still succeeds end-to-end
- [x] New `build_webeditor` CI job passed on this PR (confirms the gap is closed)
- [ ] Confirm `deploy-play` job succeeds on the next tagged release (`v6.0.0-beta.38`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)