### PR TITLE
chore: bump GitHub Actions to latest majors for Node 24 support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -39,13 +39,13 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Matches the node-version deploy-play.yml uses to build WebEditor for
       # release, so a lockfile that only resolves cleanly on a contributor's
       # local platform gets caught here instead of on release day.
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -68,11 +68,11 @@ jobs:
     steps:
       # Check out the repo so the workflow can access it
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Set up the .NET SDK (change to the specific version you’re using)
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Verify tag matches VERSION file
         if: github.ref_type == 'tag'
@@ -31,11 +31,11 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -73,7 +73,7 @@ jobs:
           EOF
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Trigger textadventures.co.uk deployment
         if: github.ref_type == 'tag'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.TA_DEPLOY_PAT }}
           repository: alexwarren/textadventures.co.uk

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       #
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -11,10 +11,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 


### PR DESCRIPTION
## Summary
- GitHub is deprecating Node 20 runners and force-running Node 20-based actions on Node 24, surfacing deprecation warnings on `actions/checkout@v4`, `actions/setup-dotnet@v4`, `actions/setup-node@v4`, `cloudflare/wrangler-action@v3`, and `peter-evans/repository-dispatch@v3`.
- Bumped each to its latest major version, all of which run on Node 24 natively: `checkout@v7`, `setup-node@v6`, `setup-dotnet@v5`, `wrangler-action@v4`, `repository-dispatch@v4`.
- No config changes needed: checked `wrangler-action@v4`'s default-Wrangler-version bump (v3→v4) against the Pages deploy step in `deploy-play.yml` — it's a static-asset upload with no Workers bundling, so none of the v3→v4 breaking changes apply.

## Test plan
- [ ] CI passes on this PR (build-and-test workflow)
- [ ] Next tag push exercises `deploy-play.yml` (checkout/setup-dotnet/setup-node/wrangler-action/repository-dispatch) and `nuget-publish.yml`/`docker-publish.yml` (checkout/setup-dotnet) successfully