### PR TITLE
fix: allow "main" scope in PR title lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -21,7 +21,8 @@ jobs:
         with:
           # Scope is optional (requireScope unset), but when given it must
           # match a project name exactly, so it clusters and capitalizes
-          # consistently in the release-please changelog.
+          # consistently in the release-please changelog. "main" is included
+          # because release-please's own PR titles are "chore(main): release X.Y.Z".
           scopes: |
             Common
             Engine
@@ -33,3 +34,4 @@ jobs:
             WebEditor
             WasmEditor
             Site
+            main


### PR DESCRIPTION
## Summary
- release-please's own release PRs are titled `chore(main): release X.Y.Z`, but the PR title lint's scope allowlist only contained project names, so every release-please PR fails the check (see [run 29283050527](https://github.com/textadventures/quest/actions/runs/29283050527)).
- Adds `main` to the allowed scopes.

## Test plan
- [ ] CI lint-pr-title check passes on this PR
- [ ] Next release-please PR title (`chore(main): release ...`) passes the check