### PR TITLE
fix(ElectronApp): arm64 Linux, mac x64 drop, ad-hoc signing

### DIFF
--- a/docs/electron-desktop-app.md
+++ b/docs/electron-desktop-app.md
@@ -218,9 +218,9 @@ Native AOT is the better long-term target; it also eliminates the cold-start JIT
 
 All three built and published by `electron-publish.yml` (see Releasing below) — unsigned everywhere for now.
 
-- macOS (arm64 + x64) — DMG
+- macOS (arm64 only) — DMG. Dropped x64: Apple's own Rosetta-deprecation warning (shown when launching an Intel build on Apple Silicon) means new Intel binaries would be investing in a platform Apple is already sunsetting, and there's no existing Intel user base for this app to preserve.
 - Windows (x64) — NSIS installer
-- Linux (x64) — AppImage (single-file, no distro-specific packaging)
+- Linux (x64 + arm64) — AppImage (single-file, no distro-specific packaging). No "universal" option here unlike macOS — ELF has no fat-binary equivalent to Mach-O's, and none of the common Linux packaging formats (AppImage, deb, rpm, Snap, Flatpak) support single-file multi-arch execution; publishing separate per-arch artifacts is the standard approach, not a workaround.
 
 `src/ElectronApp/scripts/dist.mjs` invokes electron-builder's Node API (`build({ config: { extraMetadata: { version } } })`) directly rather than its CLI, so injecting the repo's real `VERSION` at package time doesn't rely on `$(cat ...)` shell command substitution — that's bash-only and breaks under the `pwsh` shell `windows-latest` runners default to. `WASM_CONFIG=Release` (set via the GitHub Actions step's `env:`, not inline shell syntax, for the same cross-platform reason) points `copy-static.mjs` at the Release AppBundles instead of its Debug default.
 

--- a/src/ElectronApp/package.json
+++ b/src/ElectronApp/package.json
@@ -32,6 +32,7 @@
         "to": "app-static"
       }
     ],
+    "afterSign": "scripts/adhoc-sign.js",
     "mac": {
       "category": "public.app-category.productivity",
       "target": [

--- a/src/ElectronApp/package.json
+++ b/src/ElectronApp/package.json
@@ -38,7 +38,7 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["arm64", "x64"]
+          "arch": ["arm64"]
         }
       ]
     },

--- a/src/ElectronApp/package.json
+++ b/src/ElectronApp/package.json
@@ -54,7 +54,7 @@
       "target": [
         {
           "target": "AppImage",
-          "arch": ["x64"]
+          "arch": ["x64", "arm64"]
         }
       ]
     }

--- a/src/ElectronApp/scripts/adhoc-sign.js
+++ b/src/ElectronApp/scripts/adhoc-sign.js
@@ -1,0 +1,23 @@
+// Free ad-hoc code signing (no Apple Developer cert needed) as a stopgap
+// until real Developer ID signing is wired in (see docs/electron-desktop-app.md,
+// "Resolved decisions"). Apple Silicon refuses to even launch a completely
+// unsigned app ("damaged, can't be opened") rather than the milder
+// "unidentified developer" prompt Intel Macs give unsigned apps — ad-hoc
+// signing (`codesign --sign -`) satisfies the mandatory-signature
+// requirement without a real identity, downgrading that to the normal
+// bypassable Gatekeeper warning.
+//
+// electron-builder invokes this as its "afterSign" hook — CommonJS, not the
+// .mjs used elsewhere in this project, since that's what electron-builder's
+// hook loader expects.
+
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+module.exports = async function adhocSign(context) {
+    // A real identity means electron-builder's own signing step already ran.
+    if (process.env.CSC_LINK) return;
+
+    const appPath = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`);
+    execFileSync("codesign", ["--force", "--deep", "--sign", "-", appPath], { stdio: "inherit" });
+};


### PR DESCRIPTION
## Summary

Three fixes found while testing the first release build (#1865) on real machines:

- **Linux arm64**: the AppImage target only built x64, so it hit `cannot execute binary file: Exec format error` on an arm64 Ubuntu VM (e.g. the default on Apple Silicon). Added `arm64` alongside `x64` — electron-builder just downloads each arch's prebuilt Electron zip, no cross-compilation needed. Verified both build from one `npm run dist` pass in a throwaway Docker container, and `file` confirms each artifact really is the right architecture (`x86-64` / `ARM aarch64`). `electron-publish.yml`'s upload glob (`*.AppImage`) already matches both filenames, so no workflow change needed there.
- **macOS ad-hoc signing**: the mac build is currently fully unsigned (no Developer ID cert yet — that's separately in progress). Apple Silicon requires every executable to carry at least some code signature to run at all, so a copied-to-Applications, freshly-downloaded `.app` got refused outright as "damaged" rather than the milder "unidentified developer" Gatekeeper prompt Intel Macs give unsigned apps. Added `scripts/adhoc-sign.js` as electron-builder's `afterSign` hook, applying free ad-hoc signing (`codesign --sign -`) whenever `CSC_LINK` isn't set — it steps aside automatically once real signing is wired in, rather than clobbering it.
- **Dropped the Intel macOS build**: while testing, the Intel DMG showed macOS's Rosetta-deprecation warning on launch — Apple's own signal that Intel-app translation is being phased out. Since this is a brand-new app with no existing Intel Mac user base to preserve, building `arm64` only avoids investing further in a platform Apple's already sunsetting. (No universal-binary equivalent exists for the Linux side to consider the same trade-off there — ELF has no fat-binary format, and none of AppImage/deb/rpm/Snap/Flatpak support single-file multi-arch execution, so separate per-arch artifacts, which we already publish, is the standard approach on Linux, not a workaround.)

## Test plan

- [x] Both x64 and arm64 Linux AppImages build successfully from one pass; `file` confirms correct architecture for each
- [x] macOS build: `codesign -dv` confirms `Signature=adhoc` on the built `.app` (previously no signature at all)
- [x] Ad-hoc-signed app still launches and runs correctly (checked via remote debugging, not just that codesign succeeded)
- [x] `npm run dist` now produces a single arm64 DMG, not two
- [ ] Real end-to-end check that the "damaged" dialog is actually gone on a freshly-downloaded, quarantined `.app` — can't fully replicate the Gatekeeper quarantine dialog headlessly from this environment; worth confirming on the next release
- [ ] arm64 Ubuntu VM actually launching the new AppImage — same caveat, first real check is the next release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)