### PR TITLE
feat(WebEditor): default to OPFS local drafts on all browsers

### DIFF
--- a/docs/electron-desktop-app.md
+++ b/docs/electron-desktop-app.md
@@ -6,6 +6,8 @@ WasmPlayer runs the game engine inside the browser's WebAssembly sandbox. The WA
 
 Running a native .NET process locally and connecting to it from Electron's Chromium renderer gives full engine performance, while the UI (editor + player frontend) remains unchanged web technology.
 
+A second, independent motivation: an "upgrade path" for existing Quest 5 desktop users. That audience is used to a native Windows app and shouldn't be told "you now have to use a website" — a Quest Viva desktop app gives them a comparable thing to move to, regardless of whether it's WASM- or native-backed under the hood.
+
 ---
 
 ## Target architecture
@@ -240,13 +242,15 @@ Electron shell with WebEditor + ElectronFileAdapter. No LocalPlayer process.
 
 `src/ElectronApp/` — `main.ts` (window/lifecycle), `static-server.ts`, `preload.ts`, `ipc/{fs,dialog,shell}.ts`, `scripts/copy-static.mjs` (assembles `resources/app-static/{editor,AppBundle,player}` from the WebEditor/WasmEditor/WasmPlayer build outputs, mirroring `deploy-play.yml`'s `cp -r` steps). CI: `build_electron` job in `.github/workflows/build-and-test.yml`, modeled on `build_webeditor`.
 
-### Phase 2 — Native player backend
+### Phase 2 — Native player backend — deferred
 
 LocalPlayer project + backend lifecycle in Electron main process.
 
 - LocalPlayer spawns on a random port, Electron opens a player BrowserWindow
 - "Preview" in the editor saves the game then triggers `player.openGame(path)` via IPC
 - Player window navigates to `http://localhost:{port}/?game={path}`
+
+**Deferred 2026-07-15.** Nobody is complaining about WasmPlayer performance yet — unsurprising, since the app has no real usage yet, so there's no signal that the Release/AOT build's interpretation overhead is actually a felt problem rather than a theoretical one. Convenience/offline access and the Quest 5 upgrade path (see Motivation) are the load-bearing reasons for the app right now, and both are already delivered by Phase 1. Building LocalPlayer now would mean maintaining and testing a second player runtime (in addition to WasmPlayer, which the [long-term architecture direction](../CLAUDE.md) already commits to as the web player) against no concrete complaint. Revisit if a specific game or script pattern surfaces a real, felt performance problem — at that point Phase 2 can be picked up as originally scoped, nothing here blocks it.
 
 ### Phase 3 — Standalone game launcher
 

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -23,7 +23,14 @@
     // its Chromium supports showDirectoryPicker, but docs/electron-desktop-app.md
     // flags known parity bugs there (missing persistent permissions, broken
     // directory iteration). Checked once; doesn't change during the session.
-    const nativeFolder = isElectron() || hasFSA();
+    const isElectronApp = isElectron();
+    // FSA folder access (Open game folder / Save to folder) is offered as a
+    // secondary option on capable browsers — OPFS local drafts are the default
+    // everywhere else so trying the editor doesn't start with a "give this
+    // website access to a folder" prompt. See docs/electron-desktop-app.md's
+    // Motivation section and MEMORY project_electron_desktop_kickoff for why
+    // Electron itself stays folder-only rather than using OPFS.
+    const canUseFSA = !isElectronApp && hasFSA();
 
     let loading = $state(false);
     let error = $state<string | null>(null);
@@ -36,12 +43,12 @@
     let pendingZip = $state<ZipEntries | null>(null);
     let pendingFiles = $state<string[]>([]);
 
-    // Local drafts (OPFS, non-FSA/non-Electron browsers only)
+    // Local drafts (OPFS) — every non-Electron browser, regardless of FSA support.
     let drafts = $state<LocalDraftSummary[]>([]);
     const isSafari = typeof navigator !== "undefined" && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
     async function refreshDrafts() {
-        if (nativeFolder) return;
+        if (isElectronApp) return;
         drafts = (await listLocalDrafts()).sort((a, b) => b.lastModified - a.lastModified);
     }
     void refreshDrafts();
@@ -59,7 +66,7 @@
     $effect(() => {
         const params = page.url.searchParams;
         const nonce = params.get("t");
-        if (nativeFolder && params.get("action") === "open" && nonce !== handledOpenNonce) {
+        if (isElectronApp && params.get("action") === "open" && nonce !== handledOpenNonce) {
             handledOpenNonce = nonce ?? "";
             void handleOpenFolder();
         }
@@ -254,40 +261,65 @@
         await refreshDrafts();
     }
 
+    // Shared by both create paths below — validates the form and renders the
+    // template through WASM. Returns null (with createLocalError already set)
+    // if the form isn't ready yet.
+    async function buildNewGameFile(): Promise<{ filename: string; content: string } | null> {
+        const trimmed = createName.trim();
+        if (!trimmed) { createLocalError = "Please enter a game name."; return null; }
+        if (!selectedTemplateId) { createLocalError = "Please select a template."; return null; }
+        const bridge = await loadWasm();
+        const content = bridge.CreateGameFromTemplate(selectedTemplateId, trimmed);
+        return { filename: safeFilename(trimmed), content };
+    }
+
+    // Default create path: Electron → native folder (its only storage mode);
+    // every other browser → an OPFS local draft, regardless of FSA support,
+    // so trying the editor never opens with a folder-permission prompt.
     async function handleCreateLocal() {
         createLocalError = null;
-        const trimmed = createName.trim();
-        if (!trimmed) { createLocalError = "Please enter a game name."; return; }
-        if (!selectedTemplateId) { createLocalError = "Please select a template."; return; }
         creatingLocal = true;
         try {
-            const bridge = await loadWasm();
-            const content = bridge.CreateGameFromTemplate(selectedTemplateId, trimmed);
-            const filename = safeFilename(trimmed);
-            if (isElectron()) {
-                const result = await createElectronGame(filename, content);
+            const file = await buildNewGameFile();
+            if (!file) { creatingLocal = false; return; }
+            if (isElectronApp) {
+                const result = await createElectronGame(file.filename, file.content);
                 if (result) {
                     const ok = await openGame(result.bytes, result.adapter.filename, result.adapter);
                     if (ok) { goto(base || "/"); return; }
                     createLocalError = "Failed to load new game.";
                 }
-                // result === null: user cancelled the directory picker — do nothing
-            } else if (hasFSA()) {
-                const result = await createLocalGame(filename, content);
-                if (result) {
-                    const ok = await openGame(result.loaded.bytes, result.loaded.adapter.filename, result.loaded.adapter);
-                    if (ok) { goto(base || "/"); return; }
-                    createLocalError = "Failed to load new game.";
-                }
             // result === null: user cancelled the directory picker — do nothing
             } else {
-                const gameId = parseGameIdFromAslx(content);
+                const gameId = parseGameIdFromAslx(file.content);
                 if (!gameId) { createLocalError = "New game is missing a gameid."; creatingLocal = false; return; }
-                const adapter = await createLocalDraft(gameId, filename, content);
-                const ok = await openGame(new TextEncoder().encode(content), filename, adapter);
+                const adapter = await createLocalDraft(gameId, file.filename, file.content);
+                const ok = await openGame(new TextEncoder().encode(file.content), file.filename, adapter);
                 if (ok) { goto(base || "/"); return; }
                 createLocalError = "Failed to load new game.";
             }
+        } catch (err) {
+            createLocalError = String(err);
+        }
+        creatingLocal = false;
+    }
+
+    // Secondary create path, FSA-capable browsers only: saves straight to a
+    // folder on disk instead of an OPFS draft — offered alongside, not instead
+    // of, handleCreateLocal() (see canUseFSA).
+    async function handleCreateLocalFolder() {
+        createLocalError = null;
+        creatingLocal = true;
+        try {
+            const file = await buildNewGameFile();
+            if (!file) { creatingLocal = false; return; }
+            const result = await createLocalGame(file.filename, file.content);
+            if (result) {
+                const ok = await openGame(result.loaded.bytes, result.loaded.adapter.filename, result.loaded.adapter);
+                if (ok) { goto(base || "/"); return; }
+                createLocalError = "Failed to load new game.";
+            }
+        // result === null: user cancelled the directory picker — do nothing
         } catch (err) {
             createLocalError = String(err);
         }
@@ -343,7 +375,7 @@
                 <!-- Open existing game -->
                 <p class="text-surface-500-400 text-sm font-medium self-start">Open existing game</p>
 
-                {#if nativeFolder}
+                {#if isElectronApp}
                     <button type="button" class="btn preset-filled-primary-500 w-full" onclick={handleOpenFolder}>
                         Open game folder
                     </button>
@@ -351,9 +383,15 @@
                     <button type="button" class="btn preset-filled-primary-500 w-full" onclick={handleImportFile}>
                         Import game file
                     </button>
+                    {#if canUseFSA}
+                        <button type="button" class="btn preset-outlined-primary-500 w-full" onclick={handleOpenFolder}>
+                            Open game folder
+                        </button>
+                    {/if}
                     <p class="text-sm text-surface-500-400 max-w-[40ch] text-center">
                         Accepts a .aslx file or a .zip backed up from here. Imported games are stored in this
                         browser as a local draft — use <strong>Backup</strong> in the editor to save a copy to disk.
+                        {#if canUseFSA}Or open a folder on your computer to edit it there directly.{/if}
                     </p>
                 {/if}
 
@@ -361,7 +399,7 @@
                     <p class="text-error-500 text-sm">{error}</p>
                 {/if}
 
-                {#if !nativeFolder && drafts.length > 0}
+                {#if !isElectronApp && drafts.length > 0}
                     <hr class="w-full border-surface-300-700 my-2" />
                     <p class="text-surface-500-400 text-sm font-medium self-start">Your local drafts</p>
                     <div class="flex flex-col gap-2 w-full">
@@ -472,10 +510,21 @@
                                     class="btn preset-filled-primary-500 flex-1"
                                     onclick={handleCreateLocal}
                                     disabled={!createName.trim()}
-                                    title={nativeFolder ? "Choose a folder to save your game in" : "Save as a local draft in this browser"}
+                                    title={isElectronApp ? "Choose a folder to save your game in" : "Save as a local draft in this browser"}
                                 >
-                                    {nativeFolder ? "Save to my computer" : "Create local draft"}
+                                    {isElectronApp ? "Save to my computer" : "Create local draft"}
                                 </button>
+                                {#if canUseFSA}
+                                    <button
+                                        type="button"
+                                        class="btn preset-outlined-primary-500 flex-1"
+                                        onclick={handleCreateLocalFolder}
+                                        disabled={!createName.trim()}
+                                        title="Choose a folder on your computer to save your game in"
+                                    >
+                                        Save to folder…
+                                    </button>
+                                {/if}
                             {/if}
                         </div>
 

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -503,25 +503,33 @@
                                     Save to server
                                 </button>
                             {:else}
-                                <button
-                                    type="button"
-                                    class="btn preset-filled-primary-500 flex-1"
-                                    onclick={handleCreateLocal}
-                                    disabled={!createName.trim()}
-                                    title={isElectronApp ? "Choose a folder to save your game in" : "Save as a local draft in this browser"}
-                                >
-                                    {isElectronApp ? "Save to my computer" : "Create local draft"}
-                                </button>
-                                {#if canUseFSA}
+                                <div class="flex flex-col gap-1 flex-1">
                                     <button
                                         type="button"
-                                        class="btn preset-outlined-primary-500 flex-1"
-                                        onclick={handleCreateLocalFolder}
+                                        class="btn preset-filled-primary-500 w-full"
+                                        onclick={handleCreateLocal}
                                         disabled={!createName.trim()}
-                                        title="Choose a folder on your computer to save your game in"
+                                        title={isElectronApp ? "Choose a folder to save your game in" : "Save as a local draft in this browser"}
                                     >
-                                        Save to folder…
+                                        {isElectronApp ? "Save to my computer" : "Create local draft"}
                                     </button>
+                                    {#if !isElectronApp}
+                                        <p class="text-xs text-surface-500-400 text-center">Stored in this browser only</p>
+                                    {/if}
+                                </div>
+                                {#if canUseFSA}
+                                    <div class="flex flex-col gap-1 flex-1">
+                                        <button
+                                            type="button"
+                                            class="btn preset-outlined-primary-500 w-full"
+                                            onclick={handleCreateLocalFolder}
+                                            disabled={!createName.trim()}
+                                            title="Choose a folder on your computer to save your game in"
+                                        >
+                                            Save to folder…
+                                        </button>
+                                        <p class="text-xs text-surface-500-400 text-center">You'll choose a folder on this device</p>
+                                    </div>
                                 {/if}
                             {/if}
                         </div>

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -493,15 +493,18 @@
                     {:else}
                         <div class="flex gap-2">
                             {#if hasServer}
-                                <button
-                                    type="button"
-                                    class="btn preset-filled-primary-500 flex-1"
-                                    onclick={handleCreateServer}
-                                    disabled={!createName.trim()}
-                                    title="Save to textadventures.co.uk"
-                                >
-                                    Save to server
-                                </button>
+                                <div class="flex flex-col gap-1 flex-1">
+                                    <button
+                                        type="button"
+                                        class="btn preset-filled-primary-500 w-full"
+                                        onclick={handleCreateServer}
+                                        disabled={!createName.trim()}
+                                        title="Save to textadventures.co.uk"
+                                    >
+                                        Save to server
+                                    </button>
+                                    <p class="text-xs text-surface-500-400 text-center">Saved to your textadventures.co.uk account</p>
+                                </div>
                             {:else}
                                 <div class="flex flex-col gap-1 flex-1">
                                     <button

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -27,9 +27,7 @@
     // FSA folder access (Open game folder / Save to folder) is offered as a
     // secondary option on capable browsers — OPFS local drafts are the default
     // everywhere else so trying the editor doesn't start with a "give this
-    // website access to a folder" prompt. See docs/electron-desktop-app.md's
-    // Motivation section and MEMORY project_electron_desktop_kickoff for why
-    // Electron itself stays folder-only rather than using OPFS.
+    // website access to a folder" prompt.
     const canUseFSA = !isElectronApp && hasFSA();
 
     let loading = $state(false);

--- a/tests/e2e/verify-webeditor-opfs-default.mjs
+++ b/tests/e2e/verify-webeditor-opfs-default.mjs
@@ -23,6 +23,13 @@ async function run() {
     await page.waitForSelector('button:has-text("Save to folder…")', { timeout: 5000 });
     console.log('PASS: "Save to folder…" secondary FSA button is present');
 
+    // Each create button should have its own storage-location caption below
+    // it, so it's clear what "Create local draft" vs. "Save to folder…"
+    // actually means storage-wise, not just naming-wise.
+    await page.waitForSelector('text=Stored in this browser only', { timeout: 5000 });
+    await page.waitForSelector("text=You'll choose a folder on this device", { timeout: 5000 });
+    console.log('PASS: storage-location captions shown under each create button');
+
     // Primary open button should be "Import game file", with "Open game
     // folder" offered as a secondary option.
     await page.waitForSelector('button:has-text("Import game file")', { timeout: 5000 });

--- a/tests/e2e/verify-webeditor-opfs-default.mjs
+++ b/tests/e2e/verify-webeditor-opfs-default.mjs
@@ -1,0 +1,58 @@
+// Ad-hoc manual verification for the OPFS-default-storage change: on a
+// FSA-capable browser (Chromium), the /open page should now default to OPFS
+// local drafts (same as Firefox/Safari) and offer "Open game folder" /
+// "Save to folder…" as secondary FSA options, not the primary path.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+
+    // Primary create button should be the OPFS one, not the FSA one.
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    console.log('PASS: "Create local draft" is the primary create button on Chromium');
+
+    // Secondary FSA button should also be present, since this is a
+    // FSA-capable browser.
+    await page.waitForSelector('button:has-text("Save to folder…")', { timeout: 5000 });
+    console.log('PASS: "Save to folder…" secondary FSA button is present');
+
+    // Primary open button should be "Import game file", with "Open game
+    // folder" offered as a secondary option.
+    await page.waitForSelector('button:has-text("Import game file")', { timeout: 5000 });
+    await page.waitForSelector('button:has-text("Open game folder")', { timeout: 5000 });
+    console.log('PASS: "Import game file" (primary) and "Open game folder" (secondary) both present');
+
+    // Create a local draft via the default path and confirm it opens and
+    // then reappears in "Your local drafts" — proves the OPFS path still
+    // works end-to-end even though FSA is available in this browser.
+    await page.fill('input[placeholder="Game name"]', 'Chromium OPFS Default Test');
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor on Chromium');
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('text=Your local drafts', { timeout: 10000 });
+    const draftVisible = await page.isVisible('text=Chromium OPFS Default Test.aslx');
+    console.log('draft listed after reload:', draftVisible);
+    if (!draftVisible) throw new Error('Draft did not survive reload on Chromium');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/webeditor-chromium-opfs-default-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}

--- a/tests/e2e/verify-webeditor-server-mode-caption.mjs
+++ b/tests/e2e/verify-webeditor-server-mode-caption.mjs
@@ -1,0 +1,40 @@
+// Ad-hoc manual verification that the "Save to server" create button (only
+// shown when PUBLIC_HAS_SERVER=true, i.e. the textadventures.co.uk build)
+// gets the same storage-location caption as the OPFS/FSA buttons added in
+// the same change — "Saved to your textadventures.co.uk account".
+//
+// Requires a dev server started with PUBLIC_HAS_SERVER=true, e.g.:
+//   cd src/WebEditor && PUBLIC_HAS_SERVER=true npx vite dev --port 5199
+// (dev.sh's own --api-proxy flag also sets this, but needs a real
+// textadventures.co.uk backend to proxy to — not needed just to check this
+// caption renders, since it doesn't require the templates fetch to succeed.)
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5199';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Save to server")', { timeout: 15000 });
+    console.log('PASS: "Save to server" button present (PUBLIC_HAS_SERVER=true)');
+
+    const captionVisible = await page.isVisible('text=Saved to your textadventures.co.uk account');
+    console.log('PASS: storage-location caption shown under "Save to server":', captionVisible);
+    if (!captionVisible) throw new Error('Expected the server-mode caption to be visible');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/webeditor-server-mode-caption-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- OPFS local drafts are now the default open/create path for every non-Electron browser (not just non-FSA ones) — trying the editor on Chrome no longer starts with a folder-permission prompt. FSA folder access ("Open game folder" / "Save to folder…") is now offered as a secondary option on capable browsers instead of replacing the OPFS flow. Electron is unaffected.
- Every "Create new game" button now has a short caption below it clarifying where it actually stores the game: "Stored in this browser only" (OPFS), "You'll choose a folder on this device" (FSA), and "Saved to your textadventures.co.uk account" (server mode) — so the options read as different storage models, not just different labels. Mirrors the same instinct behind #1873's Electron new-game folder preview.
- Marks Electron desktop app Phase 2 (native LocalPlayer backend) as deferred in `docs/electron-desktop-app.md` — convenience/offline access and the Quest 5 upgrade path are the load-bearing reasons for the app right now, and Phase 1 already delivers both.
- First of three follow-up pieces on the editor's open/save flow; Electron gets a "Recent" list/menu and an easier new-game-creates-a-folder flow in later PRs.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run lint` — no new errors introduced (one pre-existing indent error in this file, unrelated to this change)
- [x] `tests/e2e/verify-webeditor-opfs-default.mjs` (Chromium): confirms "Create local draft"/"Import game file" are primary, "Save to folder…"/"Open game folder" appear as secondary FSA options, the storage-location captions render under each create button, and a draft created this way survives a reload
- [x] `tests/e2e/verify-webeditor-local-drafts.mjs` (existing, Firefox): confirms the non-FSA path is unchanged
- [x] `tests/e2e/verify-webeditor-server-mode-caption.mjs` (new, Chromium against a `PUBLIC_HAS_SERVER=true` dev server): confirms the server-mode caption renders under "Save to server"

🤖 Generated with [Claude Code](https://claude.com/claude-code)