### PR TITLE
fix: unbound LAUNCH_ARGS under macOS's default bash 3.2 in electron.sh

### DIFF
--- a/electron.sh
+++ b/electron.sh
@@ -63,6 +63,13 @@ echo ""
 # opens. Must be a real argv flag, not app.commandLine.appendSwitch() from
 # main.ts — Chromium's zygote/sandbox-host check runs during native startup,
 # before Electron loads and executes the app's JS at all.
-LAUNCH_ARGS=()
-[[ "$(uname -s)" == "Linux" ]] && LAUNCH_ARGS+=(--no-sandbox)
-(cd src/ElectronApp && npx electron . "${LAUNCH_ARGS[@]}")
+#
+# Branching instead of an empty LAUNCH_ARGS=() array expanded via
+# "${LAUNCH_ARGS[@]}" — macOS ships bash 3.2 by default (last GPLv2 release),
+# which treats that expansion as an unbound variable under `set -u` when the
+# array is empty; bash 4.4+ (Linux, homebrew bash) doesn't have this quirk.
+if [[ "$(uname -s)" == "Linux" ]]; then
+    (cd src/ElectronApp && npx electron . --no-sandbox)
+else
+    (cd src/ElectronApp && npx electron .)
+fi


### PR DESCRIPTION
## Summary
`electron.sh` fails on plain macOS with `./electron.sh: line 68: LAUNCH_ARGS[@]: unbound variable`. Pre-existing since #1868 (native menu bar) — `set -u` treats `"${LAUNCH_ARGS[@]}"` as unbound when the array is empty, which is exactly the macOS case (the array is only ever populated on Linux for `--no-sandbox`). Bash 3.2 (macOS's shipped default, last GPLv2 release, so it never got upgraded) has this quirk; bash 4.4+ (Linux, homebrew bash) doesn't. Not something introduced by #1871 — just surfaced while testing it.

Fix: branch on platform instead of building an args array.

## Test plan
- [x] `bash -n electron.sh`
- [x] Ran `./electron.sh` end to end on this (macOS, bash 3.2.57) machine — builds and launches the app with no error, `ps` confirms the Electron process starts with plain `.` argv (no bogus `--no-sandbox`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)