### PR TITLE
chore(WebEditor): fix ESLint backlog and add lint to CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,6 +62,32 @@ jobs:
           PUBLIC_WEBEDITOR_VERSION: ${{ github.sha }}
           BASE_PATH: /editor
 
+  lint_webeditor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: src/WebEditor/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: src/WebEditor
+
+      - name: Lint
+        run: npm run lint
+        working-directory: src/WebEditor
+
+      - name: Type check
+        run: npm run check
+        working-directory: src/WebEditor
+
   build_electron:
     runs-on: ubuntu-latest
 

--- a/src/WebEditor/eslint.config.mjs
+++ b/src/WebEditor/eslint.config.mjs
@@ -31,6 +31,15 @@ export default defineConfig([
     },
     ...sveltePlugin.configs.recommended,
     {
+        // svelte/indent (below) supersedes the base indent rule inside .svelte
+        // files — both firing at once fight over the same lines (e.g. switch/case)
+        // and neither's --fix converges.
+        files: ["**/*.svelte"],
+        rules: {
+            indent: "off",
+        },
+    },
+    {
         files: ["**/*.svelte", "**/*.ts"],
         languageOptions: {
             globals: globals.browser,

--- a/src/WebEditor/src/components/AddScriptModal.svelte
+++ b/src/WebEditor/src/components/AddScriptModal.svelte
@@ -72,7 +72,6 @@
     }
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
     bind:this={dialogEl}
     role="dialog"

--- a/src/WebEditor/src/components/AddScriptModal.svelte
+++ b/src/WebEditor/src/components/AddScriptModal.svelte
@@ -119,8 +119,8 @@
                         onclick={() => { selectedCategoryIndex = ci; }}
                         class="w-full text-left px-4 py-2.5 text-sm transition-colors {
                             selectedCategoryIndex === ci
-                                ? 'font-semibold text-primary-600-400 bg-primary-100 dark:bg-primary-900/40'
-                                : 'text-surface-700-300 hover:bg-surface-100-900'
+                                ? "font-semibold text-primary-600-400 bg-primary-100 dark:bg-primary-900/40"
+                                : "text-surface-700-300 hover:bg-surface-100-900"
                         }"
                     >{cat.name}</button>
                 {/each}
@@ -137,11 +137,11 @@
                             ondblclick={() => { selectedCommand = cmd; onOk(); }}
                             class="w-full text-left px-5 py-2 text-sm flex items-center gap-3 transition-colors {
                                 isSelected
-                                    ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300 font-medium'
-                                    : 'text-surface-700-300 hover:bg-surface-100-900'
+                                    ? "bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300 font-medium"
+                                    : "text-surface-700-300 hover:bg-surface-100-900"
                             }"
                         >
-                            <span class="w-4 flex-shrink-0 text-primary-500 {isSelected ? 'opacity-100' : 'opacity-0'}">●</span>
+                            <span class="w-4 flex-shrink-0 text-primary-500 {isSelected ? "opacity-100" : "opacity-0"}">●</span>
                             {cmd.add}
                         </button>
                     {/each}

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -334,14 +334,14 @@
                             <tr
                                 class="border-b border-surface-100-900 cursor-pointer outline-none
                                     focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500
-                                    {isSelected ? 'bg-primary-100-900' : 'hover:bg-surface-100-900'}
-                                    {dimmed ? 'text-surface-400-500' : ''}"
+                                    {isSelected ? "bg-primary-100-900" : "hover:bg-surface-100-900"}
+                                    {dimmed ? "text-surface-400-500" : ""}"
                                 tabindex={isSelected ? 0 : -1}
                                 data-attr={attr.name}
                                 onclick={() => onSelectAttribute(attr)}
                                 onkeydown={(e) => onAttrRowKeydown(e, attr)}
                             >
-                                <td class="py-0.5 px-3 truncate max-w-36 {!dimmed ? 'font-medium' : ''}" title={attr.name}>{attr.name}</td>
+                                <td class="py-0.5 px-3 truncate max-w-36 {!dimmed ? "font-medium" : ""}" title={attr.name}>{attr.name}</td>
                                 <td class="py-0.5 px-3 max-w-40 truncate" title={attr.value ?? ""}>{displayValue(attr)}</td>
                                 <td class="py-0.5 px-3 text-surface-400-500 truncate" title={attr.source}>{attr.source}</td>
                                 <td class="py-0.5 pr-2 text-right">

--- a/src/WebEditor/src/components/AttributesEditor.svelte
+++ b/src/WebEditor/src/components/AttributesEditor.svelte
@@ -243,9 +243,6 @@
         return attr.value;
     }
 
-    function typeLabel(type: string): string {
-        return TYPE_OPTIONS.find(o => o.value === type)?.label ?? type;
-    }
 </script>
 
 <div class="flex flex-col flex-1 min-h-0 text-xs">
@@ -263,7 +260,7 @@
                 </tr>
             </thead>
             <tbody>
-                {#each $fullAttributeData?.inheritedTypes ?? [] as t}
+                {#each $fullAttributeData?.inheritedTypes ?? [] as t (t.name)}
                     <tr class="border-b border-surface-100-900">
                         <td class="py-0.5 px-3">{t.name}</td>
                         <td class="py-0.5 px-3 text-surface-400-500">{t.source}</td>
@@ -291,7 +288,7 @@
                                 bind:value={addTypeValue}
                             >
                                 <option value="">Add type…</option>
-                                {#each availableTypes() as t}
+                                {#each availableTypes() as t (t)}
                                     <option value={t}>{t}</option>
                                 {/each}
                             </select>
@@ -328,7 +325,7 @@
                         </tr>
                     </thead>
                     <tbody bind:this={attrTbodyEl}>
-                        {#each $fullAttributeData?.attributes ?? [] as attr}
+                        {#each $fullAttributeData?.attributes ?? [] as attr (attr.name)}
                             {@const dimmed = attr.isInherited || attr.isDefaultType}
                             {@const isSelected = selectedAttrName === attr.name}
                             <tr
@@ -395,7 +392,7 @@
                             onchange={(e) => onChangeType((e.target as HTMLSelectElement).value)}
                             disabled={attr.isDefaultType}
                         >
-                            {#each TYPE_OPTIONS as opt}
+                            {#each TYPE_OPTIONS as opt (opt.value)}
                                 <option value={opt.value}>{opt.label}</option>
                             {/each}
                         </select>
@@ -441,7 +438,7 @@
                                 disabled={attr.isDefaultType}
                                 onchange={(e) => onObjectChange((e.target as HTMLSelectElement).value)}
                             >
-                                {#each objectNames as name}
+                                {#each objectNames as name (name)}
                                     <option value={name}>{name}</option>
                                 {/each}
                             </select>

--- a/src/WebEditor/src/components/Combobox.svelte
+++ b/src/WebEditor/src/components/Combobox.svelte
@@ -22,7 +22,7 @@
 
     // Reset highlight when filtered list changes
     $effect(() => {
-        filtered; // track
+        void filtered; // track
         activeIndex = -1;
     });
 

--- a/src/WebEditor/src/components/Combobox.svelte
+++ b/src/WebEditor/src/components/Combobox.svelte
@@ -39,7 +39,7 @@
             ? options
             : options.filter(o =>
                 o.label.toLowerCase().includes(inputValue.toLowerCase()) ||
-                o.value.toLowerCase().includes(inputValue.toLowerCase())
+                    o.value.toLowerCase().includes(inputValue.toLowerCase())
             )
     );
 
@@ -131,7 +131,7 @@
                     role="option"
                     tabindex="-1"
                     aria-selected={opt.value === value}
-                    class="px-2 py-1 text-xs cursor-pointer {i === activeIndex ? 'bg-primary-100 dark:bg-primary-900' : 'hover:bg-surface-100-900'} {opt.value === value ? 'font-medium' : ''}"
+                    class="px-2 py-1 text-xs cursor-pointer {i === activeIndex ? "bg-primary-100 dark:bg-primary-900" : "hover:bg-surface-100-900"} {opt.value === value ? "font-medium" : ""}"
                     onmousedown={(e) => { e.preventDefault(); select(opt.value); }}
                     onmouseenter={() => { activeIndex = i; }}
                 >

--- a/src/WebEditor/src/components/ElementsList.svelte
+++ b/src/WebEditor/src/components/ElementsList.svelte
@@ -28,7 +28,7 @@
     let items = $derived(
         $treeNodes.filter(n =>
             nodeTypes.includes(n.nodeType) &&
-            (showAll || n.parent === elementKey)
+                (showAll || n.parent === elementKey)
         )
     );
 
@@ -54,17 +54,17 @@
 
     let addLabel = $derived(
         nodeTypes.includes("function") ? "Add Function" :
-        nodeTypes.includes("timer") ? "Add Timer" :
-        nodeTypes.includes("verb") ? "Add Verb" :
-        nodeTypes.includes("command") ? "Add Command" :
-        nodeTypes.includes("walkthrough") ? "Add Walkthrough" :
-        nodeTypes.includes("template") ? "Add Template" :
-        nodeTypes.includes("dynamictemplate") ? "Add Dynamic Template" :
-        nodeTypes.includes("type") ? "Add Type" :
-        nodeTypes.includes("include") ? "Add Library" :
-        nodeTypes.includes("javascript") ? "Add JavaScript" :
-        isObjectList ? "Add Object" :
-        null
+            nodeTypes.includes("timer") ? "Add Timer" :
+                nodeTypes.includes("verb") ? "Add Verb" :
+                nodeTypes.includes("command") ? "Add Command" :
+                nodeTypes.includes("walkthrough") ? "Add Walkthrough" :
+                nodeTypes.includes("template") ? "Add Template" :
+                nodeTypes.includes("dynamictemplate") ? "Add Dynamic Template" :
+                nodeTypes.includes("type") ? "Add Type" :
+                nodeTypes.includes("include") ? "Add Library" :
+                nodeTypes.includes("javascript") ? "Add JavaScript" :
+                isObjectList ? "Add Object" :
+                null
     );
 
     function addPrimary() {
@@ -131,11 +131,11 @@
     <!-- Add toolbar -->
     <div class="flex items-center gap-1 mb-2">
         {#if addLabel !== null}
-        <button
-            type="button"
-            class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-            onclick={addPrimary}
-        >+ {addLabel}</button>
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                onclick={addPrimary}
+            >+ {addLabel}</button>
         {/if}
         {#if showRoomButton}
             <button

--- a/src/WebEditor/src/components/ElementsList.svelte
+++ b/src/WebEditor/src/components/ElementsList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { SvelteSet } from "svelte/reactivity";
     import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createIncludedLibrary, createJavascript, swapElements } from "$lib/editor-store";
 
     interface Props {
@@ -34,7 +35,7 @@
 
     // ── Selection ──────────────────────────────────────────────────────────────
 
-    let selectedKeys = $state(new Set<string>());
+    const selectedKeys = new SvelteSet<string>();
 
     // Derive selection in item-list order, excluding any stale keys (deleted items)
     let activeSelection = $derived(
@@ -42,9 +43,7 @@
     );
 
     function toggleSelect(key: string, checked: boolean) {
-        const next = new Set(selectedKeys);
-        if (checked) next.add(key); else next.delete(key);
-        selectedKeys = next;
+        if (checked) selectedKeys.add(key); else selectedKeys.delete(key);
     }
 
     // ── Add actions ────────────────────────────────────────────────────────────
@@ -115,15 +114,13 @@
             if ($selectedKey === key) selectNode(elementKey);
             deleteElement(key);
         }
-        selectedKeys = new Set();
+        selectedKeys.clear();
     }
 
     function onDeleteItem(key: string) {
         if ($selectedKey === key) selectNode(elementKey);
         deleteElement(key);
-        const next = new Set(selectedKeys);
-        next.delete(key);
-        selectedKeys = next;
+        selectedKeys.delete(key);
     }
 </script>
 

--- a/src/WebEditor/src/components/ListEditor.svelte
+++ b/src/WebEditor/src/components/ListEditor.svelte
@@ -51,7 +51,7 @@
                 <button
                     type="button"
                     class="text-xs flex-1 text-left px-1.5 py-0.5 hover:text-primary-600-400"
-                    onclick={() => { editingItem = {key: item.key, value: item.value}; }}
+                    onclick={() => { editingItem = { key: item.key, value: item.value }; }}
                 >{item.value}</button>
             {/if}
             <button

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -132,7 +132,7 @@
 
 {#snippet textProcessorPanel(commands: TextProcessorCommand[], attribute: string, controlType: string)}
     <div class="flex flex-col gap-0.5 shrink-0">
-        {#each commands as cmd}
+        {#each commands as cmd (cmd.command)}
             <div class="flex items-center gap-1">
                 <button
                     type="button"

--- a/src/WebEditor/src/components/PropertyEditor.svelte
+++ b/src/WebEditor/src/components/PropertyEditor.svelte
@@ -63,8 +63,8 @@
     }
 
     function insertTextProcessorText(attribute: string, controlType: string, insertBefore: string, insertAfter: string, event: MouseEvent) {
-        const wrapper = (event.target as HTMLElement).closest('.richtext-wrap');
-        const textarea = wrapper?.querySelector('textarea') as HTMLTextAreaElement | null;
+        const wrapper = (event.target as HTMLElement).closest(".richtext-wrap");
+        const textarea = wrapper?.querySelector("textarea") as HTMLTextAreaElement | null;
         if (!textarea) return;
         const start = textarea.selectionStart ?? 0;
         const end = textarea.selectionEnd ?? 0;
@@ -226,7 +226,7 @@
     {:else if ctrl.controlType === "list" && ctrl.attribute && $selectedKey}
         <ListEditor elementKey={$selectedKey} attribute={ctrl.attribute} value={attrValue(ctrl.attribute)} addPrompt={ctrl.addPrompt ?? undefined} />
     {:else if ctrl.controlType === "stringdictionary" && ctrl.attribute}
-        {@const items = (() => { try { return JSON.parse(attrValue(ctrl.attribute) ?? "[]") as {key: string, value: string}[] } catch { return [] } })()}
+        {@const items = (() => { try { return JSON.parse(attrValue(ctrl.attribute) ?? "[]") as {key: string, value: string}[]; } catch { return []; } })()}
         {@const dk = ctrl.attribute}
         <div class="flex flex-col gap-1 w-full">
             {#each items as item (item.key)}
@@ -259,7 +259,7 @@
                         <button
                             type="button"
                             class="text-xs flex-1 text-left px-1.5 py-0.5 hover:text-primary-600-400 truncate"
-                            onclick={() => { editingItem = {attribute: dk, key: item.key, value: item.value}; }}
+                            onclick={() => { editingItem = { attribute: dk, key: item.key, value: item.value }; }}
                         >{item.value}</button>
                     {/if}
                     <button
@@ -275,18 +275,18 @@
                     class="input text-xs py-0.5 px-1.5 w-24 flex-shrink-0"
                     placeholder={ctrl.caption ? "Key" : "Key"}
                     value={newDictItems[dk]?.key ?? ""}
-                    oninput={(e) => { newDictItems[dk] = {...(newDictItems[dk] ?? {key: "", value: ""}), key: (e.target as HTMLInputElement).value}; }}
+                    oninput={(e) => { newDictItems[dk] = { ...(newDictItems[dk] ?? { key: "", value: "" }), key: (e.target as HTMLInputElement).value }; }}
                 />
                 <input
                     type="text"
                     class="input text-xs py-0.5 px-1.5 flex-1"
                     placeholder="Value"
                     value={newDictItems[dk]?.value ?? ""}
-                    oninput={(e) => { newDictItems[dk] = {...(newDictItems[dk] ?? {key: "", value: ""}), value: (e.target as HTMLInputElement).value}; }}
+                    oninput={(e) => { newDictItems[dk] = { ...(newDictItems[dk] ?? { key: "", value: "" }), value: (e.target as HTMLInputElement).value }; }}
                     onkeydown={(e) => {
                         if (e.key === "Enter" && $selectedKey && newDictItems[dk]?.key?.trim()) {
                             addDictItem($selectedKey, dk, newDictItems[dk].key.trim(), newDictItems[dk].value ?? "");
-                            newDictItems[dk] = {key: "", value: ""};
+                            newDictItems[dk] = { key: "", value: "" };
                         }
                     }}
                 />
@@ -296,7 +296,7 @@
                     onclick={() => {
                         if ($selectedKey && newDictItems[dk]?.key?.trim()) {
                             addDictItem($selectedKey, dk, newDictItems[dk].key.trim(), newDictItems[dk].value ?? "");
-                            newDictItems[dk] = {key: "", value: ""};
+                            newDictItems[dk] = { key: "", value: "" };
                         }
                     }}
                 >Add</button>
@@ -451,8 +451,8 @@
                     {@render controlOnly(ctrl)}
                 </div>
             {:else}
-                <div class="flex {isMultiline ? 'items-start' : 'items-center'} gap-2 px-3 py-1.5 min-h-8">
-                    <span class="text-xs text-surface-600-400 w-32 flex-shrink-0 {isMultiline ? 'pt-0.5' : ''}">{label}:</span>
+                <div class="flex {isMultiline ? "items-start" : "items-center"} gap-2 px-3 py-1.5 min-h-8">
+                    <span class="text-xs text-surface-600-400 w-32 flex-shrink-0 {isMultiline ? "pt-0.5" : ""}">{label}:</span>
                     {@render controlOnly(ctrl)}
                 </div>
             {/if}

--- a/src/WebEditor/src/components/ScriptDictionaryEditor.svelte
+++ b/src/WebEditor/src/components/ScriptDictionaryEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { SvelteSet } from "svelte/reactivity";
     import { addScriptDictItem, removeScriptDictItem, makeScriptDictEditable } from "$lib/editor-store";
     import ScriptEditor from "./ScriptEditor.svelte";
 
@@ -19,22 +20,20 @@
 
     let keys = $derived(items.map(i => i.key));
 
-    let expandedKeys = $state(new Set<string>());
+    const expandedKeys = new SvelteSet<string>();
     let newKey = $state("");
 
     function onAdd() {
         const k = newKey.trim();
         if (k) {
             const result = addScriptDictItem(elementKey, attribute, k);
-            if (result === "ok") expandedKeys = new Set([...expandedKeys, k]);
+            if (result === "ok") expandedKeys.add(k);
             newKey = "";
         }
     }
 
     function toggleExpanded(key: string) {
-        const next = new Set(expandedKeys);
-        if (next.has(key)) next.delete(key); else next.add(key);
-        expandedKeys = next;
+        if (expandedKeys.has(key)) expandedKeys.delete(key); else expandedKeys.add(key);
     }
 </script>
 

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { SvelteSet } from "svelte/reactivity";
     import ScriptEditor from "./ScriptEditor.svelte";
     import AddScriptModal from "./AddScriptModal.svelte";
     import AssetPicker from "./AssetPicker.svelte";
@@ -62,12 +63,12 @@
     let isRoot = $derived(initialData === null);
     let codeViewMode = $state(false);
     let scriptCode = $state("");
-    let selectedIndices = $state(new Set<number>());
+    const selectedIndices = new SvelteSet<number>();
     // Set before a move mutation so the $effect restores it instead of clearing
     let nextSelection: Set<number> | null = null;
     // Tracks which expression controls the user has explicitly forced into expression mode,
     // overriding the default simple-mode detection based on value shape.
-    let expressionOverrides = $state(new Set<string>());
+    const expressionOverrides = new SvelteSet<string>();
     let objectNames = $state<string[]>([]);
     let ifTemplates = $state<IfExpressionTemplate[]>([]);
 
@@ -76,7 +77,8 @@
         const version = $scriptVersion; // track for reactivity on undo/redo
         if (isRoot) {
             scriptData = version >= 0 ? getScriptData(elementKey, attribute) : null;
-            selectedIndices = nextSelection ?? new Set();
+            selectedIndices.clear();
+            for (const i of nextSelection ?? []) selectedIndices.add(i);
             nextSelection = null;
         }
         if (categories.length === 0) {
@@ -103,7 +105,7 @@
         if (isRoot) {
             scriptData = getScriptData(elementKey, attribute);
         }
-        expressionOverrides = new Set();
+        expressionOverrides.clear();
     }
 
     function mutate(fn: () => string): boolean {
@@ -175,13 +177,11 @@
     }
 
     function setExpressionOverride(scriptIndex: number, attr: string) {
-        expressionOverrides = new Set(expressionOverrides).add(exprKey(scriptIndex, attr));
+        expressionOverrides.add(exprKey(scriptIndex, attr));
     }
 
     function clearExpressionOverride(scriptIndex: number, attr: string) {
-        const next = new Set(expressionOverrides);
-        next.delete(exprKey(scriptIndex, attr));
-        expressionOverrides = next;
+        expressionOverrides.delete(exprKey(scriptIndex, attr));
     }
 
     function onSwitchToExpression(scriptIndex: number, ctrl: ScriptControlData) {
@@ -240,9 +240,7 @@
     }
 
     function toggleSelection(i: number, checked: boolean) {
-        const next = new Set(selectedIndices);
-        if (checked) next.add(i); else next.delete(i);
-        selectedIndices = next;
+        if (checked) selectedIndices.add(i); else selectedIndices.delete(i);
     }
 
     function onCopySelected() {
@@ -368,7 +366,6 @@
             onchange={(e) => onCodeViewSave((e.target as HTMLTextAreaElement).value)}
         ></textarea>
     {:else}
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <div role="region" inert={isLocked || undefined} class={isLocked ? "opacity-60" : ""}>
             {#each scripts() as script, i (script.id)}
                 <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-start">
@@ -672,11 +669,9 @@
                     onchange={(e) => {
                         const v = (e.target as HTMLSelectElement).value;
                         if (v === "expression") {
-                            expressionOverrides = new Set(expressionOverrides).add(exprKey);
+                            expressionOverrides.add(exprKey);
                         } else {
-                            const next = new Set(expressionOverrides);
-                            next.delete(exprKey);
-                            expressionOverrides = next;
+                            expressionOverrides.delete(exprKey);
                             const tpl = ifTemplates.find(t => t.name === v);
                             if (tpl) onSetIfExpr(i, tpl.createExpression);
                         }
@@ -754,11 +749,9 @@
                         onchange={(e) => {
                             const v = (e.target as HTMLSelectElement).value;
                             if (v === "expression") {
-                                expressionOverrides = new Set(expressionOverrides).add(eiExprKey);
+                                expressionOverrides.add(eiExprKey);
                             } else {
-                                const next = new Set(expressionOverrides);
-                                next.delete(eiExprKey);
-                                expressionOverrides = next;
+                                expressionOverrides.delete(eiExprKey);
                                 const tpl = ifTemplates.find(t => t.name === v);
                                 if (tpl) onSetElseIfExpr(i, ei, tpl.createExpression);
                             }

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -244,13 +244,13 @@
     }
 
     function onCopySelected() {
+        // no scriptVersion bump — selection intentionally preserved after copy
         copyScripts(elementKey, attribute, containerPath, sortedSelection());
-    // no scriptVersion bump — selection intentionally preserved after copy
     }
 
     function onCutSelected() {
+        // selectedIndices cleared by $effect when scriptVersion bumps
         cutScripts(elementKey, attribute, containerPath, sortedSelection());
-    // selectedIndices cleared by $effect when scriptVersion bumps
     }
 
     function onDeleteSelected() {

--- a/src/WebEditor/src/components/ScriptEditor.svelte
+++ b/src/WebEditor/src/components/ScriptEditor.svelte
@@ -122,16 +122,16 @@
     }
 
     function isSimpleValue(ctrl: ScriptControlData): boolean {
-        const v = ctrl.value ?? '';
+        const v = ctrl.value ?? "";
         switch (ctrl.simpleEditor) {
-            case 'boolean':
-                return v === 'true' || v === 'false';
-            case 'number':
-            case 'numberdouble':
-                return v !== '' && Number.isFinite(Number(v));
-            case 'objects':
+            case "boolean":
+                return v === "true" || v === "false";
+            case "number":
+            case "numberdouble":
+                return v !== "" && Number.isFinite(Number(v));
+            case "objects":
                 // Bare identifier (object name) or empty — not a complex expression
-                return v === '' || /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(v);
+                return v === "" || /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(v);
             default:
                 // textbox, dropdown, file: simple when value is a quoted string literal
                 return v.length >= 2 && v.startsWith('"') && v.endsWith('"');
@@ -146,29 +146,29 @@
     }
 
     function toSimpleDisplay(ctrl: ScriptControlData): string {
-        const v = ctrl.value ?? '';
+        const v = ctrl.value ?? "";
         switch (ctrl.simpleEditor) {
-            case 'boolean':
-            case 'number':
-            case 'numberdouble':
-            case 'objects':
+            case "boolean":
+            case "number":
+            case "numberdouble":
+            case "objects":
                 return v;
             default: {
-                if (v.length < 2) return '';
-                return v.slice(1, -1).replace(/<br\/>/g, '\n').replace(/\\"/g, '"');
+                if (v.length < 2) return "";
+                return v.slice(1, -1).replace(/<br\/>/g, "\n").replace(/\\"/g, '"');
             }
         }
     }
 
     function fromSimpleToExpression(simpleValue: string, simpleEditor: string): string {
         switch (simpleEditor) {
-            case 'boolean':
-            case 'number':
-            case 'numberdouble':
-            case 'objects':
+            case "boolean":
+            case "number":
+            case "numberdouble":
+            case "objects":
                 return simpleValue;
             default: {
-                const escaped = simpleValue.replace(/"/g, '\\"').replace(/\n/g, '<br/>');
+                const escaped = simpleValue.replace(/"/g, '\\"').replace(/\n/g, "<br/>");
                 return `"${escaped}"`;
             }
         }
@@ -193,12 +193,12 @@
         // If the current value is not a valid simple value, reset to a default simple value
         if (!isSimpleValue(ctrl)) {
             switch (ctrl.simpleEditor) {
-                case 'boolean':
-                    onSetParam(scriptIndex, ctrl.attribute!, 'true');
+                case "boolean":
+                    onSetParam(scriptIndex, ctrl.attribute!, "true");
                     break;
-                case 'number':
-                case 'numberdouble':
-                    onSetParam(scriptIndex, ctrl.attribute!, '0');
+                case "number":
+                case "numberdouble":
+                    onSetParam(scriptIndex, ctrl.attribute!, "0");
                     break;
                 default:
                     onSetParam(scriptIndex, ctrl.attribute!, '""');
@@ -213,7 +213,7 @@
     function buildTemplateExpression(tmpl: IfExpressionTemplateData, changedName: string, changedValue: string): string {
         let result = tmpl.originalPattern;
         for (const ctrl of tmpl.controls) {
-            const value = ctrl.name === changedName ? changedValue : (ctrl.value ?? '');
+            const value = ctrl.name === changedName ? changedValue : (ctrl.value ?? "");
             result = result.replace(`#${ctrl.name}#`, value);
         }
         return result;
@@ -247,12 +247,12 @@
 
     function onCopySelected() {
         copyScripts(elementKey, attribute, containerPath, sortedSelection());
-        // no scriptVersion bump — selection intentionally preserved after copy
+    // no scriptVersion bump — selection intentionally preserved after copy
     }
 
     function onCutSelected() {
         cutScripts(elementKey, attribute, containerPath, sortedSelection());
-        // selectedIndices cleared by $effect when scriptVersion bumps
+    // selectedIndices cleared by $effect when scriptVersion bumps
     }
 
     function onDeleteSelected() {

--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -14,7 +14,7 @@
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
 
-    const wasmPlayerUrl = PUBLIC_WASM_PLAYER_URL || '/player/';
+    const wasmPlayerUrl = PUBLIC_WASM_PLAYER_URL || "/player/";
 
     let saving = $state(false);
 
@@ -92,62 +92,62 @@
 </script>
 
 <AppBar>
-        <AppBar.Toolbar class="grid-cols-[auto_1fr_auto]">
-            <AppBar.Lead>
-                <span class="font-semibold">Quest Viva Editor</span>
-                {#if PUBLIC_WEBEDITOR_VERSION}
-                    <span class="ml-2 text-xs text-surface-500-400">{PUBLIC_WEBEDITOR_VERSION}</span>
-                {/if}
-                {#if $gameFilename}
-                    <span class="ml-3 text-sm text-surface-500-400">{$gameFilename}{#if $isDirty} *{/if}</span>
-                {/if}
-            </AppBar.Lead>
-            <AppBar.Trail>
-                <div class="flex gap-2 items-center">
-                    <!-- Add dropdown -->
-                    <div class="add-dropdown relative">
-                        <button
-                            type="button"
-                            class="btn btn-sm preset-outlined-primary-500"
-                            onclick={toggleAdd}
-                            title="Add element"
-                        >+ Add ▾</button>
-                        {#if addOpen}
-                            <div class="absolute right-0 top-full z-[999] mt-1 w-56 bg-surface-50-950 border border-surface-200-800 rounded shadow-lg py-1">
-                                {#each addOptions as opt (opt.label)}
-                                    <button
-                                        class="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-200-800"
-                                        onclick={() => doAdd(opt.action)}
-                                    >{opt.label}</button>
-                                {/each}
-                            </div>
-                        {/if}
-                    </div>
-                    <!-- Delete button -->
-                    {#if canDelete}
-                        <button
-                            type="button"
-                            class="btn btn-sm preset-outlined-error-500"
-                            onclick={() => deleteElement(selectedNode!.key)}
-                            title={"Delete " + (selectedNode?.text ?? "")}
-                        >Delete</button>
-                    {/if}
-                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => assetManagerOpen.set(true)} title="Manage assets">🖼 Assets</button>
-                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
-                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
-                    <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleSave} disabled={saving} title="Save">💾 Save</button>
-                    {#if $canSaveAs}
-                        <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleSaveAs} disabled={saving} title="Save As">Save As…</button>
-                    {/if}
-                    {#if $canBackup}
-                        <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleBackup} disabled={saving} title="Download a .zip copy of this game and its assets">Backup…</button>
-                    {/if}
-                    {#if $gameFilename}
-                        <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => publishModalOpen.set(true)} title="Build a .quest package for distribution">Publish…</button>
-                        <button type="button" class="btn btn-sm preset-outlined-secondary-500" onclick={handlePreview} title="Preview game">▶ Preview</button>
+    <AppBar.Toolbar class="grid-cols-[auto_1fr_auto]">
+        <AppBar.Lead>
+            <span class="font-semibold">Quest Viva Editor</span>
+            {#if PUBLIC_WEBEDITOR_VERSION}
+                <span class="ml-2 text-xs text-surface-500-400">{PUBLIC_WEBEDITOR_VERSION}</span>
+            {/if}
+            {#if $gameFilename}
+                <span class="ml-3 text-sm text-surface-500-400">{$gameFilename}{#if $isDirty} *{/if}</span>
+            {/if}
+        </AppBar.Lead>
+        <AppBar.Trail>
+            <div class="flex gap-2 items-center">
+                <!-- Add dropdown -->
+                <div class="add-dropdown relative">
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-primary-500"
+                        onclick={toggleAdd}
+                        title="Add element"
+                    >+ Add ▾</button>
+                    {#if addOpen}
+                        <div class="absolute right-0 top-full z-[999] mt-1 w-56 bg-surface-50-950 border border-surface-200-800 rounded shadow-lg py-1">
+                            {#each addOptions as opt (opt.label)}
+                                <button
+                                    class="w-full text-left px-3 py-1.5 text-xs hover:bg-surface-200-800"
+                                    onclick={() => doAdd(opt.action)}
+                                >{opt.label}</button>
+                            {/each}
+                        </div>
                     {/if}
                 </div>
-            </AppBar.Trail>
-        </AppBar.Toolbar>
-    </AppBar>
+                <!-- Delete button -->
+                {#if canDelete}
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-error-500"
+                        onclick={() => deleteElement(selectedNode!.key)}
+                        title={"Delete " + (selectedNode?.text ?? "")}
+                    >Delete</button>
+                {/if}
+                <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => assetManagerOpen.set(true)} title="Manage assets">🖼 Assets</button>
+                <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
+                <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
+                <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleSave} disabled={saving} title="Save">💾 Save</button>
+                {#if $canSaveAs}
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleSaveAs} disabled={saving} title="Save As">Save As…</button>
+                {/if}
+                {#if $canBackup}
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleBackup} disabled={saving} title="Download a .zip copy of this game and its assets">Backup…</button>
+                {/if}
+                {#if $gameFilename}
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => publishModalOpen.set(true)} title="Build a .quest package for distribution">Publish…</button>
+                    <button type="button" class="btn btn-sm preset-outlined-secondary-500" onclick={handlePreview} title="Preview game">▶ Preview</button>
+                {/if}
+            </div>
+        </AppBar.Trail>
+    </AppBar.Toolbar>
+</AppBar>
 

--- a/src/WebEditor/src/components/TreePanel.svelte
+++ b/src/WebEditor/src/components/TreePanel.svelte
@@ -236,9 +236,9 @@
                     <button
                         type="button"
                         tabindex="-1"
-                        class="flex-shrink-0 size-4 flex items-center justify-center transition-transform duration-150 {expandedIds.includes(node.id) ? 'rotate-90' : ''}"
+                        class="flex-shrink-0 size-4 flex items-center justify-center transition-transform duration-150 {expandedIds.includes(node.id) ? "rotate-90" : ""}"
                         onclick={(e) => { e.stopPropagation(); toggleExpand(node.id); }}
-                        aria-label={expandedIds.includes(node.id) ? 'Collapse' : 'Expand'}
+                        aria-label={expandedIds.includes(node.id) ? "Collapse" : "Expand"}
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="size-4"><polyline points="9 18 15 12 9 6" /></svg>
                     </button>

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -141,21 +141,21 @@ export async function previewInWasmPlayer(wasmPlayerUrl: string): Promise<void> 
     const filename = _adapter.filename;
     const adapter = _adapter;
 
-    window.open(wasmPlayerUrl + '?source=editor', '_blank');
-    const bc = new BroadcastChannel('quest-preview');
+    window.open(wasmPlayerUrl + "?source=editor", "_blank");
+    const bc = new BroadcastChannel("quest-preview");
     _previewChannel = bc;
 
     bc.onmessage = async ({ data }) => {
-        if (data.type === 'ready') {
+        if (data.type === "ready") {
             // Serialize fresh on every 'ready' so WasmPlayer refreshes also pick up latest edits.
             if (!_bridge) return;
             const bytes = new TextEncoder().encode(_bridge.Save());
-            bc.postMessage({ type: 'game', bytes, filename });
-        } else if (data.type === 'resource-request') {
+            bc.postMessage({ type: "game", bytes, filename });
+        } else if (data.type === "resource-request") {
             const blob = await adapter.getAsset(data.name);
             if (blob) {
                 const dataUrl = await blobToDataUrl(blob);
-                bc.postMessage({ type: 'resource-response', id: data.id, dataUrl });
+                bc.postMessage({ type: "resource-response", id: data.id, dataUrl });
             }
         }
     };

--- a/src/WebEditor/src/routes/open/+page.svelte
+++ b/src/WebEditor/src/routes/open/+page.svelte
@@ -332,13 +332,13 @@
                 // resolved yet — cheap IPC round trip, not worth blocking the
                 // form on at mount.
                 const parentDir = electronGamesDir || await getDefaultGamesDir();
+                // Errors here (e.g. a folder with that name already exists at
+                // parentDir) are caught by this function's outer try/catch below,
+                // same as every other error path in this function.
                 const result = await createElectronGame(parentDir, file.filename, file.content);
                 const ok = await openGame(result.bytes, result.adapter.filename, result.adapter);
                 if (ok) { goto(base || "/"); return; }
                 createLocalError = "Failed to load new game.";
-            // A thrown error (e.g. a folder with that name already exists
-            // at parentDir) is caught by this function's outer try/catch
-            // below, same as every other error path here.
             } else {
                 const gameId = parseGameIdFromAslx(file.content);
                 if (!gameId) { createLocalError = "New game is missing a gameid."; creatingLocal = false; return; }
@@ -363,12 +363,12 @@
             const file = await buildNewGameFile();
             if (!file) { creatingLocal = false; return; }
             const result = await createLocalGame(file.filename, file.content);
+            // result === null: user cancelled the directory picker — do nothing
             if (result) {
                 const ok = await openGame(result.loaded.bytes, result.loaded.adapter.filename, result.loaded.adapter);
                 if (ok) { goto(base || "/"); return; }
                 createLocalError = "Failed to load new game.";
             }
-        // result === null: user cancelled the directory picker — do nothing
         } catch (err) {
             createLocalError = String(err);
         }


### PR DESCRIPTION
## Summary
- Fixed a config bug where the base `indent` rule and `svelte/indent` both applied to `.svelte` files and fought over the same lines (e.g. switch/case), preventing `--fix` from converging — scoped `indent` off for `.svelte` files.
- Auto-fixed the resulting 225 accumulated style errors (indent/quotes/semi/curly-spacing) across 10 files.
- Fixed the 20 remaining substantive findings:
  - `ScriptEditor`/`ElementsList`/`ScriptDictionaryEditor`: replaced `$state(new Set())` + copy-on-write reassignment with `SvelteSet` + in-place mutation (`svelte/prefer-svelte-reactivity`) — functionally equivalent, less boilerplate. Verified selection/expand-collapse reactivity end-to-end in a browser.
  - `AttributesEditor`/`PropertyEditor`: added keys to six `#each` blocks; dropped an unused `typeLabel()` helper superseded by native `<select>`/`<option>` markup.
  - `Combobox`: `void filtered` for the reactivity-tracking read inside `$effect` (bare expression statements trip `no-unused-expressions`).
  - `AddScriptModal`/`ScriptEditor`: dropped two stale `svelte-ignore` comments no longer suppressing anything.
- Added a `lint_webeditor` CI job (`npm run lint` + `npm run check`) — previously nothing ran lint or svelte-check in CI, which is how the 245-error backlog went unnoticed.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run build` — succeeds
- [x] Manually verified in a browser (Playwright + Firefox against the dev server): checkbox multi-select in `ElementsList` and `ScriptEditor` toggles instantly and independently; `ScriptDictionaryEditor` expand/collapse toggles per-key with no lag or cross-contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)