### PR TITLE
feat(WebEditor): autosave instead of explicit Save button

### DIFF
--- a/src/WebEditor/src/components/Toolbar.svelte
+++ b/src/WebEditor/src/components/Toolbar.svelte
@@ -2,7 +2,7 @@
     import { AppBar } from "@skeletonlabs/skeleton-svelte";
     import { PUBLIC_WASM_PLAYER_URL } from "$env/static/public";
     import {
-        gameFilename, isDirty, saveGame, saveGameAs, canSaveAs, backupGame, canBackup,
+        gameFilename, isDirty, isSaving, saveError, retrySave, saveGameAs, canSaveAs, backupGame, canBackup,
         publishModalOpen,
         previewInWasmPlayer,
         undo, redo, canUndo, canRedo,
@@ -17,11 +17,6 @@
     const wasmPlayerUrl = PUBLIC_WASM_PLAYER_URL || "/player/";
 
     let saving = $state(false);
-
-    async function handleSave() {
-        saving = true;
-        try { await saveGame(); } finally { saving = false; }
-    }
 
     async function handleSaveAs() {
         saving = true;
@@ -96,7 +91,19 @@
         <AppBar.Lead>
             <span class="font-semibold">Quest Viva Editor</span>
             {#if $gameFilename}
-                <span class="ml-3 text-sm text-surface-500-400">{$gameFilename}{#if $isDirty} *{/if}</span>
+                <span class="ml-3 text-sm text-surface-500-400">{$gameFilename}</span>
+            {/if}
+            {#if $saveError}
+                <button
+                    type="button"
+                    class="ml-3 text-sm text-error-500 underline"
+                    onclick={() => retrySave()}
+                    title={$saveError}
+                >⚠ Save failed — Retry</button>
+            {:else if $isSaving || $isDirty}
+                <span class="ml-3 text-sm text-surface-500-400">Saving…</span>
+            {:else if $gameFilename}
+                <span class="ml-3 text-sm text-surface-500-400">Saved</span>
             {/if}
         </AppBar.Lead>
         <AppBar.Trail>
@@ -132,7 +139,6 @@
                 <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => assetManagerOpen.set(true)} title="Manage assets">🖼 Assets</button>
                 <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
                 <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
-                <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleSave} disabled={saving} title="Save">💾 Save</button>
                 {#if $canSaveAs}
                     <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleSaveAs} disabled={saving} title="Save As">Save As…</button>
                 {/if}

--- a/src/WebEditor/src/lib/editor-store.ts
+++ b/src/WebEditor/src/lib/editor-store.ts
@@ -42,10 +42,19 @@ export const publishModalOpen = writable(false);
 function refreshUndoRedo() {
     canUndo.set(_bridge?.CanUndo() ?? false);
     canRedo.set(_bridge?.CanRedo() ?? false);
-    isDirty.set(_bridge?.IsDirty() ?? false);
+    const dirty = _bridge?.IsDirty() ?? false;
+    isDirty.set(dirty);
+    if (dirty) scheduleAutosave();
 }
 
 export async function openGame(bytes: Uint8Array, filename: string, adapter: FileAdapter): Promise<boolean> {
+    // Defensive reset: callers that switch games mid-session (Electron's menu
+    // actions) already await saveGame() to flush the previous game first, so
+    // this should always be a no-op in practice — but a leftover timer here
+    // would otherwise fire against the wrong _bridge/_adapter below.
+    cancelPendingAutosave();
+    isSaving.set(false);
+    saveError.set(null);
     loadingStatus.set("Starting editor…");
     _bridge = await loadWasm();
     _adapter = adapter;
@@ -163,16 +172,91 @@ export async function previewInWasmPlayer(wasmPlayerUrl: string): Promise<void> 
     };
 }
 
-export async function saveGame(): Promise<void> {
+// ── Autosave ─────────────────────────────────────────────────────────────────
+// Edits already commit into the WASM model synchronously as they're made (see
+// setAttribute etc. below, all wired to onchange/blur in the components) —
+// that's what gives the v5-style "saved as you navigate" feel at the model
+// layer. This section is only responsible for debouncing *persistence* of
+// that already-current model out to the FileAdapter (disk/OPFS/server),
+// instead of requiring an explicit Save click.
+
+export const isSaving = writable(false);
+export const saveError = writable<string | null>(null);
+
+const AUTOSAVE_DEBOUNCE_MS = 800;
+const RETRY_DELAYS_MS = [5000, 15000, 30000];
+
+let _autosaveTimer: ReturnType<typeof setTimeout> | null = null;
+let _retryTimer: ReturnType<typeof setTimeout> | null = null;
+let _retryAttempt = 0;
+let _saveInFlight: Promise<void> | null = null;
+let _resaveQueued = false;
+
+function cancelPendingAutosave(): void {
+    if (_autosaveTimer !== null) { clearTimeout(_autosaveTimer); _autosaveTimer = null; }
+    if (_retryTimer !== null) { clearTimeout(_retryTimer); _retryTimer = null; }
+}
+
+function scheduleAutosave(): void {
+    if (_autosaveTimer !== null) clearTimeout(_autosaveTimer);
+    _autosaveTimer = setTimeout(() => {
+        _autosaveTimer = null;
+        void persistNow();
+    }, AUTOSAVE_DEBOUNCE_MS);
+}
+
+// Transient failures (e.g. ServerFileAdapter's PUT hitting a network blip)
+// get a few automatic retries with backoff; scheduleRetry() is a no-op if one
+// is already pending so a burst of failures doesn't stack up timers.
+function scheduleRetry(): void {
+    if (_retryTimer !== null) return;
+    const delay = RETRY_DELAYS_MS[Math.min(_retryAttempt, RETRY_DELAYS_MS.length - 1)];
+    _retryAttempt++;
+    _retryTimer = setTimeout(() => {
+        _retryTimer = null;
+        void persistNow();
+    }, delay);
+}
+
+// Serializes the bridge and writes it via the adapter. A caller that arrives
+// while a save is already in flight (autosave firing right as a manual flush
+// is in progress, say) folds into a single follow-up save afterwards rather
+// than racing two concurrent writes to the same target.
+export function persistNow(): Promise<void> {
+    if (_saveInFlight) {
+        _resaveQueued = true;
+        return _saveInFlight;
+    }
+    _saveInFlight = doPersist().finally(() => {
+        _saveInFlight = null;
+        const queued = _resaveQueued;
+        _resaveQueued = false;
+        if (queued && get(isDirty)) void persistNow();
+    });
+    return _saveInFlight;
+}
+
+async function doPersist(): Promise<void> {
     if (!_bridge || !_adapter) return;
-    await rekeyIfGameIdChanged();
-    await _adapter.saveFile(_bridge.Save()); // Save() clears _isDirty in the bridge
-    isDirty.set(false);
-    // Re-check rather than only at load: this is what lets the banner appear the
-    // moment a fresh local draft crosses the activity threshold, instead of
-    // waiting for the user to close and reopen it.
-    if (_adapter instanceof LocalDraftAdapter) {
-        showBackupBanner.set(await shouldShowBackupBanner(_adapter.gameId));
+    isSaving.set(true);
+    try {
+        await rekeyIfGameIdChanged();
+        await _adapter.saveFile(_bridge.Save()); // Save() clears _isDirty in the bridge
+        isDirty.set(false);
+        saveError.set(null);
+        _retryAttempt = 0;
+        if (_retryTimer !== null) { clearTimeout(_retryTimer); _retryTimer = null; }
+        // Re-check rather than only at load: this is what lets the banner appear the
+        // moment a fresh local draft crosses the activity threshold, instead of
+        // waiting for the user to close and reopen it.
+        if (_adapter instanceof LocalDraftAdapter) {
+            showBackupBanner.set(await shouldShowBackupBanner(_adapter.gameId));
+        }
+    } catch (err) {
+        saveError.set(err instanceof Error ? err.message : "Save failed");
+        scheduleRetry();
+    } finally {
+        isSaving.set(false);
     }
 }
 
@@ -188,11 +272,31 @@ async function rekeyIfGameIdChanged(): Promise<void> {
     _loadedGameId = currentGameId;
 }
 
+// Forces any in-progress field edit to commit (blur fires its onchange) and
+// flushes it to storage immediately, bypassing the debounce. Used for the
+// Electron "Save" menu action, and awaited before navigating away to a
+// different game or on tab hide/close, so nothing is left stranded in the
+// debounce window.
+export async function saveGame(): Promise<void> {
+    (document.activeElement as HTMLElement | null)?.blur();
+    cancelPendingAutosave();
+    if (get(isDirty)) await persistNow();
+}
+
+// The status pill's "Retry" action after a failed autosave.
+export function retrySave(): Promise<void> {
+    cancelPendingAutosave();
+    return persistNow();
+}
+
 export async function saveGameAs(): Promise<void> {
     if (!_bridge || !_adapter) return;
+    (document.activeElement as HTMLElement | null)?.blur();
+    cancelPendingAutosave();
     const newName = await _adapter.saveFileAs(_bridge.Save()); // Save() clears _isDirty in the bridge
     if (newName) gameFilename.set(newName);
     isDirty.set(false);
+    saveError.set(null);
 }
 
 // Bundles the current game plus its assets into a downloadable .zip — the local
@@ -202,8 +306,10 @@ export async function saveGameAs(): Promise<void> {
 // but would fork the game from its templates if re-imported for further editing.
 export async function backupGame(): Promise<void> {
     if (!_bridge || !(_adapter instanceof LocalDraftAdapter)) return;
+    cancelPendingAutosave();
     const gameXml = _bridge.Save(); // Save() clears _isDirty in the bridge
     isDirty.set(false);
+    saveError.set(null);
     const zipEntries: Record<string, Uint8Array> = {
         [_adapter.filename]: new TextEncoder().encode(gameXml),
     };

--- a/src/WebEditor/src/routes/+layout.svelte
+++ b/src/WebEditor/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { PUBLIC_WEBEDITOR_VERSION } from "$env/static/public";
-    import { isDirty, isLoaded, saveGame, saveGameAs } from "$lib/editor-store";
+    import { isLoaded, saveGame, saveGameAs } from "$lib/editor-store";
     import { isElectron } from "$lib/runtime";
 
     let { children }: { children: Snippet } = $props();
@@ -32,15 +32,20 @@
             switch (action) {
                 case "new-game":
                 case "open-file": {
-                    if (get(isDirty) && !confirm("You have unsaved changes. Discard them and continue?")) return;
-                    // goto() to the exact URL already showing is a no-op in SvelteKit —
-                    // no navigation event fires, so nothing happens when the menu
-                    // action is triggered while already sitting on /open. A per-click
-                    // nonce guarantees a real navigation every time; routes/open/+page.svelte
-                    // reacts to it via $app/state's page (not onMount), which re-runs on
-                    // every navigation, remount or not.
-                    const query = action === "open-file" ? `?action=open&t=${Date.now()}` : "";
-                    void goto(`${base}/open${query}`);
+                    // Edits autosave continuously, so switching games just needs the
+                    // previous one flushed first — nothing is discarded, unlike the
+                    // old confirm()-to-discard prompt this replaced.
+                    void (async () => {
+                        if (get(isLoaded)) await saveGame();
+                        // goto() to the exact URL already showing is a no-op in SvelteKit —
+                        // no navigation event fires, so nothing happens when the menu
+                        // action is triggered while already sitting on /open. A per-click
+                        // nonce guarantees a real navigation every time; routes/open/+page.svelte
+                        // reacts to it via $app/state's page (not onMount), which re-runs on
+                        // every navigation, remount or not.
+                        const query = action === "open-file" ? `?action=open&t=${Date.now()}` : "";
+                        void goto(`${base}/open${query}`);
+                    })();
                     break;
                 }
                 case "save":
@@ -52,13 +57,15 @@
             }
         });
         // Native "Open Recent" submenu (ElectronApp's main.ts) — same
-        // dirty-check + nonce-navigation pattern as open-folder above, just
-        // carrying a specific game to load; routes/open/+page.svelte's
-        // $effect reads dir/file/t off the query string and does the actual load.
+        // flush-then-navigate pattern as open-folder above, just carrying a
+        // specific game to load; routes/open/+page.svelte's $effect reads
+        // dir/file/t off the query string and does the actual load.
         const unsubscribeRecent = window.electronApp!.menu.onOpenRecent((game) => {
-            if (get(isDirty) && !confirm("You have unsaved changes. Discard them and continue?")) return;
-            const query = `?action=open-recent&dir=${encodeURIComponent(game.dirPath)}&file=${encodeURIComponent(game.filename)}&t=${Date.now()}`;
-            void goto(`${base}/open${query}`);
+            void (async () => {
+                if (get(isLoaded)) await saveGame();
+                const query = `?action=open-recent&dir=${encodeURIComponent(game.dirPath)}&file=${encodeURIComponent(game.filename)}&t=${Date.now()}`;
+                void goto(`${base}/open${query}`);
+            })();
         });
         return () => {
             unsubscribeAction();

--- a/src/WebEditor/src/routes/+page.svelte
+++ b/src/WebEditor/src/routes/+page.svelte
@@ -4,7 +4,7 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { get } from "svelte/store";
-    import { isLoaded, isDirty, loadingStatus, addElementModal, assetManagerOpen, publishModalOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType } from "$lib/editor-store";
+    import { isLoaded, isDirty, saveGame, loadingStatus, addElementModal, assetManagerOpen, publishModalOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType } from "$lib/editor-store";
     import { loadFromServer } from "$lib/filesystem/server-adapter";
     import Toolbar from "$components/Toolbar.svelte";
     import BackupBanner from "$components/BackupBanner.svelte";
@@ -16,20 +16,36 @@
 
     let serverLoadError = $state<string | null>(null);
 
+    // Best-effort: force any focused field to commit and flush it to storage
+    // before the tab actually goes away. Can't be awaited here — the page may
+    // already be gone by the time an async write settles — so the beforeunload
+    // warning below stays as the real safety net for that narrow window.
     $effect(() => {
         if (!$isDirty) return;
-        function handleBeforeUnload(e: BeforeUnloadEvent) { e.preventDefault(); }
+        function handleBeforeUnload(e: BeforeUnloadEvent) {
+            void saveGame();
+            e.preventDefault();
+        }
         window.addEventListener("beforeunload", handleBeforeUnload);
         return () => window.removeEventListener("beforeunload", handleBeforeUnload);
     });
 
     onMount(() => {
+        // Covers tab switches, backgrounding, and the mobile-Safari-style tab
+        // closes that don't reliably fire beforeunload.
+        function handleVisibilityChange() {
+            if (document.hidden && get(isDirty)) void saveGame();
+        }
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+
         const gameId = new URLSearchParams(window.location.search).get("game");
         if (gameId) {
             loadGameFromServer(gameId);
         } else if (!get(isLoaded)) {
             goto(`${base}/open`);
         }
+
+        return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
     });
 
     async function loadGameFromServer(gameId: string) {

--- a/tests/e2e/verify-webeditor-autosave.mjs
+++ b/tests/e2e/verify-webeditor-autosave.mjs
@@ -1,0 +1,73 @@
+// Ad-hoc manual verification for the WebEditor autosave change: the explicit
+// Save button was removed in favor of debounced autosave-on-edit. This
+// confirms the status pill reflects the autosave lifecycle (no "Saved" pill
+// stuck at page load, "Saving…" appears after an edit, then "Saved"), and
+// that the edit actually lands in OPFS storage (survives a reload), not just
+// held in the WASM model.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5176';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', 'Autosave Test');
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    const saveButtonCount = await page.locator('button:has-text("💾 Save")').count();
+    if (saveButtonCount !== 0) throw new Error('Explicit Save button is still present');
+    console.log('PASS: no explicit Save button in the toolbar');
+
+    await page.waitForSelector('text=Saved', { timeout: 10000 });
+    console.log('PASS: toolbar shows "Saved" once the initial draft is written');
+
+    // Select the game node (already selected on load) and edit its
+    // description via the PropertyEditor, then blur it — this should commit
+    // into the WASM model (onchange) and kick off the debounced autosave.
+    const descBox = page.locator('textarea, input[type="text"]').first();
+    await descBox.waitFor({ timeout: 10000 });
+    const marker = `Autosave marker ${Date.now()}`;
+    await descBox.fill(marker);
+    await page.click('span:has-text("Quest Viva Editor")'); // blur onto something inert
+
+    await page.waitForSelector('text=Saving…', { timeout: 3000 });
+    console.log('PASS: "Saving…" pill appeared after edit, without clicking any Save button');
+
+    await page.waitForSelector('text=Saved', { timeout: 10000 });
+    console.log('PASS: pill returned to "Saved" after the autosave debounce fired');
+
+    // Reopen via /open (a bare reload of "/" just redirects to /open anyway,
+    // since isLoaded is in-memory SPA state) — if the edit only lived in the
+    // in-memory WASM model, it would be gone; if autosave actually persisted
+    // it to OPFS, it survives.
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('text=Your local drafts', { timeout: 10000 });
+    await page.click('button:has-text("Autosave Test.aslx")');
+    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    await page.waitForSelector('text=Saved', { timeout: 10000 });
+    const persistedValue = await page.locator('textarea, input[type="text"]').first().inputValue();
+    console.log('value after reload:', persistedValue);
+    if (persistedValue !== marker) throw new Error(`Edit did not survive reload — expected "${marker}", got "${persistedValue}"`);
+    console.log('PASS: autosaved edit survived a full page reload (persisted to OPFS)');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/webeditor-autosave-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Replace the explicit Save button with debounced autosave: edits already commit into the WASM model on blur, this just persists that model automatically instead of requiring a click.
- In-flight save coalescing + capped-backoff retry on failure, surfaced via a Saving…/Saved/Save failed toolbar pill (with click-to-retry on failure).
- Flush on tab hide/`beforeunload`, and before Electron's New Game/Open File/Open Recent menu actions (previously these blocked on a "discard unsaved changes?" confirm — nothing is discarded anymore, so they just flush first).

## Test plan
- [x] `svelte-check` and `eslint` clean
- [x] Built WasmEditor (Debug) + ran the WebEditor dev server, drove it with Playwright (`tests/e2e/verify-webeditor-autosave.mjs`): created a local draft, confirmed no Save button, edited a field, watched the pill go Saving… → Saved with no click, reopened the draft via `/open` and confirmed the edit persisted to OPFS
- [ ] Manual smoke test of Electron's New/Open/Open Recent menu flows (autosave flush path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)