### PR TITLE
fix(ElectronApp): skip ad-hoc codesign on non-macOS builds

### DIFF
--- a/src/ElectronApp/scripts/adhoc-sign.js
+++ b/src/ElectronApp/scripts/adhoc-sign.js
@@ -15,6 +15,11 @@ const { execFileSync } = require("node:child_process");
 const path = require("node:path");
 
 module.exports = async function adhocSign(context) {
+    // afterSign is a global hook (package.json's "build.afterSign" isn't
+    // platform-scoped), so this also fires for the Windows/Linux builds —
+    // codesign doesn't exist there and there's no .app to sign.
+    if (context.electronPlatformName !== "darwin") return;
+
     // A real identity means electron-builder's own signing step already ran.
     if (process.env.CSC_LINK) return;
 


### PR DESCRIPTION
## Summary
- `v6.0.0-beta.40`'s `Publish Electron desktop app` workflow failed on the Windows job with `spawnSync codesign ENOENT`.
- `afterSign` is registered as a global electron-builder hook in `package.json` (not scoped under `mac`), so `scripts/adhoc-sign.js` also runs during the Windows/Linux `electron-builder` steps. The script only guarded against `CSC_LINK` being set and unconditionally shelled out to macOS's `codesign` against a `.app` bundle that only exists on the mac build.
- Fix: bail out early unless `context.electronPlatformName === "darwin"`.

## Test plan
- [x] Verified `context.electronPlatformName` is the documented electron-builder afterSign hook property (`app-builder-lib/out/configuration.d.ts`).
- [ ] CI: confirm `Build and test` passes and, on next release tag, confirm the Windows `publish` job of `Publish Electron desktop app` succeeds.