### PR TITLE
fix(ElectronApp): set BrowserWindow icon on Linux

### DIFF
--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -143,6 +143,15 @@ function createEditorWindow(port: number): void {
         title: "Quest Viva",
         width: 1280,
         height: 860,
+        // BrowserWindow's `icon` option "is only implemented on Linux and
+        // Windows" (Electron docs) — on macOS the running app's icon comes
+        // from the .app bundle, but on Linux the window manager reads it
+        // from the live window, not from electron-builder's packaged
+        // AppImage/.desktop icon. Without this, GNOME/Ubuntu falls back to
+        // a generic icon for the window even though the AppImage itself has
+        // the right icon in its metadata. aboutIconPath() already resolves
+        // build/icons/512x512.png (dev) vs. the extraResource copy (packaged).
+        ...(process.platform !== "darwin" ? { icon: aboutIconPath() } : {}),
         webPreferences: {
             preload: path.join(__dirname, "preload.js"),
             contextIsolation: true,

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -143,15 +143,19 @@ function createEditorWindow(port: number): void {
         title: "Quest Viva",
         width: 1280,
         height: 860,
-        // BrowserWindow's `icon` option "is only implemented on Linux and
-        // Windows" (Electron docs) — on macOS the running app's icon comes
-        // from the .app bundle, but on Linux the window manager reads it
-        // from the live window, not from electron-builder's packaged
-        // AppImage/.desktop icon. Without this, GNOME/Ubuntu falls back to
-        // a generic icon for the window even though the AppImage itself has
-        // the right icon in its metadata. aboutIconPath() already resolves
-        // build/icons/512x512.png (dev) vs. the extraResource copy (packaged).
-        ...(process.platform !== "darwin" ? { icon: aboutIconPath() } : {}),
+        // BrowserWindow's `icon` option is only implemented on Linux and
+        // Windows (Electron docs), but Windows doesn't need it set here:
+        // electron-builder auto-picks up build/icon.ico for the Windows
+        // build the same way it does icon.icns for mac, so the .exe already
+        // has the icon embedded as a resource and the taskbar reads it from
+        // there. Linux has no equivalent — there's no single "the
+        // executable's icon" for an AppImage — so the window manager
+        // depends on this option instead. Without it, GNOME/Ubuntu falls
+        // back to a generic icon for the window even though the AppImage
+        // itself has the right icon in its packaged metadata.
+        // aboutIconPath() already resolves build/icons/512x512.png (dev) vs.
+        // the extraResource copy (packaged).
+        ...(process.platform === "linux" ? { icon: aboutIconPath() } : {}),
         webPreferences: {
             preload: path.join(__dirname, "preload.js"),
             contextIsolation: true,


### PR DESCRIPTION
## Summary
- #1880 fixed electron-builder's packaged AppImage/`.desktop` icon and the About panel, but never set the `icon` option on the actual `BrowserWindow` — that option is Electron's only mechanism for the running window's taskbar/alt-tab icon on Linux (per Electron docs, "only implemented on Linux and Windows"), so GNOME/Ubuntu still fell back to a generic cog icon for the live window.
- Reuses the existing `aboutIconPath()` helper (added in #1880) to point `BrowserWindow`'s `icon` option at `build/icons/512x512.png` (dev) / the packaged `extraResource` copy, on non-macOS platforms only — macOS's dock icon comes from the `.app` bundle instead.

## Test plan
- [ ] Build the AppImage and confirm the taskbar/alt-tab icon shows the QV mark instead of a generic icon on Ubuntu (to be verified by @alexwarren in his Linux VM before/after the next release)
- [x] `npm run build:ts` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)