### PR TITLE
feat(AppShell): open a local game file from the Play tab

### DIFF
--- a/src/AppShell/src/components/PlayCatalog.svelte
+++ b/src/AppShell/src/components/PlayCatalog.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import { onMount } from "svelte";
+    import { onMount, onDestroy } from "svelte";
     import { base } from "$app/paths";
     import { fetchCatalog, type CatalogCategory } from "$lib/home-catalog";
+    import { pickFile } from "$lib/filesystem/file-picker";
 
     let categories = $state<CatalogCategory[] | null>(null);
     let error = $state(false);
@@ -25,6 +26,84 @@
         const rounded = Math.max(0, Math.min(5, Math.round(rating)));
         return "★".repeat(rounded) + "☆".repeat(5 - rounded);
     }
+
+    // Two deliberate clicks, not one click-through-then-another: picking the
+    // file and starting the game are each their own genuine user gesture, so
+    // each gets its own fresh browser activation — a single click can't do
+    // both (see handleStart) because a native file dialog and a script-driven
+    // window.open() fight over the same click's single-use activation grant.
+    let pickedFile = $state<File | null>(null);
+    let pickedBytes = $state<Uint8Array | null>(null);
+    let pickError = $state<string | null>(null);
+    let starting = $state(false);
+    let startError = $state<string | null>(null);
+
+    async function handlePickFile() {
+        pickError = null;
+        startError = null;
+        const file = await pickFile(".quest,.aslx,.asl,.cas");
+        if (!file) return;
+        try {
+            pickedBytes = new Uint8Array(await file.arrayBuffer());
+            pickedFile = file;
+        } catch (err) {
+            pickError = String(err);
+        }
+    }
+
+    function handleClearPicked() {
+        pickedFile = null;
+        pickedBytes = null;
+        pickError = null;
+        startError = null;
+    }
+
+    // Kept across Start calls (not just a local var) so a new Start can close
+    // the previous one — see below.
+    let playChannel: BroadcastChannel | null = null;
+
+    // window.open() must be the very first thing this does — it's what
+    // spends this click's activation, and awaiting anything beforehand
+    // (there's nothing to await here; the bytes are already read in
+    // handlePickFile) would let the popup blocker silently no-op it. Hands
+    // the bytes to the new tab over a BroadcastChannel — the same handoff
+    // editor-store.ts's previewInWasmPlayer uses for live editor previews —
+    // see wasm-player.js's `source=local` boot branch.
+    function handleStart() {
+        if (!pickedFile || !pickedBytes) return;
+        startError = null;
+
+        // Close any previous play channel first — otherwise it would *also*
+        // answer this new tab's 'ready' broadcast (with the wrong bytes), and
+        // would go on answering a refresh of the now-superseded old tab.
+        playChannel?.close();
+
+        const popup = window.open(`${base}/player/?source=local`, "_blank");
+        if (!popup) {
+            startError = "Please allow pop-ups for this site to play the game.";
+            return;
+        }
+
+        starting = true;
+        const bytes = pickedBytes;
+        const filename = pickedFile.name;
+        const bc = new BroadcastChannel("quest-play-local");
+        playChannel = bc;
+        // Deliberately left open (not closed after the first message) —
+        // WasmPlayer re-broadcasts 'ready' on every load of that tab,
+        // including a plain refresh, so this needs to keep answering for as
+        // long as this Play tab is still open, exactly like the
+        // never-closed editor-preview channel it mirrors.
+        bc.onmessage = ({ data }) => {
+            if (data.type === "ready") {
+                bc.postMessage({ type: "game", bytes, filename });
+                starting = false;
+                handleClearPicked();
+            }
+        };
+    }
+
+    onDestroy(() => playChannel?.close());
 </script>
 
 <!-- Always dark (see +layout.svelte) — surface-950/400/800 are the fixed
@@ -36,6 +115,30 @@
      sides instead of dark. -->
 <div class="min-h-svh bg-surface-950 text-surface-100">
     <div class="flex flex-col gap-8 w-full max-w-5xl mx-auto p-8">
+        <div class="flex flex-col items-center gap-2">
+            {#if !pickedFile}
+                <button type="button" class="btn preset-outlined-primary-500" onclick={handlePickFile}>
+                    Open a game file&hellip;
+                </button>
+            {:else}
+                <div class="flex items-center gap-3">
+                    <span class="text-sm text-surface-300 truncate max-w-[20ch]">{pickedFile.name}</span>
+                    <button type="button" class="btn btn-sm preset-outlined-surface-500" onclick={handleClearPicked} disabled={starting}>
+                        Change
+                    </button>
+                    <button type="button" class="btn preset-filled-primary-500" onclick={handleStart} disabled={starting}>
+                        {starting ? "Starting…" : "Start ▶"}
+                    </button>
+                </div>
+            {/if}
+            {#if pickError}
+                <p class="text-error-500 text-sm">{pickError}</p>
+            {/if}
+            {#if startError}
+                <p class="text-error-500 text-sm">{startError}</p>
+            {/if}
+        </div>
+
         {#if loading}
             <div class="flex flex-col items-center gap-3 py-12">
                 <div class="size-10 rounded-full border-4 border-surface-800 border-t-primary-500 animate-spin"></div>
@@ -76,9 +179,5 @@
                 </section>
             {/each}
         {/if}
-
-        <p class="text-surface-400 text-sm text-center">
-            Have a game file or a link already? <a href="{base}/player/" class="anchor">Open the player</a>.
-        </p>
     </div>
 </div>

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -14,7 +14,7 @@
         (function () {
             var params = new URLSearchParams(location.search);
             if (params.get('id') || params.get('url') || params.get('source') === 'editor'
-                || window.QuestVivaConfig?.defaultGameUrl) {
+                || params.get('source') === 'local' || window.QuestVivaConfig?.defaultGameUrl) {
                 document.documentElement.classList.add('qv-booting');
             }
         })();

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -665,6 +665,29 @@ function showFileProtocolError() {
     errorEl.style.display = 'block';
 }
 
+// The AppShell tab that was going to hand over game bytes (see the
+// `source=local` boot branch below) turned out not to be there to answer —
+// closed, navigated away, or superseded by a newer Start click in that same
+// tab (see PlayCatalog.svelte's handleStart, which closes its previous
+// channel before opening a new one). Without this, that's a silent infinite
+// loading spinner with no way out; this at least gets the user back to a
+// working picker in the same tab.
+function showLocalHandoffTimeoutError() {
+    document.documentElement.classList.remove('qv-booting');
+    const pickers = document.getElementById('qv-pickers');
+    const msg = document.getElementById('qv-loading-msg');
+    const errorEl = document.getElementById('qv-error');
+    if (msg) msg.style.display = 'none';
+    if (pickers) pickers.style.display = 'block';
+    if (!errorEl) return;
+    errorEl.innerHTML = '<strong>Couldn\'t reconnect to Quest Viva.</strong> '
+        + 'This tab was waiting for a game from the Play tab it was opened from, but that tab has since been closed, '
+        + 'navigated away, or used to start a different game. Choose the file again below, or go back to Quest Viva '
+        + 'and click Start again.';
+    errorEl.style.display = 'block';
+    wireStartScreen();
+}
+
 function showLoading() {
     const pickers = document.getElementById('qv-pickers');
     const msg = document.getElementById('qv-loading-msg');
@@ -824,6 +847,38 @@ async function fetchGameBytes(url) {
             if (data.type === 'game') {
                 bc.onmessage = null;
                 await startGame(data.bytes, data.filename, bc);
+            }
+        };
+        return;
+    }
+
+    // AppShell's Play tab (see PlayCatalog.svelte) — the user already picked
+    // a file and clicked Start over there, so the game bytes are sitting in
+    // that tab's memory. Same handoff as the editor preview above, just with
+    // no resource-request handling: a locally picked file is never backed by
+    // a live FileAdapter to fetch assets from, only self-contained bytes (a
+    // .quest package embeds its resources; loose .aslx games fetch theirs by
+    // URL), exactly like the plain file-input path in wireStartScreen()
+    // below. A distinct channel name keeps this from cross-talking with a
+    // real editor-preview tab open at the same time.
+    if (params.get('source') === 'local') {
+        const bc = new BroadcastChannel('quest-play-local');
+        bc.postMessage({ type: 'ready' });
+        // Covers the case where nothing ever answers — see
+        // showLocalHandoffTimeoutError. 8s comfortably covers a normal
+        // same-tick reply; DOMContentLoaded hasn't necessarily fired yet
+        // when this timer is *set*, but it always has by the time it fires.
+        const timeoutId = window.setTimeout(() => {
+            bc.onmessage = null;
+            bc.close();
+            showLocalHandoffTimeoutError();
+        }, 8000);
+        bc.onmessage = async ({ data }) => {
+            if (data.type === 'game') {
+                window.clearTimeout(timeoutId);
+                bc.onmessage = null;
+                bc.close();
+                await startGame(data.bytes, data.filename);
             }
         };
         return;

--- a/tests/e2e/verify-appshell-play-open-file.mjs
+++ b/tests/e2e/verify-appshell-play-open-file.mjs
@@ -1,0 +1,69 @@
+// Ad-hoc manual verification: AppShell's Play tab (PlayCatalog.svelte)
+// "Open a game file…" -> pick a file -> "Start" flow. Two distinct clicks
+// (pick, then start), each with its own fresh browser activation, rather than
+// one click that tries to both show a native file dialog and open a new tab
+// (that fails — the two compete for a single click's popup-blocker
+// exemption; verified experimentally while building this). Confirms: picking
+// a file reveals the Start button, clicking Start opens a new tab, and the
+// game's bytes make it across the BroadcastChannel handoff to actually boot
+// (wasm-player.js's `source=local` boot branch).
+//
+// Requires AppShell (5174) and WasmPlayer (5175) dev servers running:
+//   node src/WasmPlayer/dev-server.mjs &
+//   (cd src/AppShell && PUBLIC_SHOW_HOME=true npx vite dev) &
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const context = await browser.newContext();
+const page = await context.newPage();
+page.on('pageerror', err => console.log('[appshell] [pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[appshell] [console.error]', msg.text()); });
+
+async function run() {
+    await page.goto(`${baseUrl}/`);
+    await page.waitForSelector('button:has-text("Open a game file…")', { timeout: 15000 });
+    console.log('[appshell] Play tab loaded, "Open a game file…" button present');
+
+    const fixturePath = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'restart-test.aslx');
+    const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        page.click('button:has-text("Open a game file…")'),
+    ]);
+    await fileChooser.setFiles(fixturePath);
+    console.log('[appshell] file picked');
+
+    await page.waitForSelector('button:has-text("Start")', { timeout: 5000 });
+    console.log('[appshell] Start button appeared with picked file name:', await page.textContent('text=restart-test.aslx'));
+
+    const [popup] = await Promise.all([
+        context.waitForEvent('page'),
+        page.click('button:has-text("Start")'),
+    ]);
+    console.log('[appshell] popup tab opened on Start click:', popup.url());
+
+    popup.on('pageerror', err => console.log('[player] [pageerror]', err.message));
+    popup.on('console', msg => { if (msg.type() === 'error') console.log('[player] [console.error]', msg.text()); });
+
+    await popup.waitForFunction(() => document.title === 'Simple', null, { timeout: 15000 });
+    console.log('[player] game booted, document.title:', await popup.title());
+
+    // Back on the AppShell tab, the picked-file UI should have reset to the plain button.
+    await page.waitForSelector('button:has-text("Open a game file…")', { timeout: 5000 });
+    console.log('[appshell] picked-file UI reset after handoff');
+
+    console.log('PASS');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-play-open-file-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}

--- a/tests/e2e/verify-appshell-play-refresh.mjs
+++ b/tests/e2e/verify-appshell-play-refresh.mjs
@@ -1,0 +1,94 @@
+// Ad-hoc manual verification for a bug found in manual testing: refreshing
+// the WasmPlayer tab opened by AppShell's Play tab "Start" flow used to spin
+// forever with no error — the BroadcastChannel handoff (see PlayCatalog.svelte
+// handleStart / wasm-player.js's `source=local` boot branch) closed itself
+// after the first message, so a refresh's fresh 'ready' broadcast had no one
+// listening. Fixed by (a) keeping the AppShell-side channel open for the
+// life of that Play tab, matching the never-closed editor-preview channel,
+// and (b) an 8s timeout in WasmPlayer that surfaces a real error (with a
+// working fallback picker) if nothing ever answers.
+//
+// Covers both paths:
+//   1. Refresh while the AppShell tab is still open -> should recover and
+//      re-boot the same game (no lost session).
+//   2. Refresh after the AppShell tab has been closed -> should show the
+//      "Couldn't reconnect" error within ~8s, not spin forever.
+//
+// Requires AppShell (5174) and WasmPlayer (5175) dev servers running.
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+const fixturePath = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'restart-test.aslx');
+
+async function startGameFromPlayTab(context, page) {
+    await page.goto(`${baseUrl}/`);
+    await page.waitForSelector('button:has-text("Open a game file…")', { timeout: 15000 });
+    const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        page.click('button:has-text("Open a game file…")'),
+    ]);
+    await fileChooser.setFiles(fixturePath);
+    await page.waitForSelector('button:has-text("Start")', { timeout: 5000 });
+
+    const [popup] = await Promise.all([
+        context.waitForEvent('page'),
+        page.click('button:has-text("Start")'),
+    ]);
+    await popup.waitForFunction(() => document.title === 'Simple', null, { timeout: 15000 });
+    return popup;
+}
+
+async function testRefreshWithOpenerStillOpen() {
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+        const popup = await startGameFromPlayTab(context, page);
+        console.log('[refresh-recovers] game booted, refreshing player tab...');
+
+        await popup.reload();
+        await popup.waitForFunction(() => document.title === 'Simple', null, { timeout: 15000 });
+        console.log('[refresh-recovers] PASS — game re-booted after refresh with AppShell tab still open');
+    } catch (err) {
+        console.error('[refresh-recovers] FAIL:', err.message);
+        await page.screenshot({ path: '/tmp/appshell-play-refresh-recovers-failure.png' });
+        process.exitCode = 1;
+    } finally {
+        await browser.close();
+    }
+}
+
+async function testRefreshAfterOpenerClosed() {
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+        const popup = await startGameFromPlayTab(context, page);
+        console.log('[refresh-errors] game booted, closing AppShell tab, then refreshing player tab...');
+        await page.close();
+
+        await popup.reload();
+        await popup.waitForSelector('text=Couldn\'t reconnect to Quest Viva', { timeout: 12000 });
+        console.log('[refresh-errors] error message shown');
+
+        // The fallback picker in that same error state should still work.
+        const [fileChooser] = await Promise.all([
+            popup.waitForEvent('filechooser'),
+            popup.click('#qv-file-btn'),
+        ]);
+        await fileChooser.setFiles(fixturePath);
+        await popup.waitForFunction(() => document.title === 'Simple', null, { timeout: 15000 });
+        console.log('[refresh-errors] PASS — error shown within timeout, and its fallback picker still works');
+    } catch (err) {
+        console.error('[refresh-errors] FAIL:', err.message);
+        await popup?.screenshot({ path: '/tmp/appshell-play-refresh-errors-failure.png' }).catch(() => {});
+        process.exitCode = 1;
+    } finally {
+        await browser.close();
+    }
+}
+
+await testRefreshWithOpenerStillOpen();
+await testRefreshAfterOpenerClosed();


### PR DESCRIPTION
## Summary
- Adds an "Open a game file…" picker to AppShell's Play tab home screen so a game on disk can be started directly, alongside the existing catalog.
- Picking and starting are two separate clicks (each keeps its own browser activation) — the native file dialog and the new player tab's `window.open()` can't both ride the same click's popup-blocker exemption.
- Picked bytes are handed to the new WasmPlayer tab over a `BroadcastChannel` (`quest-play-local`), mirroring the existing editor-preview handoff.
- Fixes a bug found in manual testing: refreshing that player tab used to spin forever with no error once the AppShell channel had already answered once. The AppShell-side channel now stays open for the life of the Play tab, and WasmPlayer adds an 8s timeout that surfaces a real "couldn't reconnect" error with a working fallback picker if nothing answers.

## Test plan
- [x] Added `tests/e2e/verify-appshell-play-open-file.mjs` — pick a file, click Start, confirm the game boots in the new tab and the picker UI resets.
- [x] Added `tests/e2e/verify-appshell-play-refresh.mjs` — refresh with the AppShell tab still open (recovers), and refresh after it's closed (shows the reconnect error within the timeout, fallback picker still works).
- [ ] Reviewer: run both against local dev servers per the comments at the top of each script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)