### PR TITLE
feat(ElectronApp): one-click local play, unrestricted autoplay, sibling resources

### DIFF
--- a/src/AppShell/src/components/PlayCatalog.svelte
+++ b/src/AppShell/src/components/PlayCatalog.svelte
@@ -3,6 +3,10 @@
     import { base } from "$app/paths";
     import { fetchCatalog, type CatalogCategory } from "$lib/home-catalog";
     import { pickFile } from "$lib/filesystem/file-picker";
+    import { isElectron } from "$lib/runtime";
+    import { openElectronPlayFile, loadElectronFile } from "$lib/filesystem/electron-adapter";
+
+    const isElectronApp = isElectron();
 
     let categories = $state<CatalogCategory[] | null>(null);
     let error = $state(false);
@@ -27,11 +31,79 @@
         return "★".repeat(rounded) + "☆".repeat(5 - rounded);
     }
 
+    // Kept across handoffs (not just a local var) so a new one can close the
+    // previous — otherwise a stale channel would *also* answer a new
+    // window's 'ready' broadcast (with the wrong bytes), and would go on
+    // answering a refresh of the now-superseded old window.
+    let playChannel: BroadcastChannel | null = null;
+
+    function blobToDataUrl(blob: Blob): Promise<string> {
+        return new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.readAsDataURL(blob);
+        });
+    }
+
+    let electronBusy = $state(false);
+    let electronError = $state<string | null>(null);
+
+    // Electron: a single click launches the game — no second "Start" click
+    // needed, because the player window here is created by the *main*
+    // process (see ipc/player.ts's player:openWindow), not by this
+    // renderer's own window.open(). Renderer-driven window.open() is what
+    // forces the browser build's two-click flow below (a native file dialog
+    // and a script-driven window.open() can't share one click's activation
+    // grant — see handleBrowserStart); main-process window creation isn't
+    // subject to that at all. Also wires 'resource-request' (not just
+    // 'ready') over the handoff channel, backed by a real ElectronFileAdapter
+    // — the same mechanism editor-store.ts's previewInWasmPlayer uses — so a
+    // loose .aslx that references sibling images/sounds in its folder keeps
+    // working, not just self-contained .quest packages.
+    async function handleElectronPlay() {
+        electronError = null;
+        const picked = await openElectronPlayFile();
+        if (!picked) return;
+
+        electronBusy = true;
+        try {
+            const { bytes, adapter } = await loadElectronFile(picked.dirPath, picked.filename);
+
+            playChannel?.close();
+            const bc = new BroadcastChannel("quest-play-local");
+            playChannel = bc;
+            bc.onmessage = async ({ data }) => {
+                if (data.type === "ready") {
+                    bc.postMessage({ type: "game", bytes, filename: picked.filename });
+                } else if (data.type === "resource-request") {
+                    const blob = await adapter.getAsset(data.name);
+                    if (blob) {
+                        const dataUrl = await blobToDataUrl(blob);
+                        bc.postMessage({ type: "resource-response", id: data.id, dataUrl });
+                    }
+                }
+            };
+
+            const opened = await window.electronApp!.player.openWindow();
+            if (!opened) {
+                electronError = "Couldn't open the player window.";
+                bc.close();
+                playChannel = null;
+            }
+        } catch (err) {
+            electronError = String(err);
+        } finally {
+            electronBusy = false;
+        }
+    }
+
+    // ── Browser build only (isElectronApp false) ────────────────────────────
     // Two deliberate clicks, not one click-through-then-another: picking the
     // file and starting the game are each their own genuine user gesture, so
     // each gets its own fresh browser activation — a single click can't do
-    // both (see handleStart) because a native file dialog and a script-driven
-    // window.open() fight over the same click's single-use activation grant.
+    // both (see handleBrowserStart) because a native file dialog and a
+    // script-driven window.open() fight over the same click's single-use
+    // activation grant.
     let pickedFile = $state<File | null>(null);
     let pickedBytes = $state<Uint8Array | null>(null);
     let pickError = $state<string | null>(null);
@@ -58,24 +130,19 @@
         startError = null;
     }
 
-    // Kept across Start calls (not just a local var) so a new Start can close
-    // the previous one — see below.
-    let playChannel: BroadcastChannel | null = null;
-
     // window.open() must be the very first thing this does — it's what
     // spends this click's activation, and awaiting anything beforehand
     // (there's nothing to await here; the bytes are already read in
     // handlePickFile) would let the popup blocker silently no-op it. Hands
-    // the bytes to the new tab over a BroadcastChannel — the same handoff
-    // editor-store.ts's previewInWasmPlayer uses for live editor previews —
-    // see wasm-player.js's `source=local` boot branch.
-    function handleStart() {
+    // the bytes to the new tab over a BroadcastChannel — see wasm-player.js's
+    // `source=local` boot branch. No resource-request handling on this path:
+    // a raw picked File has no directory to resolve sibling assets against
+    // (unlike the Electron path above), so this only really supports
+    // self-contained .quest packages.
+    function handleBrowserStart() {
         if (!pickedFile || !pickedBytes) return;
         startError = null;
 
-        // Close any previous play channel first — otherwise it would *also*
-        // answer this new tab's 'ready' broadcast (with the wrong bytes), and
-        // would go on answering a refresh of the now-superseded old tab.
         playChannel?.close();
 
         const popup = window.open(`${base}/player/?source=local`, "_blank");
@@ -116,7 +183,14 @@
 <div class="min-h-svh bg-surface-950 text-surface-100">
     <div class="flex flex-col gap-8 w-full max-w-5xl mx-auto p-8">
         <div class="flex flex-col items-center gap-2">
-            {#if !pickedFile}
+            {#if isElectronApp}
+                <button type="button" class="btn preset-outlined-primary-500" onclick={handleElectronPlay} disabled={electronBusy}>
+                    {electronBusy ? "Opening…" : "Open a game file…"}
+                </button>
+                {#if electronError}
+                    <p class="text-error-500 text-sm">{electronError}</p>
+                {/if}
+            {:else if !pickedFile}
                 <button type="button" class="btn preset-outlined-primary-500" onclick={handlePickFile}>
                     Open a game file&hellip;
                 </button>
@@ -126,15 +200,15 @@
                     <button type="button" class="btn btn-sm preset-outlined-surface-500" onclick={handleClearPicked} disabled={starting}>
                         Change
                     </button>
-                    <button type="button" class="btn preset-filled-primary-500" onclick={handleStart} disabled={starting}>
+                    <button type="button" class="btn preset-filled-primary-500" onclick={handleBrowserStart} disabled={starting}>
                         {starting ? "Starting…" : "Start ▶"}
                     </button>
                 </div>
             {/if}
-            {#if pickError}
+            {#if !isElectronApp && pickError}
                 <p class="text-error-500 text-sm">{pickError}</p>
             {/if}
-            {#if startError}
+            {#if !isElectronApp && startError}
                 <p class="text-error-500 text-sm">{startError}</p>
             {/if}
         </div>

--- a/src/AppShell/src/lib/electron-types.d.ts
+++ b/src/AppShell/src/lib/electron-types.d.ts
@@ -58,6 +58,14 @@ interface ElectronMenuApi {
     onOpenRecent(callback: (game: { dirPath: string; filename: string }) => void): () => void;
 }
 
+// id: catalog game (textadventures.co.uk id); omitted: a locally-picked
+// file, whose bytes/resources the caller hands over separately via the
+// 'quest-play-local' BroadcastChannel — see ipc/player.ts and
+// PlayCatalog.svelte.
+interface ElectronPlayerApi {
+    openWindow(request?: { id?: string }): Promise<boolean>;
+}
+
 interface ElectronApi {
     fs: ElectronFsApi;
     dialog: ElectronDialogApi;
@@ -66,6 +74,7 @@ interface ElectronApi {
     paths: ElectronPathsApi;
     recent: ElectronRecentApi;
     menu: ElectronMenuApi;
+    player: ElectronPlayerApi;
     // Not yet populated by preload.ts — "Mac" | "Windows" | "Linux", sent as
     // analytics metadata alongside webhome_games_list/webhome_game_play (see
     // ClientInfo on textadventures.co.uk's ApiController). Declared optional

--- a/src/AppShell/src/lib/filesystem/electron-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/electron-adapter.ts
@@ -83,8 +83,29 @@ export class ElectronFileAdapter implements FileAdapter {
     get filename() { return this._filename; }
     readonly canSaveAs = true;
 
+    // Resource names reaching getAsset() can be attacker-controlled — a
+    // downloaded game's own <javascript>/image/sound references, forwarded
+    // here verbatim from the WasmPlayer 'resource-request' handoff (see
+    // PlayCatalog.svelte and editor-store.ts's previewInWasmPlayer). window
+    // .electronApp.path.join is a plain string join with no traversal
+    // protection (see preload.ts), so without this a name like
+    // "../../../../.ssh/id_rsa" would resolve outside dirPath and getAsset
+    // would happily read it. Collapses "." / ".." segments ourselves and
+    // rejects anything that would climb above dirPath, rather than trusting
+    // the joined path.
     private resolve(name: string): string {
-        return electronApp().path.join(this.dirPath, name);
+        const sep = this.dirPath.includes("\\") && !this.dirPath.includes("/") ? "\\" : "/";
+        const segments: string[] = [];
+        for (const part of name.replace(/\\/g, "/").split("/")) {
+            if (part === "" || part === ".") continue;
+            if (part === "..") {
+                if (segments.length === 0) throw new Error(`Resource name escapes its game folder: ${name}`);
+                segments.pop();
+                continue;
+            }
+            segments.push(part);
+        }
+        return electronApp().path.join(this.dirPath, segments.join(sep));
     }
 
     async saveFile(data: Uint8Array | string): Promise<void> {
@@ -138,6 +159,18 @@ export class ElectronFileAdapter implements FileAdapter {
  */
 export async function openElectronFile(): Promise<{ dirPath: string; filename: string } | null> {
     const filePath = await electronApp().dialog.openFile({ filters: ASLX_FILTER });
+    if (!filePath) return null;
+    return { dirPath: dirname(filePath), filename: basename(filePath) };
+}
+
+// Broader than ASLX_FILTER above (which is Save/SaveAs-scoped, and the
+// editor only ever opens unpacked .aslx) — Play accepts every format
+// WasmPlayer itself can boot, matching the browser build's pickFile(".quest,
+// .aslx,.asl,.cas") in PlayCatalog.svelte.
+const PLAY_FILTER = [{ name: "Quest game files", extensions: ["quest", "aslx", "asl", "cas"] }];
+
+export async function openElectronPlayFile(): Promise<{ dirPath: string; filename: string } | null> {
+    const filePath = await electronApp().dialog.openFile({ filters: PLAY_FILTER });
     if (!filePath) return null;
     return { dirPath: dirname(filePath), filename: basename(filePath) };
 }

--- a/src/AppShell/src/routes/play/[id]/+page.svelte
+++ b/src/AppShell/src/routes/play/[id]/+page.svelte
@@ -3,10 +3,24 @@
     import { page } from "$app/state";
     import { base } from "$app/paths";
     import { fetchGameDetails, type GameDetails } from "$lib/home-catalog";
+    import { isElectron } from "$lib/runtime";
+
+    const isElectronApp = isElectron();
 
     let details = $state<GameDetails | null>(null);
     let error = $state(false);
     let loading = $state(true);
+
+    // Electron: open a dedicated player window with no filesystem bridge
+    // (see ipc/player.ts), rather than navigating this editor window itself
+    // to /player/?id= — that in-place nav would otherwise carry this
+    // window's own window.electronApp (fs/dialog access) straight into a
+    // downloaded, third-party game's page, and Quest games can eval their
+    // own <javascript> resources (see wasm-player.js's WebPlayer.runJs).
+    function handleElectronPlay() {
+        if (!details) return;
+        void window.electronApp!.player.openWindow({ id: details.id });
+    }
 
     onMount(async () => {
         const id = page.params.id;
@@ -58,7 +72,11 @@
                     <p class="text-sm whitespace-pre-line">{details.description}</p>
                 {/if}
                 <div class="flex gap-3 mt-2">
-                    <a href="{base}/player/?id={details.id}" class="btn preset-filled-primary-500">Play</a>
+                    {#if isElectronApp}
+                        <button type="button" class="btn preset-filled-primary-500" onclick={handleElectronPlay}>Play</button>
+                    {:else}
+                        <a href="{base}/player/?id={details.id}" class="btn preset-filled-primary-500">Play</a>
+                    {/if}
                     <a href={details.url} target="_blank" rel="noopener" class="btn preset-outlined-primary-500">View on textadventures.co.uk</a>
                 </div>
             </div>

--- a/src/ElectronApp/src/ipc/player.ts
+++ b/src/ElectronApp/src/ipc/player.ts
@@ -1,0 +1,57 @@
+import { ipcMain, BrowserWindow, shell } from "electron";
+
+export interface PlayerWindowRequest {
+    // Catalog game (textadventures.co.uk id) vs. a locally-picked file whose
+    // bytes/resource-request handling PlayCatalog.svelte hands over the
+    // BroadcastChannel once this window signals 'ready' — see wasm-player.js's
+    // `source=local` boot branch.
+    id?: string;
+}
+
+// Backs window.electronApp.player in preload.ts. Takes a request *shape*, not
+// a URL — the renderer never gets to hand main.ts an arbitrary string to
+// navigate a new window to, only the two known player boot modes.
+//
+// Deliberately no preload here (unlike editorWindow): the player window runs
+// arbitrary game content, including game-supplied <javascript> resources
+// executed via eval (see wasm-player.js's WebPlayer.runJs) — an untrusted
+// trust boundary that must never get window.electronApp's fs/dialog bridge.
+// A locally-picked game's sibling resources are instead resolved by
+// PlayCatalog.svelte (which *does* have fs access) answering
+// 'resource-request' messages over the same BroadcastChannel used to hand
+// over the initial game bytes, exactly like the existing editor-preview path.
+export function registerPlayerHandlers(getOrigin: () => string | null): void {
+    ipcMain.handle("player:openWindow", (_event, request?: PlayerWindowRequest) => {
+        const origin = getOrigin();
+        if (!origin) return false;
+
+        const url = request?.id
+            ? `${origin}/player/?id=${encodeURIComponent(request.id)}`
+            : `${origin}/player/?source=local`;
+
+        const win = new BrowserWindow({
+            width: 1000,
+            height: 800,
+            webPreferences: {
+                contextIsolation: true,
+                nodeIntegration: false,
+                // Electron's own default is already no-user-gesture-required
+                // (unlike stock Chrome) — set explicitly so this doesn't
+                // silently change if that default ever does. Paired with
+                // wasm-player.js's Electron-UA check, which skips its
+                // "click to begin" sound-activation gate entirely here.
+                autoplayPolicy: "no-user-gesture-required",
+            },
+        });
+        // Games can't open further windows of their own — same-origin
+        // player navigation isn't a thing a game needs, and anything else
+        // (a game script's window.open to some external URL) goes to the OS
+        // browser instead of spawning another in-app window.
+        win.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
+            void shell.openExternal(targetUrl);
+            return { action: "deny" };
+        });
+        void win.loadURL(url);
+        return true;
+    });
+}

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -6,6 +6,7 @@ import { registerDialogHandlers } from "./ipc/dialog";
 import { registerShellHandlers } from "./ipc/shell";
 import { registerPathsHandlers } from "./ipc/paths";
 import { registerRecentHandlers } from "./ipc/recent";
+import { registerPlayerHandlers } from "./ipc/player";
 import { listRecentGames, clearRecentGames, type RecentGame } from "./recent-games";
 
 // Without this, Electron's default macOS menu ("About "/"Quit ") falls back
@@ -160,6 +161,15 @@ function createEditorWindow(port: number): void {
             preload: path.join(__dirname, "preload.js"),
             contextIsolation: true,
             nodeIntegration: false,
+            // This window never actually plays untrusted game content itself
+            // (catalog play and local-file play both go through
+            // ipc/player.ts's dedicated player windows instead, precisely to
+            // keep this window's fs/dialog-capable preload away from game
+            // content — see setWindowOpenHandler below and player.ts). Set
+            // here anyway for belt-and-suspenders consistency with every
+            // other player-window surface, rather than relying on Electron's
+            // already-permissive default.
+            autoplayPolicy: "no-user-gesture-required",
         },
     });
 
@@ -176,7 +186,22 @@ function createEditorWindow(port: number): void {
     // second app window.
     editorWindow.webContents.setWindowOpenHandler(({ url }) => {
         if (url.startsWith(`http://127.0.0.1:${port}/player/`)) {
-            return { action: "allow" };
+            return {
+                action: "allow",
+                // No preload for this popup — matches ipc/player.ts's
+                // main-process-created player windows: it's untrusted game
+                // content (games can eval their own <javascript> resources),
+                // so it must never get window.electronApp's fs/dialog bridge.
+                // autoplayPolicy explicit for the same reason as
+                // createEditorWindow's own webPreferences above.
+                overrideBrowserWindowOptions: {
+                    webPreferences: {
+                        contextIsolation: true,
+                        nodeIntegration: false,
+                        autoplayPolicy: "no-user-gesture-required",
+                    },
+                },
+            };
         }
         void shell.openExternal(url);
         return { action: "deny" };
@@ -195,6 +220,7 @@ app.whenReady().then(async () => {
     registerShellHandlers();
     registerPathsHandlers();
     registerRecentHandlers(() => void refreshMenu());
+    registerPlayerHandlers(() => (staticServer ? `http://127.0.0.1:${staticServer.port}` : null));
     await refreshMenu();
 
     const root = staticRoot();

--- a/src/ElectronApp/src/preload.ts
+++ b/src/ElectronApp/src/preload.ts
@@ -83,4 +83,13 @@ contextBridge.exposeInMainWorld("electronApp", {
             return () => ipcRenderer.removeListener("open-recent-game", listener);
         },
     },
+    player: {
+        // Opens a dedicated player BrowserWindow (see ipc/player.ts) rather
+        // than a renderer-driven window.open() — sidesteps the browser's
+        // popup-blocker/user-activation rules entirely (main-process window
+        // creation isn't subject to them), which is what lets Play launch
+        // straight from a single file-picker click instead of needing a
+        // second "Start" click to satisfy a fresh gesture.
+        openWindow: (request?: { id?: string }): Promise<boolean> => ipcRenderer.invoke("player:openWindow", request),
+    },
 });

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -98,6 +98,12 @@ function finishSync(showCommandDiv) {
 // might play a sound before the player has had any chance to interact with
 // the page themselves (typing a command is itself a fresh activation).
 function activationLikelyGranted() {
+    // Electron's own default autoplay policy is already unrestricted (unlike
+    // stock Chrome's), and ipc/player.ts's player windows set it explicitly —
+    // true regardless of how the window was created (in-place nav, popup, or
+    // a main-process-created window), so the gate below would only ever add
+    // friction there, never actually prevent a blocked sound.
+    if (navigator.userAgent.includes('Electron/')) return true;
     return !('userActivation' in navigator) || navigator.userActivation.hasBeenActive;
 }
 
@@ -853,14 +859,18 @@ async function fetchGameBytes(url) {
     }
 
     // AppShell's Play tab (see PlayCatalog.svelte) — the user already picked
-    // a file and clicked Start over there, so the game bytes are sitting in
-    // that tab's memory. Same handoff as the editor preview above, just with
-    // no resource-request handling: a locally picked file is never backed by
-    // a live FileAdapter to fetch assets from, only self-contained bytes (a
-    // .quest package embeds its resources; loose .aslx games fetch theirs by
-    // URL), exactly like the plain file-input path in wireStartScreen()
-    // below. A distinct channel name keeps this from cross-talking with a
-    // real editor-preview tab open at the same time.
+    // a file and clicked Start (browser build) or the window just got opened
+    // straight from the file picker (Electron, see ipc/player.ts), so the
+    // game bytes are sitting in that tab's memory. Same handoff as the editor
+    // preview above, including resource-request support: in the browser
+    // build a raw picked File has nothing to answer those with (so they just
+    // go unanswered — fine for a self-contained .quest package, which is all
+    // the plain file-input path in wireStartScreen() below ever supported
+    // either), but Electron's PlayCatalog.svelte backs the picked file with a
+    // real ElectronFileAdapter and answers them from disk, exactly like
+    // editor-store.ts's previewInWasmPlayer does for the live editor. A
+    // distinct channel name keeps this from cross-talking with a real
+    // editor-preview tab open at the same time.
     if (params.get('source') === 'local') {
         const bc = new BroadcastChannel('quest-play-local');
         bc.postMessage({ type: 'ready' });
@@ -876,9 +886,11 @@ async function fetchGameBytes(url) {
         bc.onmessage = async ({ data }) => {
             if (data.type === 'game') {
                 window.clearTimeout(timeoutId);
+                // Not closed (unlike the timeout branch above) — startGame
+                // reassigns bc.onmessage itself to keep answering
+                // 'resource-response' messages for the rest of the session.
                 bc.onmessage = null;
-                bc.close();
-                await startGame(data.bytes, data.filename);
+                await startGame(data.bytes, data.filename, bc);
             }
         };
         return;

--- a/tests/e2e/verify-electron-play-local-file.mjs
+++ b/tests/e2e/verify-electron-play-local-file.mjs
@@ -1,0 +1,119 @@
+// Ad-hoc manual verification for Electron's Play tab "Open a game file…"
+// flow (PlayCatalog.svelte's handleElectronPlay): a single click on the
+// button should pick a file via the native dialog *and* launch it — no
+// separate "Start" click (unlike the browser build, which needs one to get a
+// fresh activation for its own window.open()). The launched player window is
+// created by the main process (ipc/player.ts's player:openWindow), so it
+// isn't subject to that activation requirement at all.
+//
+// Also verifies the two things that only work because of it:
+//  - sibling resources: restart-test.aslx references an external
+//    restart-test.js in the same folder, which only loads if the
+//    'resource-request' BroadcastChannel handoff (backed by a real
+//    ElectronFileAdapter reading from disk, not just raw bytes) is wired up.
+//  - no "click to begin" sound-activation gate: wasm-player.js's
+//    activationLikelyGranted() should short-circuit on the Electron user
+//    agent, so the game boots straight through even though this window was
+//    never focus-clicked before Bridge.Begin() ran.
+//
+// Uses Playwright's _electron launcher against the already-built
+// src/ElectronApp/dist — run electron.sh once first (or the build steps
+// inside it) so dist/ and resources/app-static exist.
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, copyFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const electronAppDir = join(import.meta.dirname, '..', '..', 'src', 'ElectronApp');
+const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'))('electron');
+
+const userDataDir = mkdtempSync(join(tmpdir(), 'quest-electron-userdata-'));
+const gameDir = mkdtempSync(join(tmpdir(), 'quest-electron-play-'));
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const aslxPath = join(gameDir, 'restart-test.aslx');
+copyFileSync(join(fixturesDir, 'restart-test.aslx'), aslxPath);
+copyFileSync(join(fixturesDir, 'restart-test.js'), join(gameDir, 'restart-test.js'));
+
+let app;
+try {
+    app = await electron.launch({
+        executablePath: electronExecutablePath,
+        args: [electronAppDir, `--user-data-dir=${userDataDir}`],
+    });
+    const win = await app.firstWindow();
+    win.on('pageerror', err => console.log('[editor] [pageerror]', err.message));
+    win.on('console', msg => { if (msg.type() === 'error') console.log('[editor] [console.error]', msg.text()); });
+
+    await app.evaluate(({ dialog }, fp) => {
+        dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [fp] });
+    }, aslxPath);
+
+    // Root is the Play tab (PUBLIC_SHOW_HOME=true, see electron.sh).
+    await win.waitForSelector('button:has-text("Open a game file…")', { timeout: 30000 });
+    console.log('[editor] Play tab loaded, "Open a game file…" button present');
+
+    const [playerWindow] = await Promise.all([
+        app.waitForEvent('window'),
+        win.click('button:has-text("Open a game file…")'),
+    ]);
+    console.log('[editor] single click opened a new player window — no separate Start click needed');
+
+    playerWindow.on('pageerror', err => console.log('[player] [pageerror]', err.message));
+    playerWindow.on('console', msg => { if (msg.type() === 'error') console.log('[player] [console.error]', msg.text()); });
+
+    await playerWindow.waitForFunction(() => document.title === 'Simple', null, { timeout: 15000 });
+    console.log('[player] game booted, document.title:', await playerWindow.title());
+
+    // No "click to begin" gate: the start screen overlay should already be
+    // gone (game UI visible) without this test ever having interacted with
+    // the player window at all.
+    const gateVisible = await playerWindow.isVisible('#qv-clicktobegin');
+    console.log('PASS: no click-to-begin sound gate shown:', !gateVisible);
+    if (gateVisible) throw new Error('Unexpected click-to-begin gate in Electron player window');
+
+    // Sibling resource (restart-test.js) loaded via the resource-request
+    // handoff and ran, injecting its sidebar pane.
+    await playerWindow.waitForSelector('.newwindow-test-pane', { timeout: 10000 });
+    const scriptRuns = await playerWindow.evaluate(() => window.__restartTestScriptRuns);
+    console.log('PASS: sibling restart-test.js loaded from disk over resource-request, ran', scriptRuns, 'time(s)');
+    if (scriptRuns !== 1) throw new Error(`Expected restart-test.js to run exactly once, got ${scriptRuns}`);
+
+    // Back on the editor window, the button should be its plain idle state
+    // again (not stuck showing "Opening…").
+    await win.waitForSelector('button:has-text("Open a game file…"):not([disabled])', { timeout: 5000 });
+    console.log('PASS: Play tab button reset to idle after handoff');
+
+    // Catalog play (play/[id]/+page.svelte's handleElectronPlay) drives the
+    // same player:openWindow IPC with an {id} — exercised directly here
+    // (rather than via a real textadventures.co.uk catalog fetch) to confirm
+    // it opens a *separate* window instead of navigating this editor window
+    // itself, which is what closes the filesystem-access hole this change
+    // was meant to fix: a downloaded game's <javascript> can eval, and this
+    // editor window's own preload exposes window.electronApp's fs bridge.
+    const editorUrlBefore = win.url();
+    const [catalogPlayerWindow] = await Promise.all([
+        app.waitForEvent('window'),
+        win.evaluate(() => window.electronApp.player.openWindow({ id: 'catalog-test-id' })),
+    ]);
+    console.log('PASS: catalog play opened a separate window:', catalogPlayerWindow.url());
+    if (!catalogPlayerWindow.url().includes('/player/?id=catalog-test-id')) {
+        throw new Error(`Unexpected catalog player window URL: ${catalogPlayerWindow.url()}`);
+    }
+    if (win.url() !== editorUrlBefore) {
+        throw new Error(`Editor window navigated in-place (${editorUrlBefore} -> ${win.url()}) instead of staying put`);
+    }
+    console.log('PASS: editor window itself did not navigate (still fs-bridge-capable, but never sees game content)');
+    await catalogPlayerWindow.close();
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await app?.close();
+    rmSync(userDataDir, { recursive: true, force: true });
+    rmSync(gameDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Follow-up to #1885, addressing three friction points in the Electron desktop app's Play flow:

- **One click, not two, to open and launch a local game file.** The previous Play tab required picking a file *then* clicking a separate "Start" button, because a renderer-driven `window.open()` needs its own fresh user activation, which the native file dialog consumes. In Electron the new player window is instead created by the **main process** (`ipc/player.ts`'s `player:openWindow`), which isn't subject to that restriction — so a single click now picks and launches the game.
- **No "click to begin" sound-activation gate in Electron.** Electron's autoplay is unrestricted by default (unlike stock Chrome); `wasm-player.js` now skips the gate when it detects the Electron user agent, and `autoplayPolicy: "no-user-gesture-required"` is set explicitly on every player-window surface rather than relying on the implicit default.
- **Sibling resources for loose `.aslx` files.** Local Play now reuses the same `resource-request`-over-`BroadcastChannel` handoff the editor's Preview button already used, backed by a real `ElectronFileAdapter` reading from disk — so a game that references images/sounds in its own folder works when played directly, not just self-contained `.quest` packages.

**Also fixed while in the area:** catalog "Play" in Electron was navigating the *editor window itself* (which has full filesystem IPC access) into the WasmPlayer page for a downloaded game — and Quest games can `eval` their own embedded `<javascript>` resources. That gave any catalog game a path to read/write files on the user's machine. Fixed by routing all play launches (catalog and local-file) through dedicated player windows with no filesystem bridge at all. While extending the resource-lookup path to untrusted game-supplied resource names, also hardened `ElectronFileAdapter.resolve()` against `../` path traversal, which wasn't checked before.

## Test plan

- [x] `dotnet build` (WasmEditor, WasmPlayer) — clean
- [x] `npm run build` (AppShell, ElectronApp) — clean, `tsc --noEmit` clean, ESLint clean
- [x] New `tests/e2e/verify-electron-play-local-file.mjs` (Playwright `_electron`) — passes: single-click open+play, no click-to-begin gate, sibling `.js` resource loads over the resource-request channel, catalog Play opens a separate window without navigating the editor window in place
- [x] Confirmed no regression against the other existing Electron e2e tests (one, `verify-electron-open-file.mjs`, already fails on `main` before this change too — a pre-existing gap from the earlier Play/Create home-screen work, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)