### PR TITLE
ci: wire up manually-dispatched e2e workflow, fix stale/broken e2e scripts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,295 @@
+name: e2e
+
+# Manual only, not on every push/PR — these are Playwright browser/Electron-
+# driven verification scripts (tests/e2e/*.mjs), not the dotnet test suite.
+# They drive real dev servers / a packaged Electron app end-to-end rather than
+# mocking anything, so they're slower and younger than dotnet test. Good to
+# run before cutting a release, or after touching AppShell/WasmPlayer/
+# WebPlayer/ElectronApp. Each job below matches one of the distinct local
+# setups documented in the individual scripts' header comments — see those
+# for the "why" behind each one.
+on:
+  workflow_dispatch:
+
+jobs:
+  # AppShell (Debug WasmEditor), one Vite dev server shared by every script
+  # that doesn't need a special AppShell build/env — each script normally
+  # defaults to its own port for local ad-hoc use, but here they both get
+  # pointed at the same instance via an explicit baseUrl arg.
+  #
+  # NOT included here: verify-appshell-play-open-file.mjs and
+  # verify-appshell-play-refresh.mjs — both hang forever booting
+  # fixtures/restart-test.aslx via the Play tab's browser file-picker
+  # (?source=local), a real product bug, not CI flakiness. See
+  # https://github.com/textadventures/quest/issues/1887. Re-add once fixed,
+  # or once they're pointed at a self-contained fixture.
+  appshell_chromium:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet workload install wasm-tools
+
+      - run: dotnet build src/WasmEditor/WasmEditor.csproj -c Debug
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: |
+            src/AppShell/package-lock.json
+            tests/e2e/package-lock.json
+
+      - run: npm ci
+        working-directory: src/AppShell
+      - run: npm ci
+        working-directory: tests/e2e
+      - run: npx playwright install --with-deps chromium
+        working-directory: tests/e2e
+
+      - name: Start AppShell dev server (5174)
+        run: npx vite dev --port 5174 &
+        working-directory: src/AppShell
+        env:
+          PUBLIC_SHOW_HOME: true
+
+      - name: Wait for dev server
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf "http://localhost:5174/" > /dev/null && break
+            [ "$i" -eq 30 ] && { echo "port 5174 never came up"; exit 1; }
+            sleep 1
+          done
+
+      - run: node verify-appshell-opfs-default.mjs http://localhost:5174
+        working-directory: tests/e2e
+      - run: node verify-appshell-autosave.mjs http://localhost:5174
+        working-directory: tests/e2e
+
+  # OPFS local-drafts behavior on non-FSA browsers, against a Release
+  # WasmEditor build — createSyncAccessHandle (Safari's write path, proxied
+  # here by WebKit) needs the AOT build's real dotnet runtime bits present.
+  appshell_opfs_firefox_webkit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet workload install wasm-tools
+
+      - run: dotnet build src/WasmEditor/WasmEditor.csproj -c Release
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: |
+            src/AppShell/package-lock.json
+            tests/e2e/package-lock.json
+
+      - run: npm ci
+        working-directory: src/AppShell
+      - run: npm ci
+        working-directory: tests/e2e
+      - run: npx playwright install --with-deps firefox webkit
+        working-directory: tests/e2e
+
+      - name: Start AppShell dev server (5174, Release WasmEditor)
+        run: npx vite dev --port 5174 &
+        working-directory: src/AppShell
+        env:
+          WASM_CONFIG: Release
+
+      - name: Wait for dev server
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf "http://localhost:5174/" > /dev/null && break
+            [ "$i" -eq 30 ] && { echo "port 5174 never came up"; exit 1; }
+            sleep 1
+          done
+
+      - run: node verify-appshell-local-drafts.mjs http://localhost:5174 firefox
+        working-directory: tests/e2e
+      - run: node verify-appshell-local-drafts.mjs http://localhost:5174 webkit
+        working-directory: tests/e2e
+      - run: node verify-appshell-drafts-rekey-backup.mjs http://localhost:5174
+        working-directory: tests/e2e
+      - run: node verify-appshell-multi-aslx-zip.mjs http://localhost:5174
+        working-directory: tests/e2e
+
+  # PUBLIC_HAS_SERVER=true (textadventures.co.uk build mode) — only checks
+  # /open's button/caption text, never enters the editor, so no WasmEditor
+  # build needed at all.
+  appshell_server_mode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: |
+            src/AppShell/package-lock.json
+            tests/e2e/package-lock.json
+
+      - run: npm ci
+        working-directory: src/AppShell
+      - run: npm ci
+        working-directory: tests/e2e
+      - run: npx playwright install --with-deps chromium
+        working-directory: tests/e2e
+
+      - name: Start AppShell dev server (5174, PUBLIC_HAS_SERVER=true)
+        run: npx vite dev --port 5174 &
+        working-directory: src/AppShell
+        env:
+          PUBLIC_HAS_SERVER: true
+
+      - name: Wait for dev server
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf "http://localhost:5174/" > /dev/null && break
+            [ "$i" -eq 30 ] && { echo "port 5174 never came up"; exit 1; }
+            sleep 1
+          done
+
+      - run: node verify-appshell-server-mode-caption.mjs http://localhost:5174
+        working-directory: tests/e2e
+
+  # WasmPlayer alone, no AppShell involved.
+  wasmplayer_chromium:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet workload install wasm-tools
+      - run: dotnet build src/WasmPlayer/WasmPlayer.csproj -c Debug
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - run: npm ci
+        working-directory: tests/e2e
+      - run: npx playwright install --with-deps chromium
+        working-directory: tests/e2e
+
+      - name: Start WasmPlayer dev server (5175)
+        run: node src/WasmPlayer/dev-server.mjs &
+
+      - name: Wait for dev server
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf "http://localhost:5175/" > /dev/null && break
+            [ "$i" -eq 30 ] && { echo "port 5175 never came up"; exit 1; }
+            sleep 1
+          done
+
+      - run: node verify-wasmplayer-restart-sidebar-dup.mjs http://localhost:5175
+        working-directory: tests/e2e
+
+  # WebPlayer (ASP.NET Core + Blazor Server), Development mode with Dev:Enabled
+  # (appsettings.Development.json already sets this — see /dev/open's
+  # RequiresConfig("Dev:Enabled") gate).
+  webplayer_chromium:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - run: npm ci
+        working-directory: tests/e2e
+      - run: npx playwright install --with-deps chromium
+        working-directory: tests/e2e
+
+      - name: Start WebPlayer (5099, Development)
+        run: dotnet run --configuration Release --no-launch-profile --urls http://localhost:5099 --project src/WebPlayer &
+        env:
+          ASPNETCORE_ENVIRONMENT: Development
+
+      - name: Wait for WebPlayer
+        run: |
+          for i in $(seq 1 60); do
+            curl -sf "http://localhost:5099/" > /dev/null && break
+            [ "$i" -eq 60 ] && { echo "port 5099 never came up"; exit 1; }
+            sleep 2
+          done
+
+      - run: node verify-webplayer-legacy-save.mjs http://localhost:5099
+        working-directory: tests/e2e
+      - run: node verify-webplayer-restart-chrome-reset.mjs http://localhost:5099
+        working-directory: tests/e2e
+
+  # Real, packaged Electron app (Playwright's _electron launcher) — macos-
+  # latest, not ubuntu-latest (unlike build_electron in build-and-test.yml,
+  # which only proves the build pipeline, never launches Electron itself): a
+  # real Electron window on Linux CI needs both Xvfb (no X server in the
+  # container) and --no-sandbox (the SUID-root chrome-sandbox helper needs
+  # setup a plain `npm install` doesn't do — see electron.sh's comment on this
+  # same issue). macOS runners have a real GUI session already, so neither
+  # applies. Also the runner electron-publish.yml already uses for DMG builds.
+  electron:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet workload install wasm-tools
+
+      - run: dotnet build src/WasmEditor/WasmEditor.csproj -c Debug
+      - run: dotnet build src/WasmPlayer/WasmPlayer.csproj -c Debug
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: |
+            src/AppShell/package-lock.json
+            src/ElectronApp/package-lock.json
+            tests/e2e/package-lock.json
+
+      - run: npm ci
+        working-directory: src/AppShell
+      - run: npm run build
+        working-directory: src/AppShell
+        env:
+          PUBLIC_SHOW_HOME: true
+
+      - run: npm ci
+        working-directory: src/ElectronApp
+      - run: npm run build
+        working-directory: src/ElectronApp
+
+      - run: npm ci
+        working-directory: tests/e2e
+
+      - run: node verify-electron-open-file.mjs
+        working-directory: tests/e2e
+      - run: node verify-electron-new-game-folder.mjs
+        working-directory: tests/e2e
+      - run: node verify-electron-recent-games.mjs
+        working-directory: tests/e2e
+      - run: node verify-electron-play-local-file.mjs
+        working-directory: tests/e2e

--- a/src/AppShell/src/lib/filesystem/electron-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/electron-adapter.ts
@@ -120,7 +120,7 @@ export class ElectronFileAdapter implements FileAdapter {
         if (!path) return null;
         await electronApp().fs.writeFile(path, data);
         this._filename = basename(path);
-        void trackRecent(dirname(path), this._filename);
+        await trackRecent(dirname(path), this._filename);
         return this._filename;
     }
 
@@ -177,7 +177,7 @@ export async function openElectronPlayFile(): Promise<{ dirPath: string; filenam
 
 export async function loadElectronFile(dirPath: string, filename: string): Promise<{ bytes: Uint8Array; adapter: ElectronFileAdapter }> {
     const bytes = await electronApp().fs.readFile(electronApp().path.join(dirPath, filename));
-    void trackRecent(dirPath, filename);
+    await trackRecent(dirPath, filename);
     return { bytes, adapter: new ElectronFileAdapter(dirPath, filename) };
 }
 
@@ -228,6 +228,6 @@ export async function createElectronGame(
     await electronApp().fs.mkdir(dirPath);
     const filePath = electronApp().path.join(dirPath, filename);
     await electronApp().fs.writeFile(filePath, content);
-    void trackRecent(dirPath, filename);
+    await trackRecent(dirPath, filename);
     return { bytes: new TextEncoder().encode(content), adapter: new ElectronFileAdapter(dirPath, filename) };
 }

--- a/tests/e2e/verify-appshell-drafts-rekey-backup.mjs
+++ b/tests/e2e/verify-appshell-drafts-rekey-backup.mjs
@@ -42,8 +42,11 @@ try {
     // --- Scenario 1: GameId rekey ---
     await createDraft('Rekey Test'); // exactly 1 draft now, still inside the editor
     await page.click('button:has-text("Generate")'); // regenerate gameid
-    await page.click('button:has-text("Save")');
-    await page.waitForTimeout(500); // saveFile/rekey is async, no visible loading indicator to wait on
+    // No explicit Save button anymore (debounced autosave-on-edit replaced
+    // it — see verify-appshell-autosave.mjs) — wait for the pill to cycle
+    // through the same Saving…/Saved lifecycle instead of clicking one.
+    await page.waitForSelector('text=Saving…', { timeout: 3000 });
+    await page.waitForSelector('text=Saved', { timeout: 10000 });
 
     const after = await draftCount();
     console.log('drafts after rekey + save (expect 1, not 2):', after);

--- a/tests/e2e/verify-electron-new-game-folder.mjs
+++ b/tests/e2e/verify-electron-new-game-folder.mjs
@@ -62,11 +62,14 @@ try {
         }, labelPath);
     }
 
-    // 1. Fresh /open, type a name — the preview should show the *parent*
-    // folder only (Documents/Quest Games, the stubbed fake one), not the
-    // game's own subfolder — "Change location…" only ever changes the
-    // parent, so showing the child folder name next to it read as if that
-    // were also choosable.
+    // 1. Root now lands on the Play tab by default — the /open form lives
+    // behind the "Create" tab. Fresh /open, type a name — the preview should
+    // show the *parent* folder only (Documents/Quest Games, the stubbed fake
+    // one), not the game's own subfolder — "Change location…" only ever
+    // changes the parent, so showing the child folder name next to it read
+    // as if that were also choosable.
+    await win.waitForSelector('a:has-text("Create")', { timeout: 30000 });
+    await win.click('a:has-text("Create")');
     await win.waitForSelector('button:has-text("Open game…")', { timeout: 30000 });
     await win.fill('input[placeholder="Game name"]', 'Game A');
     const previewLocator = win.locator('text=Will be created as a new folder in:');

--- a/tests/e2e/verify-electron-open-file.mjs
+++ b/tests/e2e/verify-electron-open-file.mjs
@@ -57,7 +57,11 @@ try {
         }, filePathOrDir);
     }
 
-    // 1. Button label should say "Open game…", not "Open game folder".
+    // 1. Root now lands on the Play tab (PlayCatalog) by default — the /open
+    // form lives behind the "Create" tab. Button label there should say
+    // "Open game…", not "Open game folder".
+    await win.waitForSelector('a:has-text("Create")', { timeout: 30000 });
+    await win.click('a:has-text("Create")');
     await win.waitForSelector('button:has-text("Open game…")', { timeout: 30000 });
     console.log('PASS: create-game page shows "Open game…" (not "Open game folder") on Electron');
 

--- a/tests/e2e/verify-electron-recent-games.mjs
+++ b/tests/e2e/verify-electron-recent-games.mjs
@@ -7,17 +7,19 @@
 // Debug, npm run build in AppShell and ElectronApp) so dist/ and
 // resources/app-static exist.
 //
-// Games are created through the app's own "Create new game" flow (with the
-// folder-picker dialog stubbed to a throwaway temp dir) rather than hand-
+// Games are created through the app's own "Create new game" flow (at the
+// default location, stubbed to a throwaway temp dir) rather than hand-
 // written .aslx fixtures — a hand-written minimal game is a lot of surface
 // to get right (see examples/blank.aslx), and this exercises the real
 // createElectronGame() trackRecent() path anyway.
 //
 // --user-data-dir isolates this run's recent-games.json from the real app's
-// userData (~/Library/Application Support/Quest Viva on mac) so this doesn't
-// pollute or depend on whatever the user has actually opened before.
+// userData (~/Library/Application Support/Quest Viva on mac), and the
+// app.getPath('documents') stub below isolates game files themselves, so
+// this doesn't pollute or depend on whatever the user has actually opened
+// before.
 import { _electron as electron } from 'playwright';
-import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
@@ -30,10 +32,6 @@ const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'
 
 const userDataDir = mkdtempSync(join(tmpdir(), 'quest-electron-userdata-'));
 const gamesRoot = mkdtempSync(join(tmpdir(), 'quest-electron-games-'));
-const gameADir = join(gamesRoot, 'Game A');
-const gameBDir = join(gamesRoot, 'Game B');
-mkdirSync(gameADir);
-mkdirSync(gameBDir);
 
 let app;
 try {
@@ -41,6 +39,17 @@ try {
         executablePath: electronExecutablePath,
         args: [electronAppDir, `--user-data-dir=${userDataDir}`],
     });
+
+    // Stub app.getPath('documents') before the renderer gets a chance to call
+    // paths:defaultGamesDir (fired on /open's mount) — createGame() below
+    // never opens the "Change location…" picker, so without this the game
+    // would land in the real user's ~/Documents/Quest Games instead of this
+    // throwaway temp dir.
+    await app.evaluate(({ app: electronAppSingleton }, fakeDocs) => {
+        const original = electronAppSingleton.getPath.bind(electronAppSingleton);
+        electronAppSingleton.getPath = (name) => (name === 'documents' ? fakeDocs : original(name));
+    }, gamesRoot);
+
     const win = await app.firstWindow();
     win.on('pageerror', err => console.log('[pageerror]', err.message));
     win.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
@@ -74,20 +83,21 @@ try {
         }, labelPath);
     }
 
-    // Drives the "Create new game" form, stubbing the folder-picker dialog to
-    // return dirPath — exercises createElectronGame()'s trackRecent() call.
-    async function createGame(name, dirPath) {
-        await app.evaluate(({ dialog }, dir) => {
-            dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [dir] });
-        }, dirPath);
+    // Drives the "Create new game" form at the default location (stubbed
+    // above to gamesRoot) — exercises createElectronGame()'s trackRecent()
+    // call.
+    async function createGame(name) {
         await win.fill('input[placeholder="Game name"]', name);
         await win.waitForSelector('text=Text adventure', { timeout: 10000 });
-        await win.click('button:has-text("Save to my computer")');
+        await win.click('button:has-text("Create")');
         await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
     }
 
-    // 1. Fresh app, no recent games yet.
-    await win.waitForSelector('button:has-text("Open game folder")', { timeout: 30000 });
+    // 1. Fresh app, no recent games yet. Root lands on the Play tab by
+    // default — the /open form lives behind the "Create" tab.
+    await win.waitForSelector('a:has-text("Create")', { timeout: 30000 });
+    await win.click('a:has-text("Create")');
+    await win.waitForSelector('button:has-text("Open game…")', { timeout: 30000 });
     const noneYet = await win.isVisible('text=Recent');
     console.log('PASS: no "Recent" section before anything is opened:', !noneYet);
     if (noneYet) throw new Error('Recent section shown with an empty list');
@@ -96,7 +106,7 @@ try {
     if (!hasNoRecentPlaceholder) throw new Error('Expected "No Recent Games" placeholder in the native menu');
 
     // 2. Create Game A.
-    await createGame('Game A', gameADir);
+    await createGame('Game A');
     console.log('PASS: Game A created via "Create new game"');
 
     // 3. Go back to /open via File > New Game… (the only in-app way back to
@@ -114,7 +124,7 @@ try {
 
     // 4. Create Game B, then click Game A's Recent entry on /open — should
     // load it directly, no picker.
-    await createGame('Game B', gameBDir);
+    await createGame('Game B');
     await clickMenuItem('File', 'New Game…');
     await win.waitForSelector('text=Game B.aslx', { timeout: 10000 });
     await win.click('button:has-text("Game A.aslx")');
@@ -130,7 +140,7 @@ try {
     // 6. Remove one entry from the /open page, confirm it's gone from both
     // the page and the native menu.
     await clickMenuItem('File', 'New Game…');
-    await win.waitForSelector('text=Game A.aslx', { timeout: 10000 });
+    await win.waitForSelector('text=Game A.aslx', { timeout: 20000 });
     const gameARow = win.locator('div.flex.items-center.gap-2.w-full', { hasText: 'Game A.aslx' }).locator('button:has-text("Remove")');
     await gameARow.click();
     await win.waitForSelector('text=Game A.aslx', { state: 'detached', timeout: 5000 }).catch(() => {});


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/e2e.yml` (`workflow_dispatch`, not on push/PR) with one job per distinct local setup the `tests/e2e/*.mjs` scripts already documented in their own headers: `appshell_chromium`, `appshell_opfs_firefox_webkit` (Release WasmEditor build), `appshell_server_mode`, `wasmplayer_chromium`, `webplayer_chromium`, and `electron` (macOS runner — Electron needs a real GUI session, unlike `build_electron` in `build-and-test.yml` which only proves the build pipeline). These scripts were previously never run anywhere but a developer's own machine.
- Fixes three Electron e2e scripts (`verify-electron-open-file.mjs`, `verify-electron-new-game-folder.mjs`, `verify-electron-recent-games.mjs`) that broke when the Play/Create home screen changed root's default view from `/open` to the Play tab — they now click the "Create" tab first.
- `verify-electron-recent-games.mjs` had two further bugs: it never stubbed `app.getPath('documents')`, so it was writing test games into the real `~/Documents/Quest Games`, and it clicked a `"Save to my computer"` button that no longer exists (now `"Create"`).
- Fixes a real intermittent race in `src/AppShell/src/lib/filesystem/electron-adapter.ts`: `trackRecent()` was fire-and-forget at all 3 call sites, so the editor could show a freshly loaded/created game before the `recent-games.json` write actually landed. Now awaited (it already swallows its own errors internally, so this is safe).
- Fixes `verify-appshell-drafts-rekey-backup.mjs`, which clicked an explicit "Save" button that the autosave change already removed — now waits for the Saving…/Saved pill instead, same pattern as `verify-appshell-autosave.mjs`.

**Deliberately excluded from the new workflow:** `verify-appshell-play-open-file.mjs` and `verify-appshell-play-refresh.mjs` both hit a genuine hang — booting a locally-picked file with sibling resources via the Play tab never resolves (`getResourceUrl()` in `wasm-player.js` has no timeout, and a raw browser `File` has no way to answer the resource-request). Filed as #1887 rather than fixed here.

## Test plan

- [x] All included e2e scripts run manually against real local dev servers (AppShell Debug/Release, WasmPlayer, WebPlayer, packaged Electron app) and pass, several stress-tested 5-20x for flakiness
- [x] `dotnet build` (WasmEditor, WasmPlayer, WebPlayer) — clean
- [x] `npm run build` (AppShell) — clean; ESLint clean on the changed file
- [x] `.github/workflows/e2e.yml` validated for YAML syntax; commands verified locally but **not yet run on an actual GitHub Actions runner** — worth watching the first dispatch for macOS/Linux-specific surprises

🤖 Generated with [Claude Code](https://claude.com/claude-code)