### PR TITLE
fix(WasmPlayer): time out unanswered resource-request handoffs instead of hanging forever

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,17 +12,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  # AppShell (Debug WasmEditor), one Vite dev server shared by every script
-  # that doesn't need a special AppShell build/env — each script normally
-  # defaults to its own port for local ad-hoc use, but here they both get
-  # pointed at the same instance via an explicit baseUrl arg.
-  #
-  # NOT included here: verify-appshell-play-open-file.mjs and
-  # verify-appshell-play-refresh.mjs — both hang forever booting
-  # fixtures/restart-test.aslx via the Play tab's browser file-picker
-  # (?source=local), a real product bug, not CI flakiness. See
-  # https://github.com/textadventures/quest/issues/1887. Re-add once fixed,
-  # or once they're pointed at a self-contained fixture.
+  # AppShell (Debug WasmEditor) + WasmPlayer (Debug), one Vite dev server and
+  # one WasmPlayer dev server shared by every script that doesn't need a
+  # special AppShell build/env — each script normally defaults to its own
+  # port for local ad-hoc use, but here they both get pointed at the same
+  # instances via an explicit baseUrl arg. WasmPlayer is needed because
+  # verify-appshell-play-open-file.mjs and verify-appshell-play-refresh.mjs
+  # boot a game through AppShell's Play tab, which proxies /player to it (see
+  # vite.config.ts).
   appshell_chromium:
     runs-on: ubuntu-latest
     steps:
@@ -34,6 +31,7 @@ jobs:
       - run: dotnet workload install wasm-tools
 
       - run: dotnet build src/WasmEditor/WasmEditor.csproj -c Debug
+      - run: dotnet build src/WasmPlayer/WasmPlayer.csproj -c Debug
 
       - uses: actions/setup-node@v6
         with:
@@ -49,6 +47,17 @@ jobs:
         working-directory: tests/e2e
       - run: npx playwright install --with-deps chromium
         working-directory: tests/e2e
+
+      - name: Start WasmPlayer dev server (5175)
+        run: node src/WasmPlayer/dev-server.mjs &
+
+      - name: Wait for WasmPlayer dev server
+        run: |
+          for i in $(seq 1 30); do
+            curl -sf "http://localhost:5175/" > /dev/null && break
+            [ "$i" -eq 30 ] && { echo "port 5175 never came up"; exit 1; }
+            sleep 1
+          done
 
       - name: Start AppShell dev server (5174)
         run: npx vite dev --port 5174 &
@@ -67,6 +76,10 @@ jobs:
       - run: node verify-appshell-opfs-default.mjs http://localhost:5174
         working-directory: tests/e2e
       - run: node verify-appshell-autosave.mjs http://localhost:5174
+        working-directory: tests/e2e
+      - run: node verify-appshell-play-open-file.mjs http://localhost:5174
+        working-directory: tests/e2e
+      - run: node verify-appshell-play-refresh.mjs http://localhost:5174
         working-directory: tests/e2e
 
   # OPFS local-drafts behavior on non-FSA browsers, against a Release

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -38,12 +38,35 @@ function computeGameId(filename) {
     return filename.split('/').pop();
 }
 
+// Nothing guarantees a 'resource-response' ever arrives: a raw picked File in
+// the browser build's Play-tab flow has no responder for anything beyond the
+// game file itself (see the source=local boot branch's comment), and even a
+// real responder (the editor tab, Electron's ElectronFileAdapter) can vanish
+// mid-request if that tab/window closes. Either way, without this timeout the
+// promise sits pending forever, hanging whatever engine code awaited it — so
+// fall back to the bare filename (same as the no-editorChannel case above),
+// letting the browser attempt — and if unresolvable, cleanly fail — a plain
+// relative fetch instead of hanging.
+const RESOURCE_REQUEST_TIMEOUT_MS = 5000;
+
 function getResourceUrl(name) {
     if (resourceRoot) return Promise.resolve(resourceRoot + name);
     if (!editorChannel) return Promise.resolve(name);
     return new Promise(resolve => {
         const id = crypto.randomUUID();
-        pendingResources.set(id, resolve);
+        const timeoutId = window.setTimeout(() => {
+            pendingResources.delete(id);
+            // The subsequent fetch of the bare filename will very likely also
+            // fail (and the browser will log that on its own) — but that
+            // failure alone won't explain itself, so name the actual cause
+            // here: nobody answered the resource-request handoff in time.
+            console.error(`[Quest] Timed out waiting for resource "${name}" — the tab/window that should have supplied it never answered. Falling back to a plain relative fetch, which will likely fail unless the game is self-contained.`);
+            resolve(name);
+        }, RESOURCE_REQUEST_TIMEOUT_MS);
+        pendingResources.set(id, dataUrl => {
+            window.clearTimeout(timeoutId);
+            resolve(dataUrl);
+        });
         editorChannel.postMessage({ type: 'resource-request', name, id });
     });
 }


### PR DESCRIPTION
## Summary
- `getResourceUrl()` in `wasm-player.js` now applies a 5s timeout to the `resource-request` BroadcastChannel handoff. If nothing answers — a raw picked `File` in the browser Play tab's `source=local` flow has no responder at all, or a real responder (editor tab, Electron's `ElectronFileAdapter`) closes mid-request — it falls back to the bare filename and logs a clear `[Quest]` console error, instead of leaving the promise pending forever and hanging the boot on "Loading…".
- Fixes #1887 (browser Play tab hangs opening a loose `.aslx` with sibling resources) and the same-root-cause #1788 (unanswered request when the editor preview tab closes mid-session).
- Re-enables `verify-appshell-play-open-file.mjs` and `verify-appshell-play-refresh.mjs` in the `appshell_chromium` e2e job (they were excluded pending this fix), adding the WasmPlayer dev-server build/start steps they need since AppShell proxies `/player` to it.

## Test plan
- [x] `dotnet build --configuration Release` — full solution builds clean
- [x] Ran `appshell_chromium`'s scripts by hand against Debug WasmEditor/WasmPlayer dev servers: `verify-appshell-opfs-default.mjs`, `verify-appshell-autosave.mjs`, `verify-appshell-play-open-file.mjs`, `verify-appshell-play-refresh.mjs` — all pass
- [x] Confirmed the timeout fallback fires and logs the new console error (previously: hung forever with no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)