### PR TITLE
fix(ElectronApp): show a confirm dialog instead of silently blocking window close on unsaved changes

### DIFF
--- a/src/ElectronApp/src/ipc/player.ts
+++ b/src/ElectronApp/src/ipc/player.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow, shell } from "electron";
+import { ipcMain, BrowserWindow, dialog, shell } from "electron";
 
 export interface PlayerWindowRequest {
     // Catalog game (textadventures.co.uk id) vs. a locally-picked file whose
@@ -50,6 +50,23 @@ export function registerPlayerHandlers(getOrigin: () => string | null): void {
         win.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
             void shell.openExternal(targetUrl);
             return { action: "deny" };
+        });
+        // playercore.js's beforeunload handler calls e.preventDefault() once
+        // hasUnsavedProgress is set (i.e. after a turn) — a real browser
+        // would show its native "Leave site?" dialog for that, but Electron
+        // gives no UI of its own; will-prevent-unload is the hook it exposes
+        // for main to provide one. Without this, the window silently refuses
+        // to close (same gap as createEditorWindow's handler in main.ts).
+        win.webContents.on("will-prevent-unload", (event) => {
+            const choice = dialog.showMessageBoxSync(win, {
+                type: "question",
+                buttons: ["Cancel", "Leave"],
+                defaultId: 0,
+                cancelId: 0,
+                message: "Leave without saving?",
+                detail: "You've made progress in this game that hasn't been saved. If you leave now, it'll be lost.",
+            });
+            if (choice === 1) event.preventDefault();
         });
         void win.loadURL(url);
         return true;

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, shell, type MenuItemConstructorOptions } from "electron";
+import { app, BrowserWindow, Menu, dialog, shell, type MenuItemConstructorOptions } from "electron";
 import path from "node:path";
 import { startStaticServer, type StaticServerHandle } from "./static-server";
 import { registerFsHandlers } from "./ipc/fs";
@@ -178,6 +178,26 @@ function createEditorWindow(port: number): void {
     // and playing, so it's just "Quest Viva" here — override the page's title
     // instead of changing the shared app.html tag.
     editorWindow.on("page-title-updated", (event) => event.preventDefault());
+
+    // AppShell's edit/+page.svelte calls e.preventDefault() in its own
+    // beforeunload handler whenever there are unsaved changes — in a regular
+    // browser that triggers the native "Leave site?" confirmation, but
+    // Electron doesn't show any UI for that on its own; will-prevent-unload
+    // is the hook it gives main for exactly this. Without a handler here the
+    // window just silently refuses to close (no dialog, no feedback) and
+    // Force Quit becomes the only way out.
+    editorWindow.webContents.on("will-prevent-unload", (event) => {
+        if (!editorWindow) return;
+        const choice = dialog.showMessageBoxSync(editorWindow, {
+            type: "question",
+            buttons: ["Cancel", "Leave"],
+            defaultId: 0,
+            cancelId: 0,
+            message: "Leave without saving?",
+            detail: "You have unsaved changes. If you leave now, they'll be lost.",
+        });
+        if (choice === 1) event.preventDefault();
+    });
 
     // The editor's Preview button calls window.open('/player/...') unchanged
     // from the browser build (see previewInWasmPlayer() in editor-store.ts) —


### PR DESCRIPTION
## Summary
- Windows in ElectronApp were getting stuck open — clicking the red close button did nothing, and only Force Quit would get rid of them.
- Root cause: both the editor (`edit/+page.svelte`) and the player (`playercore.js`, shared with WebPlayer/WasmPlayer) register a `beforeunload` handler that calls `e.preventDefault()` while there are unsaved changes/progress. In a regular browser that triggers the native "Leave site?" confirmation, but Electron shows no UI for that on its own — without a `will-prevent-unload` handler on the corresponding `BrowserWindow`'s `webContents`, the close is just silently blocked forever.
- Added a `will-prevent-unload` handler to both the editor window (`main.ts`) and each player window (`ipc/player.ts`) that shows a native "Leave without saving?" dialog (Cancel/Leave) and allows the close through on "Leave".

## Test plan
- [x] Built and launched the Electron app locally
- [x] Player: played a game, took a turn, clicked close — confirmed the new dialog appears and "Leave" closes the window (previously stuck)
- [ ] Editor: same fix applied, same pattern as the player (already verified working) — not independently reproduced manually since the editor's 800ms autosave debounce clears the dirty flag before a close attempt can usually catch it

🤖 Generated with [Claude Code](https://claude.com/claude-code)