### PR TITLE
fix(ElectronApp): split editor/play Recent lists, focus window on File menu actions

### DIFF
--- a/src/AppShell/src/components/PlayCatalog.svelte
+++ b/src/AppShell/src/components/PlayCatalog.svelte
@@ -4,7 +4,8 @@
     import { fetchCatalog, type CatalogCategory } from "$lib/home-catalog";
     import { pickFile } from "$lib/filesystem/file-picker";
     import { isElectron } from "$lib/runtime";
-    import { openElectronPlayFile, loadElectronFile } from "$lib/filesystem/electron-adapter";
+    import { openElectronPlayFile, loadElectronFile, listRecentGames, removeRecentGame } from "$lib/filesystem/electron-adapter";
+    import type { RecentGame } from "$lib/filesystem/electron-adapter";
 
     const isElectronApp = isElectron();
 
@@ -48,33 +49,40 @@
     let electronBusy = $state(false);
     let electronError = $state<string | null>(null);
 
-    // Electron: a single click launches the game — no second "Start" click
-    // needed, because the player window here is created by the *main*
-    // process (see ipc/player.ts's player:openWindow), not by this
-    // renderer's own window.open(). Renderer-driven window.open() is what
-    // forces the browser build's two-click flow below (a native file dialog
-    // and a script-driven window.open() can't share one click's activation
-    // grant — see handleBrowserStart); main-process window creation isn't
-    // subject to that at all. Also wires 'resource-request' (not just
-    // 'ready') over the handoff channel, backed by a real ElectronFileAdapter
-    // — the same mechanism editor-store.ts's previewInWasmPlayer uses — so a
-    // loose .aslx that references sibling images/sounds in its folder keeps
-    // working, not just self-contained .quest packages.
-    async function handleElectronPlay() {
-        electronError = null;
-        const picked = await openElectronPlayFile();
-        if (!picked) return;
+    // Recently played (Electron only) — mirrors Quest 5's desktop Play tab,
+    // which had its own recent list separate from the editor's. Tracked as
+    // its own "play"-kind list (see electron-adapter.ts's RecentKind) so a
+    // game opened here never shows up in File > Open Recent, which loads
+    // into the editor instead.
+    let recentPlayed = $state<RecentGame[]>([]);
 
+    async function refreshRecentPlayed() {
+        if (!isElectronApp) return;
+        recentPlayed = await listRecentGames("play");
+    }
+    void refreshRecentPlayed();
+
+    // Shared by the file-picker flow below and by clicking a Recently Played
+    // entry — loads the game's bytes/adapter, hands them to a freshly
+    // launched player window over the handoff channel, and answers its
+    // sibling-resource requests for as long as that window is open. Wires
+    // 'resource-request' (not just 'ready'), backed by a real
+    // ElectronFileAdapter — the same mechanism editor-store.ts's
+    // previewInWasmPlayer uses — so a loose .aslx that references sibling
+    // images/sounds in its folder keeps working, not just self-contained
+    // .quest packages.
+    async function playElectronFile(dirPath: string, filename: string) {
         electronBusy = true;
         try {
-            const { bytes, adapter } = await loadElectronFile(picked.dirPath, picked.filename);
+            const { bytes, adapter } = await loadElectronFile(dirPath, filename, "play");
+            void refreshRecentPlayed();
 
             playChannel?.close();
             const bc = new BroadcastChannel("quest-play-local");
             playChannel = bc;
             bc.onmessage = async ({ data }) => {
                 if (data.type === "ready") {
-                    bc.postMessage({ type: "game", bytes, filename: picked.filename });
+                    bc.postMessage({ type: "game", bytes, filename });
                 } else if (data.type === "resource-request") {
                     const blob = await adapter.getAsset(data.name);
                     if (blob) {
@@ -95,6 +103,39 @@
         } finally {
             electronBusy = false;
         }
+    }
+
+    // Electron: a single click launches the game — no second "Start" click
+    // needed, because the player window here is created by the *main*
+    // process (see ipc/player.ts's player:openWindow), not by this
+    // renderer's own window.open(). Renderer-driven window.open() is what
+    // forces the browser build's two-click flow below (a native file dialog
+    // and a script-driven window.open() can't share one click's activation
+    // grant — see handleBrowserStart); main-process window creation isn't
+    // subject to that at all.
+    async function handleElectronPlay() {
+        electronError = null;
+        const picked = await openElectronPlayFile();
+        if (!picked) return;
+        await playElectronFile(picked.dirPath, picked.filename);
+    }
+
+    async function handleRemoveRecentPlayed(game: RecentGame) {
+        await removeRecentGame(game.dirPath, game.filename, "play");
+        await refreshRecentPlayed();
+    }
+
+    function folderName(dirPath: string): string {
+        return dirPath.split(/[\\/]/).pop() || dirPath;
+    }
+
+    function relativeTime(ms: number): string {
+        const mins = Math.round((Date.now() - ms) / 60000);
+        if (mins < 1) return "just now";
+        if (mins < 60) return `${mins}m ago`;
+        const hours = Math.round(mins / 60);
+        if (hours < 24) return `${hours}h ago`;
+        return `${Math.round(hours / 24)}d ago`;
     }
 
     // ── Browser build only (isElectronApp false) ────────────────────────────
@@ -212,6 +253,33 @@
                 <p class="text-error-500 text-sm">{startError}</p>
             {/if}
         </div>
+
+        {#if isElectronApp && recentPlayed.length > 0}
+            <section class="flex flex-col gap-3 w-full max-w-sm mx-auto">
+                <h2 class="text-sm font-semibold text-surface-400 self-start">Recently played</h2>
+                <div class="flex flex-col gap-2 w-full">
+                    {#each recentPlayed as game (game.dirPath + "/" + game.filename)}
+                        <div class="flex items-center gap-2 w-full">
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 flex-1 min-w-0 flex-col! items-start! h-auto! py-2 gap-0.5"
+                                onclick={() => playElectronFile(game.dirPath, game.filename)}
+                                disabled={electronBusy}
+                            >
+                                <span class="w-full truncate text-left">{game.filename}</span>
+                                <span class="w-full truncate text-left text-surface-400 text-xs">{folderName(game.dirPath)} · {relativeTime(game.lastOpened)}</span>
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-error-500"
+                                title="Remove from Recently Played"
+                                onclick={() => handleRemoveRecentPlayed(game)}
+                            >Remove</button>
+                        </div>
+                    {/each}
+                </div>
+            </section>
+        {/if}
 
         {#if loading}
             <div class="flex flex-col items-center gap-3 py-12">

--- a/src/AppShell/src/lib/electron-types.d.ts
+++ b/src/AppShell/src/lib/electron-types.d.ts
@@ -43,11 +43,17 @@ interface ElectronRecentGame {
     lastOpened: number;
 }
 
+// "edit" = opened/created/saved-as through the editor (File > Open Recent,
+// the /open page's Recent section); "play" = opened through the Play tab's
+// file picker (that tab's own Recently Played list) — two separate lists,
+// see ElectronApp's recent-games.ts.
+type ElectronRecentKind = "edit" | "play";
+
 interface ElectronRecentApi {
-    list(): Promise<ElectronRecentGame[]>;
-    add(dirPath: string, filename: string): Promise<ElectronRecentGame[]>;
-    remove(dirPath: string, filename: string): Promise<ElectronRecentGame[]>;
-    onChanged(callback: () => void): () => void;
+    list(kind: ElectronRecentKind): Promise<ElectronRecentGame[]>;
+    add(kind: ElectronRecentKind, dirPath: string, filename: string): Promise<ElectronRecentGame[]>;
+    remove(kind: ElectronRecentKind, dirPath: string, filename: string): Promise<ElectronRecentGame[]>;
+    onChanged(callback: (kind: ElectronRecentKind) => void): () => void;
 }
 
 // action is one of MenuAction in ElectronApp's src/main.ts ("new-game" |

--- a/src/AppShell/src/lib/filesystem/electron-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/electron-adapter.ts
@@ -50,19 +50,26 @@ export interface RecentGame {
     lastOpened: number;
 }
 
-export async function listRecentGames(): Promise<RecentGame[]> {
-    return electronApp().recent.list();
+// Mirrors ElectronRecentKind. "edit" (the default below) is every editor
+// entry point — open/create/save-as, all in this file; "play" is only
+// PlayCatalog.svelte's file picker. Kept as separate lists on the main-process
+// side (see ElectronApp's recent-games.ts) precisely so a game opened to play
+// never shows up in File > Open Recent (which loads into the editor).
+export type RecentKind = "edit" | "play";
+
+export async function listRecentGames(kind: RecentKind = "edit"): Promise<RecentGame[]> {
+    return electronApp().recent.list(kind);
 }
 
-export async function removeRecentGame(dirPath: string, filename: string): Promise<void> {
-    await electronApp().recent.remove(dirPath, filename);
+export async function removeRecentGame(dirPath: string, filename: string, kind: RecentKind = "edit"): Promise<void> {
+    await electronApp().recent.remove(kind, dirPath, filename);
 }
 
 // Best-effort: the recent list is a convenience, so a tracking failure should
-// never surface as an error on the actual open/create/save-as it followed.
-async function trackRecent(dirPath: string, filename: string): Promise<void> {
+// never surface as an error on the actual open/create/save-as/play it followed.
+async function trackRecent(dirPath: string, filename: string, kind: RecentKind = "edit"): Promise<void> {
     try {
-        await electronApp().recent.add(dirPath, filename);
+        await electronApp().recent.add(kind, dirPath, filename);
     } catch {
         // ignore
     }
@@ -175,9 +182,16 @@ export async function openElectronPlayFile(): Promise<{ dirPath: string; filenam
     return { dirPath: dirname(filePath), filename: basename(filePath) };
 }
 
-export async function loadElectronFile(dirPath: string, filename: string): Promise<{ bytes: Uint8Array; adapter: ElectronFileAdapter }> {
+// kind defaults to "edit" for the /open (editor) callers; PlayCatalog.svelte
+// passes "play" explicitly so a game opened to play tracks into its own
+// Recently Played list instead of the editor's Recent — see RecentKind above.
+export async function loadElectronFile(
+    dirPath: string,
+    filename: string,
+    kind: RecentKind = "edit",
+): Promise<{ bytes: Uint8Array; adapter: ElectronFileAdapter }> {
     const bytes = await electronApp().fs.readFile(electronApp().path.join(dirPath, filename));
-    await trackRecent(dirPath, filename);
+    await trackRecent(dirPath, filename, kind);
     return { bytes, adapter: new ElectronFileAdapter(dirPath, filename) };
 }
 

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -498,11 +498,11 @@
                             <div class="flex items-center gap-2 w-full">
                                 <button
                                     type="button"
-                                    class="btn btn-sm preset-outlined-primary-500 flex-1 justify-between"
+                                    class="btn btn-sm preset-outlined-primary-500 flex-1 min-w-0 flex-col! items-start! h-auto! py-2 gap-0.5"
                                     onclick={() => loadFromElectron(game.dirPath, game.filename)}
                                 >
-                                    <span>{game.filename}</span>
-                                    <span class="text-surface-500-400 text-xs truncate max-w-[16ch]">{folderName(game.dirPath)} · {relativeTime(game.lastOpened)}</span>
+                                    <span class="w-full truncate text-left">{game.filename}</span>
+                                    <span class="w-full truncate text-left text-surface-500-400 text-xs">{folderName(game.dirPath)} · {relativeTime(game.lastOpened)}</span>
                                 </button>
                                 <button
                                     type="button"

--- a/src/ElectronApp/src/ipc/recent.ts
+++ b/src/ElectronApp/src/ipc/recent.ts
@@ -1,21 +1,24 @@
 import { ipcMain } from "electron";
-import { listRecentGames, addRecentGame, removeRecentGame } from "../recent-games";
+import { listRecentGames, addRecentGame, removeRecentGame, type RecentKind } from "../recent-games";
 
-// Backs window.electronApp.recent in preload.ts. onChange fires after any
-// mutation so main.ts can rebuild the native "Open Recent" submenu — recent-games.ts
-// itself doesn't know about the Menu, this keeps that wiring in main.ts.
-export function registerRecentHandlers(onChange: () => void): void {
-    ipcMain.handle("recent:list", async () => listRecentGames());
+// Backs window.electronApp.recent in preload.ts. Every call carries a
+// RecentKind ("edit" vs "play" — see recent-games.ts) since the two lists are
+// stored and surfaced separately. onChange fires after any mutation, with the
+// kind that changed, so main.ts can rebuild the native "Open Recent" submenu
+// (edit-kind only) and/or notify the renderer — recent-games.ts itself
+// doesn't know about the Menu or any window, that wiring stays in main.ts.
+export function registerRecentHandlers(onChange: (kind: RecentKind) => void): void {
+    ipcMain.handle("recent:list", async (_event, kind: RecentKind) => listRecentGames(kind));
 
-    ipcMain.handle("recent:add", async (_event, dirPath: string, filename: string) => {
-        const games = await addRecentGame(dirPath, filename);
-        onChange();
+    ipcMain.handle("recent:add", async (_event, kind: RecentKind, dirPath: string, filename: string) => {
+        const games = await addRecentGame(kind, dirPath, filename);
+        onChange(kind);
         return games;
     });
 
-    ipcMain.handle("recent:remove", async (_event, dirPath: string, filename: string) => {
-        const games = await removeRecentGame(dirPath, filename);
-        onChange();
+    ipcMain.handle("recent:remove", async (_event, kind: RecentKind, dirPath: string, filename: string) => {
+        const games = await removeRecentGame(kind, dirPath, filename);
+        onChange(kind);
         return games;
     });
 }

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -7,7 +7,7 @@ import { registerShellHandlers } from "./ipc/shell";
 import { registerPathsHandlers } from "./ipc/paths";
 import { registerRecentHandlers } from "./ipc/recent";
 import { registerPlayerHandlers } from "./ipc/player";
-import { listRecentGames, clearRecentGames, type RecentGame } from "./recent-games";
+import { listRecentGames, clearRecentGames, type RecentGame, type RecentKind } from "./recent-games";
 
 // Without this, Electron's default macOS menu ("About "/"Quit ") falls back
 // to package.json's "name" ("quest-viva-desktop") in dev — set as early as
@@ -59,7 +59,31 @@ let staticServer: StaticServerHandle | null = null;
 // a type since they're separate npm projects, so keep them in sync by hand.
 type MenuAction = "new-game" | "open-file" | "save" | "save-as";
 
+// Every File-menu editor action is reachable even while a player window (or,
+// on mac, no window at all) is frontmost — mac has one shared app-level menu
+// bar, and Windows/Linux windows without their own menu fall back to the
+// same application menu. Without this, "New Game"/"Open Game" would silently
+// operate on an editorWindow the user isn't even looking at. Also un-minimizes:
+// show() alone doesn't un-minimize on all platforms.
+function focusEditorWindow(): void {
+    if (!editorWindow) return;
+    if (editorWindow.isMinimized()) editorWindow.restore();
+    editorWindow.show();
+    editorWindow.focus();
+}
+
+// Notifies the renderer that a recent list changed for reasons outside its
+// own control-flow (native "Clear Recent", or a mutation made through the
+// other window/tab) — an already-mounted /open page (edit-kind) or Play tab
+// (play-kind) has no other way to hear about it. Renderer-initiated
+// add/remove (Open/Remove buttons) already update local state directly and
+// don't depend on this round trip.
+function broadcastRecentChanged(kind: RecentKind): void {
+    editorWindow?.webContents.send("recent-games-changed", kind);
+}
+
 function sendMenuAction(action: MenuAction): void {
+    focusEditorWindow();
     editorWindow?.webContents.send("menu-action", action);
 }
 
@@ -67,6 +91,7 @@ function sendMenuAction(action: MenuAction): void {
 // MenuAction) since it needs to carry a path — a dedicated channel instead of
 // overloading sendMenuAction/onAction with a payload.
 function sendOpenRecentGame(game: RecentGame): void {
+    focusEditorWindow();
     editorWindow?.webContents.send("open-recent-game", { dirPath: game.dirPath, filename: game.filename });
 }
 
@@ -89,7 +114,15 @@ function buildAppMenu(recentGames: RecentGame[]): Menu {
                 click: () => sendOpenRecentGame(game),
             })),
             { type: "separator" },
-            { label: "Clear Recent", click: () => { void clearRecentGames().then(refreshMenu); } },
+            {
+                label: "Clear Recent",
+                click: () => {
+                    void clearRecentGames("edit").then(async () => {
+                        await refreshMenu();
+                        broadcastRecentChanged("edit");
+                    });
+                },
+            },
         ]
         : [{ label: "No Recent Games", enabled: false }];
     const template: MenuItemConstructorOptions[] = [
@@ -128,15 +161,15 @@ function buildAppMenu(recentGames: RecentGame[]): Menu {
     return Menu.buildFromTemplate(template);
 }
 
-// Re-reads the recent-games list from disk and re-applies the app menu —
-// called once at startup and again after every recent:add/remove (via
-// registerRecentHandlers' onChange) and after "Clear Recent". Also notifies
-// the renderer: the /open page's own Remove button already updates its local
-// state directly, but a change that originates in the main process (Clear
-// Recent) has no other way to reach an already-mounted /open page.
+// Re-reads the edit-kind recent-games list from disk and re-applies the app
+// menu — called once at startup and again after every edit-kind
+// recent:add/remove (via registerRecentHandlers' onChange) and after "Clear
+// Recent". The native "Open Recent" submenu only ever reflects the editor's
+// list — a game opened to play never belongs there, see recent-games.ts's
+// RecentKind — so play-kind changes skip this entirely (see the onChange
+// wiring in app.whenReady below).
 async function refreshMenu(): Promise<void> {
-    Menu.setApplicationMenu(buildAppMenu(await listRecentGames()));
-    editorWindow?.webContents.send("recent-games-changed");
+    Menu.setApplicationMenu(buildAppMenu(await listRecentGames("edit")));
 }
 
 function createEditorWindow(port: number): void {
@@ -239,7 +272,12 @@ app.whenReady().then(async () => {
     registerDialogHandlers();
     registerShellHandlers();
     registerPathsHandlers();
-    registerRecentHandlers(() => void refreshMenu());
+    // Edit-kind changes rebuild the native "Open Recent" submenu; both kinds
+    // also get broadcast to the renderer (see broadcastRecentChanged).
+    registerRecentHandlers((kind) => {
+        if (kind === "edit") void refreshMenu();
+        broadcastRecentChanged(kind);
+    });
     registerPlayerHandlers(() => (staticServer ? `http://127.0.0.1:${staticServer.port}` : null));
     await refreshMenu();
 

--- a/src/ElectronApp/src/preload.ts
+++ b/src/ElectronApp/src/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
-import type { RecentGame } from "./recent-games";
+import type { RecentGame, RecentKind } from "./recent-games";
 
 interface FileFilter {
     name: string;
@@ -49,16 +49,25 @@ contextBridge.exposeInMainWorld("electronApp", {
         defaultGamesDir: (): Promise<string> => ipcRenderer.invoke("paths:defaultGamesDir"),
     },
     recent: {
-        list: (): Promise<RecentGame[]> => ipcRenderer.invoke("recent:list"),
-        add: (dirPath: string, filename: string): Promise<RecentGame[]> => ipcRenderer.invoke("recent:add", dirPath, filename),
-        remove: (dirPath: string, filename: string): Promise<RecentGame[]> => ipcRenderer.invoke("recent:remove", dirPath, filename),
-        // Fires whenever the recent list changes from outside the /open page
-        // itself — e.g. the native "Clear Recent" menu item, which mutates
-        // the list entirely in the main process with no renderer round trip
-        // otherwise. The /open page's own Remove button already updates its
-        // local state directly and doesn't need this.
-        onChanged: (callback: () => void): (() => void) => {
-            const listener = () => callback();
+        // kind distinguishes the editor's Recent (backs File > Open Recent
+        // and the /open page) from the Play tab's Recently Played — see
+        // recent-games.ts's RecentKind. Two separate on-disk lists, so
+        // playing a game never pollutes the list File > Open Recent loads
+        // into the editor, and vice versa.
+        list: (kind: RecentKind): Promise<RecentGame[]> => ipcRenderer.invoke("recent:list", kind),
+        add: (kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> =>
+            ipcRenderer.invoke("recent:add", kind, dirPath, filename),
+        remove: (kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> =>
+            ipcRenderer.invoke("recent:remove", kind, dirPath, filename),
+        // Fires whenever a recent list changes from outside the page that's
+        // showing it — e.g. the native "Clear Recent" menu item (edit-kind
+        // only), which mutates the list entirely in the main process with no
+        // renderer round trip otherwise. Callback receives which kind changed
+        // so a listener can ignore updates to the other list. Pages that
+        // mutate their own list locally (e.g. a Remove button) already update
+        // their local state directly and don't need this for that path.
+        onChanged: (callback: (kind: RecentKind) => void): (() => void) => {
+            const listener = (_event: Electron.IpcRendererEvent, kind: RecentKind) => callback(kind);
             ipcRenderer.on("recent-games-changed", listener);
             return () => ipcRenderer.removeListener("recent-games-changed", listener);
         },

--- a/src/ElectronApp/src/recent-games.ts
+++ b/src/ElectronApp/src/recent-games.ts
@@ -8,19 +8,27 @@ export interface RecentGame {
     lastOpened: number;
 }
 
-// Most-recently-used list of opened/created/saved-as game folders, shown in
-// the native File > Open Recent submenu and on the /open page. Small enough
-// (10 entries max) that a plain JSON file under userData is simpler than
-// pulling in a dependency for it.
+// "edit" = opened/created/saved-as through the editor (/open) — backs the
+// native File > Open Recent submenu and the /open page's Recent section.
+// "play" = opened through the Play tab's file picker — backs that tab's own
+// Recently Played list. Two separate stores (not one list with a kind field)
+// so picking a game to play never surfaces it as something File > Open
+// Recent would load into the editor, and vice versa — see the ElectronApp
+// File-menu-vs-Play split this was introduced for.
+export type RecentKind = "edit" | "play";
+
+// Small enough (10 entries max, per kind) that a plain JSON file under
+// userData is simpler than pulling in a dependency for it.
 const MAX_RECENT = 10;
 
-function storePath(): string {
-    return path.join(app.getPath("userData"), "recent-games.json");
+function storePath(kind: RecentKind): string {
+    const filename = kind === "edit" ? "recent-games.json" : "recent-played.json";
+    return path.join(app.getPath("userData"), filename);
 }
 
-async function readAll(): Promise<RecentGame[]> {
+async function readAll(kind: RecentKind): Promise<RecentGame[]> {
     try {
-        const text = await fs.readFile(storePath(), "utf-8");
+        const text = await fs.readFile(storePath(kind), "utf-8");
         const parsed = JSON.parse(text) as unknown;
         return Array.isArray(parsed) ? (parsed as RecentGame[]) : [];
     } catch {
@@ -29,30 +37,30 @@ async function readAll(): Promise<RecentGame[]> {
     }
 }
 
-async function writeAll(games: RecentGame[]): Promise<void> {
-    await fs.writeFile(storePath(), JSON.stringify(games));
+async function writeAll(kind: RecentKind, games: RecentGame[]): Promise<void> {
+    await fs.writeFile(storePath(kind), JSON.stringify(games));
 }
 
-export async function listRecentGames(): Promise<RecentGame[]> {
-    return readAll();
+export async function listRecentGames(kind: RecentKind): Promise<RecentGame[]> {
+    return readAll(kind);
 }
 
 // Upserts by (dirPath, filename) and moves it to the front — entries are
 // always written most-recent-first, so callers don't need to re-sort.
-export async function addRecentGame(dirPath: string, filename: string): Promise<RecentGame[]> {
-    const games = (await readAll()).filter((g) => !(g.dirPath === dirPath && g.filename === filename));
+export async function addRecentGame(kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> {
+    const games = (await readAll(kind)).filter((g) => !(g.dirPath === dirPath && g.filename === filename));
     games.unshift({ dirPath, filename, lastOpened: Date.now() });
     const capped = games.slice(0, MAX_RECENT);
-    await writeAll(capped);
+    await writeAll(kind, capped);
     return capped;
 }
 
-export async function removeRecentGame(dirPath: string, filename: string): Promise<RecentGame[]> {
-    const games = (await readAll()).filter((g) => !(g.dirPath === dirPath && g.filename === filename));
-    await writeAll(games);
+export async function removeRecentGame(kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> {
+    const games = (await readAll(kind)).filter((g) => !(g.dirPath === dirPath && g.filename === filename));
+    await writeAll(kind, games);
     return games;
 }
 
-export async function clearRecentGames(): Promise<void> {
-    await writeAll([]);
+export async function clearRecentGames(kind: RecentKind): Promise<void> {
+    await writeAll(kind, []);
 }


### PR DESCRIPTION
## Summary
- File > New Game / Open Game / Save / Save As / Open Recent now restore/show/focus the editor window before acting — previously they'd silently operate on it while a player window was frontmost, with no visible feedback.
- Recent-game tracking is now split into separate "edit" and "play" lists (`recent-games.json` / `recent-played.json`), so opening a game to play no longer pollutes File > Open Recent (which loads into the editor). The Play tab gets its own "Recently played" section instead, mirroring Quest 5's desktop app.
- Cleaned up the ragged single-line layout of both Recent lists (Play tab's Recently Played, and the editor's `/open` Recent) — filename and folder/time metadata now stack on two lines instead of a `justify-between` row that looked uneven depending on filename length.
- Both lists are capped at 10 entries each (unchanged `MAX_RECENT`, now per-kind).

## Test plan
- [x] `tsc --noEmit` clean in `src/ElectronApp`
- [x] `svelte-check` clean in `src/AppShell`
- [x] `tests/e2e/verify-electron-recent-games.mjs` passes (existing edit-kind Recent coverage)
- [x] `tests/e2e/verify-electron-play-local-file.mjs` passes (existing Play flow coverage)
- [x] Manual Playwright verification: playing a game no longer appears in File > Open Recent, appears in Play tab's Recently Played instead; File > New Game focuses the editor window when a player window was frontmost
- [x] Visual check (screenshots) of both Recent list layouts in the running Electron app

🤖 Generated with [Claude Code](https://claude.com/claude-code)