### PR TITLE
fix(AppShell): stop centering the Create tab against the full viewport

### DIFF
--- a/src/AppShell/src/routes/+layout.svelte
+++ b/src/AppShell/src/routes/+layout.svelte
@@ -24,6 +24,16 @@
     // rendering could disagree about which one was actually showing.)
     const showTabs = $derived(showHome && page.url.pathname !== `${base}/edit`);
 
+    // Measured so pages that vertically center their content (e.g. /open)
+    // can subtract the actual header+tabs height via the --home-bar-height
+    // custom property below, instead of centering within the full 100svh
+    // and landing too far down. bind:clientHeight re-measures on resize.
+    let homeBarHeight = $state(0);
+    $effect(() => {
+        if (showTabs) document.documentElement.style.setProperty("--home-bar-height", `${homeBarHeight}px`);
+        else document.documentElement.style.removeProperty("--home-bar-height");
+    });
+
     // Play (and its game-detail pages) are always dark, matching the look the
     // standalone Home page had before this was folded into AppShell — Create
     // (/open) keeps following the editor's own light/dark system preference,
@@ -95,7 +105,7 @@
 </script>
 
 {#if showTabs}
-    <div class={isPlayContext ? "bg-surface-950" : ""}>
+    <div class={isPlayContext ? "bg-surface-950" : ""} bind:clientHeight={homeBarHeight}>
         <HomeHeader forceDark={isPlayContext} />
         <HomeTabs forceDark={isPlayContext} />
     </div>

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -417,7 +417,7 @@
     const creating = $derived(creatingLocal || creatingServer);
 </script>
 
-<main class="flex flex-col items-center justify-center min-h-svh gap-6 p-8">
+<main class="flex flex-col items-center justify-center min-h-[calc(100svh-var(--home-bar-height,0px))] gap-6 p-8">
     <h1 class="text-3xl font-semibold">Quest Viva Editor</h1>
 
     {#if loading}


### PR DESCRIPTION
## Summary
- The Play/Create tab bar (`+layout.svelte`) sits above `/open`'s content, but `/open` centered itself with `min-h-svh` (the full viewport height) instead of the space actually left below the tab bar — pushing the Create tab's content, including the loading spinner, noticeably too far down.
- `+layout.svelte` now measures the tab bar's real height via `bind:clientHeight` and exposes it as a `--home-bar-height` CSS variable (only while the tab bar is shown).
- `/open`'s `<main>` centers within `calc(100svh - var(--home-bar-height, 0px))` instead of raw `100svh`. When the tab bar isn't shown (`/edit`, or textadventures.co.uk's standalone `/open` with no tabs), the variable is unset and behavior is unchanged.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors
- [x] Verified visually with Playwright screenshots (`PUBLIC_SHOW_HOME=true` dev server): content shifted up ~53px, now correctly centered in the remaining space below the tab bar
- [x] Confirmed `/edit` (no tab bar) and other centered-content pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)