### PR TITLE
feat(AppShell): replace emoji icons with Lucide and tidy the editor toolbar

### DIFF
--- a/src/AppShell/package-lock.json
+++ b/src/AppShell/package-lock.json
@@ -31,6 +31,31 @@
         "vite": "^8.0.16"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -38,6 +63,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -291,7 +317,6 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -774,7 +799,6 @@
       "integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -817,7 +841,6 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -1222,7 +1245,6 @@
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1278,7 +1300,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1386,7 +1407,6 @@
       "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2081,7 +2101,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2311,7 +2330,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3255,7 +3273,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3283,7 +3300,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -3562,7 +3578,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3693,8 +3708,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -3776,7 +3790,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3839,7 +3852,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/src/AppShell/package-lock.json
+++ b/src/AppShell/package-lock.json
@@ -8,6 +8,7 @@
       "name": "quest-app-shell",
       "version": "0.0.1",
       "dependencies": {
+        "@lucide/svelte": "^1.25.0",
         "fflate": "^0.8.3"
       },
       "devDependencies": {
@@ -30,31 +31,6 @@
         "vite": "^8.0.16"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -62,7 +38,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -316,6 +291,7 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -324,7 +300,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -335,7 +310,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -346,7 +320,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -356,18 +329,25 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lucide/svelte": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.25.0.tgz",
+      "integrity": "sha512-v9m+dD68jxVnqkU3K59mG/RSRFlPGzmKCGSyMfnXcaGv9jODDQMyQkcp1CGvk3Y/cUj9v7f8rw1n//K0B53xGQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^5"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -773,7 +753,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
       "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -795,6 +774,7 @@
       "integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -837,6 +817,7 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -1226,7 +1207,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1242,6 +1222,7 @@
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1250,7 +1231,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1298,6 +1278,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1403,8 +1384,9 @@
       "version": "8.59.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
       "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2098,8 +2080,8 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2138,7 +2120,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -2148,7 +2129,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -2197,7 +2177,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2297,7 +2276,6 @@
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -2333,6 +2311,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2453,7 +2432,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -2491,7 +2469,6 @@
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.6.tgz",
       "integrity": "sha512-WN0clHt0a4mzC780UBVVBpsj4vSSjOFNRd2WjYtduB9HeKxm1sjHMNUwLEHVjI3FdCQD/Hurgz9ftbKEzP79Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2729,7 +2706,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -3089,7 +3065,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -3112,7 +3087,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -3281,6 +3255,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3308,6 +3283,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -3585,8 +3561,8 @@
       "version": "5.55.7",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3717,7 +3693,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -3799,6 +3776,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3861,6 +3839,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3996,7 +3975,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     }
   }

--- a/src/AppShell/package.json
+++ b/src/AppShell/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint src --fix"
   },
   "dependencies": {
+    "@lucide/svelte": "^1.25.0",
     "fflate": "^0.8.3"
   },
   "devDependencies": {

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -16,6 +16,20 @@
         assetManagerOpen,
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
+    import Home from "@lucide/svelte/icons/home";
+    import ImageIcon from "@lucide/svelte/icons/image";
+    import Undo2 from "@lucide/svelte/icons/undo-2";
+    import Redo2 from "@lucide/svelte/icons/redo-2";
+    import Plus from "@lucide/svelte/icons/plus";
+    import ChevronDown from "@lucide/svelte/icons/chevron-down";
+    import Trash2 from "@lucide/svelte/icons/trash-2";
+    import Save from "@lucide/svelte/icons/save";
+    import Download from "@lucide/svelte/icons/download";
+    import Package from "@lucide/svelte/icons/package";
+    import Play from "@lucide/svelte/icons/play";
+    import Check from "@lucide/svelte/icons/check";
+    import LoaderCircle from "@lucide/svelte/icons/loader-circle";
+    import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
 
     const wasmPlayerUrl = PUBLIC_WASM_PLAYER_URL || "/player/";
     const showHome = PUBLIC_SHOW_HOME === "true";
@@ -105,30 +119,29 @@
             {#if showHome}
                 <button
                     type="button"
-                    class="btn btn-sm preset-outlined-primary-500 mr-3"
+                    class="toolbar-icon-btn mr-2"
                     onclick={handleHome}
                     title="Back to Home"
-                >🏠 Home</button>
+                ><Home size={16} /></button>
             {/if}
-            <span class="font-semibold">Quest Viva Editor</span>
             {#if $gameFilename}
-                <span class="ml-3 text-sm text-surface-500-400">{$gameFilename}</span>
+                <span class="font-mono text-sm font-medium">{$gameFilename}</span>
             {/if}
             {#if $saveError}
                 <button
                     type="button"
-                    class="ml-3 text-sm text-error-500 underline"
+                    class="save-chip save-chip-error"
                     onclick={() => retrySave()}
                     title={$saveError}
-                >⚠ Save failed — Retry</button>
+                ><TriangleAlert size={13} /> Save failed — Retry</button>
             {:else if $isSaving || $isDirty}
-                <span class="ml-3 text-sm text-surface-500-400">Saving…</span>
+                <span class="save-chip save-chip-saving"><LoaderCircle size={13} class="animate-spin" /> Saving…</span>
             {:else if $gameFilename}
-                <span class="ml-3 text-sm text-surface-500-400">Saved</span>
+                <span class="save-chip save-chip-saved"><Check size={13} /> Saved</span>
             {/if}
         </AppBar.Lead>
         <AppBar.Trail>
-            <div class="flex gap-2 items-center">
+            <div class="flex gap-1.5 items-center">
                 <!-- Add dropdown -->
                 <div class="add-dropdown relative">
                     <button
@@ -136,7 +149,7 @@
                         class="btn btn-sm preset-outlined-primary-500"
                         onclick={toggleAdd}
                         title="Add element"
-                    >+ Add ▾</button>
+                    ><Plus size={14} /> Add <ChevronDown size={12} /></button>
                     {#if addOpen}
                         <div class="absolute right-0 top-full z-[999] mt-1 w-56 bg-surface-50-950 border border-surface-200-800 rounded shadow-lg py-1">
                             {#each addOptions as opt (opt.label)}
@@ -155,23 +168,77 @@
                         class="btn btn-sm preset-outlined-error-500"
                         onclick={() => deleteElement(selectedNode!.key)}
                         title={"Delete " + (selectedNode?.text ?? "")}
-                    >Delete</button>
+                    ><Trash2 size={14} /> Delete</button>
                 {/if}
-                <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => assetManagerOpen.set(true)} title="Manage assets">🖼 Assets</button>
-                <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={undo} disabled={!$canUndo} title="Undo">↩ Undo</button>
-                <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={redo} disabled={!$canRedo} title="Redo">↪ Redo</button>
+                <div class="toolbar-divider"></div>
+                <button type="button" class="toolbar-icon-btn" onclick={() => assetManagerOpen.set(true)} title="Manage assets"><ImageIcon size={16} /></button>
+                <button type="button" class="toolbar-icon-btn" onclick={undo} disabled={!$canUndo} title="Undo"><Undo2 size={16} /></button>
+                <button type="button" class="toolbar-icon-btn" onclick={redo} disabled={!$canRedo} title="Redo"><Redo2 size={16} /></button>
+                <div class="toolbar-divider"></div>
                 {#if $canSaveAs}
-                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleSaveAs} disabled={saving} title="Save As">Save As…</button>
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleSaveAs} disabled={saving} title="Save As"><Save size={14} /> Save As…</button>
                 {/if}
                 {#if $canBackup}
-                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleBackup} disabled={saving} title="Download a .zip copy of this game and its assets">Backup…</button>
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={handleBackup} disabled={saving} title="Download a .zip copy of this game and its assets"><Download size={14} /> Backup…</button>
                 {/if}
                 {#if $gameFilename}
-                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => publishModalOpen.set(true)} title="Build a .quest package for distribution">Publish…</button>
-                    <button type="button" class="btn btn-sm preset-outlined-secondary-500" onclick={handlePreview} title="Preview game">▶ Preview</button>
+                    <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={() => publishModalOpen.set(true)} title="Build a .quest package for distribution"><Package size={14} /> Publish…</button>
+                    <div class="toolbar-divider"></div>
+                    <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handlePreview} title="Preview game"><Play size={14} /> Preview</button>
                 {/if}
             </div>
         </AppBar.Trail>
     </AppBar.Toolbar>
 </AppBar>
+
+<style>
+    .toolbar-icon-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2rem;
+        border-radius: var(--radius-container);
+        color: var(--color-surface-500-400);
+    }
+    .toolbar-icon-btn:hover:not(:disabled) {
+        background-color: var(--color-surface-200-800);
+        color: var(--color-primary-500);
+    }
+    .toolbar-icon-btn:disabled {
+        opacity: 0.4;
+    }
+    .toolbar-divider {
+        width: 1px;
+        height: 1.25rem;
+        background-color: var(--color-surface-200-800);
+        margin: 0 0.25rem;
+    }
+    .save-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        margin-left: 0.75rem;
+        padding: 0.15rem 0.55rem 0.15rem 0.45rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        line-height: 1.4;
+    }
+    .save-chip-saved {
+        color: var(--color-success-600-400);
+        background-color: color-mix(in srgb, var(--color-success-500) 12%, transparent);
+    }
+    .save-chip-saving {
+        color: var(--color-surface-500-400);
+    }
+    .save-chip-error {
+        color: var(--color-error-500);
+        background-color: color-mix(in srgb, var(--color-error-500) 12%, transparent);
+        cursor: pointer;
+    }
+    .save-chip-error:hover {
+        text-decoration: underline;
+    }
+</style>
 

--- a/tests/e2e/verify-appshell-autosave.mjs
+++ b/tests/e2e/verify-appshell-autosave.mjs
@@ -20,7 +20,7 @@ async function run() {
     await page.fill('input[placeholder="Game name"]', 'Autosave Test');
     await page.waitForSelector('text=Text adventure', { timeout: 10000 });
     await page.click('button:has-text("Create local draft")');
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     console.log('PASS: local draft created and opened in the editor');
 
     const saveButtonCount = await page.locator('button:has-text("💾 Save")').count();
@@ -37,7 +37,7 @@ async function run() {
     await descBox.waitFor({ timeout: 10000 });
     const marker = `Autosave marker ${Date.now()}`;
     await descBox.fill(marker);
-    await page.click('span:has-text("Quest Viva Editor")'); // blur onto something inert
+    await page.click('.toolbar-divider'); // blur onto something inert
 
     await page.waitForSelector('text=Saving…', { timeout: 3000 });
     console.log('PASS: "Saving…" pill appeared after edit, without clicking any Save button');
@@ -52,7 +52,7 @@ async function run() {
     await page.goto(`${baseUrl}/open`);
     await page.waitForSelector('text=Your local drafts', { timeout: 10000 });
     await page.click('button:has-text("Autosave Test.aslx")');
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     await page.waitForSelector('text=Saved', { timeout: 10000 });
     const persistedValue = await page.locator('textarea, input[type="text"]').first().inputValue();
     console.log('value after reload:', persistedValue);

--- a/tests/e2e/verify-appshell-drafts-rekey-backup.mjs
+++ b/tests/e2e/verify-appshell-drafts-rekey-backup.mjs
@@ -27,7 +27,7 @@ async function createDraft(name) {
     await page.fill('input[placeholder="Game name"]', name);
     await page.waitForSelector('text=Text adventure', { timeout: 10000 });
     await page.click('button:has-text("Create local draft")');
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
 }
 
 async function draftCount() {
@@ -55,7 +55,7 @@ try {
 
     // --- Scenario 2: Backup / Import round trip ---
     await createDraft('Backup Test');
-    await page.click('button:has-text("🖼 Assets")');
+    await page.click('button[title="Manage assets"]');
     const dialog = page.locator('div[role="dialog"]');
     const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
@@ -84,8 +84,8 @@ try {
         page.click('button:has-text("Import game file")'),
     ]);
     await fileChooser2.setFiles(zipPath);
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
-    await page.click('button:has-text("🖼 Assets")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    await page.click('button[title="Manage assets"]');
     const assetRestored = await page.locator('div[role="dialog"]').locator('text=restart-test.js').isVisible();
     console.log('asset restored after backup/import round trip:', assetRestored);
     if (!assetRestored) throw new Error('Asset missing after re-importing backed-up zip');

--- a/tests/e2e/verify-appshell-home-button.mjs
+++ b/tests/e2e/verify-appshell-home-button.mjs
@@ -23,13 +23,13 @@ async function run() {
     await page.fill('input[placeholder="Game name"]', 'Home Button Test');
     await page.waitForSelector('text=Text adventure', { timeout: 10000 });
     await page.click('button:has-text("Create local draft")');
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     console.log('PASS: local draft created and opened in the editor (/edit)');
 
-    await page.waitForSelector('button:has-text("🏠 Home")', { timeout: 5000 });
+    await page.waitForSelector('button[title="Back to Home"]', { timeout: 5000 });
     console.log('PASS: Home button present in the toolbar when PUBLIC_SHOW_HOME=true');
 
-    await page.click('button:has-text("🏠 Home")');
+    await page.click('button[title="Back to Home"]');
     await page.waitForURL(url => url.pathname === '/' || url.pathname === '', { timeout: 10000 });
     await page.waitForSelector('text=Open a game file…', { timeout: 10000 });
     console.log('PASS: clicking Home navigated back to root Home page (Play tab visible), url =', page.url());

--- a/tests/e2e/verify-appshell-local-drafts.mjs
+++ b/tests/e2e/verify-appshell-local-drafts.mjs
@@ -35,12 +35,11 @@ async function run() {
     await page.fill('input[placeholder="Game name"]', 'Local Draft Test');
     await page.waitForSelector('text=Text adventure', { timeout: 10000 }); // templates finished loading
     await page.click('button:has-text("Create local draft")');
-    await page.waitForSelector('text=Quest Viva Editor >> visible=true', { timeout: 5000 }).catch(() => {});
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     console.log(`[${browserType}] new local draft created and opened in the editor`);
 
     // Upload an asset via the standalone asset manager.
-    await page.click('button:has-text("🖼 Assets")');
+    await page.click('button[title="Manage assets"]');
     const fixturePath = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'restart-test.js');
     // Reuse an existing small fixture file as arbitrary asset bytes — content doesn't matter, just persistence.
     const dialog = page.locator('div[role="dialog"]');
@@ -61,8 +60,8 @@ async function run() {
     if (!draftVisible) throw new Error('Draft did not survive reload');
 
     await page.click('button:has-text("Local Draft Test.aslx")');
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
-    await page.click('button:has-text("🖼 Assets")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    await page.click('button[title="Manage assets"]');
     const assetVisible = await page.locator('div[role="dialog"]').locator('text=restart-test.js').isVisible();
     console.log(`[${browserType}] asset still present after reload:`, assetVisible);
     if (!assetVisible) throw new Error('Asset did not survive reload — OPFS orphaning bug still present');

--- a/tests/e2e/verify-appshell-multi-aslx-zip.mjs
+++ b/tests/e2e/verify-appshell-multi-aslx-zip.mjs
@@ -61,7 +61,7 @@ try {
     if (!mainVisible || !libVisible || readmeVisible) throw new Error('Picker did not list exactly the two .aslx entries');
 
     await page.click('button:has-text("Library.aslx")');
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     const filenameShown = await page.isVisible('text=Library.aslx');
     console.log('opened Library.aslx (preserving its real name):', filenameShown);
     if (!filenameShown) throw new Error('Did not open the chosen entry under its own filename');

--- a/tests/e2e/verify-appshell-opfs-default.mjs
+++ b/tests/e2e/verify-appshell-opfs-default.mjs
@@ -42,7 +42,7 @@ async function run() {
     await page.fill('input[placeholder="Game name"]', 'Chromium OPFS Default Test');
     await page.waitForSelector('text=Text adventure', { timeout: 10000 });
     await page.click('button:has-text("Create local draft")');
-    await page.waitForSelector('button:has-text("🖼 Assets")', { timeout: 30000 });
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     console.log('PASS: local draft created and opened in the editor on Chromium');
 
     await page.goto(`${baseUrl}/open`);


### PR DESCRIPTION
## Summary
- Replace emoji (🏠 🖼 ↩ ↪ ▶) in the editor toolbar with `@lucide/svelte` icons, which render consistently across OSes and inherit the button's text color
- Drop the static "Quest Viva Editor" label — dead weight that never changes, competing for space with the filename which does
- Turn the plain-text save status ("Saved" / "Saving…" / "⚠ Save failed") into a colored icon+text chip, so a failed save has real visual weight instead of reading like the same gray caption as everything else
- Group the toolbar buttons into clusters (structure edits / frequent actions / file actions / run) with hairline dividers; Assets/Undo/Redo go icon-only with a tooltip since they're used constantly, Save As/Backup/Publish keep labels since they're rarer; Preview becomes the one filled accent button

Design mockup that this follows: interactively reviewed and approved before implementation.

## Test plan
- [x] `npm run check` / `npm run lint` / `npm run build` in `src/AppShell` all pass
- [x] Manually drove the editor in a real browser (Playwright) against a built `WasmEditor` bundle — verified light and dark rendering, Home/Add/Assets/Undo/Redo buttons, and the Saved/Saving status chip
- [x] Updated `tests/e2e/verify-appshell-*.mjs` scripts whose selectors matched the old emoji/text button labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)