### PR TITLE
fix(AppShell): preserve language selection when toggling game type on Create tab

### DIFF
--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -153,6 +153,13 @@
     let selectedTemplate = $derived(templates.find(t => t.id === selectedTemplateId) ?? null);
     let textAdventureTemplates = $derived(templates.filter(t => t.type === "textadventure"));
     let gamebookTemplates = $derived(templates.filter(t => t.type === "gamebook"));
+    let lastTextAdventureTemplateId = $state("");
+
+    $effect(() => {
+        if (selectedTemplate?.type === "textadventure") {
+            lastTextAdventureTemplateId = selectedTemplate.id;
+        }
+    });
 
     // Local creation state
     let creatingLocal = $state(false);
@@ -584,8 +591,13 @@
                                             checked={selectedTemplate?.type === type.value}
                                             disabled={creating}
                                             onchange={() => {
-                                                const list = type.value === "gamebook" ? gamebookTemplates : textAdventureTemplates;
-                                                selectedTemplateId = list[0]?.id ?? "";
+                                                if (type.value === "gamebook") {
+                                                    selectedTemplateId = gamebookTemplates[0]?.id ?? "";
+                                                } else {
+                                                    const preferred = textAdventureTemplates.find(t => t.id === lastTextAdventureTemplateId);
+                                                    const english = textAdventureTemplates.find(t => t.label === "English");
+                                                    selectedTemplateId = (preferred ?? english ?? textAdventureTemplates[0])?.id ?? "";
+                                                }
                                             }}
                                         />
                                         <span class="text-sm">{type.label}</span>


### PR DESCRIPTION
## Summary
- On the Create tab's "Create new game" form, toggling from Text Adventure to Gamebook and back reset the language dropdown to Danish instead of English or the user's prior selection.
- Track the last-selected text-adventure template (via an `$effect`) and restore it when switching back to Text Adventure, falling back to English, then the first template.

## Test plan
- [x] Verified manually in the browser: select a non-default language, toggle to Gamebook and back, confirm the language selection is preserved.
- [x] `npm run check` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)