### PR TITLE
fix(AppShell): stabilize the toolbar save-status pill

### DIFF
--- a/src/AppShell/src/components/AttributesEditor.svelte
+++ b/src/AppShell/src/components/AttributesEditor.svelte
@@ -480,6 +480,7 @@
                 type="text"
                 placeholder="Add attribute..."
                 class="input text-xs py-0 px-1.5 h-6 flex-1 min-w-0"
+                data-staging
                 bind:value={newAttrName}
                 onkeydown={(e) => { if (e.key === "Enter") onAddAttribute(); }}
             />

--- a/src/AppShell/src/components/DictionaryEditor.svelte
+++ b/src/AppShell/src/components/DictionaryEditor.svelte
@@ -76,6 +76,7 @@
             type="text"
             class="input text-xs py-0.5 px-1.5 w-20 flex-shrink-0"
             placeholder="Key"
+            data-staging
             bind:value={newKey}
             onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
         />
@@ -83,6 +84,7 @@
             type="text"
             class="input text-xs py-0.5 px-1.5 flex-1"
             placeholder="Value"
+            data-staging
             bind:value={newValue}
             onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
         />

--- a/src/AppShell/src/components/ListEditor.svelte
+++ b/src/AppShell/src/components/ListEditor.svelte
@@ -66,6 +66,7 @@
             type="text"
             class="input text-xs py-0.5 px-1.5 flex-1"
             placeholder={addPrompt}
+            data-staging
             bind:value={newItemValue}
             onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
         />

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -274,6 +274,7 @@
                     type="text"
                     class="input text-xs py-0.5 px-1.5 w-24 flex-shrink-0"
                     placeholder={ctrl.caption ? "Key" : "Key"}
+                    data-staging
                     value={newDictItems[dk]?.key ?? ""}
                     oninput={(e) => { newDictItems[dk] = { ...(newDictItems[dk] ?? { key: "", value: "" }), key: (e.target as HTMLInputElement).value }; }}
                 />
@@ -281,6 +282,7 @@
                     type="text"
                     class="input text-xs py-0.5 px-1.5 flex-1"
                     placeholder="Value"
+                    data-staging
                     value={newDictItems[dk]?.value ?? ""}
                     oninput={(e) => { newDictItems[dk] = { ...(newDictItems[dk] ?? { key: "", value: "" }), value: (e.target as HTMLInputElement).value }; }}
                     onkeydown={(e) => {

--- a/src/AppShell/src/components/ScriptDictionaryEditor.svelte
+++ b/src/AppShell/src/components/ScriptDictionaryEditor.svelte
@@ -81,6 +81,7 @@
                 type="text"
                 class="input text-xs py-0.5 px-1.5 flex-1"
                 placeholder="Add entry key…"
+                data-staging
                 bind:value={newKey}
                 onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
             />

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -5,7 +5,7 @@
     import { base } from "$app/paths";
     import { PUBLIC_WASM_PLAYER_URL, PUBLIC_SHOW_HOME } from "$env/static/public";
     import {
-        gameFilename, isLoaded, isDirty, isSaving, isEditingField, saveError, retrySave, saveGame, saveGameAs, canSaveAs, backupGame, canBackup,
+        gameFilename, isLoaded, isDirty, isSaving, isEditingField, getLastEditedElement, saveError, retrySave, saveGame, saveGameAs, canSaveAs, backupGame, canBackup,
         publishModalOpen,
         previewInWasmPlayer,
         undo, redo, canUndo, canRedo,
@@ -44,6 +44,14 @@
     async function handleHome() {
         if (get(isLoaded)) await saveGame();
         void goto(`${base}/`);
+    }
+
+    // Clicking the chip itself steals focus away from whatever field the
+    // author was mid-edit in — put it back once the save completes.
+    async function handleSaveNow() {
+        const field = getLastEditedElement();
+        await saveGame();
+        field?.focus();
     }
 
     async function handleSaveAs() {
@@ -141,7 +149,7 @@
                 <button
                     type="button"
                     class="save-chip save-chip-unsaved"
-                    onclick={() => saveGame()}
+                    onclick={handleSaveNow}
                     title="Save now"
                 ><Circle size={8} fill="currentColor" /> Unsaved</button>
             {:else if $gameFilename}

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -5,7 +5,7 @@
     import { base } from "$app/paths";
     import { PUBLIC_WASM_PLAYER_URL, PUBLIC_SHOW_HOME } from "$env/static/public";
     import {
-        gameFilename, isLoaded, isDirty, isSaving, saveError, retrySave, saveGame, saveGameAs, canSaveAs, backupGame, canBackup,
+        gameFilename, isLoaded, isDirty, isSaving, isEditingField, saveError, retrySave, saveGame, saveGameAs, canSaveAs, backupGame, canBackup,
         publishModalOpen,
         previewInWasmPlayer,
         undo, redo, canUndo, canRedo,
@@ -30,6 +30,7 @@
     import Check from "@lucide/svelte/icons/check";
     import LoaderCircle from "@lucide/svelte/icons/loader-circle";
     import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
+    import Circle from "@lucide/svelte/icons/circle";
 
     const wasmPlayerUrl = PUBLIC_WASM_PLAYER_URL || "/player/";
     const showHome = PUBLIC_SHOW_HOME === "true";
@@ -134,8 +135,15 @@
                     onclick={() => retrySave()}
                     title={$saveError}
                 ><TriangleAlert size={13} /> Save failed — Retry</button>
-            {:else if $isSaving || $isDirty}
+            {:else if $isSaving}
                 <span class="save-chip save-chip-saving"><LoaderCircle size={13} class="animate-spin" /> Saving…</span>
+            {:else if $isDirty || $isEditingField}
+                <button
+                    type="button"
+                    class="save-chip save-chip-unsaved"
+                    onclick={() => saveGame()}
+                    title="Save now"
+                ><Circle size={8} fill="currentColor" /> Unsaved</button>
             {:else if $gameFilename}
                 <span class="save-chip save-chip-saved"><Check size={13} /> Saved</span>
             {/if}
@@ -224,6 +232,13 @@
         font-size: 0.75rem;
         font-weight: 600;
         line-height: 1.4;
+        white-space: nowrap;
+    }
+    .save-chip-saved,
+    .save-chip-saving,
+    .save-chip-unsaved {
+        min-width: 6.25rem;
+        justify-content: center;
     }
     .save-chip-saved {
         color: var(--color-success-600-400);
@@ -231,6 +246,14 @@
     }
     .save-chip-saving {
         color: var(--color-surface-500-400);
+    }
+    .save-chip-unsaved {
+        color: var(--color-warning-600-400);
+        background-color: color-mix(in srgb, var(--color-warning-500) 12%, transparent);
+        cursor: pointer;
+    }
+    .save-chip-unsaved:hover {
+        text-decoration: underline;
     }
     .save-chip-error {
         color: var(--color-error-500);

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -42,7 +42,15 @@ export const isDirty = writable(false);
 // isDirty, since saveGame() blurs the focused field first — which flushes any
 // pending edit into the bridge — before checking real isDirty and persisting.
 export const isEditingField = writable(false);
-export function markFieldEditing() {
+// Not reactive state, just a plain reference — the toolbar's "Unsaved" chip
+// uses this to restore focus to whatever the author was typing in after a
+// click-to-save, since that click itself steals focus onto the chip.
+let _lastEditedElement: HTMLElement | null = null;
+export function getLastEditedElement(): HTMLElement | null {
+    return _lastEditedElement;
+}
+export function markFieldEditing(el?: HTMLElement) {
+    if (el) _lastEditedElement = el;
     isEditingField.set(true);
 }
 export function clearFieldEditing() {

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -33,6 +33,21 @@ export const fullAttributeData = writable<FullAttributeData | null>(null);
 export const canUndo = writable(false);
 export const canRedo = writable(false);
 export const isDirty = writable(false);
+// True while a field somewhere in the editor has an in-progress, not-yet-committed
+// edit (set on input, cleared on focusout via a delegated listener in
+// edit/+page.svelte) — the underlying attribute only commits to the WASM bridge
+// on change/blur, so isDirty alone stays false while typing. Doesn't trigger
+// autosave itself (nothing has actually changed in the bridge yet), but the
+// toolbar pill and the close-tab/switch-tab guards both treat it the same as
+// isDirty, since saveGame() blurs the focused field first — which flushes any
+// pending edit into the bridge — before checking real isDirty and persisting.
+export const isEditingField = writable(false);
+export function markFieldEditing() {
+    isEditingField.set(true);
+}
+export function clearFieldEditing() {
+    isEditingField.set(false);
+}
 export const scriptVersion = writable(0);
 export const scriptClipboardHasContent = writable(false);
 export const assets = writable<AssetInfo[]>([]);

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -4,7 +4,7 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { get } from "svelte/store";
-    import { isLoaded, isDirty, saveGame, loadingStatus, addElementModal, assetManagerOpen, publishModalOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType } from "$lib/editor-store";
+    import { isLoaded, isDirty, isEditingField, markFieldEditing, clearFieldEditing, saveGame, loadingStatus, addElementModal, assetManagerOpen, publishModalOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType } from "$lib/editor-store";
     import { loadFromServer } from "$lib/filesystem/server-adapter";
     import Toolbar from "$components/Toolbar.svelte";
     import BackupBanner from "$components/BackupBanner.svelte";
@@ -16,12 +16,28 @@
 
     let serverLoadError = $state<string | null>(null);
 
+    // Delegated at the panel level so every field-editing component (property
+    // panel, script editor, nested dictionary/list editors, ...) is covered
+    // without each one having to wire this up itself. "input"/"focusout" both
+    // bubble, unlike "change"/"blur". Elements the user is still just typing
+    // into to filter/stage something — not committing a value yet, e.g. the
+    // "add new item" boxes in ListEditor/DictionaryEditor — opt out via
+    // data-staging so the pill/unload guard don't treat searching as editing.
+    function handleFieldInput(e: Event) {
+        if ((e.target as HTMLElement).closest("[data-staging]")) return;
+        markFieldEditing();
+    }
+
     // Best-effort: force any focused field to commit and flush it to storage
-    // before the tab actually goes away. Can't be awaited here — the page may
-    // already be gone by the time an async write settles — so the beforeunload
-    // warning below stays as the real safety net for that narrow window.
+    // before the tab actually goes away. saveGame() itself blurs the focused
+    // field first (flushing a pending edit into the bridge via its change
+    // event) before checking isDirty, so isEditingField only needs to get the
+    // listener attached — the actual flush happens inside saveGame(). Can't be
+    // awaited here — the page may already be gone by the time an async write
+    // settles — so the beforeunload warning below stays as the real safety net
+    // for that narrow window.
     $effect(() => {
-        if (!$isDirty) return;
+        if (!$isDirty && !$isEditingField) return;
         function handleBeforeUnload(e: BeforeUnloadEvent) {
             void saveGame();
             e.preventDefault();
@@ -34,7 +50,7 @@
         // Covers tab switches, backgrounding, and the mobile-Safari-style tab
         // closes that don't reliably fire beforeunload.
         function handleVisibilityChange() {
-            if (document.hidden && get(isDirty)) void saveGame();
+            if (document.hidden && (get(isDirty) || get(isEditingField))) void saveGame();
         }
         document.addEventListener("visibilitychange", handleVisibilityChange);
 
@@ -89,7 +105,7 @@
     <div class="flex flex-col h-svh overflow-hidden">
         <Toolbar />
         <BackupBanner />
-        <div class="flex flex-1 overflow-hidden">
+        <div class="flex flex-1 overflow-hidden" oninput={handleFieldInput} onfocusout={clearFieldEditing}>
             <TreePanel />
             <PropertyEditor />
         </div>

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -24,8 +24,9 @@
     // "add new item" boxes in ListEditor/DictionaryEditor — opt out via
     // data-staging so the pill/unload guard don't treat searching as editing.
     function handleFieldInput(e: Event) {
-        if ((e.target as HTMLElement).closest("[data-staging]")) return;
-        markFieldEditing();
+        const target = e.target as HTMLElement;
+        if (target.closest("[data-staging]")) return;
+        markFieldEditing(target);
     }
 
     // Best-effort: force any focused field to commit and flush it to storage


### PR DESCRIPTION
## Summary
- The Saved/Saving… toolbar pill had no fixed width, so it shoved the Save As/Backup/Publish buttons around every time it changed text; it also only reflected the WASM bridge's committed state, which lags behind actual typing, so it claimed "Saved" while a field had uncommitted keystrokes — and the close-tab/switch-tab guard didn't protect that in-progress edit either.
- Fixed pill width and added a distinct, non-spinning "Unsaved" state so "Saving…" only ever shows while a save is actually in flight, and gated the beforeunload/visibilitychange guards on the same in-progress-edit flag so closing the tab mid-keystroke is now caught.
- The "Unsaved" chip is clickable — it flushes and saves immediately, bypassing the autosave debounce, and refocuses whatever field the author was typing in afterwards so they can keep going without re-clicking.
- Field-editing detection is a single delegated listener on the editor panel, so it covers PropertyEditor, ScriptEditor, and nested list/dictionary editors without per-field wiring.

## Test plan
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm run lint` (eslint, clean)
- [x] Manual browser verification via Playwright (dev server + local drafts): pill stays fixed-width across Saved/Saving/Unsaved; typing shows "Unsaved" not "Saving…" in both PropertyEditor and ScriptEditor fields; staging boxes (add-item/add-attribute) don't falsely flip the pill; hiding the tab mid-keystroke flushes and persists the edit (survives reload); clicking "Unsaved" saves promptly and returns focus to the field, allowing continued typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)