### PR TITLE
fix(AppShell): keep Delete button visible but disabled instead of hiding it

### DIFF
--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -177,15 +177,15 @@
                         </div>
                     {/if}
                 </div>
-                <!-- Delete button -->
-                {#if canDelete}
-                    <button
-                        type="button"
-                        class="btn btn-sm preset-outlined-error-500"
-                        onclick={() => deleteElement(selectedNode!.key)}
-                        title={"Delete " + (selectedNode?.text ?? "")}
-                    ><Trash2 size={14} /> Delete</button>
-                {/if}
+                <!-- Delete button: always rendered, disabled when nothing deletable is
+                     selected, so surrounding buttons don't shift as selection changes -->
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-error-500"
+                    onclick={() => selectedNode && deleteElement(selectedNode.key)}
+                    disabled={!canDelete}
+                    title={canDelete ? "Delete " + (selectedNode?.text ?? "") : "Delete"}
+                ><Trash2 size={14} /> Delete</button>
                 <div class="toolbar-divider"></div>
                 <button type="button" class="toolbar-icon-btn" onclick={() => assetManagerOpen.set(true)} title="Manage assets"><ImageIcon size={16} /></button>
                 <button type="button" class="toolbar-icon-btn" onclick={undo} disabled={!$canUndo} title="Undo"><Undo2 size={16} /></button>


### PR DESCRIPTION
## Summary
- The editor toolbar's Delete button was conditionally mounted based on tree selection, so it popped in/out and shifted the Undo/Redo buttons and dividers next to it every time the selection changed.
- Now the Delete button always renders and is just `disabled` when the current selection isn't deletable, matching the existing disabled pattern used by Undo/Redo/Save As/Backup.
- Left the env/adapter-driven buttons (Home, Save As, Backup, Publish/Preview) as conditional renders since those don't change mid-session.

## Test plan
- [x] `npm run check` (svelte-check) passes with 0 errors/warnings
- [ ] Manual: select various element types in the tree and confirm Delete stays in place, greying out for non-deletable nodes instead of disappearing