### PR TITLE
fix(WasmPlayer): stop shipping debug symbols that fetch from raw.githubusercontent.com

### DIFF
--- a/src/WasmEditor/WasmEditor.csproj
+++ b/src/WasmEditor/WasmEditor.csproj
@@ -9,6 +9,13 @@
         <LangVersion>default</LangVersion>
         <RunAOTCompilation>true</RunAOTCompilation>
         <WasmEmitSymbolMap>true</WasmEmitSymbolMap>
+        <!-- Release is what ships (Electron, static hosting, often offline). Shipping .pdb files
+             embeds SourceLink metadata pointing at raw.githubusercontent.com, which Chrome DevTools'
+             WASM debugger fetches from when attached — undesirable for an offline-capable app.
+             The dotnet.js/.runtime.js source maps have the same problem, pointing at dotnet/dotnet
+             on GitHub. Debug builds keep both for local dev-server debugging. -->
+        <WasmDebugLevel Condition="'$(Configuration)' == 'Release'">0</WasmDebugLevel>
+        <WasmEmitSourceMap Condition="'$(Configuration)' == 'Release'">false</WasmEmitSourceMap>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\EditorCore\EditorCore.csproj"/>

--- a/src/WasmPlayer/WasmPlayer.csproj
+++ b/src/WasmPlayer/WasmPlayer.csproj
@@ -8,6 +8,13 @@
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
         <RunAOTCompilation>true</RunAOTCompilation>
+        <!-- Release is what ships (Electron, static hosting, often offline). Shipping .pdb files
+             embeds SourceLink metadata pointing at raw.githubusercontent.com, which Chrome DevTools'
+             WASM debugger fetches from when attached — undesirable for an offline-capable app.
+             The dotnet.js/.runtime.js source maps have the same problem, pointing at dotnet/dotnet
+             on GitHub. Debug builds keep both for local dev-server debugging. -->
+        <WasmDebugLevel Condition="'$(Configuration)' == 'Release'">0</WasmDebugLevel>
+        <WasmEmitSourceMap Condition="'$(Configuration)' == 'Release'">false</WasmEmitSourceMap>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\PlayerCore\PlayerCore.csproj"/>


### PR DESCRIPTION
## Summary
- Release builds of WasmPlayer/WasmEditor were shipping `.pdb` files with embedded SourceLink metadata (`raw.githubusercontent.com/textadventures/quest/<commit>/*`), plus `dotnet.js.map`/`dotnet.runtime.js.map` with unfilled `sourcesContent` pointing at `dotnet/dotnet` on GitHub.
- Chrome DevTools fetches this source content from GitHub whenever it attaches — a network dependency that's undesirable for offline-capable targets like ElectronApp.
- Set `WasmDebugLevel=0` and `WasmEmitSourceMap=false`, scoped to `Release` config only, on `WasmPlayer.csproj` and `WasmEditor.csproj`. Debug builds are untouched, so local dev-server debugging still works.

## Test plan
- [x] `dotnet build --configuration Release src/WasmPlayer/WasmPlayer.csproj` succeeds
- [x] Confirmed Release `AppBundle` has zero `.pdb`, zero `.map`, and zero `raw.githubusercontent.com` references (also verified for WasmEditor's AppBundle)
- [x] Confirmed Debug `AppBundle` still ships `.pdb`/`.map` files and `debugLevel: -1` (unaffected)
- [x] `dotnet build --configuration Release` (full solution) succeeds
- [x] Started `node dev-server.mjs --release` and confirmed the game page, `dotnet.js`, and `dotnet.boot.js` all serve 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)