### PR TITLE
fix: send client info (source/version/platform) on game-load requests

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: verify
+description: How to runtime-verify changes in this repo (WasmPlayer/WebPlayer/AppShell/ElectronApp) via Playwright, no automated verify harness exists yet
+---
+
+# Verifying changes in Quest Viva
+
+No CI-integrated e2e suite. `tests/e2e/*.mjs` is a growing set of ad-hoc,
+hand-run Playwright scripts (`quest-e2e` package, `playwright` installed
+there) — one file per bug/feature, run directly with `node`, not via `npm
+test`. Follow that convention: write a new `verify-<topic>.mjs` there, run it
+with `node verify-<topic>.mjs`, leave it checked in for future regression
+reruns.
+
+## Browser surface (WasmPlayer / WebPlayer / AppShell)
+
+1. Rebuild whatever project you touched, e.g.:
+   `dotnet build src/WasmPlayer/WasmPlayer.csproj` (Debug — fast interpreter,
+   good enough for behavior checks; static JS like `wasm-player.js` is a
+   plain copy into `bin/Debug/net10.0/browser-wasm/AppBundle/` on every
+   build, no separate step needed).
+2. Start the relevant dev server, e.g. `node src/WasmPlayer/dev-server.mjs`
+   (serves `http://localhost:5175`, reads `?id=`/`?url=` query params).
+3. Drive it with `playwright`'s `chromium.launch()` from a script in
+   `tests/e2e/`. Use `page.route('**/some/api/**', ...)` to intercept and
+   inspect outgoing requests (query params etc.) without needing a real
+   backend — `route.fulfill()` with a synthetic response is enough when you
+   only care about the request shape, not full game boot.
+
+## Electron surface
+
+1. Rebuild the touched dotnet project(s) first (WasmPlayer/WasmEditor), then:
+   `cd src/ElectronApp && npm run build` — runs `tsc` (preload.ts/main.ts
+   etc.) and `copy-static.mjs`, which copies `src/AppShell/build` (editor UI)
+   + WasmEditor's and WasmPlayer's `AppBundle` output into
+   `resources/app-static/{editor,AppBundle,player}`. **`copy-static.mjs`
+   does *not* rebuild AppShell** — if `src/AppShell/build` doesn't exist yet
+   or is stale relative to a change you made there, build it first (`cd
+   src/AppShell && npm run build`; the Home/Play-tab root needs
+   `PUBLIC_SHOW_HOME=true` set at that build time, see `docs/deployment-domains.md`).
+2. Drive with Playwright's `_electron` launcher:
+   ```js
+   import { _electron as electron } from 'playwright';
+   import { createRequire } from 'node:module';
+   const electronAppDir = join(import.meta.dirname, '..', '..', 'src', 'ElectronApp');
+   const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'))('electron');
+   const app = await electron.launch({
+       executablePath: electronExecutablePath,
+       args: [electronAppDir, `--user-data-dir=${mkdtempSync(...)}`],
+   });
+   const win = await app.firstWindow(); // the editor/Home window
+   ```
+   See `tests/e2e/verify-electron-play-local-file.mjs` for a full working
+   example (native dialog stubbing via `app.evaluate(({dialog}) => {...})`,
+   waiting for a second BrowserWindow via `app.waitForEvent('window')`).
+3. **Gotcha**: the player `BrowserWindow` (opened via
+   `window.electronApp.player.openWindow(...)`, see `ipc/player.ts`)
+   deliberately has **no preload script** — it renders untrusted game
+   content, so `window.electronApp` is undefined there. Only the
+   editor/Home window has the preload bridge. Don't expect
+   `window.electronApp.*` to exist inside a player window.
+4. **Gotcha**: to intercept a request fired immediately on a *new* window's
+   first navigation (e.g. a player window's boot-time fetch), register the
+   route at the browser-context level — `app.context().route(...)` — *before*
+   triggering whatever opens that window. A route added on the page/window
+   object after `app.waitForEvent('window')` resolves can already be too
+   late.
+
+## What NOT to do
+
+Don't just run `dotnet test`/`npm run build`/typecheck and call it verified
+— those confirm compilation, not runtime behavior. Actually launch the dev
+server or the Electron app and observe the real request/DOM/behavior.

--- a/src/AppShell/src/lib/electron-types.d.ts
+++ b/src/AppShell/src/lib/electron-types.d.ts
@@ -81,11 +81,12 @@ interface ElectronApi {
     recent: ElectronRecentApi;
     menu: ElectronMenuApi;
     player: ElectronPlayerApi;
-    // Not yet populated by preload.ts — "Mac" | "Windows" | "Linux", sent as
-    // analytics metadata alongside webhome_games_list/webhome_game_play (see
-    // ClientInfo on textadventures.co.uk's ApiController). Declared optional
-    // here so callers read through automatically once preload.ts adds it.
-    platform?: string;
+    // Populated by preload.ts from process.platform (main/preload only —
+    // unavailable in the sandboxed renderer). Sent as analytics metadata
+    // alongside webhome_games_list/webhome_game_play (see ClientInfo on
+    // textadventures.co.uk's ApiController). Optional since process.platform
+    // could in principle be something outside this union (e.g. freebsd).
+    platform?: "Mac" | "Windows" | "Linux";
 }
 
 declare global {

--- a/src/ElectronApp/src/preload.ts
+++ b/src/ElectronApp/src/preload.ts
@@ -20,9 +20,23 @@ function joinPath(...segments: string[]): string {
         .join(sep);
 }
 
+// Sent as analytics metadata alongside webhome_games_list/webhome_game_play
+// (see ClientInfo on textadventures.co.uk's ApiController, and
+// home-catalog.ts's clientInfoParams()). process.platform is only available
+// here in the preload context, not the sandboxed renderer.
+function hostPlatform(): "Mac" | "Windows" | "Linux" | undefined {
+    switch (process.platform) {
+        case "darwin": return "Mac";
+        case "win32": return "Windows";
+        case "linux": return "Linux";
+        default: return undefined;
+    }
+}
+
 // Matches the window.electronApp shape sketched in docs/electron-desktop-app.md
 // and consumed by src/AppShell/src/lib/filesystem/electron-adapter.ts.
 contextBridge.exposeInMainWorld("electronApp", {
+    platform: hostPlatform(),
     fs: {
         readFile: (path: string): Promise<Uint8Array> => ipcRenderer.invoke("fs:readFile", path),
         writeFile: (path: string, data: Uint8Array | string): Promise<void> => ipcRenderer.invoke("fs:writeFile", path, data),

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -13,8 +13,6 @@ console.log(
     'color:#64748b'
 );
 
-var platform = "wasmplayer";
-
 var _audio = null;
 
 const pendingResources = new Map();
@@ -128,6 +126,30 @@ function activationLikelyGranted() {
     // friction there, never actually prevent a blocked sound.
     if (navigator.userAgent.includes('Electron/')) return true;
     return !('userActivation' in navigator) || navigator.userActivation.hasBeenActive;
+}
+
+// Attached to the api/Game/{id} fetch below as analytics metadata (see
+// ClientInfo on textadventures.co.uk's ApiController) — mirrors AppShell's
+// home-catalog.ts clientInfoParams(), which does the same for the Catalog and
+// GameDetails calls. This player window runs untrusted game content and
+// deliberately has no preload bridge (see ipc/player.ts), so unlike
+// home-catalog.ts it can't read window.electronApp.platform; Electron and its
+// host OS are instead sniffed from the UA, the same signal
+// activationLikelyGranted() above already relies on.
+function clientInfoParams() {
+    const params = new URLSearchParams();
+    const isElectron = navigator.userAgent.includes('Electron/');
+    params.set('source', isElectron ? 'electron' : 'web');
+    if (window.QuestVivaVersion) params.set('version', window.QuestVivaVersion);
+    if (isElectron) {
+        const ua = navigator.userAgent;
+        const platform = ua.includes('Macintosh') ? 'Mac'
+            : ua.includes('Windows') ? 'Windows'
+            : (ua.includes('Linux') || ua.includes('X11')) ? 'Linux'
+            : null;
+        if (platform) params.set('platform', platform);
+    }
+    return params;
 }
 
 // Shows a "click to begin" prompt in the still-visible start screen and
@@ -936,7 +958,7 @@ async function fetchGameBytes(url) {
         const gamePromise = (async () => {
             const apiRoot = window.QuestVivaConfig?.textAdventuresApiRoot
                 ?? 'https://textadventures.co.uk/api/';
-            const apiResponse = await fetch(`${apiRoot}game/${id}`);
+            const apiResponse = await fetch(`${apiRoot}game/${id}?${clientInfoParams()}`);
             if (!apiResponse.ok) {
                 const err = new Error(`API: HTTP ${apiResponse.status}`);
                 err.status = apiResponse.status;

--- a/tests/e2e/verify-clientinfo-electron.mjs
+++ b/tests/e2e/verify-clientinfo-electron.mjs
@@ -1,0 +1,79 @@
+// Ad-hoc manual verification: preload.ts now populates window.electronApp.platform
+// from process.platform, and wasm-player.js's api/Game/{id} fetch now attaches
+// source/version/platform query params. Requires a fresh build:
+//   dotnet build src/WasmPlayer/WasmPlayer.csproj
+//   (cd src/ElectronApp && npm run build)
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const electronAppDir = join(import.meta.dirname, '..', '..', 'src', 'ElectronApp');
+const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'))('electron');
+
+const userDataDir = mkdtempSync(join(tmpdir(), 'quest-electron-userdata-'));
+
+let app;
+try {
+    app = await electron.launch({
+        executablePath: electronExecutablePath,
+        args: [electronAppDir, `--user-data-dir=${userDataDir}`],
+    });
+    const win = await app.firstWindow();
+    win.on('pageerror', err => console.log('[editor] [pageerror]', err.message));
+
+    await win.waitForSelector('button:has-text("Open a game file…")', { timeout: 30000 });
+
+    const platform = await win.evaluate(() => window.electronApp.platform);
+    console.log('window.electronApp.platform in editor window:', platform);
+    if (!['Mac', 'Windows', 'Linux'].includes(platform)) {
+        throw new Error(`Expected a mapped platform, got ${JSON.stringify(platform)}`);
+    }
+    console.log('PASS: preload.ts populated window.electronApp.platform');
+
+    // Intercept at the context level so the route is already active before
+    // the new player window navigates and fires its api/game/{id} fetch.
+    let capturedUrl = null;
+    await app.context().route('**/api/game/**', async (route) => {
+        capturedUrl = route.request().url();
+        await route.fulfill({
+            status: 404,
+            contentType: 'application/json',
+            body: JSON.stringify({ message: 'not found (expected — test id)' }),
+        });
+    });
+
+    const [playerWindow] = await Promise.all([
+        app.waitForEvent('window'),
+        win.evaluate(() => window.electronApp.player.openWindow({ id: 'clientinfo-test-id' })),
+    ]);
+    playerWindow.on('pageerror', err => console.log('[player] [pageerror]', err.message));
+
+    await playerWindow.waitForTimeout(1500);
+
+    console.log('Captured request URL:', capturedUrl);
+    if (!capturedUrl) throw new Error('no request to api/game/* was observed from the player window');
+
+    const url = new URL(capturedUrl);
+    const source = url.searchParams.get('source');
+    const version = url.searchParams.get('version');
+    const gamePlatform = url.searchParams.get('platform');
+    console.log({ source, version, platform: gamePlatform });
+
+    if (source !== 'electron') throw new Error(`expected source=electron, got ${source}`);
+    if (!version) throw new Error('expected a version param, got none');
+    if (!['Mac', 'Windows', 'Linux'].includes(gamePlatform)) {
+        throw new Error(`expected a UA-sniffed platform, got ${JSON.stringify(gamePlatform)}`);
+    }
+    console.log('PASS: player window\'s api/Game/{id} fetch carries source/version/platform');
+
+    await playerWindow.close();
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await app?.close();
+    rmSync(userDataDir, { recursive: true, force: true });
+}

--- a/tests/e2e/verify-clientinfo-web.mjs
+++ b/tests/e2e/verify-clientinfo-web.mjs
@@ -1,0 +1,39 @@
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+let capturedUrl = null;
+await page.route('**/api/game/**', async (route) => {
+    capturedUrl = route.request().url();
+    await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'not found (expected — test id)' }),
+    });
+});
+
+await page.goto(`${baseUrl}/?id=test-game-id`);
+await page.waitForTimeout(1500);
+
+await browser.close();
+
+console.log('Captured request URL:', capturedUrl);
+if (!capturedUrl) {
+    console.error('FAIL: no request to api/game/* was observed');
+    process.exit(1);
+}
+const url = new URL(capturedUrl);
+const source = url.searchParams.get('source');
+const version = url.searchParams.get('version');
+const platform = url.searchParams.get('platform');
+console.log({ source, version, platform });
+
+if (source !== 'web') { console.error(`FAIL: expected source=web, got ${source}`); process.exit(1); }
+if (!version) { console.error('FAIL: expected a version param, got none'); process.exit(1); }
+if (platform !== null) { console.error(`FAIL: expected no platform param on plain web build, got ${platform}`); process.exit(1); }
+
+console.log('PASS');


### PR DESCRIPTION
## Summary

The server-side `ClientInfo` (`source`/`version`/`platform`) support on textadventures.co.uk's `ApiController` was only half-wired up client-side:

- `home-catalog.ts`'s `Catalog`/`GameDetails` calls already sent it.
- `wasm-player.js`'s `api/Game/{id}` fetch — the one that actually loads a game and fires the `webhome_game_play` tracking event — sent **no params at all**. There was a vestigial, unused `var platform = "wasmplayer"` in that file instead of an actual wire-up.
- Even where it *was* wired up, `window.electronApp.platform` was declared in `electron-types.d.ts` but never populated by `preload.ts`, so it was always `undefined` in the Electron build.

This PR closes both gaps:
- `wasm-player.js` now attaches `source`/`version`/`platform` to the `api/Game/{id}` fetch. The player `BrowserWindow` deliberately has no preload bridge (it renders untrusted game content — see `ipc/player.ts`), so `source`/`platform` are UA-sniffed there rather than read from `window.electronApp`.
- `preload.ts` now populates `window.electronApp.platform` from `process.platform` (mapped to `"Mac"`/`"Windows"`/`"Linux"`), so the existing `Catalog`/`GameDetails` wiring in `home-catalog.ts` actually sends a real value in the Electron build.

## Test plan

Verified end-to-end with Playwright against the real running apps (not just typecheck) — see `tests/e2e/verify-clientinfo-web.mjs` and `tests/e2e/verify-clientinfo-electron.mjs`:

- [x] Browser build (`WasmPlayer` dev server): captured outgoing request is `.../api/game/<id>?source=web&version=6.0.0-beta.42`, no `platform`.
- [x] Electron editor window: `window.electronApp.platform` now reads `"Mac"` (on this machine) instead of `undefined`.
- [x] Electron player window (opened the same way the catalog Play button does, `player.openWindow({ id })`): captured outgoing request is `.../api/game/<id>?source=electron&version=6.0.0-beta.42&platform=Mac`.
- [x] `tsc --noEmit` clean on ElectronApp, `svelte-check` clean on AppShell, `node --check` clean on `wasm-player.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)