### PR TITLE
feat(AppShell): show a dismissible update banner for the desktop app

### DIFF
--- a/src/AppShell/src/components/PlayCatalog.svelte
+++ b/src/AppShell/src/components/PlayCatalog.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import { base } from "$app/paths";
-    import { fetchCatalog, type CatalogCategory } from "$lib/home-catalog";
+    import { fetchCatalog, type CatalogCategory, type UpdateInfo } from "$lib/home-catalog";
     import { pickFile } from "$lib/filesystem/file-picker";
     import { isElectron } from "$lib/runtime";
     import { openElectronPlayFile, loadElectronFile, listRecentGames, removeRecentGame } from "$lib/filesystem/electron-adapter";
     import type { RecentGame } from "$lib/filesystem/electron-adapter";
+    import UpdateBanner from "$components/UpdateBanner.svelte";
 
     const isElectronApp = isElectron();
 
     let categories = $state<CatalogCategory[] | null>(null);
+    let update = $state<UpdateInfo | null>(null);
     let error = $state(false);
     let loading = $state(true);
 
@@ -17,7 +19,9 @@
         loading = true;
         error = false;
         try {
-            categories = await fetchCatalog();
+            const result = await fetchCatalog();
+            categories = result.categories;
+            update = result.update;
         } catch {
             error = true;
         } finally {
@@ -222,6 +226,9 @@
      wider than 5xl shows the page's real (light-mode) background down the
      sides instead of dark. -->
 <div class="min-h-svh bg-surface-950 text-surface-100">
+    {#if isElectronApp && update}
+        <UpdateBanner {update} />
+    {/if}
     <div class="flex flex-col gap-8 w-full max-w-5xl mx-auto p-8">
         <div class="flex flex-col items-center gap-2">
             {#if isElectronApp}

--- a/src/AppShell/src/components/UpdateBanner.svelte
+++ b/src/AppShell/src/components/UpdateBanner.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import type { UpdateInfo } from "$lib/home-catalog";
+
+    let { update }: { update: UpdateInfo } = $props();
+
+    const dismissedKey = "questviva-update-dismissed-version";
+
+    let manuallyDismissed = $state(false);
+
+    // Dismissing only suppresses this specific version's banner — a later
+    // release with a newer latestVersion re-triggers it.
+    const dismissed = $derived(
+        manuallyDismissed ||
+        (typeof localStorage !== "undefined" && localStorage.getItem(dismissedKey) === update.latestVersion)
+    );
+
+    function handleDismiss() {
+        localStorage.setItem(dismissedKey, update.latestVersion);
+        manuallyDismissed = true;
+    }
+</script>
+
+{#if !dismissed}
+    <div class="flex items-center gap-3 px-4 py-2 bg-primary-100-900 border-b border-primary-300-700 text-sm">
+        <span class="flex-1">Quest Viva {update.latestVersion} is available.</span>
+        <a href={update.url} target="_blank" rel="noopener" class="btn btn-sm preset-filled-primary-500">Download</a>
+        <button type="button" class="btn btn-sm preset-tonal" onclick={handleDismiss}>Later</button>
+    </div>
+{/if}

--- a/src/AppShell/src/components/UpdateBanner.svelte
+++ b/src/AppShell/src/components/UpdateBanner.svelte
@@ -21,9 +21,16 @@
 </script>
 
 {#if !dismissed}
-    <div class="flex items-center gap-3 px-4 py-2 bg-primary-100-900 border-b border-primary-300-700 text-sm">
+    <!-- Fixed shades throughout (bg-primary-900, preset-outlined-surface-500),
+         not Skeleton's paired light/dark-auto-switching tokens
+         (bg-primary-100-900, preset-tonal, etc — see presets.css's use of
+         light-dark()): the Play tab is force-dark regardless of system theme
+         (unlike the editor, where BackupBanner's use of those pairs is fine),
+         so an auto-switching background/text pair here would go low-contrast
+         under a light-mode system. -->
+    <div class="flex items-center gap-3 px-4 py-2 bg-primary-900 border-b border-primary-700 text-sm">
         <span class="flex-1">Quest Viva {update.latestVersion} is available.</span>
         <a href={update.url} target="_blank" rel="noopener" class="btn btn-sm preset-filled-primary-500">Download</a>
-        <button type="button" class="btn btn-sm preset-tonal" onclick={handleDismiss}>Later</button>
+        <button type="button" class="btn btn-sm preset-outlined-surface-500" onclick={handleDismiss}>Later</button>
     </div>
 {/if}

--- a/src/AppShell/src/lib/home-catalog.ts
+++ b/src/AppShell/src/lib/home-catalog.ts
@@ -15,6 +15,15 @@ export interface CatalogCategory {
     games: CatalogGame[];
 }
 
+// Present only for Electron clients running an outdated build (see
+// ApiController.Catalog on textadventures.co.uk, which compares client.Version
+// against the latest tagged GitHub release) — web builds are static-redeployed
+// on every release and are always current, so this is always null there.
+export interface UpdateInfo {
+    latestVersion: string;
+    url: string;
+}
+
 export interface GameDetails {
     id: string;
     name: string;
@@ -49,13 +58,13 @@ function clientInfoParams(): URLSearchParams {
     return params;
 }
 
-export async function fetchCatalog(): Promise<CatalogCategory[]> {
+export async function fetchCatalog(): Promise<{ categories: CatalogCategory[]; update: UpdateInfo | null }> {
     const params = clientInfoParams();
     params.set("maxAslVersion", String(MAX_ASL_VERSION));
     const response = await fetch(`${API_ROOT}/Catalog?${params}`);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const data = await response.json() as { categories: CatalogCategory[] };
-    return data.categories;
+    const data = await response.json() as { categories: CatalogCategory[]; update: UpdateInfo | null };
+    return { categories: data.categories, update: data.update ?? null };
 }
 
 export async function fetchGameDetails(id: string): Promise<GameDetails> {

--- a/tests/e2e/verify-update-banner-web.mjs
+++ b/tests/e2e/verify-update-banner-web.mjs
@@ -1,0 +1,32 @@
+// Ad-hoc manual verification: the update-check banner never renders on a
+// non-Electron (web) build, even if the server hypothetically returned a
+// non-null update field — belt-and-braces alongside the server-side gate
+// (ApiController.Catalog only computes Update for source=electron).
+// Requires the dev server running: ./dev.sh
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+const update = { latestVersion: 'v6.0.0-beta.99', url: 'https://github.com/textadventures/quest/releases/latest' };
+await page.route('**/api/Catalog**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ categories: [], update }),
+}));
+
+await page.goto(`${baseUrl}/`);
+await page.waitForSelector('button:has-text("Open a game file")', { timeout: 30000 });
+await page.waitForTimeout(1000);
+
+const bannerCount = await page.locator('text=is available').count();
+await browser.close();
+
+if (bannerCount !== 0) {
+    console.error('FAIL: banner rendered on a non-Electron build even though the server (hypothetically) returned update info');
+    process.exit(1);
+}
+console.log('PASS: no banner on web build, even with a non-null update in the response (client-side isElectronApp guard)');

--- a/tests/e2e/verify-update-banner.mjs
+++ b/tests/e2e/verify-update-banner.mjs
@@ -1,0 +1,102 @@
+// Ad-hoc manual verification: the desktop app's update-check banner
+// (UpdateBanner.svelte, PlayCatalog.svelte, home-catalog.ts's fetchCatalog).
+// Requires a fresh build:
+//   PUBLIC_SHOW_HOME=true npm run build --prefix src/AppShell
+//   dotnet build src/WasmEditor/WasmEditor.csproj
+//   dotnet build src/WasmPlayer/WasmPlayer.csproj
+//   (cd src/ElectronApp && npm run build)
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const electronAppDir = join(import.meta.dirname, '..', '..', 'src', 'ElectronApp');
+const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'))('electron');
+
+function catalogResponse(update) {
+    return {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ categories: [], update }),
+    };
+}
+
+async function launch() {
+    const userDataDir = mkdtempSync(join(tmpdir(), 'quest-electron-userdata-'));
+    const app = await electron.launch({
+        executablePath: electronExecutablePath,
+        args: [electronAppDir, `--user-data-dir=${userDataDir}`],
+    });
+    return { app, userDataDir };
+}
+
+let failed = false;
+
+// ── Run 1: no update available — banner must not render ────────────────────
+{
+    const { app, userDataDir } = await launch();
+    try {
+        await app.context().route('**/api/Catalog**', route => route.fulfill(catalogResponse(null)));
+
+        const win = await app.firstWindow();
+        win.on('pageerror', err => console.log('[pageerror]', err.message));
+        await win.waitForSelector('button:has-text("Open a game file…")', { timeout: 30000 });
+        await win.waitForTimeout(1000);
+
+        const bannerVisible = await win.locator('text=is available').count();
+        if (bannerVisible !== 0) throw new Error('banner rendered despite update:null');
+        console.log('PASS: no banner when update is null');
+    } catch (err) {
+        console.error('FAIL (run 1):', err.message);
+        failed = true;
+    } finally {
+        await app.close();
+        rmSync(userDataDir, { recursive: true, force: true });
+    }
+}
+
+// ── Run 2: update available — banner renders, links out, dismiss persists ──
+{
+    const { app, userDataDir } = await launch();
+    try {
+        const update = { latestVersion: 'v6.0.0-beta.99', url: 'https://github.com/textadventures/quest/releases/latest' };
+        await app.context().route('**/api/Catalog**', route => route.fulfill(catalogResponse(update)));
+
+        const win = await app.firstWindow();
+        win.on('pageerror', err => console.log('[pageerror]', err.message));
+        await win.waitForSelector('button:has-text("Open a game file…")', { timeout: 30000 });
+
+        const banner = win.locator('text=Quest Viva v6.0.0-beta.99 is available.');
+        await banner.waitFor({ timeout: 10000 });
+        console.log('PASS: banner rendered with the latest version');
+
+        const downloadLink = win.locator('a:has-text("Download")');
+        const href = await downloadLink.getAttribute('href');
+        if (href !== update.url) throw new Error(`expected Download link href ${update.url}, got ${href}`);
+        console.log('PASS: Download link points at', href);
+
+        await win.locator('button:has-text("Later")').click();
+        await banner.waitFor({ state: 'detached', timeout: 5000 });
+        console.log('PASS: banner dismissed on "Later" click');
+
+        await win.reload();
+        await win.waitForSelector('button:has-text("Open a game file…")', { timeout: 30000 });
+        await win.waitForTimeout(1000);
+        const stillHidden = await win.locator('text=is available').count();
+        if (stillHidden !== 0) throw new Error('banner reappeared after reload despite dismissal');
+        console.log('PASS: dismissal persists across reload');
+    } catch (err) {
+        console.error('FAIL (run 2):', err.message);
+        failed = true;
+    } finally {
+        await app.close();
+        rmSync(userDataDir, { recursive: true, force: true });
+    }
+}
+
+if (failed) {
+    process.exitCode = 1;
+} else {
+    console.log('PASS: all checks passed');
+}


### PR DESCRIPTION
## Summary
- `fetchCatalog()` now returns the `update` field textadventures.co.uk's `Catalog` API reports for outdated Electron clients (textadventures/textadventures.co.uk#69).
- New `UpdateBanner.svelte` renders on the Play tab: current-vs-latest message, a "Download" link to `github.com/textadventures/quest/releases/latest` (routed to the OS browser via Electron's existing `setWindowOpenHandler`, no new IPC needed), and a "Later" dismiss that's remembered per-version in `localStorage` — a later release re-triggers it.
- Gated to Electron only (`isElectronApp`) client-side, on top of the server-side gate (web clients never even get a non-null `update`).

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run build` (`PUBLIC_SHOW_HOME=true`) — clean
- [x] `tests/e2e/verify-update-banner.mjs` — real packaged Electron app via Playwright: banner text/version, Download link href, "Later" dismissal, dismissal persists across reload
- [x] `tests/e2e/verify-update-banner-web.mjs` — confirms no banner on a plain web build even when the (intercepted) API response includes a non-null update