### PR TITLE
fix(Engine): preserve insertion order in OrderedDictionary after remove+add

### DIFF
--- a/src/Engine/QuestDictionary.cs
+++ b/src/Engine/QuestDictionary.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System.Collections;
 using System.Collections.Specialized;
+using System.Linq;
 
 namespace QuestViva.Engine;
 
@@ -603,12 +604,23 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
 
     IDictionaryEnumerator IOrderedDictionary.GetEnumerator()
     {
-        return Dictionary.GetEnumerator();
+        return new OrderedDictionaryEnumerator(List.GetEnumerator());
     }
 
     IDictionaryEnumerator IDictionary.GetEnumerator()
     {
-        return Dictionary.GetEnumerator();
+        return new OrderedDictionaryEnumerator(List.GetEnumerator());
+    }
+
+    private sealed class OrderedDictionaryEnumerator(IEnumerator<KeyValuePair<TKey, TValue>> inner)
+        : IDictionaryEnumerator
+    {
+        public DictionaryEntry Entry => new(inner.Current.Key, inner.Current.Value);
+        public object Key => inner.Current.Key;
+        public object Value => inner.Current.Value;
+        public object Current => Entry;
+        public bool MoveNext() => inner.MoveNext();
+        public void Reset() => inner.Reset();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
@@ -1123,7 +1135,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> continue to be reflected in
     ///     the key collection.
     /// </remarks>
-    public ICollection<TKey> Keys => Dictionary.Keys;
+    public ICollection<TKey> Keys => List.Select(kvp => kvp.Key).ToList();
 
     /// <summary>
     ///     Gets the value associated with the specified key.
@@ -1159,7 +1171,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> continue to be reflected in
     ///     the value collection.
     /// </remarks>
-    public ICollection<TValue> Values => Dictionary.Values;
+    public ICollection<TValue> Values => List.Select(kvp => kvp.Value).ToList();
 
     /// <summary>
     ///     Adds the specified value to the
@@ -1331,6 +1343,6 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
 
     public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
     {
-        return Dictionary.GetEnumerator();
+        return List.GetEnumerator();
     }
 }

--- a/tests/EngineTests/QuestDictionaryTests.cs
+++ b/tests/EngineTests/QuestDictionaryTests.cs
@@ -1,0 +1,37 @@
+using QuestViva.Engine;
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+// Regression test: OrderedDictionary<TKey,TValue>'s Keys/Values/GetEnumerator used to read from
+// the internal hash-based Dictionary<TKey,TValue> instead of the insertion-ordered List, even
+// though preserving insertion order is the whole point of the class. Dictionary<TKey,TValue>
+// happens to enumerate in insertion order as long as nothing is ever removed, which hid the bug -
+// but a remove followed by an add reuses the freed slot, and enumeration order then diverges from
+// the true append order. Any aslx script doing "dictionary remove" then "dictionary add" then
+// "foreach" over the same dictionary would silently see the wrong order.
+[TestClass]
+public class QuestDictionaryTests
+{
+    [TestMethod]
+    public void Foreach_AfterRemoveAndReAdd_PreservesTrueInsertionOrder()
+    {
+        var dict = new QuestDictionary<string>();
+        dict.Add("a", "1");
+        dict.Add("b", "2");
+        dict.Add("c", "3");
+        dict.Add("d", "4");
+        dict.Remove("b");
+        dict.Add("e", "5");
+
+        dict.Keys.ShouldBe(["a", "c", "d", "e"]);
+
+        var viaForeach = new List<string>();
+        foreach (var kvp in dict)
+        {
+            viaForeach.Add(kvp.Key);
+        }
+
+        viaForeach.ShouldBe(["a", "c", "d", "e"]);
+    }
+}


### PR DESCRIPTION
## Summary
- `OrderedDictionary<TKey,TValue>` (backing `QuestDictionary<T>`) is meant to preserve insertion order, but `Keys`, `Values`, the public `GetEnumerator()`, and the `IDictionaryEnumerator` implementations all read from the internal hash-based `Dictionary<TKey,TValue>` instead of the ordered `List`.
- This was masked because `Dictionary<TKey,TValue>` happens to enumerate in insertion order as long as nothing is ever removed. Once a key is removed and a new one added, .NET reuses the freed slot, so the hash-based enumeration silently diverges from the true append order.
- Any aslx script doing `dictionary remove` then `dictionary add` then `foreach` over the same dictionary (a completely ordinary pattern) would get scrambled iteration order with no indication anything was wrong.
- Fix: `Dictionary` is now used only for O(1) lookups (`ContainsKey`/`TryGetValue`/indexer get); everything that needs order (`Keys`, `Values`, enumeration) reads from `List`.

Investigated while root-causing an unrelated "It saies nothing" bug report from a published game — that turned out to be caused entirely by the game's own frozen copy of an old, buggy `Conjugate` function (embedded by the Quest 5.8 desktop editor circa 2018), unrelated to this repo. This fix is an independent hygiene find made along the way.

## Test plan
- [x] Added `tests/EngineTests/QuestDictionaryTests.cs` reproducing add/remove/re-add and asserting both `.Keys` and plain `foreach` return the true insertion order
- [x] `dotnet test` — full solution suite passes (326 tests across Engine/Legacy/PlayerCore/EditorCore/WebPlayer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)