### PR TITLE
fix(AppShell): hide desktop download link on mobile, fix local editor link

### DIFF
--- a/src/AppShell/src/components/HomeHeader.svelte
+++ b/src/AppShell/src/components/HomeHeader.svelte
@@ -16,7 +16,9 @@
     <h1 class="text-xl font-semibold">Quest Viva</h1>
     <div class="ml-auto flex items-center gap-1">
         {#if !isElectronApp}
-            <DownloadButton compact />
+            <div class="hidden sm:block">
+                <DownloadButton compact />
+            </div>
         {/if}
         <a
             href="https://textadventures.co.uk/community/discord"

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -682,7 +682,7 @@
                         {#if hasServer}
                             <p class="text-xs text-surface-500-400 max-w-[40ch] text-center self-center">
                                 Want to keep this game only on your own device? Use the
-                                <a class="anchor" href="https://play.questviva.com/editor/">play.questviva.com editor</a> instead.
+                                <a class="anchor" href="https://play.questviva.com/open">play.questviva.com editor</a> instead.
                             </p>
                         {/if}
                     {/if}


### PR DESCRIPTION
## Summary
- Hide the top-bar "Desktop app" download button on mobile viewports (`hidden sm:block`) — it cluttered the bar and isn't relevant there.
- Fix the textadventures.co.uk-mode "local-only editor" link on the Create tab, which pointed to `https://play.questviva.com/editor/` (404s) — now points to `https://play.questviva.com/open`.

## Test plan
- [ ] Load AppShell at a mobile viewport width and confirm the desktop download button is gone from the top bar (Discord/GitHub icons still show)
- [ ] Confirm it still shows at desktop widths
- [ ] In textadventures.co.uk mode (server available), click the "play.questviva.com editor" link on the Create tab and confirm it lands on `/open` instead of 404ing

🤖 Generated with [Claude Code](https://claude.com/claude-code)