### PR TITLE
feat(WasmPlayer): add a resizable Debugger with attribute override

### DIFF
--- a/src/Common/IGameDebug.cs
+++ b/src/Common/IGameDebug.cs
@@ -15,6 +15,13 @@ public interface IGameDebug
     List<string> GetObjects(string type);
     DebugData GetDebugData(string tab, string obj);
     Task<bool> AssertAsync(string expression);
+
+    // Debugger attribute override — runs `{element}.{attribute} = {valueExpression}`
+    // through the game's own script engine, so it gets the same type coercion
+    // (quoted strings, numbers, booleans, bare-identifier object references)
+    // as a script the game itself could run. Returns null on success, or an
+    // error message (bad syntax, unknown element, ...) on failure.
+    Task<string?> SetAttributeAsync(string element, string attribute, string valueExpression);
 }
 
 public class DebugDataItem
@@ -37,6 +44,22 @@ public class DebugDataItem
     }
 
     public string Value { get; private set; }
+
+    // A version of Value pre-formatted as valid script syntax (quoted string,
+    // lowercase true/false, bare object name, ...) rather than a
+    // human-readable label — what the WasmPlayer debugger's attribute
+    // override pre-fills its input with, so most edits are a direct Apply
+    // instead of the user having to hand-quote/rewrite Value themselves. Null
+    // for callers that don't populate it (e.g. Legacy's V4Game), in which
+    // case Value is the only thing available to pre-fill with.
+    public string? EditValue { get; set; }
+
+    // Whether the WasmPlayer debugger should offer an override control for
+    // this attribute at all — false for value kinds with no simple literal
+    // syntax to write back (lists, dictionaries, scripts, ...), where an
+    // override textbox would just be a dead end. True by default so callers
+    // that don't populate it (e.g. Legacy's V4Game) keep the old behaviour.
+    public bool CanOverride { get; set; } = true;
 
     public bool IsInherited { get; set; }
 

--- a/src/Engine/Fields.cs
+++ b/src/Engine/Fields.cs
@@ -133,6 +133,40 @@ public class Fields
         {typeof(List<string>), ListFormatter}
     };
 
+    // Debugger attribute-override pre-fill (see WasmPlayerBridge's debugger):
+    // unlike s_formatters above (a human-readable *display* string — an
+    // Element shows as "Object: kitchen", a string has no quotes, a bool
+    // reads "True"), this produces a value already written as valid script
+    // syntax, ready to feed straight into ScriptFactory.CreateScript for
+    // "element.attribute = <this>". Types with no entry here (lists, dicts,
+    // scripts, ...) fall back to the same display string, which isn't
+    // generally re-enterable — there's no simple literal syntax for those,
+    // so the debugger's override hint still covers that residual case.
+    private static readonly Dictionary<Type, DebugFormatDelegate> s_editFormatters = new()
+    {
+        {typeof(bool), v => (bool) v ? "true" : "false"},
+        {typeof(string), v => "\"" + ((string) v).Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""},
+        {typeof(Element), v => ((Element) v).Name}
+    };
+
+    // Which value kinds the debugger's override control should even offer —
+    // the types above (their ToString() already needs the s_editFormatters
+    // rewrite to become valid script syntax) plus plain numeric types (whose
+    // ToString() already *is* valid script syntax, no rewrite needed). Lists,
+    // dictionaries, scripts etc. have no simple literal syntax to write back,
+    // so there's deliberately no entry for them here — an override textbox
+    // for those would just be a dead end.
+    private static readonly HashSet<Type> s_overridableValueTypes = new()
+    {
+        typeof(bool), typeof(string), typeof(Element),
+        typeof(int), typeof(double), typeof(long), typeof(float), typeof(decimal), typeof(short)
+    };
+
+    private static bool CanOverrideValue(object value)
+    {
+        return value == null || s_overridableValueTypes.Contains(value.GetType());
+    }
+
     private readonly Dictionary<string, object> m_attributes = new();
     private readonly Element m_element;
     private readonly Dictionary<string, IExtendableField> m_extendableFields = new();
@@ -647,6 +681,18 @@ public class Fields
         return GetFormatter(value == null ? null : value.GetType()).Invoke(value);
     }
 
+    private string FormatEditValue(object value)
+    {
+        if (value == null)
+        {
+            return "null";
+        }
+
+        return s_editFormatters.TryGetValue(value.GetType(), out var formatter)
+            ? formatter.Invoke(value)
+            : FormatDebugData(value);
+    }
+
     internal DebugData GetDebugData()
     {
         var result = new DebugData();
@@ -655,6 +701,8 @@ public class Fields
         {
             var attributeData = Get(attribute, true);
             var debugDataItem = new DebugDataItem(FormatDebugData(attributeData.Value));
+            debugDataItem.EditValue = FormatEditValue(attributeData.Value);
+            debugDataItem.CanOverride = CanOverrideValue(attributeData.Value);
             debugDataItem.Source = attributeData.Source;
             debugDataItem.IsInherited = attributeData.IsInherited;
 

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -630,6 +630,28 @@ public partial class WorldModel : IGame, IGameDebug
         return expression.ExecuteAsync(c);
     }
 
+    public async Task<string?> SetAttributeAsync(string element, string attribute, string valueExpression)
+    {
+        try
+        {
+            // Call ExecuteAsync directly rather than going through the normal
+            // RunScriptAsync(IScript) path — that one is designed for scripts
+            // running as part of the game's own turn logic, so it deliberately
+            // swallows exceptions (reporting them into the transcript instead of
+            // faulting the whole turn over one bad script). AssertAsync (above)
+            // takes the same direct route for the same reason: the debugger
+            // needs the real exception back, to show inline instead of losing it
+            // into the game's own output.
+            var script = new ScriptFactory(this).CreateScript($"{element}.{attribute} = {valueExpression}");
+            await script.ExecuteAsync(new Context());
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
     public event EventHandler<ElementFieldUpdatedEventArgs>? ElementFieldUpdated;
     public event EventHandler<ElementRefreshEventArgs>? ElementRefreshed;
     public event EventHandler<ElementFieldUpdatedEventArgs>? ElementMetaFieldUpdated;

--- a/src/Legacy/V4Game.Debug.cs
+++ b/src/Legacy/V4Game.Debug.cs
@@ -72,6 +72,14 @@ public partial class V4Game
         return ExecuteConditions(expression, _nullContext);
     }
 
+    // Legacy (Quest 4 and earlier) games can't be loaded from the editor, so
+    // the WasmPlayer debugger's attribute override never becomes reachable
+    // for a V4Game in practice — not worth implementing.
+    public Task<string> SetAttributeAsync(string element, string attribute, string valueExpression)
+    {
+        return Task.FromResult("Not supported for legacy games");
+    }
+
     private DebugData GetVariableDebugData(VariableType[] variable)
     {
         if (variable == null || variable.Length == 0)

--- a/src/PlayerCore/WalkthroughRunner.cs
+++ b/src/PlayerCore/WalkthroughRunner.cs
@@ -107,7 +107,7 @@ public class WalkthroughRunner(IGameDebug game, string walkthrough)
                 }
             } while ((_waiting || _pausing) && !_cancelled);
 
-            Thread.Sleep(delay);
+            await Task.Delay(delay);
         }
     }
 

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -228,6 +228,79 @@ public partial class WasmPlayerBridge
     [JSExport]
     public static byte[] GetSaveGameBytes() => _pendingSaveBytes ?? [];
 
+    // ── Debugger ─────────────────────────────────────────────────────────────
+    // Mirrors WebPlayer's Debugger.razor/Attributes.razor/Walkthrough.razor,
+    // which drive IGameDebug directly as Blazor components — WasmPlayer has no
+    // Blazor runtime, so the same data is surfaced here as JSON strings for a
+    // plain-JS dialog (see wasm-player.js) to render, following the existing
+    // convention for structured cross-boundary payloads (JsUpdateList etc).
+
+    private static IGameDebug? GameDebug => _game as IGameDebug;
+
+    [JSExport]
+    public static bool IsDebugEnabled() => GameDebug?.DebugEnabled ?? false;
+
+    [JSExport]
+    public static string GetDebuggerObjectTypesJson() =>
+        JsonSerializer.Serialize(GameDebug?.DebuggerObjectTypes.ToArray() ?? [], WasmJsonContext.Default.StringArray);
+
+    [JSExport]
+    public static string GetDebugObjectsJson(string type) =>
+        JsonSerializer.Serialize(GameDebug?.GetObjects(type).ToArray() ?? [], WasmJsonContext.Default.StringArray);
+
+    [JSExport]
+    public static string GetDebugDataJson(string tab, string obj) =>
+        JsonSerializer.Serialize(GameDebug?.GetDebugData(tab, obj) ?? DebugData.Empty, WasmJsonContext.Default.DebugData);
+
+    [JSExport]
+    public static string GetWalkthroughNamesJson() =>
+        JsonSerializer.Serialize(GameDebug?.Walkthroughs.Walkthroughs.Keys.ToArray() ?? [], WasmJsonContext.Default.StringArray);
+
+    [JSExport]
+    public static string GetWalkthroughStepsJson(string name)
+    {
+        var steps = GameDebug != null && GameDebug.Walkthroughs.Walkthroughs.TryGetValue(name, out var walkthrough)
+            ? walkthrough.Steps
+            : [];
+        return JsonSerializer.Serialize(steps, WasmJsonContext.Default.StringArray);
+    }
+
+    [JSExport]
+    public static async Task<string?> SetDebugAttribute(string element, string attribute, string valueExpression)
+    {
+        if (GameDebug == null) return "Debugging is not available for this game";
+        return await GameDebug.SetAttributeAsync(element, attribute, valueExpression);
+    }
+
+    [JSExport]
+    public static async Task<string?> RunWalkthrough(string name)
+    {
+        if (_ui == null || GameDebug == null) return "Debugging is not available for this game";
+        if (_ui.Runner != null) return "A walkthrough is already running";
+
+        var runner = new WalkthroughRunner(GameDebug, name);
+        if (runner.Steps == 0) return $"Walkthrough \"{name}\" was not found or has no steps";
+
+        _ui.Runner = runner;
+        try
+        {
+            await runner.Run();
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+        finally
+        {
+            _ui.Runner = null;
+            _ui.FlushBuffer();
+        }
+    }
+
+    [JSExport]
+    public static void CancelWalkthrough() => _ui?.Runner?.Cancel();
+
     // ── C# → JS imports ─────────────────────────────────────────────────────
 
     [JSImport("addTextAndScroll", "wasm-player")]
@@ -353,6 +426,45 @@ public partial class WasmPlayerBridge
         public string GameId { get; }
         public bool IsFinished { get; private set; }
 
+        // Non-null while a debugger walkthrough is running — see RunWalkthrough
+        // JSExport. When set, IPlayer calls that would normally prompt the user
+        // (menu/wait/pause/question/synchronous sound) are instead answered by
+        // the runner's own recorded steps, exactly mirroring WebPlayer's
+        // Player.cs Runner property/branching.
+        private WalkthroughRunner? _runner;
+
+        public WalkthroughRunner? Runner
+        {
+            get => _runner;
+            set
+            {
+                if (_runner != null)
+                {
+                    _runner.Output -= RunnerOutput;
+                    _runner.ClearBuffer -= RunnerClearBuffer;
+                }
+
+                _runner = value;
+                if (_runner != null)
+                {
+                    _runner.Output += RunnerOutput;
+                    _runner.ClearBuffer += RunnerClearBuffer;
+                }
+            }
+        }
+
+        private Task RunnerOutput(string text)
+        {
+            OutputText(text);
+            return Task.CompletedTask;
+        }
+
+        private Task RunnerClearBuffer()
+        {
+            FlushBuffer();
+            return Task.CompletedTask;
+        }
+
         public WasmPlayerUi(string gameId, IGame game)
         {
             GameId = gameId;
@@ -475,6 +587,12 @@ public partial class WasmPlayerBridge
         // IPlayer
         void IPlayer.ShowMenu(MenuData menuData)
         {
+            if (Runner != null)
+            {
+                Runner.ShowMenu(menuData);
+                return;
+            }
+
             FlushBeforeInteraction();
             JsShowMenu(menuData.Caption,
                 JsonSerializer.Serialize(
@@ -485,18 +603,36 @@ public partial class WasmPlayerBridge
 
         void IPlayer.DoWait()
         {
+            if (Runner != null)
+            {
+                Runner.BeginWait();
+                return;
+            }
+
             FlushBeforeInteraction();
             JsBeginWait();
         }
 
         void IPlayer.DoPause(int ms)
         {
+            if (Runner != null)
+            {
+                Runner.BeginPause();
+                return;
+            }
+
             FlushBeforeInteraction();
             JsBeginPause(ms);
         }
 
         void IPlayer.ShowQuestion(string caption)
         {
+            if (Runner != null)
+            {
+                Runner.ShowQuestion(caption);
+                return;
+            }
+
             FlushBeforeInteraction();
             JsShowQuestion(caption);
         }
@@ -505,6 +641,12 @@ public partial class WasmPlayerBridge
 
         async Task IPlayer.PlaySoundAsync(string filename, bool synchronous, bool looped)
         {
+            if (Runner != null && synchronous)
+            {
+                synchronous = false;
+                Runner.BeginWait();
+            }
+
             FlushBeforeInteraction();
             JsPlaySound(await GetUrlAsync(filename), synchronous, looped);
         }
@@ -637,4 +779,5 @@ public partial class WasmPlayerBridge
 [JsonSerializable(typeof(Dictionary<string, string>))]
 [JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(DebugData))]
 internal partial class WasmJsonContext : JsonSerializerContext { }

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -89,6 +89,24 @@
     </div>
 </div>
 
+<!-- Shown by restartGameCore (wasm-player.js) around the actual restart —
+     Bridge.Initialise re-parses the embedded Core library XML from scratch
+     every time (confirmed not cacheable), which blocks the single WASM UI
+     thread for a couple of seconds with no way for anything else to paint
+     meanwhile. A plain "Loading…" div sitting in the DOM the whole time
+     wouldn't help — see nextPaint()'s doc comment — restartGameCore
+     explicitly yields a frame after unhiding this so it's actually visible
+     before the freeze starts. Not a <dialog>: it only needs to sit above the
+     ordinary game chrome, never above qv-saves/questVivaDebugger (both
+     already closed by the time this shows — see restartGameCore). Same
+     spinner styling as #qv-loading-msg above for a consistent look. -->
+<div id="qv-restarting" class="qv-chrome hidden" role="status" aria-live="polite">
+    <div class="flex flex-col items-center gap-3 text-surface-100 text-sm text-center">
+        <div class="animate-spin rounded-full h-8 w-8 border-2 border-surface-300 border-t-transparent" aria-hidden="true"></div>
+        <span>Restarting&hellip;</span>
+    </div>
+</div>
+
 <dialog id="qv-saves" class="qv-chrome" data-mode="boot">
     <!-- ICONS_SPRITE: spliced in at build time by scripts/build-icons.mjs (into
          generated/index.html) — a hidden <symbol> defs block, kept inside

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -127,5 +127,29 @@
         </div>
     </div>
 </dialog>
+
+<!-- Debugger — only ever shown in editor-preview sessions (see wasm-player.js's
+     WebPlayer.setCanDebug call in initWasmPlayer). #cmdDebug (in playercore.htm,
+     part of the shared WebPlayer/WasmPlayer chrome) already opens this dialog
+     by id via showModal() — see playercore.js's initPlayerUI. -->
+<dialog id="questVivaDebugger" class="qv-chrome">
+    <div class="card preset-filled-surface-100-900 w-full p-6 space-y-4" data-theme="wintry">
+        <div class="flex items-start justify-between gap-4">
+            <h2 class="h3">Debugger</h2>
+            <button id="qv-debugger-close" type="button" class="btn-icon preset-tonal-surface" aria-label="Close">
+                <svg class="qv-icon" aria-hidden="true"><use href="#x"></use></svg>
+            </button>
+        </div>
+
+        <div id="qv-debugger-tabs" class="flex flex-wrap gap-2"></div>
+
+        <div class="flex gap-4">
+            <ul id="qv-debugger-list" class="space-y-1 w-48 shrink-0 overflow-y-auto"></ul>
+            <div id="qv-debugger-detail" class="flex-1 overflow-y-auto text-sm">
+                <p class="text-surface-500">Select an item to view details.</p>
+            </div>
+        </div>
+    </div>
+</dialog>
 </body>
 </html>

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -131,24 +131,34 @@
 <!-- Debugger — only ever shown in editor-preview sessions (see wasm-player.js's
      WebPlayer.setCanDebug call in initWasmPlayer). #cmdDebug (in playercore.htm,
      part of the shared WebPlayer/WasmPlayer chrome) already opens this dialog
-     by id via showModal() — see playercore.js's initPlayerUI. -->
+     by id via showModal() — see playercore.js's initPlayerUI.
+
+     Position/size are entirely JS-driven (wireDebuggerMoveResize in
+     wasm-player.js applies them right after every showModal(), before the
+     first paint) rather than left to the browser's default dialog centering,
+     so the whole card is a flex column filling exactly the applied
+     width/height — #qv-debugger-panes (and List/Detail inside it) flex-fill
+     the remaining vertical space rather than a fixed rem height. -->
 <dialog id="questVivaDebugger" class="qv-chrome">
-    <div class="card preset-filled-surface-100-900 w-full p-6 space-y-4" data-theme="wintry">
-        <div class="flex items-start justify-between gap-4">
+    <div class="card preset-filled-surface-100-900 p-6 flex flex-col h-full" id="qv-debugger-card" data-theme="wintry">
+        <div id="qv-debugger-titlebar" class="flex items-start justify-between gap-4 mb-4">
             <h2 class="h3">Debugger</h2>
             <button id="qv-debugger-close" type="button" class="btn-icon preset-tonal-surface" aria-label="Close">
                 <svg class="qv-icon" aria-hidden="true"><use href="#x"></use></svg>
             </button>
         </div>
 
-        <div id="qv-debugger-tabs" class="flex flex-wrap gap-2"></div>
+        <div id="qv-debugger-tabs" class="flex flex-wrap gap-2 mb-4"></div>
 
-        <div class="flex gap-4">
-            <ul id="qv-debugger-list" class="space-y-1 w-48 shrink-0 overflow-y-auto"></ul>
+        <div class="flex flex-1" id="qv-debugger-panes" style="min-height:0">
+            <ul id="qv-debugger-list" class="space-y-1 shrink-0 overflow-y-auto"></ul>
+            <div id="qv-debugger-splitter" role="separator" aria-orientation="vertical" aria-label="Resize object list"></div>
             <div id="qv-debugger-detail" class="flex-1 overflow-y-auto text-sm">
                 <p class="text-surface-500">Select an item to view details.</p>
             </div>
         </div>
+
+        <div id="qv-debugger-resize-handle" aria-hidden="true"></div>
     </div>
 </dialog>
 </body>

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -37,7 +37,8 @@
    classes (btn, input, anchor, ...) already set their own color/font-size
    explicitly, so font-family is the only property that needs resetting here. */
 :scope#qv-start,
-:scope#qv-saves {
+:scope#qv-saves,
+:scope#questVivaDebugger {
     font-family: var(--font-sans);
 }
 
@@ -76,6 +77,154 @@
 
 :scope#qv-saves[data-mode="manage"] [data-mode-text="boot"] {
     display: none;
+}
+
+/* Debugger — wider than #qv-saves to fit a two-pane object list + attribute
+   table layout; height capped so a long attribute list scrolls internally
+   rather than growing the dialog past the viewport. */
+:scope#questVivaDebugger {
+    border: none;
+    border-radius: 0.75rem;
+    padding: 0;
+    max-width: 48rem;
+    width: 100%;
+}
+
+:scope#questVivaDebugger::backdrop {
+    background: rgb(0 0 0 / 0.5);
+}
+
+/* Fixed (not max-) height: the dialog's overall size stays constant across
+   tabs — a short Walkthrough list vs. a long attribute table used to make
+   the whole dialog visibly grow/shrink on every tab click, since only the
+   content's natural height was constrained. Both panes scroll internally
+   instead. */
+#qv-debugger-list {
+    height: 24rem;
+    overflow-y: auto;
+}
+
+/* #qv-debugger-detail is a flex column so the override panel / walkthrough
+   Run controls (.qv-debugger-footer) can be pinned below the table/step
+   list instead of scrolling away with it — see renderDebuggerAttributesDetail's
+   doc comment for why (a long inherited-attribute table used to push the
+   Apply button off the bottom of the visible area). */
+#qv-debugger-detail {
+    height: 24rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.qv-debugger-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.qv-debugger-footer {
+    flex-shrink: 0;
+    border-top: 1px solid var(--color-surface-300-700);
+    padding-top: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+/* Left-hand object/walkthrough list — a plain selectable list (block rows
+   with a hover/selected background), not hyperlinks; it was previously
+   styled with Skeleton's .anchor class, which reads as a list of links
+   rather than a list of selectable items. */
+.qv-debugger-list-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 0.375rem 0.5rem;
+    border-radius: var(--radius-base);
+    font-size: var(--text-sm);
+}
+
+.qv-debugger-list-item:hover {
+    background: var(--color-surface-200-800);
+}
+
+/* .qv-debugger-list-item:hover above would otherwise win over the plain
+   .qv-debugger-row-selected background below (two classes + :hover beats one
+   class on specificity), pairing the selected item's light contrast-color
+   text with that hover's neutral grey background — hard to read. A slightly
+   darker shade of the same selected color keeps it readable and still gives
+   hover feedback that the row remains clickable. */
+.qv-debugger-list-item.qv-debugger-row-selected:hover {
+    background: var(--color-primary-600);
+}
+
+/* Skeleton's plain .input class (used elsewhere, e.g. #qv-saves-name-input)
+   renders with a transparent background and only a faint focus-ring-style
+   border — barely readable as an editable field against this dialog's card
+   background. Explicit border/background here instead of relying on that. */
+.qv-debugger-input {
+    border-radius: var(--radius-base);
+    width: 100%;
+    padding-block: var(--spacing);
+    padding-inline: calc(var(--spacing) * 3);
+    border: 1px solid var(--color-surface-300-700);
+    background-color: var(--color-surface-50-950);
+    color: inherit;
+}
+
+.qv-debugger-input:focus {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: -1px;
+}
+
+/* Attribute table — fixed layout with wrapping so a long Value/Source
+   (e.g. a list-valued attribute) can't push the table wider than the
+   dialog; an earlier version put the override input+button+hint in a 4th
+   table column and it never had room to render. Overriding now happens in
+   a single panel below the table instead (#qv-debugger-override), populated
+   for whichever row was last clicked. */
+.qv-debugger-table {
+    table-layout: fixed;
+    width: 100%;
+}
+
+.qv-debugger-table th,
+.qv-debugger-table td {
+    overflow-wrap: break-word;
+}
+
+/* Column headers weren't visually differentiated from the body rows —
+   Tailwind's preflight reset unsets <th>'s default bold weight, so with no
+   explicit styling a <thead> row just looks like another row of text. */
+.qv-debugger-table thead th {
+    text-align: left;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-surface-500);
+    border-bottom: 1px solid var(--color-surface-300-700);
+    padding-bottom: 0.5rem;
+}
+
+#qv-debugger-detail [data-attr-row] {
+    cursor: pointer;
+}
+
+/* Marks a table row as an inherited attribute (from a type, not the object
+   itself) with a muted text color — deliberately *not* opacity, which used
+   to combine with .qv-debugger-row-selected's light contrast-color text and
+   blue background by fading both toward the card's background together,
+   leaving low-contrast light-grey-on-light-blue text once a row was both
+   inherited and selected. */
+.qv-debugger-row-inherited {
+    color: var(--color-surface-500);
+}
+
+/* Shared selected-row highlight — the left-hand list (.qv-debugger-list-item)
+   and the attribute table's rows (data-attr-row) both use this same class.
+   Declared after .qv-debugger-row-inherited so an inherited *and* selected
+   row's color still resolves to the readable contrast color, not the muted
+   one (same specificity — source order decides the tie). */
+.qv-debugger-row-selected {
+    background: var(--color-primary-500);
+    color: var(--color-primary-contrast-500);
 }
 
 /* Icons reference generated/icons.svg (a curated subset of Lucide's sprite,

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -79,28 +79,98 @@
     display: none;
 }
 
-/* Debugger — wider than #qv-saves to fit a two-pane object list + attribute
-   table layout; height capped so a long attribute list scrolls internally
-   rather than growing the dialog past the viewport. */
+/* Debugger — movable and resizable (wireDebuggerMoveResize in wasm-player.js
+   sets explicit left/top/width/height right after every showModal(), before
+   the first paint — see that function's doc comment). margin:0 is required
+   for those inline top/left values to actually take effect: the UA
+   stylesheet's default centering for <dialog> relies on auto margins, which
+   would otherwise still apply and fight the explicit position. No
+   max-width/fixed width here at all — every dimension is JS-driven, with
+   sensible defaults computed on first open. */
 :scope#questVivaDebugger {
     border: none;
     border-radius: 0.75rem;
     padding: 0;
-    max-width: 48rem;
-    width: 100%;
+    margin: 0;
 }
 
 :scope#questVivaDebugger::backdrop {
     background: rgb(0 0 0 / 0.5);
 }
 
-/* Fixed (not max-) height: the dialog's overall size stays constant across
-   tabs — a short Walkthrough list vs. a long attribute table used to make
-   the whole dialog visibly grow/shrink on every tab click, since only the
-   content's natural height was constrained. Both panes scroll internally
-   instead. */
+#qv-debugger-titlebar {
+    cursor: move;
+    touch-action: none;
+}
+
+/* Applied to the dialog itself (not <body> — everything in this stylesheet
+   is wrapped in `@scope (.qv-chrome)` by scope-css.mjs, and <body> is an
+   *ancestor* of .qv-chrome roots, never a descendant, so a bare `body`
+   selector here would silently never match anything; :scope is the one
+   selector @scope lets match the root itself) for the duration of any drag
+   (move/resize/splitter/column-resize — see startDebuggerDrag) so dragging
+   over table text or the title bar doesn't also highlight/select it along
+   the way. user-select:none inherits to every descendant on its own. */
+:scope.qv-debugger-drag-active {
+    user-select: none;
+}
+
+/* The resize handle needs to sit above the scrollable panes/table without
+   being clipped by their overflow:auto — absolute positioning within the
+   card (position:relative) keeps it reachable regardless of scroll state. */
+#qv-debugger-card {
+    position: relative;
+}
+
+#qv-debugger-resize-handle {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 1rem;
+    height: 1rem;
+    cursor: nwse-resize;
+    touch-action: none;
+}
+
+#qv-debugger-resize-handle::before {
+    content: '';
+    position: absolute;
+    right: 0.25rem;
+    bottom: 0.25rem;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-right: 2px solid var(--color-surface-400-600);
+    border-bottom: 2px solid var(--color-surface-400-600);
+}
+
+/* Draggable divider between the object/walkthrough list and the detail pane
+   (adjusts #qv-debugger-list's width — see wireDebuggerSplitter). A little
+   wider than its visible line so it's actually easy to grab. */
+#qv-debugger-splitter {
+    flex-shrink: 0;
+    width: 0.75rem;
+    margin-inline: -0.25rem;
+    cursor: col-resize;
+    touch-action: none;
+    position: relative;
+}
+
+#qv-debugger-splitter::after {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    left: 50%;
+    width: 1px;
+    background: var(--color-surface-300-700);
+}
+
+#qv-debugger-splitter:hover::after,
+#qv-debugger-splitter.qv-debugger-dragging::after {
+    background: var(--color-primary-500);
+    width: 2px;
+}
+
 #qv-debugger-list {
-    height: 24rem;
     overflow-y: auto;
 }
 
@@ -108,9 +178,11 @@
    Run controls (.qv-debugger-footer) can be pinned below the table/step
    list instead of scrolling away with it — see renderDebuggerAttributesDetail's
    doc comment for why (a long inherited-attribute table used to push the
-   Apply button off the bottom of the visible area). */
+   Apply button off the bottom of the visible area). Both panes fill
+   whatever height #qv-debugger-panes ends up with (flex:1 in the card's
+   column, which itself fills the JS-applied dialog height) rather than a
+   fixed rem value, so resizing the dialog actually grows/shrinks them. */
 #qv-debugger-detail {
-    height: 24rem;
     display: flex;
     flex-direction: column;
 }
@@ -199,6 +271,7 @@
    Tailwind's preflight reset unsets <th>'s default bold weight, so with no
    explicit styling a <thead> row just looks like another row of text. */
 .qv-debugger-table thead th {
+    position: relative;
     text-align: left;
     font-size: var(--text-xs);
     text-transform: uppercase;
@@ -206,6 +279,29 @@
     color: var(--color-surface-500);
     border-bottom: 1px solid var(--color-surface-300-700);
     padding-bottom: 0.5rem;
+}
+
+/* Resizable-column drag handle — sits on the right edge of a resizable
+   header (all but the last column; the last one just absorbs whatever width
+   is left over, see the <colgroup> built in renderDebuggerAttributesDetail).
+   Wider than its visible line for an easier grab target, same treatment as
+   #qv-debugger-splitter above. z-index keeps it grabbable over the header
+   text/sort-indicator it overlaps. */
+.qv-debugger-col-resize {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: -0.375rem;
+    width: 0.75rem;
+    cursor: col-resize;
+    touch-action: none;
+    z-index: 1;
+}
+
+.qv-debugger-col-resize:hover,
+.qv-debugger-col-resize.qv-debugger-dragging {
+    background: var(--color-primary-500);
+    opacity: 0.5;
 }
 
 #qv-debugger-detail [data-attr-row] {

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -57,15 +57,19 @@
    same z-index tier as #qv-start (both just sit in the normal stacking
    context; qv-saves/questVivaDebugger are actual <dialog>s and always
    render above this regardless, which is fine since both are already closed
-   by the time restartGameCore shows this). Semi-transparent dark background
-   makes clear the whole page is intentionally busy, not just unresponsive. */
+   by the time restartGameCore shows this). Fully opaque, matching #qv-start
+   above — not a translucent backdrop like the dialogs' ::backdrop rules
+   below: this needs to fully mask #divOutput, which Bridge.Begin() writes to
+   progressively *before* its own JS promise resolves (i.e. before this
+   overlay gets hidden again) — a translucent background let that new
+   output visibly bleed through right at the tail end of a restart. */
 :scope#qv-restarting {
     position: fixed;
     inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgb(0 0 0 / 0.6);
+    background: var(--color-surface-950);
 }
 
 :scope#qv-restarting.hidden {

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -38,7 +38,8 @@
    explicitly, so font-family is the only property that needs resetting here. */
 :scope#qv-start,
 :scope#qv-saves,
-:scope#questVivaDebugger {
+:scope#questVivaDebugger,
+:scope#qv-restarting {
     font-family: var(--font-sans);
 }
 
@@ -50,6 +51,25 @@
     justify-content: center;
     padding: 1rem;
     background: var(--color-surface-950);
+}
+
+/* Not a <dialog> (see its doc comment in index.html) — position:fixed at the
+   same z-index tier as #qv-start (both just sit in the normal stacking
+   context; qv-saves/questVivaDebugger are actual <dialog>s and always
+   render above this regardless, which is fine since both are already closed
+   by the time restartGameCore shows this). Semi-transparent dark background
+   makes clear the whole page is intentionally busy, not just unresponsive. */
+:scope#qv-restarting {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgb(0 0 0 / 0.6);
+}
+
+:scope#qv-restarting.hidden {
+    display: none;
 }
 
 /* Save/load manager — a native <dialog>, shown via showModal() so the

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -43,9 +43,21 @@
     font-family: var(--font-sans);
 }
 
+/* z-index:9999 on both this and #qv-restarting below: the shared game chrome
+   (playercore.css, not this file) gives #sidebar z-index:1000 and #qv-status
+   (the top toolbar, holding Debug/Restart) z-index:100 — both plain
+   position:fixed elements with no z-index of their own would otherwise
+   render *underneath* those regardless of DOM order (an unstyled sibling
+   with z-index:auto always loses to one with an explicit z-index, no matter
+   which comes later in the document). #qv-start isn't known to hit this in
+   practice (the sidebar is still display:none this early), but #qv-restarting
+   definitely does — a restart's sidebar panes were already visible from the
+   previous session and can become visible again mid-restart, popping in
+   front of what's supposed to be a fully opaque overlay. */
 :scope#qv-start {
     position: fixed;
     inset: 0;
+    z-index: 9999;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -66,6 +78,7 @@
 :scope#qv-restarting {
     position: fixed;
     inset: 0;
+    z-index: 9999;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -188,6 +188,11 @@
 .qv-debugger-table th,
 .qv-debugger-table td {
     overflow-wrap: break-word;
+    /* Default (middle) vertical-align made a long wrapped Value visually
+       drag the same row's Attribute/Source cells down to stay centered
+       against it — top-aligning keeps the attribute name anchored to the
+       first line of its value regardless of how many lines it wraps to. */
+    vertical-align: top;
 }
 
 /* Column headers weren't visually differentiated from the body rows —
@@ -205,6 +210,16 @@
 
 #qv-debugger-detail [data-attr-row] {
     cursor: pointer;
+}
+
+#qv-debugger-detail [data-sort-col] {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+#qv-debugger-detail [data-sort-col]:hover {
+    color: var(--color-surface-900-100);
 }
 
 /* Marks a table row as an inherited attribute (from a type, not the object

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -275,15 +275,18 @@ function swapInPlayerUi() {
     const startScreenEl = document.getElementById('qv-start');
     const savesDialogEl = document.getElementById('qv-saves');
     const debuggerDialogEl = document.getElementById('questVivaDebugger');
+    const restartingEl = document.getElementById('qv-restarting');
     startScreenEl?.remove();
     savesDialogEl?.remove();
     debuggerDialogEl?.remove();
+    restartingEl?.remove();
 
     document.body.innerHTML = originalPlayerHtml;
 
     if (startScreenEl) document.body.appendChild(startScreenEl);
     if (savesDialogEl) document.body.appendChild(savesDialogEl);
     if (debuggerDialogEl) document.body.appendChild(debuggerDialogEl);
+    if (restartingEl) document.body.appendChild(restartingEl);
     return startScreenEl;
 }
 
@@ -451,29 +454,45 @@ async function restartGameCore(saveBytes) {
     swapInPlayerUi();
     resetGameOutput();
 
-    const ok = saveBytes
-        ? await Bridge.InitialiseWithSave(originalGameBytes, originalGameFilename, saveBytes)
-        : await Bridge.Initialise(originalGameBytes, originalGameFilename);
-    if (!ok) {
-        showSavesError('Failed to load that save.');
-        return;
+    // Bridge.Initialise/Begin re-run the whole game's startup (Bridge.Initialise
+    // in particular re-parses the embedded Core library XML from scratch every
+    // time — confirmed not cacheable) with no genuine await inside either, so
+    // they block the single WASM UI thread for a couple of seconds with
+    // nothing else able to paint meanwhile — same reasoning as withBusyButton's
+    // nextPaint(). Without yielding a frame *after* unhiding the spinner and
+    // *before* that blocking work starts, it would sit queued and invisible
+    // for the whole freeze, same as if it was never shown at all.
+    const restartingEl = document.getElementById('qv-restarting');
+    restartingEl?.classList.remove('hidden');
+    await nextPaint();
+
+    try {
+        const ok = saveBytes
+            ? await Bridge.InitialiseWithSave(originalGameBytes, originalGameFilename, saveBytes)
+            : await Bridge.Initialise(originalGameBytes, originalGameFilename);
+        if (!ok) {
+            showSavesError('Failed to load that save.');
+            return;
+        }
+
+        await maybeGateOnActivation(originalGameBytes);
+
+        await setupPaperJs();
+        WebPlayer.initUI();
+        wireDebuggerButton();
+        wireDebuggerRestartButton(currentIsPreview);
+        // Used to be an unconditional true — harmless while restartGame was only
+        // ever reachable from the Saves dialog, which editor-preview sessions
+        // never had access to in the first place (Save itself is hidden there).
+        // Now that the new Restart button (wireDebuggerRestartButton) makes
+        // restartGame reachable *from* a preview session too, hardcoding true
+        // here would wrongly re-enable Save after a preview restart.
+        WebPlayer.setCanSave(!currentIsPreview);
+        WebPlayer.setCanDebug(currentIsPreview && Bridge.IsDebugEnabled());
+        await Bridge.Begin();
+    } finally {
+        restartingEl?.classList.add('hidden');
     }
-
-    await maybeGateOnActivation(originalGameBytes);
-
-    await setupPaperJs();
-    WebPlayer.initUI();
-    wireDebuggerButton();
-    wireDebuggerRestartButton(currentIsPreview);
-    // Used to be an unconditional true — harmless while restartGame was only
-    // ever reachable from the Saves dialog, which editor-preview sessions
-    // never had access to in the first place (Save itself is hidden there).
-    // Now that the new Restart button (wireDebuggerRestartButton) makes
-    // restartGame reachable *from* a preview session too, hardcoding true
-    // here would wrongly re-enable Save after a preview restart.
-    WebPlayer.setCanSave(!currentIsPreview);
-    WebPlayer.setCanDebug(currentIsPreview && Bridge.IsDebugEnabled());
-    await Bridge.Begin();
 }
 
 // Wraps initWasmPlayer with the boot-time "Continue / New Game" prompt: if

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -753,6 +753,166 @@ let debuggerAttrSearch = '';
 // when the object actually changes or an override is applied.
 let debuggerAttrData = null;
 
+// ── Move/resize/splitter/column-resize state ────────────────────────────────
+// All in px, all session-only (in-memory, not persisted across a page
+// reload) — a dev tool's window geometry isn't worth the complexity of
+// persisting across reloads, but it should survive closing/reopening the
+// dialog and game restarts within the same session, so these live at module
+// scope rather than being recomputed/reset on every render.
+
+const DEBUGGER_DEFAULT_WIDTH = 768;
+const DEBUGGER_DEFAULT_HEIGHT = 600;
+const DEBUGGER_MIN_WIDTH = 480;
+const DEBUGGER_MIN_HEIGHT = 360;
+const DEBUGGER_MIN_LIST_WIDTH = 100;
+const DEBUGGER_MIN_DETAIL_WIDTH = 200;
+const DEBUGGER_MIN_COLUMN_WIDTH = 60;
+
+// null until the first time the dialog is ever opened — see applyDebuggerRect.
+let debuggerRect = null;
+let debuggerListWidth = 192; // matches the old w-48 (12rem) Tailwind default
+let debuggerColWidths = { attribute: 160, value: 260 }; // 'source' just takes whatever's left
+
+// Generic pointer-drag helper — used by the title bar, resize handle,
+// splitter, and column-resize handles below. onMove receives the raw
+// pointermove event; the caller computes whatever delta it needs from
+// clientX/clientY captured at drag start. document.body.style.cursor is a
+// plain inline style (works regardless of the .qv-chrome CSS scoping); the
+// user-select:none class goes on the dialog itself, not <body> — see
+// :scope.qv-debugger-drag-active's doc comment in chrome.css for why.
+function startDebuggerDrag(startEvent, cursor, onMove, onEnd) {
+    startEvent.preventDefault();
+    const dlg = document.getElementById('questVivaDebugger');
+    dlg.classList.add('qv-debugger-drag-active');
+    document.body.style.cursor = cursor;
+
+    const move = (e) => onMove(e);
+    const end = (e) => {
+        document.removeEventListener('pointermove', move);
+        document.removeEventListener('pointerup', end);
+        dlg.classList.remove('qv-debugger-drag-active');
+        document.body.style.cursor = '';
+        if (onEnd) onEnd(e);
+    };
+
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', end);
+}
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), Math.max(min, max));
+}
+
+// Applied right after every showModal() (see wireDebuggerButton/restartGame's
+// call sites), before the browser gets a chance to paint — so the dialog
+// never visibly flashes at its old browser-default centered position first.
+// Computes a centered default the very first time it's called; every
+// subsequent call (reopening the dialog, or after the user drags/resizes)
+// just re-applies whatever debuggerRect currently holds.
+function applyDebuggerRect() {
+    const dlg = document.getElementById('questVivaDebugger');
+    if (!dlg) return;
+
+    if (!debuggerRect) {
+        const width = Math.min(DEBUGGER_DEFAULT_WIDTH, window.innerWidth - 40);
+        const height = Math.min(DEBUGGER_DEFAULT_HEIGHT, window.innerHeight - 40);
+        debuggerRect = {
+            left: Math.round((window.innerWidth - width) / 2),
+            top: Math.round((window.innerHeight - height) / 2),
+            width,
+            height,
+        };
+    }
+
+    dlg.style.left = `${debuggerRect.left}px`;
+    dlg.style.top = `${debuggerRect.top}px`;
+    dlg.style.width = `${debuggerRect.width}px`;
+    dlg.style.height = `${debuggerRect.height}px`;
+}
+
+function wireDebuggerMoveResize() {
+    const dlg = document.getElementById('questVivaDebugger');
+    const titlebar = document.getElementById('qv-debugger-titlebar');
+    const resizeHandle = document.getElementById('qv-debugger-resize-handle');
+
+    titlebar.addEventListener('pointerdown', (e) => {
+        if (e.target.closest('#qv-debugger-close')) return;
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const { left: startLeft, top: startTop, width, height } = debuggerRect;
+
+        startDebuggerDrag(e, 'move', (moveEvent) => {
+            const left = clamp(startLeft + (moveEvent.clientX - startX), 0, window.innerWidth - width);
+            const top = clamp(startTop + (moveEvent.clientY - startY), 0, window.innerHeight - height);
+            debuggerRect = { ...debuggerRect, left, top };
+            dlg.style.left = `${left}px`;
+            dlg.style.top = `${top}px`;
+        });
+    });
+
+    resizeHandle.addEventListener('pointerdown', (e) => {
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const { left, top, width: startWidth, height: startHeight } = debuggerRect;
+
+        startDebuggerDrag(e, 'nwse-resize', (moveEvent) => {
+            const width = clamp(startWidth + (moveEvent.clientX - startX), DEBUGGER_MIN_WIDTH, window.innerWidth - left);
+            const height = clamp(startHeight + (moveEvent.clientY - startY), DEBUGGER_MIN_HEIGHT, window.innerHeight - top);
+            debuggerRect = { ...debuggerRect, width, height };
+            dlg.style.width = `${width}px`;
+            dlg.style.height = `${height}px`;
+        });
+    });
+}
+
+function wireDebuggerSplitter() {
+    const splitter = document.getElementById('qv-debugger-splitter');
+    const list = document.getElementById('qv-debugger-list');
+    const panes = document.getElementById('qv-debugger-panes');
+
+    splitter.addEventListener('pointerdown', (e) => {
+        const startX = e.clientX;
+        const startWidth = list.getBoundingClientRect().width;
+        splitter.classList.add('qv-debugger-dragging');
+
+        startDebuggerDrag(e, 'col-resize', (moveEvent) => {
+            const containerWidth = panes.getBoundingClientRect().width;
+            const maxWidth = containerWidth - DEBUGGER_MIN_DETAIL_WIDTH - splitter.getBoundingClientRect().width;
+            debuggerListWidth = clamp(startWidth + (moveEvent.clientX - startX), DEBUGGER_MIN_LIST_WIDTH, maxWidth);
+            list.style.width = `${debuggerListWidth}px`;
+        }, () => splitter.classList.remove('qv-debugger-dragging'));
+    });
+}
+
+// Attribute-table column resizing — only the first two columns (Attribute,
+// Value) get a drag handle; Source just absorbs whatever width is left over
+// (see the <colgroup> built in renderDebuggerAttributesDetail), matching how
+// #qv-debugger-splitter only needs to move one boundary for a two-pane
+// layout. Wired once in ensureDebuggerWired via delegation, since the
+// handles themselves are rebuilt on every renderDebuggerAttributesDetail
+// call (a fresh object/tab, or after Apply).
+function wireDebuggerColumnResize(startEvent) {
+    const handle = startEvent.target.closest('[data-resize-col]');
+    if (!handle) return false;
+
+    const key = handle.dataset.resizeCol;
+    const table = handle.closest('table');
+    const col = table.querySelector(`col[data-col="${key}"]`);
+    if (!col) return true;
+
+    const startX = startEvent.clientX;
+    const startWidth = debuggerColWidths[key];
+    handle.classList.add('qv-debugger-dragging');
+
+    startDebuggerDrag(startEvent, 'col-resize', (moveEvent) => {
+        const width = Math.max(DEBUGGER_MIN_COLUMN_WIDTH, startWidth + (moveEvent.clientX - startX));
+        debuggerColWidths = { ...debuggerColWidths, [key]: width };
+        col.style.width = `${width}px`;
+    }, () => handle.classList.remove('qv-debugger-dragging'));
+
+    return true;
+}
+
 // DebugDataItem.Value is a human-readable *display* string (Fields.cs's
 // DefaultFormatter just calls ToString() — a string has no quotes, a bool
 // reads "True"/"False", an object reference reads as "Object: kitchen").
@@ -847,9 +1007,14 @@ function renderDebuggerAttrRows() {
     const tbody = document.getElementById('qv-debugger-attr-tbody');
     if (!tbody) return;
 
+    // Only the label <span> gets its text replaced — a resize handle
+    // (.qv-debugger-col-resize) is a sibling inside the same <th>, and
+    // setting th.textContent directly would wipe that handle out on every
+    // sort/search re-render.
     document.querySelectorAll('#qv-debugger-detail [data-sort-col]').forEach(th => {
         const col = th.dataset.sortCol;
-        th.textContent = DEBUGGER_ATTR_COLUMNS.find(c => c.key === col).label + debuggerAttrSortIndicator(col);
+        const label = th.querySelector('.qv-debugger-sort-label');
+        if (label) label.textContent = DEBUGGER_ATTR_COLUMNS.find(c => c.key === col).label + debuggerAttrSortIndicator(col);
     });
 
     const attrs = sortedFilteredDebuggerAttrs();
@@ -890,10 +1055,20 @@ function renderDebuggerAttributesDetail(tab, obj) {
 
     if (!attrs.includes(debuggerSelectedAttr)) debuggerSelectedAttr = null;
 
+    // Only Attribute/Value get an explicit <col> width + resize handle —
+    // Source (the last column) just takes whatever width table-layout:fixed
+    // leaves over, the same "only one boundary to drag" simplification
+    // wireDebuggerSplitter uses for the two-pane list/detail split.
     detail.innerHTML = `<input type="text" class="qv-debugger-input mb-2" id="qv-debugger-attr-search" placeholder="Search attributes…" autocomplete="off" value="${_esc(debuggerAttrSearch)}">`
         + '<div class="qv-debugger-scroll">'
-        + '<table class="table qv-debugger-table"><thead><tr>'
-        + DEBUGGER_ATTR_COLUMNS.map(c => `<th data-sort-col="${c.key}">${_esc(c.label)}${debuggerAttrSortIndicator(c.key)}</th>`).join('')
+        + '<table class="table qv-debugger-table">'
+        + `<colgroup><col data-col="attribute" style="width:${debuggerColWidths.attribute}px">`
+        + `<col data-col="value" style="width:${debuggerColWidths.value}px"><col data-col="source"></colgroup>`
+        + '<thead><tr>'
+        + DEBUGGER_ATTR_COLUMNS.map(c => '<th data-sort-col="' + c.key + '">'
+            + `<span class="qv-debugger-sort-label">${_esc(c.label)}${debuggerAttrSortIndicator(c.key)}</span>`
+            + (c.key === 'source' ? '' : `<span class="qv-debugger-col-resize" data-resize-col="${c.key}"></span>`)
+            + '</th>').join('')
         + '</tr></thead><tbody id="qv-debugger-attr-tbody"></tbody></table>'
         + '</div>'
         + '<div id="qv-debugger-override" class="qv-debugger-footer"></div>';
@@ -1034,6 +1209,17 @@ function ensureDebuggerWired() {
 
     document.getElementById('qv-debugger-close').addEventListener('click', () => dlg.close());
 
+    // Only needs setting once — #qv-debugger-list itself is never rebuilt
+    // (only its innerHTML, by renderDebuggerList), so this inline width
+    // survives every re-render and even a game restart (the dialog is on
+    // swapInPlayerUi's preserve-list). Subsequent changes come from dragging
+    // the splitter (wireDebuggerSplitter).
+    document.getElementById('qv-debugger-list').style.width = `${debuggerListWidth}px`;
+
+    wireDebuggerMoveResize();
+    wireDebuggerSplitter();
+    document.getElementById('qv-debugger-detail').addEventListener('pointerdown', wireDebuggerColumnResize);
+
     document.getElementById('qv-debugger-tabs').addEventListener('click', (e) => {
         const btn = e.target.closest('[data-tab]');
         if (btn) selectDebuggerTab(btn.dataset.tab);
@@ -1055,6 +1241,12 @@ function ensureDebuggerWired() {
     });
 
     document.getElementById('qv-debugger-detail').addEventListener('click', async (e) => {
+        // A completed column-resize drag (pointerdown+move+pointerup on
+        // [data-resize-col], handled separately above) still fires a
+        // trailing click on whatever's underneath — swallow it here so it
+        // doesn't also toggle that column's sort direction.
+        if (e.target.closest('[data-resize-col]')) return;
+
         const sortCol = e.target.closest('[data-sort-col]');
         if (sortCol) {
             const col = sortCol.dataset.sortCol;
@@ -1100,6 +1292,7 @@ function wireDebuggerButton() {
     if (!cmdDebug) return;
     cmdDebug.addEventListener('click', () => {
         ensureDebuggerWired();
+        applyDebuggerRect();
         debuggerActiveTab = 'Walkthrough';
         // If a walkthrough is running (started on a previous open of this
         // dialog, which fully rebuilds #qv-debugger-detail on every open —

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -261,30 +261,40 @@ async function setupPaperJs() {
 }
 
 // Replaces document.body with a fresh copy of the player chrome, preserving
-// #qv-start/#qv-saves (the static markup's overlays, which live outside the
-// swapped-in playerHtml and would otherwise be destroyed by the innerHTML
-// assignment). Used both for the initial boot and for a mid-session restart
-// ("Start from the beginning" / Load) — a restart must get a genuinely new
-// DOM, not just a cleared output pane, because games commonly use their
-// external <javascript> resources to inject their own elements elsewhere in
-// the chrome (e.g. a custom sidebar pane). Those run again on every restart
-// (RegisterExternalScripts fires on every Initialise call), so anything short
-// of a full DOM reset here leaves the previous run's injected elements in
-// place for the new run to duplicate.
+// #qv-start/#qv-saves/#questVivaDebugger (the static markup's overlays, which
+// live outside the swapped-in playerHtml and would otherwise be destroyed by
+// the innerHTML assignment). Used both for the initial boot and for a
+// mid-session restart ("Start from the beginning" / Load) — a restart must
+// get a genuinely new DOM, not just a cleared output pane, because games
+// commonly use their external <javascript> resources to inject their own
+// elements elsewhere in the chrome (e.g. a custom sidebar pane). Those run
+// again on every restart (RegisterExternalScripts fires on every Initialise
+// call), so anything short of a full DOM reset here leaves the previous run's
+// injected elements in place for the new run to duplicate.
 function swapInPlayerUi() {
     const startScreenEl = document.getElementById('qv-start');
     const savesDialogEl = document.getElementById('qv-saves');
+    const debuggerDialogEl = document.getElementById('questVivaDebugger');
     startScreenEl?.remove();
     savesDialogEl?.remove();
+    debuggerDialogEl?.remove();
 
     document.body.innerHTML = originalPlayerHtml;
 
     if (startScreenEl) document.body.appendChild(startScreenEl);
     if (savesDialogEl) document.body.appendChild(savesDialogEl);
+    if (debuggerDialogEl) document.body.appendChild(debuggerDialogEl);
     return startScreenEl;
 }
 
+// Remembered across a mid-session restart (restartGame doesn't get isPreview
+// as a parameter — it just re-initialises on top of the same boot session),
+// so the Debug button's visibility stays correct after "Start from the
+// beginning"/Load in an editor-preview session.
+let currentIsPreview = false;
+
 async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false) {
+    currentIsPreview = isPreview;
     const [htmResponse, { dotnet }] = await Promise.all([
         fetch('playercore.htm'),
         import('./_framework/dotnet.js'),
@@ -383,6 +393,7 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
 
     WebPlayer.onSaveClick = () => openSavesDialog('manage');
     WebPlayer.initUI();
+    wireDebuggerButton();
     // Editor-preview sessions (isPreview) don't offer saving at all — by
     // design: a save captures the whole game state, so reloading one while
     // iterating would show stale state that doesn't reflect the developer's
@@ -391,6 +402,10 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
     // BroadcastChannel (to hand off the picked file's bytes and answer
     // resource requests) but is a real play session and should offer saving.
     WebPlayer.setCanSave(!isPreview);
+    // Only ever shown in editor-preview sessions (see the module doc comment
+    // above the Debugger section) — never for a normal play session, even
+    // though the loaded game itself might have DebugEnabled true.
+    WebPlayer.setCanDebug(isPreview && Bridge.IsDebugEnabled());
 
     await Bridge.Begin();
 }
@@ -424,7 +439,9 @@ async function restartGame(saveBytes) {
 
     await setupPaperJs();
     WebPlayer.initUI();
+    wireDebuggerButton();
     WebPlayer.setCanSave(true);
+    WebPlayer.setCanDebug(currentIsPreview && Bridge.IsDebugEnabled());
     await Bridge.Begin();
 }
 
@@ -696,6 +713,315 @@ async function openSavesDialog(mode, gameId = WebPlayer.gameId) {
     }
 
     dlg.showModal();
+}
+
+// ── Debugger (#questVivaDebugger) ─────────────────────────────────────────────
+// Only ever opened in editor-preview sessions (see WebPlayer.setCanDebug's
+// call site in initWasmPlayer/restartGame) — element browser, per-tab
+// attribute inspector with a "hack your own game" override, and a walkthrough
+// runner. Mirrors WebPlayer's Debugger/Attributes/Walkthrough.razor, which
+// drive IGameDebug directly as Blazor components; here the same data comes
+// over the bridge as JSON (Bridge.Get*Json — see WasmPlayerBridge.cs) for
+// plain-DOM rendering instead.
+
+let debuggerWired = false;
+let debuggerActiveTab = 'Walkthrough';
+let debuggerSelectedItem = null;
+// Name of the walkthrough currently running, or null — the source of truth
+// for the Run/Cancel/status UI, *not* the DOM elements themselves. Closing
+// and reopening the dialog (or switching tabs/objects) rebuilds
+// #qv-debugger-detail from scratch, which used to silently lose whatever
+// Run/Cancel state only lived in the old (now-replaced) DOM nodes — a
+// walkthrough kept running with no way to see its status or cancel it once
+// the dialog was reopened. Every render of the Walkthrough detail panel
+// checks this instead, so it comes back correctly regardless of how many
+// times the panel gets rebuilt while a walkthrough is running.
+let runningWalkthroughName = null;
+// Which attribute row (if any) has its override panel open — a single
+// fixed panel below the table, not one input per row (an earlier version
+// tried cramming input+button+hint into a 4th table column and it didn't
+// fit at any reasonable dialog width).
+let debuggerSelectedAttr = null;
+
+// DebugDataItem.Value is a human-readable *display* string (Fields.cs's
+// DefaultFormatter just calls ToString() — a string has no quotes, a bool
+// reads "True"/"False", an object reference reads as "Object: kitchen").
+// EditValue (same object, a sibling field) is the same underlying value
+// pre-formatted as valid script syntax instead — quoted string, lowercase
+// true/false, bare object name — ready to feed straight into Apply. Only
+// shown at all when item.CanOverride is true (see Fields.cs's
+// CanOverrideValue) — lists/dicts/scripts have no simple literal syntax to
+// write back, so those get a short note instead of a dead-end textbox (see
+// renderDebuggerOverridePanel).
+const DEBUGGER_OVERRIDE_HINT = 'Edit and Apply to change this value for the rest of the session';
+
+function renderDebuggerTabs(types) {
+    const tabs = document.getElementById('qv-debugger-tabs');
+    const allTabs = ['Walkthrough', ...types];
+    tabs.innerHTML = allTabs.map(tab =>
+        `<button type="button" class="btn btn-sm ${tab === debuggerActiveTab ? 'preset-filled-primary-500' : 'preset-tonal-surface'}" data-tab="${_esc(tab)}">${_esc(tab)}</button>`
+    ).join('');
+}
+
+function renderDebuggerList() {
+    const list = document.getElementById('qv-debugger-list');
+    const items = debuggerActiveTab === 'Walkthrough'
+        ? JSON.parse(Bridge.GetWalkthroughNamesJson())
+        : JSON.parse(Bridge.GetDebugObjectsJson(debuggerActiveTab));
+
+    if (!items.length) {
+        list.innerHTML = '<li class="text-sm text-surface-500 px-2 py-1">Nothing here.</li>';
+        return;
+    }
+
+    // A plain selectable list, not hyperlinks — .qv-debugger-list-item is a
+    // block row with its own hover/selected background (shares
+    // .qv-debugger-row-selected with the attribute table below).
+    list.innerHTML = items.map(item => {
+        const selected = item === debuggerSelectedItem;
+        return `<li><button type="button" class="qv-debugger-list-item${selected ? ' qv-debugger-row-selected' : ''}" data-item="${_esc(item)}" aria-selected="${selected}">${_esc(item)}</button></li>`;
+    }).join('');
+}
+
+function renderDebuggerWalkthroughDetail(name) {
+    const detail = document.getElementById('qv-debugger-detail');
+    const steps = JSON.parse(Bridge.GetWalkthroughStepsJson(name));
+    const running = name === runningWalkthroughName;
+    detail.innerHTML = '<div class="qv-debugger-scroll">'
+        + '<ol class="list-decimal list-inside space-y-1">'
+        + steps.map(step => `<li>${_esc(step)}</li>`).join('')
+        + '</ol>'
+        + '</div>'
+        + '<div class="qv-debugger-footer flex gap-2 items-center">'
+        + `<button type="button" class="btn preset-filled-primary-500" data-run-walkthrough="${_esc(name)}"${running ? ' disabled' : ''}>Run</button>`
+        + `<button type="button" class="btn preset-tonal-surface${running ? '' : ' hidden'}" data-cancel-walkthrough>Cancel</button>`
+        + `<span class="text-sm" data-walkthrough-status>${running ? 'Running…' : ''}</span>`
+        + '</div>';
+}
+
+// The table (which can run to a couple dozen rows for an inherited-heavy
+// object like the default player) scrolls in its own inner region
+// (.qv-debugger-scroll); the override panel is a separate, non-scrolling
+// footer so selecting a row near the top of a long table doesn't require
+// scrolling past everything else to reach the Apply button.
+function renderDebuggerAttributesDetail(tab, obj) {
+    const detail = document.getElementById('qv-debugger-detail');
+    const data = JSON.parse(Bridge.GetDebugDataJson(tab, obj)).Data || {};
+    const attrs = Object.keys(data);
+
+    if (!attrs.length) {
+        detail.innerHTML = '<p class="text-surface-500">No attributes.</p>';
+        return;
+    }
+
+    if (!attrs.includes(debuggerSelectedAttr)) debuggerSelectedAttr = null;
+
+    detail.innerHTML = '<div class="qv-debugger-scroll">'
+        + '<table class="table qv-debugger-table"><thead><tr>'
+        + '<th>Attribute</th><th>Value</th><th>Source</th>'
+        + '</tr></thead><tbody>'
+        + attrs.map(attr => {
+            const item = data[attr];
+            const classes = [item.IsInherited ? 'qv-debugger-row-inherited' : '', attr === debuggerSelectedAttr ? 'qv-debugger-row-selected' : ''];
+            return `<tr class="${classes.join(' ')}" data-attr-row="${_esc(attr)}">`
+                + `<td>${_esc(attr)}</td>`
+                + `<td>${_esc(item.Value)}</td>`
+                + `<td>${_esc(item.Source ?? '')}</td>`
+                + '</tr>';
+        }).join('')
+        + '</tbody></table>'
+        + '</div>'
+        + '<div id="qv-debugger-override" class="qv-debugger-footer"></div>';
+
+    if (debuggerSelectedAttr) renderDebuggerOverridePanel(debuggerSelectedAttr, data[debuggerSelectedAttr]);
+}
+
+// renderDebuggerAttributesDetail rebuilds the whole #qv-debugger-detail
+// subtree (innerHTML), which resets .qv-debugger-scroll's scroll position to
+// 0 — fine for a genuine switch to a different object/tab (starting back at
+// the top makes sense there), but jarring for a same-object re-render:
+// selecting a row further down a long table, or re-rendering after Apply,
+// used to visibly snap the table back to the top. Callers that are
+// re-rendering the *same* object wrap the call in this so the scroll
+// position survives the rebuild.
+function withPreservedDebuggerScroll(renderFn) {
+    const before = document.querySelector('#qv-debugger-detail .qv-debugger-scroll');
+    const previousScrollTop = before ? before.scrollTop : 0;
+    renderFn();
+    const after = document.querySelector('#qv-debugger-detail .qv-debugger-scroll');
+    if (after) after.scrollTop = previousScrollTop;
+}
+
+// The single "click a row above to edit it" panel — populated for whichever
+// attribute is currently selected, instead of one input per row (see
+// debuggerSelectedAttr's doc comment). item.CanOverride is false for value
+// kinds with no simple literal syntax to write back (lists, dictionaries,
+// scripts, ...) — an override textbox for those would just be a dead end, so
+// a short note is shown instead of one (see Fields.cs's CanOverrideValue).
+function renderDebuggerOverridePanel(attr, item) {
+    const panel = document.getElementById('qv-debugger-override');
+    if (!panel) return;
+
+    if (!item.CanOverride) {
+        panel.innerHTML = `<div class="text-sm font-semibold mb-1">${_esc(attr)}</div>`
+            + '<div class="text-xs text-surface-500">This value isn\'t a simple type the debugger can override directly.</div>';
+        return;
+    }
+
+    panel.innerHTML = `<div class="text-sm font-semibold mb-2">Override <code>${_esc(attr)}</code></div>`
+        + '<div class="flex gap-2 items-center">'
+        + `<input class="qv-debugger-input flex-1" type="text" value="${_esc(item.EditValue ?? item.Value)}" id="qv-debugger-override-input">`
+        + '<button type="button" class="btn preset-tonal-primary" id="qv-debugger-override-apply">Apply</button>'
+        + '</div>'
+        + `<div class="text-xs text-surface-500 mt-1">${_esc(DEBUGGER_OVERRIDE_HINT)}</div>`
+        + '<div class="text-xs preset-tonal-error hidden mt-1" id="qv-debugger-override-error"></div>';
+}
+
+function renderDebuggerDetail() {
+    const detail = document.getElementById('qv-debugger-detail');
+    if (!debuggerSelectedItem) {
+        detail.innerHTML = '<p class="text-surface-500">Select an item to view details.</p>';
+        return;
+    }
+
+    if (debuggerActiveTab === 'Walkthrough') {
+        renderDebuggerWalkthroughDetail(debuggerSelectedItem);
+    } else {
+        renderDebuggerAttributesDetail(debuggerActiveTab, debuggerSelectedItem);
+    }
+}
+
+function selectDebuggerTab(tab) {
+    debuggerActiveTab = tab;
+    // Same reasoning as wireDebuggerButton's reopen handling: switching back
+    // to the Walkthrough tab while one is running should land on it, not a
+    // blank "Select an item to view details."
+    debuggerSelectedItem = tab === 'Walkthrough' ? runningWalkthroughName : null;
+    debuggerSelectedAttr = null;
+    renderDebuggerTabs(JSON.parse(Bridge.GetDebuggerObjectTypesJson()));
+    renderDebuggerList();
+    renderDebuggerDetail();
+}
+
+async function applyDebugAttribute(attr, value) {
+    const errorEl = document.getElementById('qv-debugger-override-error');
+    const error = await Bridge.SetDebugAttribute(debuggerSelectedItem, attr, value);
+    if (error) {
+        if (errorEl) {
+            errorEl.textContent = error;
+            errorEl.classList.remove('hidden');
+        }
+        return;
+    }
+    // Re-render so Value/Source reflect the change (and any knock-on effects
+    // the assignment had on other attributes of the same object) — the
+    // override panel stays open on the same attribute (debuggerSelectedAttr
+    // is unchanged) so applying again is a tight loop.
+    withPreservedDebuggerScroll(() => renderDebuggerAttributesDetail(debuggerActiveTab, debuggerSelectedItem));
+}
+
+// Re-queries the DOM fresh rather than capturing element references once at
+// the start of a run — the detail panel can be rebuilt from scratch one or
+// more times while a walkthrough is running (closing/reopening the dialog,
+// see wireDebuggerButton's doc comment), which would otherwise leave a
+// stale/detached reference that no longer matches anything visible.
+// [data-walkthrough-status]/[data-cancel-walkthrough] aren't name-scoped
+// (only one detail panel exists at a time), so they're only touched when the
+// panel currently on screen is actually still showing this walkthrough —
+// otherwise the status of a *different* walkthrough the user has since
+// selected would get clobbered.
+function updateWalkthroughRunUi(name, { running, status }) {
+    const runBtn = document.querySelector(`[data-run-walkthrough="${CSS.escape(name)}"]`);
+    if (runBtn) runBtn.disabled = running;
+
+    if (debuggerActiveTab !== 'Walkthrough' || debuggerSelectedItem !== name) return;
+    const cancelBtn = document.querySelector('[data-cancel-walkthrough]');
+    const statusEl = document.querySelector('[data-walkthrough-status]');
+    if (cancelBtn) cancelBtn.classList.toggle('hidden', !running);
+    if (statusEl) statusEl.textContent = status;
+}
+
+async function runSelectedWalkthrough(name) {
+    runningWalkthroughName = name;
+    updateWalkthroughRunUi(name, { running: true, status: 'Running…' });
+    try {
+        const error = await Bridge.RunWalkthrough(name);
+        updateWalkthroughRunUi(name, { running: false, status: error ? `Error: ${error}` : 'Done' });
+    } finally {
+        runningWalkthroughName = null;
+    }
+}
+
+function ensureDebuggerWired() {
+    if (debuggerWired) return;
+    debuggerWired = true;
+
+    const dlg = document.getElementById('questVivaDebugger');
+    if (!dlg) return;
+
+    document.getElementById('qv-debugger-close').addEventListener('click', () => dlg.close());
+
+    document.getElementById('qv-debugger-tabs').addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-tab]');
+        if (btn) selectDebuggerTab(btn.dataset.tab);
+    });
+
+    document.getElementById('qv-debugger-list').addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-item]');
+        if (!btn) return;
+        debuggerSelectedItem = btn.dataset.item;
+        debuggerSelectedAttr = null;
+        renderDebuggerList();
+        renderDebuggerDetail();
+    });
+
+    document.getElementById('qv-debugger-detail').addEventListener('click', async (e) => {
+        const attrRow = e.target.closest('[data-attr-row]');
+        if (attrRow) {
+            debuggerSelectedAttr = attrRow.dataset.attrRow;
+            withPreservedDebuggerScroll(() => renderDebuggerAttributesDetail(debuggerActiveTab, debuggerSelectedItem));
+            return;
+        }
+
+        if (e.target.closest('#qv-debugger-override-apply')) {
+            const input = document.getElementById('qv-debugger-override-input');
+            await applyDebugAttribute(debuggerSelectedAttr, input ? input.value : '');
+            return;
+        }
+
+        const runBtn = e.target.closest('[data-run-walkthrough]');
+        if (runBtn) {
+            await runSelectedWalkthrough(runBtn.dataset.runWalkthrough);
+            return;
+        }
+
+        if (e.target.closest('[data-cancel-walkthrough]')) {
+            Bridge.CancelWalkthrough();
+        }
+    });
+}
+
+// Called after every WebPlayer.initUI() — #cmdDebug is part of playercore.htm,
+// which is fully replaced on every boot/restart (see swapInPlayerUi), so its
+// showModal() listener (wired in the shared playercore.js) is fresh each time
+// and this "populate on open" listener needs re-attaching alongside it.
+function wireDebuggerButton() {
+    const cmdDebug = document.getElementById('cmdDebug');
+    if (!cmdDebug) return;
+    cmdDebug.addEventListener('click', () => {
+        ensureDebuggerWired();
+        debuggerActiveTab = 'Walkthrough';
+        // If a walkthrough is running (started on a previous open of this
+        // dialog, which fully rebuilds #qv-debugger-detail on every open —
+        // see runningWalkthroughName's doc comment), jump straight to it so
+        // its Running…/Cancel state is immediately visible again, rather
+        // than resetting to a blank "Select an item to view details."
+        debuggerSelectedItem = runningWalkthroughName;
+        debuggerSelectedAttr = null;
+        renderDebuggerTabs(JSON.parse(Bridge.GetDebuggerObjectTypesJson()));
+        renderDebuggerList();
+        renderDebuggerDetail();
+    });
 }
 
 // Nothing here can ever work over file:// — the runtime fetches its own

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -411,6 +411,19 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
     await Bridge.Begin();
 }
 
+// Guards restartGame against overlapping calls — e.g. impatiently clicking
+// Restart/"Start from the beginning" again while a slow restart (loading a
+// large game, low-end device) is still in flight. Two concurrent restarts
+// each call swapInPlayerUi() and Bridge.Initialise(...), racing to rebuild
+// the DOM and reinitialise the shared WasmPlayerBridge static game/UI state
+// out from under each other — the visible symptom was old game output left
+// on screen alongside "This game has finished" (a stale WasmPlayerUi
+// instance's HandleFinished still firing against DOM a second restart had
+// already replaced). withBusyButton (used by callers below) already disables
+// the clicked button for the duration, but this is the actual guard: it's
+// what protects restartGame itself regardless of which control called it.
+let restartInProgress = false;
+
 // Reloads a save (or, with saveBytes null, the fresh original game) on top
 // of the already-booted WASM runtime — used for in-game Load and "Start
 // from the beginning". Rebuilds the player chrome from scratch via
@@ -424,6 +437,16 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
 // brand-new elements each time, not the same live ones, so this isn't the
 // double-binding repeat-init the old comment here used to warn about.
 async function restartGame(saveBytes) {
+    if (restartInProgress) return;
+    restartInProgress = true;
+    try {
+        await restartGameCore(saveBytes);
+    } finally {
+        restartInProgress = false;
+    }
+}
+
+async function restartGameCore(saveBytes) {
     document.getElementById('qv-saves')?.close();
     swapInPlayerUi();
     resetGameOutput();
@@ -640,7 +663,7 @@ function ensureSavesDialogWired() {
         if (bootChoiceResolve) e.preventDefault();
     });
 
-    document.getElementById('qv-saves-start-new').addEventListener('click', () => {
+    document.getElementById('qv-saves-start-new').addEventListener('click', (e) => {
         if (bootChoiceResolve) {
             const resolve = bootChoiceResolve;
             bootChoiceResolve = null;
@@ -650,7 +673,13 @@ function ensureSavesDialogWired() {
         }
         // Manage mode: restarting mid-session, matches WebPlayer's Slots
         // "Start from the beginning" button (no confirm() there either).
-        restartGame(null);
+        // withBusyButton's disable+busy-label+forced-paint makes a slow
+        // restart (a large game, a low-end device) read as "working" rather
+        // than unresponsive — restartGame itself also now guards against
+        // overlapping calls (see restartInProgress's doc comment), but
+        // without this there was no visible feedback at all inviting
+        // exactly the impatient re-click that guard exists for.
+        withBusyButton(e.currentTarget, 'Restarting…', () => restartGame(null));
     });
 
     document.getElementById('qv-saves-list').addEventListener('click', async (e) => {
@@ -1343,7 +1372,19 @@ function wireDebuggerRestartButton(isPreview) {
     cmdRestart.id = 'cmdRestart';
     cmdRestart.type = 'button';
     cmdRestart.textContent = 'Restart';
-    cmdRestart.addEventListener('click', () => restartGame(null));
+    cmdRestart.addEventListener('click', (e) => {
+        // Unlike #qv-saves-start-new (inside #qv-saves, which survives
+        // swapInPlayerUi untouched — see restartGameCore), this button is
+        // itself destroyed almost immediately by swapInPlayerUi and only
+        // recreated near the end of restartGameCore, so there's no "restore
+        // it afterward" state worth preserving the way withBusyButton does
+        // elsewhere — just disable it synchronously so a double-click fired
+        // in the same tick (before the DOM swap actually runs) doesn't
+        // start a second restart. restartGame's restartInProgress guard is
+        // the real protection against overlapping restarts either way.
+        e.currentTarget.disabled = true;
+        restartGame(null);
+    });
     cmdDebug.insertAdjacentElement('afterend', cmdRestart);
     // Matches the jQuery UI ".ui-button" look cmdDebug/cmdSave already have
     // (applied to them by initPlayerUI's "$('#gameBorder button').button()"

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -394,6 +394,7 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
     WebPlayer.onSaveClick = () => openSavesDialog('manage');
     WebPlayer.initUI();
     wireDebuggerButton();
+    wireDebuggerRestartButton(isPreview);
     // Editor-preview sessions (isPreview) don't offer saving at all — by
     // design: a save captures the whole game state, so reloading one while
     // iterating would show stale state that doesn't reflect the developer's
@@ -440,7 +441,14 @@ async function restartGame(saveBytes) {
     await setupPaperJs();
     WebPlayer.initUI();
     wireDebuggerButton();
-    WebPlayer.setCanSave(true);
+    wireDebuggerRestartButton(currentIsPreview);
+    // Used to be an unconditional true — harmless while restartGame was only
+    // ever reachable from the Saves dialog, which editor-preview sessions
+    // never had access to in the first place (Save itself is hidden there).
+    // Now that the new Restart button (wireDebuggerRestartButton) makes
+    // restartGame reachable *from* a preview session too, hardcoding true
+    // here would wrongly re-enable Save after a preview restart.
+    WebPlayer.setCanSave(!currentIsPreview);
     WebPlayer.setCanDebug(currentIsPreview && Bridge.IsDebugEnabled());
     await Bridge.Begin();
 }
@@ -760,8 +768,15 @@ let debuggerAttrData = null;
 // dialog and game restarts within the same session, so these live at module
 // scope rather than being recomputed/reset on every render.
 
-const DEBUGGER_DEFAULT_WIDTH = 768;
-const DEBUGGER_DEFAULT_HEIGHT = 600;
+// Default size scales with the viewport (roughly three-quarters of it)
+// rather than a fixed px value, so it actually uses the room available on a
+// typical editor-preview window instead of looking small in the middle of
+// it — capped at DEBUGGER_MAX_*_DEFAULT so it doesn't balloon absurdly large
+// on an oversized monitor, and floored at DEBUGGER_MIN_* (below) so it never
+// starts out smaller than the resize handle's own minimum.
+const DEBUGGER_DEFAULT_SIZE_FRACTION = 0.75;
+const DEBUGGER_MAX_DEFAULT_WIDTH = 1100;
+const DEBUGGER_MAX_DEFAULT_HEIGHT = 820;
 const DEBUGGER_MIN_WIDTH = 480;
 const DEBUGGER_MIN_HEIGHT = 360;
 const DEBUGGER_MIN_LIST_WIDTH = 100;
@@ -814,8 +829,8 @@ function applyDebuggerRect() {
     if (!dlg) return;
 
     if (!debuggerRect) {
-        const width = Math.min(DEBUGGER_DEFAULT_WIDTH, window.innerWidth - 40);
-        const height = Math.min(DEBUGGER_DEFAULT_HEIGHT, window.innerHeight - 40);
+        const width = clamp(Math.round(window.innerWidth * DEBUGGER_DEFAULT_SIZE_FRACTION), DEBUGGER_MIN_WIDTH, Math.min(DEBUGGER_MAX_DEFAULT_WIDTH, window.innerWidth - 40));
+        const height = clamp(Math.round(window.innerHeight * DEBUGGER_DEFAULT_SIZE_FRACTION), DEBUGGER_MIN_HEIGHT, Math.min(DEBUGGER_MAX_DEFAULT_HEIGHT, window.innerHeight - 40));
         debuggerRect = {
             left: Math.round((window.innerWidth - width) / 2),
             top: Math.round((window.innerHeight - height) / 2),
@@ -1305,6 +1320,36 @@ function wireDebuggerButton() {
         renderDebuggerList();
         renderDebuggerDetail();
     });
+}
+
+// Editor-preview sessions hide the Save button entirely (see
+// setCanSave(!isPreview) above) — and "Start from the beginning"/Load only
+// ever lived inside the Save/Load dialog that button opens — so a preview
+// session had no way to restart the game at all. Adds a plain "Restart"
+// button next to Debug instead, calling restartGame(null) directly (same
+// as "Start from the beginning", no confirmation there either).
+//
+// #cmdDebug (and this button, once created) is part of playercore.htm,
+// fully replaced on every boot/restart (see swapInPlayerUi) — so unlike
+// wireDebuggerButton, which just re-attaches a listener to whatever
+// #cmdDebug currently exists, this recreates the button itself from scratch
+// every time, since the old one (if any) was just destroyed along with the
+// rest of the previous playercore.htm content.
+function wireDebuggerRestartButton(isPreview) {
+    const cmdDebug = document.getElementById('cmdDebug');
+    if (!cmdDebug || !isPreview) return;
+
+    const cmdRestart = document.createElement('button');
+    cmdRestart.id = 'cmdRestart';
+    cmdRestart.type = 'button';
+    cmdRestart.textContent = 'Restart';
+    cmdRestart.addEventListener('click', () => restartGame(null));
+    cmdDebug.insertAdjacentElement('afterend', cmdRestart);
+    // Matches the jQuery UI ".ui-button" look cmdDebug/cmdSave already have
+    // (applied to them by initPlayerUI's "$('#gameBorder button').button()"
+    // — which already ran by the time this is called, so it never touches
+    // this button; do it explicitly here instead).
+    $(cmdRestart).button();
 }
 
 // Nothing here can ever work over file:// — the runtime fetches its own

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -742,6 +742,16 @@ let runningWalkthroughName = null;
 // tried cramming input+button+hint into a 4th table column and it didn't
 // fit at any reasonable dialog width).
 let debuggerSelectedAttr = null;
+// Sort/filter state for the attribute table — reset whenever a different
+// object/tab is selected (renderDebuggerList's click handler / selectDebuggerTab),
+// but preserved across same-object re-renders (Apply, row selection).
+let debuggerAttrSort = { column: 'attribute', direction: 'asc' };
+let debuggerAttrSearch = '';
+// The current object's raw {attrName: DebugDataItem} data, cached so
+// re-sorting/re-filtering (every keystroke in the search box, every header
+// click) doesn't need a fresh Bridge round-trip each time — only rebuilt
+// when the object actually changes or an override is applied.
+let debuggerAttrData = null;
 
 // DebugDataItem.Value is a human-readable *display* string (Fields.cs's
 // DefaultFormatter just calls ToString() — a string has no quotes, a bool
@@ -799,15 +809,79 @@ function renderDebuggerWalkthroughDetail(name) {
         + '</div>';
 }
 
+const DEBUGGER_ATTR_COLUMNS = [
+    { key: 'attribute', label: 'Attribute' },
+    { key: 'value', label: 'Value' },
+    { key: 'source', label: 'Source' },
+];
+
+function debuggerAttrSortIndicator(column) {
+    if (debuggerAttrSort.column !== column) return '';
+    return debuggerAttrSort.direction === 'asc' ? ' ▲' : ' ▼';
+}
+
+// Applies debuggerAttrSearch (matches against the attribute name or its
+// display value) and debuggerAttrSort to debuggerAttrData's keys.
+function sortedFilteredDebuggerAttrs() {
+    const query = debuggerAttrSearch.trim().toLowerCase();
+    let attrs = Object.keys(debuggerAttrData);
+    if (query) {
+        attrs = attrs.filter(attr =>
+            attr.toLowerCase().includes(query) || debuggerAttrData[attr].Value.toLowerCase().includes(query));
+    }
+
+    const { column, direction } = debuggerAttrSort;
+    const sortKey = attr => column === 'attribute' ? attr
+        : column === 'value' ? debuggerAttrData[attr].Value
+            : (debuggerAttrData[attr].Source ?? '');
+    attrs.sort((a, b) => sortKey(a).localeCompare(sortKey(b), undefined, { sensitivity: 'base' }));
+    if (direction === 'desc') attrs.reverse();
+    return attrs;
+}
+
+// Rebuilds just the <tbody> (and the header sort indicators) — deliberately
+// not the whole panel, so re-sorting/typing in the search box doesn't touch
+// .qv-debugger-scroll (would reset its scroll position) or the search
+// <input> itself (would drop keyboard focus mid-keystroke).
+function renderDebuggerAttrRows() {
+    const tbody = document.getElementById('qv-debugger-attr-tbody');
+    if (!tbody) return;
+
+    document.querySelectorAll('#qv-debugger-detail [data-sort-col]').forEach(th => {
+        const col = th.dataset.sortCol;
+        th.textContent = DEBUGGER_ATTR_COLUMNS.find(c => c.key === col).label + debuggerAttrSortIndicator(col);
+    });
+
+    const attrs = sortedFilteredDebuggerAttrs();
+    if (!attrs.length) {
+        tbody.innerHTML = '<tr><td colspan="3" class="text-surface-500">No matching attributes.</td></tr>';
+        return;
+    }
+
+    tbody.innerHTML = attrs.map(attr => {
+        const item = debuggerAttrData[attr];
+        const classes = [item.IsInherited ? 'qv-debugger-row-inherited' : '', attr === debuggerSelectedAttr ? 'qv-debugger-row-selected' : ''];
+        return `<tr class="${classes.join(' ')}" data-attr-row="${_esc(attr)}">`
+            + `<td>${_esc(attr)}</td>`
+            + `<td>${_esc(item.Value)}</td>`
+            + `<td>${_esc(item.Source ?? '')}</td>`
+            + '</tr>';
+    }).join('');
+}
+
 // The table (which can run to a couple dozen rows for an inherited-heavy
 // object like the default player) scrolls in its own inner region
 // (.qv-debugger-scroll); the override panel is a separate, non-scrolling
 // footer so selecting a row near the top of a long table doesn't require
-// scrolling past everything else to reach the Apply button.
+// scrolling past everything else to reach the Apply button. Sorting/search
+// only ever rebuild the <tbody> (see renderDebuggerAttrRows) — this function
+// is the one that talks to the bridge and rebuilds the whole panel shell
+// (search box, sortable headers, override panel), for a genuine object
+// switch or after Apply changes the underlying data.
 function renderDebuggerAttributesDetail(tab, obj) {
     const detail = document.getElementById('qv-debugger-detail');
-    const data = JSON.parse(Bridge.GetDebugDataJson(tab, obj)).Data || {};
-    const attrs = Object.keys(data);
+    debuggerAttrData = JSON.parse(Bridge.GetDebugDataJson(tab, obj)).Data || {};
+    const attrs = Object.keys(debuggerAttrData);
 
     if (!attrs.length) {
         detail.innerHTML = '<p class="text-surface-500">No attributes.</p>';
@@ -816,24 +890,21 @@ function renderDebuggerAttributesDetail(tab, obj) {
 
     if (!attrs.includes(debuggerSelectedAttr)) debuggerSelectedAttr = null;
 
-    detail.innerHTML = '<div class="qv-debugger-scroll">'
+    detail.innerHTML = `<input type="text" class="qv-debugger-input mb-2" id="qv-debugger-attr-search" placeholder="Search attributes…" autocomplete="off" value="${_esc(debuggerAttrSearch)}">`
+        + '<div class="qv-debugger-scroll">'
         + '<table class="table qv-debugger-table"><thead><tr>'
-        + '<th>Attribute</th><th>Value</th><th>Source</th>'
-        + '</tr></thead><tbody>'
-        + attrs.map(attr => {
-            const item = data[attr];
-            const classes = [item.IsInherited ? 'qv-debugger-row-inherited' : '', attr === debuggerSelectedAttr ? 'qv-debugger-row-selected' : ''];
-            return `<tr class="${classes.join(' ')}" data-attr-row="${_esc(attr)}">`
-                + `<td>${_esc(attr)}</td>`
-                + `<td>${_esc(item.Value)}</td>`
-                + `<td>${_esc(item.Source ?? '')}</td>`
-                + '</tr>';
-        }).join('')
-        + '</tbody></table>'
+        + DEBUGGER_ATTR_COLUMNS.map(c => `<th data-sort-col="${c.key}">${_esc(c.label)}${debuggerAttrSortIndicator(c.key)}</th>`).join('')
+        + '</tr></thead><tbody id="qv-debugger-attr-tbody"></tbody></table>'
         + '</div>'
         + '<div id="qv-debugger-override" class="qv-debugger-footer"></div>';
 
-    if (debuggerSelectedAttr) renderDebuggerOverridePanel(debuggerSelectedAttr, data[debuggerSelectedAttr]);
+    renderDebuggerAttrRows();
+    document.getElementById('qv-debugger-attr-search').addEventListener('input', (e) => {
+        debuggerAttrSearch = e.target.value;
+        renderDebuggerAttrRows();
+    });
+
+    if (debuggerSelectedAttr) renderDebuggerOverridePanel(debuggerSelectedAttr, debuggerAttrData[debuggerSelectedAttr]);
 }
 
 // renderDebuggerAttributesDetail rebuilds the whole #qv-debugger-detail
@@ -898,6 +969,8 @@ function selectDebuggerTab(tab) {
     // blank "Select an item to view details."
     debuggerSelectedItem = tab === 'Walkthrough' ? runningWalkthroughName : null;
     debuggerSelectedAttr = null;
+    debuggerAttrSort = { column: 'attribute', direction: 'asc' };
+    debuggerAttrSearch = '';
     renderDebuggerTabs(JSON.parse(Bridge.GetDebuggerObjectTypesJson()));
     renderDebuggerList();
     renderDebuggerDetail();
@@ -971,15 +1044,32 @@ function ensureDebuggerWired() {
         if (!btn) return;
         debuggerSelectedItem = btn.dataset.item;
         debuggerSelectedAttr = null;
+        // Fresh sort/search state for whichever object was just selected —
+        // a leftover filter/sort from the previous object would otherwise
+        // silently carry over and could hide attributes the user expects
+        // to see (e.g. a search term that happens to match nothing here).
+        debuggerAttrSort = { column: 'attribute', direction: 'asc' };
+        debuggerAttrSearch = '';
         renderDebuggerList();
         renderDebuggerDetail();
     });
 
     document.getElementById('qv-debugger-detail').addEventListener('click', async (e) => {
+        const sortCol = e.target.closest('[data-sort-col]');
+        if (sortCol) {
+            const col = sortCol.dataset.sortCol;
+            debuggerAttrSort = debuggerAttrSort.column === col
+                ? { column: col, direction: debuggerAttrSort.direction === 'asc' ? 'desc' : 'asc' }
+                : { column: col, direction: 'asc' };
+            renderDebuggerAttrRows();
+            return;
+        }
+
         const attrRow = e.target.closest('[data-attr-row]');
         if (attrRow) {
             debuggerSelectedAttr = attrRow.dataset.attrRow;
-            withPreservedDebuggerScroll(() => renderDebuggerAttributesDetail(debuggerActiveTab, debuggerSelectedItem));
+            renderDebuggerAttrRows();
+            renderDebuggerOverridePanel(debuggerSelectedAttr, debuggerAttrData[debuggerSelectedAttr]);
             return;
         }
 

--- a/tests/e2e/fixtures/debugger-test.aslx
+++ b/tests/e2e/fixtures/debugger-test.aslx
@@ -1,0 +1,33 @@
+<asl version="580">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="DebuggerTest">
+    <score type="int">0</score>
+  </game>
+  <object name="kitchen">
+    <object name="player">
+      <inherit name="defaultplayer" />
+    </object>
+    <description>A kitchen.</description>
+  </object>
+  <object name="livingroom">
+    <description>A living room.</description>
+  </object>
+  <walkthrough name="basic">
+    <steps>
+      <![CDATA[
+      assert:game.score = 0
+      look
+      ]]>
+    </steps>
+  </walkthrough>
+  <walkthrough name="slow">
+    <steps>
+      <![CDATA[
+      look
+      delay:2000
+      look
+      ]]>
+    </steps>
+  </walkthrough>
+</asl>

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -1,0 +1,329 @@
+// Manual verification for the new WasmPlayer Debugger (element browser +
+// attribute override + walkthrough runner), added alongside the existing
+// WebPlayer Blazor Debugger. Checks:
+//   1. The Debug button stays hidden for a normal (non-preview) session.
+//   2. It appears for an editor-preview session (?source=editor handoff,
+//      same BroadcastChannel protocol AppShell's live preview uses).
+//   3. The dialog's tabs/object list/attribute table populate correctly.
+//   4. Overriding an attribute (moving the player between rooms via `parent`)
+//      actually changes live game state.
+//   5. A bad override expression surfaces an inline error, not a crash.
+//   6. The walkthrough runner runs a walkthrough to completion.
+//
+// Requires the WasmPlayer dev server running locally:
+//   node ../../src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+let failed = false;
+
+function check(label, condition) {
+    console.log(`${condition ? 'PASS' : 'FAIL'}: ${label}`);
+    if (!condition) failed = true;
+}
+
+// ── 1. Non-preview session: Debug button must stay hidden ──────────────────
+{
+    const page = await browser.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/debugger-test.aslx`);
+    await page.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+    await page.waitForTimeout(300);
+    const display = await page.$eval('#cmdDebug', el => getComputedStyle(el).display);
+    check('Debug button hidden in a normal play session', display === 'none');
+    await page.close();
+}
+
+// ── 2. Editor-preview session: hand off game bytes over BroadcastChannel ───
+// BroadcastChannel is scoped per browser-context storage partition — each
+// browser.newPage() call creates a brand-new isolated context in Playwright
+// (unlike two ordinary tabs in the same real browser window/profile, which
+// is what AppShell's editor + its live-preview tab actually are), so both
+// pages here must share one explicit context or the channel can't bridge them.
+const context = await browser.newContext();
+const previewPage = await context.newPage();
+previewPage.on('pageerror', err => console.log('[pageerror]', err.message));
+previewPage.on('console', msg => {
+    if (msg.type() === 'error') console.log('[console.error]', msg.text());
+});
+
+const senderPage = await context.newPage();
+const fixtureUrl = `${baseUrl}/e2e-fixtures/debugger-test.aslx`;
+await senderPage.goto(baseUrl);
+
+// Registers the BroadcastChannel listener *before* previewPage navigates —
+// otherwise previewPage's boot IIFE can post 'ready' before anyone is
+// listening (BroadcastChannel drops messages with no live listener, it
+// doesn't queue them), and the handoff below would hang forever.
+const handoffDone = senderPage.evaluate(async (url) => {
+    const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
+    await new Promise((resolve) => {
+        const bc = new BroadcastChannel('quest-preview');
+        bc.onmessage = ({ data }) => {
+            if (data.type === 'ready') {
+                bc.postMessage({ type: 'game', bytes, filename: 'debugger-test.aslx' });
+                resolve();
+            }
+        };
+    });
+}, fixtureUrl);
+
+await previewPage.goto(`${baseUrl}/?source=editor`);
+await handoffDone;
+
+await previewPage.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+await previewPage.waitForTimeout(300);
+
+const previewDisplay = await previewPage.$eval('#cmdDebug', el => getComputedStyle(el).display);
+check('Debug button visible in an editor-preview session', previewDisplay !== 'none');
+
+// ── 3. Open the dialog, check tabs ──────────────────────────────────────────
+await previewPage.click('#cmdDebug');
+await previewPage.waitForSelector('#questVivaDebugger[open]', { timeout: 5000 });
+
+const tabLabels = await previewPage.$$eval('#qv-debugger-tabs button', els => els.map(el => el.textContent));
+check('Tabs include Walkthrough/Objects/Game', ['Walkthrough', 'Objects', 'Game'].every(t => tabLabels.includes(t)));
+
+// The dialog used to visibly resize on every tab switch (max-height instead
+// of a fixed height on the two panes) — Walkthrough starts selected with
+// nothing chosen yet (shortest content); Objects, once player/parent is
+// selected below, renders a table + override panel (much taller content).
+// The dialog's own box should stay put regardless.
+const sizeOnWalkthroughTab = await previewPage.$eval('#questVivaDebugger', el => {
+    const r = el.getBoundingClientRect();
+    return { width: r.width, height: r.height };
+});
+
+// ── 4. Objects tab → select player → override parent to move rooms ─────────
+await previewPage.click('#qv-debugger-tabs button:text("Objects")');
+const objectItems = await previewPage.$$eval('#qv-debugger-list [data-item]', els => els.map(el => el.dataset.item));
+check('Objects list includes player/kitchen/livingroom', ['player', 'kitchen', 'livingroom'].every(o => objectItems.includes(o)));
+
+// The left-hand list should read as a selectable list, not a list of
+// hyperlinks (no more Skeleton .anchor class).
+const listItemClasses = await previewPage.$$eval('#qv-debugger-list [data-item]', els => els.map(el => el.className));
+check('Object list items are not styled as hyperlinks', listItemClasses.every(c => !c.includes('anchor')));
+
+await previewPage.click('#qv-debugger-list [data-item="player"]');
+await previewPage.waitForSelector('[data-attr-row="parent"]');
+
+// Column headers should be visually differentiated from the body rows.
+const headerStyle = await previewPage.$eval('.qv-debugger-table thead th', el => {
+    const s = getComputedStyle(el);
+    return { textTransform: s.textTransform, borderBottomWidth: s.borderBottomWidth };
+});
+check(
+    'Table headers are visually differentiated (uppercase + bottom border)',
+    headerStyle.textTransform === 'uppercase' && parseFloat(headerStyle.borderBottomWidth) > 0
+);
+
+// player (inherits defaultplayer) has a list-valued attribute (pov_alt) —
+// no simple literal syntax to write one of those back, so no override
+// textbox should be offered for it.
+await previewPage.waitForSelector('[data-attr-row="pov_alt"]');
+await previewPage.click('[data-attr-row="pov_alt"]');
+await previewPage.waitForSelector('#qv-debugger-override');
+const povAltHasInput = await previewPage.$('#qv-debugger-override-input');
+check('No override textbox for a list-valued attribute (pov_alt)', povAltHasInput === null);
+
+// pov_alt is inherited from the defaultplayer type — its selected-row text
+// color used to fade toward the selected blue background (opacity-60
+// combined with .qv-debugger-row-selected's light contrast text), reading as
+// low-contrast light-grey-on-light-blue. Selected should win over inherited.
+const povAltSelectedColor = await previewPage.$eval('[data-attr-row="pov_alt"]', el => getComputedStyle(el).color);
+await previewPage.click('#qv-debugger-list [data-item="kitchen"]');
+await previewPage.click('#qv-debugger-list [data-item="player"]');
+await previewPage.waitForSelector('[data-attr-row="pov_alt"]');
+const povAltUnselectedColor = await previewPage.$eval('[data-attr-row="pov_alt"]', el => getComputedStyle(el).color);
+check(
+    'Selected+inherited row keeps readable (non-muted) text color',
+    povAltSelectedColor !== povAltUnselectedColor
+);
+
+// Hovering a *selected* list item used to fall back to the plain hover's
+// neutral grey background (higher specificity than the plain selected-blue
+// rule) while keeping the selected item's light contrast-color text.
+await previewPage.click('#qv-debugger-list [data-item="player"]');
+await previewPage.hover('#qv-debugger-list [data-item="player"]');
+const selectedHoverBackground = await previewPage.$eval(
+    '#qv-debugger-list [data-item="player"]',
+    el => getComputedStyle(el).backgroundColor
+);
+await previewPage.hover('#qv-debugger-list [data-item="kitchen"]');
+const unselectedHoverBackground = await previewPage.$eval(
+    '#qv-debugger-list [data-item="kitchen"]',
+    el => getComputedStyle(el).backgroundColor
+);
+check(
+    'Hovering the selected list item does not fall back to the plain (low-contrast) hover background',
+    selectedHoverBackground !== unselectedHoverBackground
+);
+
+await previewPage.click('[data-attr-row="parent"]');
+await previewPage.waitForSelector('#qv-debugger-override-input');
+
+const sizeWithOverridePanelOpen = await previewPage.$eval('#questVivaDebugger', el => {
+    const r = el.getBoundingClientRect();
+    return { width: r.width, height: r.height };
+});
+check(
+    'Dialog size stays constant across tabs/content (no more per-tab resize)',
+    sizeOnWalkthroughTab.width === sizeWithOverridePanelOpen.width
+        && sizeOnWalkthroughTab.height === sizeWithOverridePanelOpen.height
+);
+
+// The table's Value column still shows the human-readable display string
+// (Element.ToString()'s "Type: name", e.g. "Object: kitchen"), but the
+// override input is pre-filled from DebugDataItem.EditValue — the same
+// value pre-formatted as valid script syntax (Fields.cs's s_editFormatters) —
+// so it should show just the bare name, already appliable as-is.
+const parentValueCell = await previewPage.$eval('[data-attr-row="parent"] td:nth-child(2)', el => el.textContent);
+check('Value column shows the display form ("Object: kitchen")', /Object:\s*kitchen/i.test(parentValueCell));
+
+const parentBefore = await previewPage.$eval('#qv-debugger-override-input', el => el.value);
+check('Override input is pre-filled with the bare, appliable name ("kitchen")', parentBefore === 'kitchen');
+
+await previewPage.fill('#qv-debugger-override-input', 'livingroom');
+await previewPage.click('#qv-debugger-override-apply');
+await previewPage.waitForFunction(
+    () => /livingroom/i.test(document.querySelector('#qv-debugger-override-input')?.value ?? '')
+);
+const parentAfter = await previewPage.$eval('#qv-debugger-override-input', el => el.value);
+check('Override applied: player.parent is now livingroom', /livingroom/i.test(parentAfter));
+
+// Confirm it's a *real* game-state change, not just a UI re-render: close the
+// dialog and ask the game itself where the player is.
+await previewPage.click('#qv-debugger-close');
+await previewPage.fill('#txtCommand', 'look');
+await previewPage.press('#txtCommand', 'Enter');
+await previewPage.waitForTimeout(300);
+const outputText = await previewPage.$eval('#divOutput', el => el.textContent);
+console.log('  output after look:', JSON.stringify(outputText).slice(0, 300));
+check('The live game reflects the move (output mentions livingroom)', /livingroom/i.test(outputText));
+
+// ── String attributes pre-fill correctly quoted ─────────────────────────────
+await previewPage.click('#cmdDebug');
+await previewPage.waitForSelector('#questVivaDebugger[open]');
+await previewPage.click('#qv-debugger-tabs button:text("Objects")');
+await previewPage.click('#qv-debugger-list [data-item="kitchen"]');
+await previewPage.waitForSelector('[data-attr-row="description"]');
+await previewPage.click('[data-attr-row="description"]');
+await previewPage.waitForSelector('#qv-debugger-override-input');
+const descriptionEditValue = await previewPage.$eval('#qv-debugger-override-input', el => el.value);
+check('String attribute pre-fills quoted (kitchen.description)', descriptionEditValue === '"A kitchen."');
+await previewPage.click('#qv-debugger-close');
+
+// ── Selecting a row shouldn't reset the attribute table's scroll position ──
+// player (inherits defaultplayer) has enough attributes to actually scroll.
+await previewPage.click('#cmdDebug');
+await previewPage.waitForSelector('#questVivaDebugger[open]');
+await previewPage.click('#qv-debugger-tabs button:text("Objects")');
+await previewPage.click('#qv-debugger-list [data-item="player"]');
+await previewPage.waitForSelector('.qv-debugger-scroll');
+await previewPage.$eval('.qv-debugger-scroll', el => { el.scrollTop = 50; });
+const scrollBeforeRowClick = await previewPage.$eval('.qv-debugger-scroll', el => el.scrollTop);
+await previewPage.click('[data-attr-row="type"]');
+await previewPage.waitForSelector('#qv-debugger-override-input');
+const scrollAfterRowClick = await previewPage.$eval('.qv-debugger-scroll', el => el.scrollTop);
+check(
+    'Clicking an attribute row preserves scroll position',
+    scrollBeforeRowClick > 0 && scrollAfterRowClick === scrollBeforeRowClick
+);
+await previewPage.click('#qv-debugger-close');
+
+// ── 5. Bad override expression → inline error, no crash ────────────────────
+await previewPage.click('#cmdDebug');
+await previewPage.waitForSelector('#questVivaDebugger[open]');
+await previewPage.click('#qv-debugger-tabs button:text("Objects")');
+await previewPage.click('#qv-debugger-list [data-item="player"]');
+await previewPage.waitForSelector('[data-attr-row="parent"]');
+await previewPage.click('[data-attr-row="parent"]');
+await previewPage.waitForSelector('#qv-debugger-override-input');
+await previewPage.fill('#qv-debugger-override-input', 'this is not valid script syntax {{{');
+await previewPage.click('#qv-debugger-override-apply');
+await previewPage.waitForFunction(() => {
+    const el = document.querySelector('#qv-debugger-override-error');
+    return el && !el.classList.contains('hidden') && el.textContent.length > 0;
+}, { timeout: 5000 });
+const errorText = await previewPage.$eval('#qv-debugger-override-error', el => el.textContent);
+check('Bad override shows an inline error', errorText.length > 0);
+console.log('  error text:', errorText);
+
+// ── 6. Walkthrough runner ───────────────────────────────────────────────────
+await previewPage.click('#qv-debugger-tabs button:text("Walkthrough")');
+const walkthroughItems = await previewPage.$$eval('#qv-debugger-list [data-item]', els => els.map(el => el.dataset.item));
+check('Walkthrough list includes "basic"', walkthroughItems.includes('basic'));
+
+await previewPage.click('#qv-debugger-list [data-item="basic"]');
+await previewPage.waitForSelector('[data-run-walkthrough="basic"]');
+
+// Cancel should be hidden until a walkthrough is actually running — it was
+// previously shown at all times, a dead control before/after a run.
+const cancelHiddenBeforeRun = await previewPage.$eval('[data-cancel-walkthrough]', el => el.classList.contains('hidden'));
+check('Cancel is hidden before a walkthrough is running', cancelHiddenBeforeRun);
+
+await previewPage.click('[data-run-walkthrough="basic"]');
+const cancelVisibleWhileRunning = await previewPage.$eval('[data-cancel-walkthrough]', el => !el.classList.contains('hidden'));
+check('Cancel appears while the walkthrough is running', cancelVisibleWhileRunning);
+
+await previewPage.waitForFunction(() => {
+    const el = document.querySelector('[data-walkthrough-status]');
+    return el && el.textContent && el.textContent !== 'Running…';
+}, { timeout: 15000 });
+const walkthroughStatus = await previewPage.$eval('[data-walkthrough-status]', el => el.textContent);
+check('Walkthrough runs to completion', walkthroughStatus === 'Done');
+
+const cancelHiddenAfterRun = await previewPage.$eval('[data-cancel-walkthrough]', el => el.classList.contains('hidden'));
+check('Cancel is hidden again once the walkthrough finishes', cancelHiddenAfterRun);
+
+// ── Closing and reopening the dialog mid-run must not lose Cancel ──────────
+// #qv-debugger-detail is fully rebuilt every time the dialog (re)opens, which
+// used to silently drop whatever Run/Cancel/status state only lived in the
+// DOM nodes from before — a walkthrough kept running with no way to see it
+// or cancel it once reopened. "slow" has a 2s delay so there's a real window
+// to close/reopen while it's still going.
+await previewPage.click('#qv-debugger-list [data-item="slow"]');
+await previewPage.waitForSelector('[data-run-walkthrough="slow"]');
+await previewPage.click('[data-run-walkthrough="slow"]');
+await previewPage.waitForFunction(() => document.querySelector('[data-walkthrough-status]')?.textContent === 'Running…');
+
+await previewPage.click('#qv-debugger-close');
+await previewPage.waitForFunction(() => !document.getElementById('questVivaDebugger').open);
+await previewPage.click('#cmdDebug');
+await previewPage.waitForSelector('#questVivaDebugger[open]');
+
+const reopenedState = await previewPage.evaluate(() => ({
+    activeTab: document.querySelector('#qv-debugger-tabs button.preset-filled-primary-500')?.textContent,
+    status: document.querySelector('[data-walkthrough-status]')?.textContent,
+    cancelHidden: document.querySelector('[data-cancel-walkthrough]')?.classList.contains('hidden'),
+    runDisabled: document.querySelector('[data-run-walkthrough="slow"]')?.disabled,
+}));
+check(
+    'Reopening the dialog mid-walkthrough lands back on it with Running…/Cancel restored',
+    reopenedState.activeTab === 'Walkthrough'
+        && reopenedState.status === 'Running…'
+        && reopenedState.cancelHidden === false
+        && reopenedState.runDisabled === true
+);
+
+// Cancel should still actually work post-reopen (updateWalkthroughRunUi's
+// fresh DOM queries, not stale references captured before the reopen).
+await previewPage.click('[data-cancel-walkthrough]');
+await previewPage.waitForFunction(() => {
+    const el = document.querySelector('[data-walkthrough-status]');
+    return el && el.textContent && el.textContent !== 'Running…';
+}, { timeout: 15000 });
+const cancelledStatus = await previewPage.$eval('[data-walkthrough-status]', el => el.textContent);
+check('Cancel still works after reopening the dialog', cancelledStatus !== 'Running…');
+const cancelHiddenAfterCancel = await previewPage.$eval('[data-cancel-walkthrough]', el => el.classList.contains('hidden'));
+check('Cancel hides again after cancelling', cancelHiddenAfterCancel);
+
+await browser.close();
+
+if (failed) {
+    console.error('\nFAIL: one or more checks failed.');
+    process.exit(1);
+}
+console.log('\nPASS');

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -46,7 +46,7 @@ function check(label, condition) {
 // enough room that clamping (staying within the viewport, see
 // applyDebuggerRect/wireDebuggerMoveResize) never kicks in and confounds an
 // exact-pixel-delta assertion.
-const context = await browser.newContext({ viewport: { width: 1400, height: 1000 } });
+const context = await browser.newContext({ viewport: { width: 1800, height: 1300 } });
 const previewPage = await context.newPage();
 previewPage.on('pageerror', err => console.log('[pageerror]', err.message));
 previewPage.on('console', msg => {
@@ -83,9 +83,24 @@ await previewPage.waitForTimeout(300);
 const previewDisplay = await previewPage.$eval('#cmdDebug', el => getComputedStyle(el).display);
 check('Debug button visible in an editor-preview session', previewDisplay !== 'none');
 
+// Editor-preview sessions hide Save entirely, so "Start from the beginning"
+// (which only lives inside the Save/Load dialog) was otherwise unreachable —
+// a standalone Restart button next to Debug covers that gap.
+const restartVisible = await previewPage.$eval('#cmdRestart', el => getComputedStyle(el).display !== 'none').catch(() => false);
+check('Restart button appears next to Debug in an editor-preview session', restartVisible);
+
 // ── 3. Open the dialog, check tabs ──────────────────────────────────────────
 await previewPage.click('#cmdDebug');
 await previewPage.waitForSelector('#questVivaDebugger[open]', { timeout: 5000 });
+
+// Default size should use a good chunk of the viewport (roughly 3/4) rather
+// than a small fixed size sitting in the middle of a much bigger window.
+const dialogSize = await previewPage.$eval('#questVivaDebugger', el => el.getBoundingClientRect());
+const viewport = previewPage.viewportSize();
+check(
+    'Debugger default size uses most of the viewport, not a small fixed box',
+    dialogSize.width > viewport.width * 0.6 && dialogSize.height > viewport.height * 0.6
+);
 
 const tabLabels = await previewPage.$$eval('#qv-debugger-tabs button', els => els.map(el => el.textContent));
 check('Tabs include Walkthrough/Objects/Game', ['Walkthrough', 'Objects', 'Game'].every(t => tabLabels.includes(t)));
@@ -435,6 +450,17 @@ const cancelledStatus = await previewPage.$eval('[data-walkthrough-status]', el 
 check('Cancel still works after reopening the dialog', cancelledStatus !== 'Running…');
 const cancelHiddenAfterCancel = await previewPage.$eval('[data-cancel-walkthrough]', el => el.classList.contains('hidden'));
 check('Cancel hides again after cancelling', cancelHiddenAfterCancel);
+
+// ── Restart button actually restarts the game ───────────────────────────────
+// The player was moved to livingroom via an override earlier in this run —
+// restarting should bring the game back to its real starting state (kitchen),
+// confirming this isn't just a UI no-op.
+await previewPage.click('#qv-debugger-close');
+await previewPage.click('#cmdRestart');
+await previewPage.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+await previewPage.waitForFunction(() => document.getElementById('divOutput')?.textContent.length > 20, { timeout: 10000 });
+const outputAfterRestart = await previewPage.$eval('#divOutput', el => el.textContent);
+check('Restart brings the game back to its initial state', /You are in a kitchen/i.test(outputAfterRestart));
 
 await browser.close();
 

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -42,7 +42,11 @@ function check(label, condition) {
 // (unlike two ordinary tabs in the same real browser window/profile, which
 // is what AppShell's editor + its live-preview tab actually are), so both
 // pages here must share one explicit context or the channel can't bridge them.
-const context = await browser.newContext();
+// A generous viewport, so the movable/resizable dialog checks below have
+// enough room that clamping (staying within the viewport, see
+// applyDebuggerRect/wireDebuggerMoveResize) never kicks in and confounds an
+// exact-pixel-delta assertion.
+const context = await browser.newContext({ viewport: { width: 1400, height: 1000 } });
 const previewPage = await context.newPage();
 previewPage.on('pageerror', err => console.log('[pageerror]', err.message));
 previewPage.on('console', msg => {
@@ -300,6 +304,68 @@ await previewPage.waitForFunction(() => {
 const errorText = await previewPage.$eval('#qv-debugger-override-error', el => el.textContent);
 check('Bad override shows an inline error', errorText.length > 0);
 console.log('  error text:', errorText);
+
+// ── Movable/resizable dialog, splitter, resizable columns ──────────────────
+async function dragBy(page, handleSelector, dx, dy) {
+    const box = await page.$eval(handleSelector, el => {
+        const r = el.getBoundingClientRect();
+        return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    });
+    await page.mouse.move(box.x, box.y);
+    await page.mouse.down();
+    await page.mouse.move(box.x + dx, box.y + dy, { steps: 5 });
+    await page.mouse.up();
+}
+
+const rectBefore = await previewPage.$eval('#questVivaDebugger', el => el.getBoundingClientRect().toJSON());
+
+await dragBy(previewPage, '#qv-debugger-titlebar', -120, 60);
+const rectAfterMove = await previewPage.$eval('#questVivaDebugger', el => el.getBoundingClientRect().toJSON());
+check(
+    'Dragging the title bar moves the dialog',
+    rectAfterMove.left === rectBefore.left - 120 && rectAfterMove.top === rectBefore.top + 60
+);
+
+await dragBy(previewPage, '#qv-debugger-resize-handle', 150, 100);
+const rectAfterResize = await previewPage.$eval('#questVivaDebugger', el => el.getBoundingClientRect().toJSON());
+check(
+    'Dragging the resize handle grows the dialog',
+    rectAfterResize.width === rectAfterMove.width + 150 && rectAfterResize.height === rectAfterMove.height + 100
+);
+
+const listWidthBefore = await previewPage.$eval('#qv-debugger-list', el => el.getBoundingClientRect().width);
+await dragBy(previewPage, '#qv-debugger-splitter', 80, 0);
+const listWidthAfter = await previewPage.$eval('#qv-debugger-list', el => el.getBoundingClientRect().width);
+check('Dragging the splitter resizes the object list pane', Math.round(listWidthAfter - listWidthBefore) === 80);
+
+// The table header (containing the resize handle) isn't sticky, so if the
+// table happens to be scrolled a long way down — e.g. clicking "parent" a
+// few steps ago auto-scrolled the (long, alphabetically-sorted) player
+// attribute list a good way down to bring that row into view — the header
+// itself can be scrolled out of the visible viewport entirely. Reset scroll
+// first so the handle is actually reachable, same idea as the "type" row
+// click earlier using el.click() directly to sidestep Playwright's
+// scroll-into-view.
+await previewPage.$eval('.qv-debugger-scroll', el => { el.scrollTop = 0; });
+
+const attrColWidthBefore = await previewPage.$eval('[data-attr-row] td:first-child', el => el.getBoundingClientRect().width);
+await dragBy(previewPage, '[data-resize-col="attribute"]', 60, 0);
+const attrColWidthAfter = await previewPage.$eval('[data-attr-row] td:first-child', el => el.getBoundingClientRect().width);
+check('Dragging a column handle resizes that column', Math.round(attrColWidthAfter - attrColWidthBefore) === 60);
+
+// Reopening should keep the same custom rect (position/size survive a
+// close/reopen, same idea as the walkthrough Running… state does).
+await previewPage.click('#qv-debugger-close');
+await previewPage.click('#cmdDebug');
+await previewPage.waitForSelector('#questVivaDebugger[open]');
+const rectAfterReopen = await previewPage.$eval('#questVivaDebugger', el => el.getBoundingClientRect().toJSON());
+check(
+    'Dialog position/size persist across close/reopen',
+    rectAfterReopen.left === rectAfterResize.left
+        && rectAfterReopen.top === rectAfterResize.top
+        && rectAfterReopen.width === rectAfterResize.width
+        && rectAfterReopen.height === rectAfterResize.height
+);
 
 // ── 6. Walkthrough runner ───────────────────────────────────────────────────
 await previewPage.click('#qv-debugger-tabs button:text("Walkthrough")');

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -224,13 +224,63 @@ await previewPage.click('#qv-debugger-list [data-item="player"]');
 await previewPage.waitForSelector('.qv-debugger-scroll');
 await previewPage.$eval('.qv-debugger-scroll', el => { el.scrollTop = 50; });
 const scrollBeforeRowClick = await previewPage.$eval('.qv-debugger-scroll', el => el.scrollTop);
-await previewPage.click('[data-attr-row="type"]');
+// Dispatch the click directly rather than page.click() — Playwright's
+// actionability checks scroll a target into view first if it isn't fully
+// visible, which would confound this specific assertion (scrollTop changing
+// because Playwright itself scrolled it, not because of a rendering bug).
+await previewPage.$eval('[data-attr-row="type"]', el => el.click());
 await previewPage.waitForSelector('#qv-debugger-override-input');
 const scrollAfterRowClick = await previewPage.$eval('.qv-debugger-scroll', el => el.scrollTop);
 check(
     'Clicking an attribute row preserves scroll position',
     scrollBeforeRowClick > 0 && scrollAfterRowClick === scrollBeforeRowClick
 );
+
+// ── Attribute table: sortable columns + search box ──────────────────────────
+const attrColumn = colIndex => previewPage.$$eval(
+    `#qv-debugger-attr-tbody tr td:nth-child(${colIndex})`,
+    els => els.map(el => el.textContent)
+);
+
+const defaultOrder = await attrColumn(1);
+check('Attribute column starts sorted ascending by default', JSON.stringify(defaultOrder) === JSON.stringify([...defaultOrder].sort((a, b) => a.localeCompare(b))));
+
+await previewPage.click('[data-sort-col="attribute"]');
+const descOrder = await attrColumn(1);
+check('Clicking the active sort column reverses direction', JSON.stringify(descOrder) === JSON.stringify([...defaultOrder].reverse()));
+
+const sortHeaderText = await previewPage.$eval('[data-sort-col="attribute"]', el => el.textContent);
+check('Sort indicator shows on the active column', sortHeaderText.includes('▼'));
+
+await previewPage.click('[data-sort-col="value"]');
+const valueOrder = await attrColumn(2);
+check('Sorting by Value column actually sorts by value', JSON.stringify(valueOrder) === JSON.stringify([...valueOrder].sort((a, b) => a.localeCompare(b))));
+
+await previewPage.fill('#qv-debugger-attr-search', 'pov');
+const filteredAttrs = await attrColumn(1);
+// The filter matches on attribute *value* too (not just name), so this
+// isn't just the pov_* attributes — some other attribute apparently holds
+// script/text referencing "pov" in its value. Assert the search actually
+// narrowed the list and definitely includes the obvious name matches,
+// rather than assuming every result's own name contains "pov".
+check(
+    'Search box filters the attribute table',
+    filteredAttrs.length > 0
+        && filteredAttrs.length < defaultOrder.length
+        && filteredAttrs.includes('pov_alt')
+        && filteredAttrs.includes('pov_used')
+);
+
+await previewPage.fill('#qv-debugger-attr-search', 'nonexistent-attribute-xyz');
+const noMatchText = await previewPage.$eval('#qv-debugger-attr-tbody', el => el.textContent);
+check('Search box shows a no-match message rather than an empty table', noMatchText.includes('No matching attributes'));
+
+// Selecting a *different* object should reset the leftover filter, or the
+// new object could appear to have no attributes at all for no visible reason.
+await previewPage.click('#qv-debugger-list [data-item="kitchen"]');
+await previewPage.waitForSelector('#qv-debugger-attr-tbody [data-attr-row]');
+const searchAfterObjectSwitch = await previewPage.$eval('#qv-debugger-attr-search', el => el.value);
+check('Switching objects resets the search filter', searchAfterObjectSwitch === '');
 await previewPage.click('#qv-debugger-close');
 
 // ── 5. Bad override expression → inline error, no crash ────────────────────

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -457,8 +457,25 @@ check('Cancel hides again after cancelling', cancelHiddenAfterCancel);
 // confirming this isn't just a UI no-op.
 await previewPage.click('#qv-debugger-close');
 await previewPage.click('#cmdRestart');
+
+// Bridge.Initialise/Begin block the single WASM UI thread with no chance for
+// anything else to paint, so this spinner is the only feedback a restart is
+// even happening — confirm it actually appears (not just present-but-hidden
+// in the DOM the whole time) and then goes away again once settled.
+await previewPage.waitForSelector('#qv-restarting:not(.hidden)', { timeout: 2000 });
+const spinnerVisible = await previewPage.$eval('#qv-restarting', el => getComputedStyle(el).display !== 'none');
+check('Restarting spinner is shown while the restart is in progress', spinnerVisible);
+
 await previewPage.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
 await previewPage.waitForFunction(() => document.getElementById('divOutput')?.textContent.length > 20, { timeout: 10000 });
+// Output can already be visible slightly before restartGameCore's finally
+// block (which hides the spinner) actually runs — flushed text and the
+// JS await returning aren't quite the same instant (same reasoning as the
+// 300ms buffer a few checks below, for restartInProgress).
+await previewPage.waitForFunction(() => document.getElementById('qv-restarting')?.classList.contains('hidden'), { timeout: 5000 });
+const spinnerHiddenAfter = await previewPage.$eval('#qv-restarting', el => getComputedStyle(el).display === 'none');
+check('Restarting spinner hides again once the restart finishes', spinnerHiddenAfter);
+
 const outputAfterRestart = await previewPage.$eval('#divOutput', el => el.textContent);
 check('Restart brings the game back to its initial state', /You are in a kitchen/i.test(outputAfterRestart));
 

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -466,6 +466,27 @@ await previewPage.waitForSelector('#qv-restarting:not(.hidden)', { timeout: 2000
 const spinnerVisible = await previewPage.$eval('#qv-restarting', el => getComputedStyle(el).display !== 'none');
 check('Restarting spinner is shown while the restart is in progress', spinnerVisible);
 
+// #sidebar (Inventory/Places and Objects/Compass) and #qv-status (the top
+// toolbar) both carry a high z-index in the shared playercore.css
+// (1000/100) — #qv-restarting used to have no z-index of its own, so those
+// painted *above* it regardless of DOM order, popping through what was
+// supposed to be a fully opaque overlay. elementFromPoint at coordinates
+// inside both regions should resolve to the overlay itself (or one of its
+// own children), not something from the underlying game chrome.
+const paintOrderCheck = await previewPage.evaluate(() => {
+    const overlay = document.getElementById('qv-restarting');
+    const topAtSidebarSpot = document.elementFromPoint(window.innerWidth - 20, 100);
+    const topAtToolbarSpot = document.elementFromPoint(window.innerWidth - 20, 10);
+    return {
+        sidebarSpotIsOverlay: overlay.contains(topAtSidebarSpot) || topAtSidebarSpot === overlay,
+        toolbarSpotIsOverlay: overlay.contains(topAtToolbarSpot) || topAtToolbarSpot === overlay,
+    };
+});
+check(
+    'Restarting overlay paints above the sidebar/toolbar (not popped through by their z-index)',
+    paintOrderCheck.sidebarSpotIsOverlay && paintOrderCheck.toolbarSpotIsOverlay
+);
+
 await previewPage.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
 await previewPage.waitForFunction(() => document.getElementById('divOutput')?.textContent.length > 20, { timeout: 10000 });
 // Output can already be visible slightly before restartGameCore's finally

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -462,6 +462,62 @@ await previewPage.waitForFunction(() => document.getElementById('divOutput')?.te
 const outputAfterRestart = await previewPage.$eval('#divOutput', el => el.textContent);
 check('Restart brings the game back to its initial state', /You are in a kitchen/i.test(outputAfterRestart));
 
+// restartInProgress (the guard under test just below) only clears once
+// restartGame's whole async chain — including the trailing Bridge.Begin() —
+// actually settles; #divOutput can already show real content slightly
+// before that promise resolves (flushed output vs. the JS await returning
+// aren't quite the same instant). A brief pause here avoids the *next*
+// restartGame(null) call below being guarded out by this preceding button
+// click's restart rather than by the thing actually being tested.
+await previewPage.waitForTimeout(300);
+
+// ── restartGame ignores an overlapping call ─────────────────────────────────
+// Firing two restarts back-to-back (no await between) used to race — both
+// call swapInPlayerUi()/Bridge.Initialise(...) concurrently, which could
+// leave old game output on screen alongside a stale "This game has
+// finished" pane state. Calling restartGame twice with no intervening await
+// is deterministic (single-threaded JS): the second call's guard check is
+// guaranteed to see restartInProgress already set by the first,
+// synchronously, regardless of how fast/slow the actual restart happens to
+// be for this fixture.
+//
+// Verified by counting how many times document.body's children actually get
+// replaced (swapInPlayerUi's innerHTML assignment), via a MutationObserver,
+// rather than by intercepting an internal function — reassigning
+// window.<bareGlobalFnName>/an exported object's method from page.evaluate()
+// turned out not to reliably affect calls already resolved against that
+// same binding elsewhere in this script (confirmed empirically: even a
+// *single* restartGame(null) call showed 0 intercepted calls either way).
+async function countBodyMutationsDuring(page, fn) {
+    await page.evaluate(() => {
+        window.__mutCount = 0;
+        window.__mutObserver = new MutationObserver((mutations) => {
+            window.__mutCount += mutations.filter(m => m.type === 'childList').length;
+        });
+        window.__mutObserver.observe(document.body, { childList: true });
+    });
+    await fn();
+    return page.evaluate(() => {
+        window.__mutObserver.disconnect();
+        return window.__mutCount;
+    });
+}
+
+const singleRestartMutations = await countBodyMutationsDuring(previewPage, () => previewPage.evaluate(() => window.restartGame(null)));
+const doubleRestartMutations = await countBodyMutationsDuring(previewPage, () => previewPage.evaluate(() =>
+    Promise.all([window.restartGame(null), window.restartGame(null)])));
+check(
+    'A second overlapping restartGame call is ignored (guarded)',
+    doubleRestartMutations <= singleRestartMutations
+);
+
+await previewPage.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+const outputAfterDoubleRestart = await previewPage.$eval('#divOutput', el => el.textContent);
+check(
+    'Game is in a coherent, playable state after an overlapping restart attempt',
+    /You are in a kitchen/i.test(outputAfterDoubleRestart) && !outputAfterDoubleRestart.includes('finished')
+);
+
 await browser.close();
 
 if (failed) {


### PR DESCRIPTION
## Summary

Ports WebPlayer's Blazor Debugger to WasmPlayer as plain HTML/JS driven through the JSExport/JSImport bridge (no framework), gated on editor-preview sessions, plus a few capabilities beyond the original:

- **Element browser + attribute inspector** across all debugger tabs (Objects, Exits, Commands, Game, Turn Scripts, Timers), with sortable columns and a search box.
- **Attribute override** — edit a value and Apply runs it through the game's own script engine (`ScriptFactory`/`SetAttributeAsync`), so it gets the same type coercion a real script would. The override input pre-fills as valid script syntax (quoted strings, lowercase booleans, bare object names) via a new `DebugDataItem.EditValue`/`CanOverride`, and is hidden entirely for value kinds with no simple literal syntax (lists, dicts, scripts).
- **Walkthrough runner** with Run/Cancel, correctly restoring its Running…/Cancel state even if the dialog is closed and reopened mid-run.
- **Movable and resizable dialog** — draggable title bar, a resize handle, a splitter between the object list and attribute pane, and per-column resize handles, all vanilla JS pointer-drag. Position/size/pane-split/column widths persist for the session.
- **Restart button** next to Debug — editor-preview sessions hide Save entirely (and "Start from the beginning" only lived inside the Save/Load dialog Save opens), so there was previously no way to restart a preview session at all. Includes a "Restarting…" overlay, since `Bridge.Initialise` (re-parsing the embedded Core library, confirmed not cacheable) blocks the single WASM UI thread for a couple of seconds with nothing else able to paint.
- `restartGame` now guards against overlapping calls — clicking Restart again while one was in flight used to race two concurrent `Bridge.Initialise`/`swapInPlayerUi` calls, which could leave old game output on screen alongside a stale "This game has finished" pane state.

## Test plan

- [x] `dotnet build --configuration Release` — full solution
- [x] `dotnet test --configuration Release` — 316 unit tests pass
- [x] `tests/e2e/verify-wasmplayer-debugger.mjs` (Playwright, run against `node src/WasmPlayer/dev-server.mjs`) — 42 checks covering the debugger UI, attribute override (success + error path), walkthrough run/cancel, move/resize/splitter/column-resize, and the restart guard/spinner/z-index fixes
- [x] Manually verified in-browser via screenshots at each step

🤖 Generated with [Claude Code](https://claude.com/claude-code)