### PR TITLE
feat(AppShell): add room Exits editor tab

### DIFF
--- a/src/AppShell/src/components/ConfirmDialog.svelte
+++ b/src/AppShell/src/components/ConfirmDialog.svelte
@@ -1,26 +1,29 @@
 <script lang="ts">
-    import { confirmState } from "$lib/confirm";
+    import { dialogState } from "$lib/confirm";
 
     let dialogEl = $state<HTMLDivElement>();
-    $effect(() => { if ($confirmState) dialogEl?.focus(); });
+    $effect(() => { if ($dialogState) dialogEl?.focus(); });
 
-    function respond(result: boolean) {
-        $confirmState?.resolve(result);
-        confirmState.set(null);
+    function respond(result: unknown) {
+        $dialogState?.resolve(result);
+        dialogState.set(null);
     }
 
+    // The last choice is treated as the primary/default action (filled button, rightmost) —
+    // matches how the 2-choice confirmDialog() wrapper orders [cancel, confirm].
     function handleKeydown(e: KeyboardEvent) {
-        if (e.key === "Escape") respond(false);
-        if (e.key === "Enter") respond(true);
+        if (!$dialogState) return;
+        if (e.key === "Escape") respond(null);
+        if (e.key === "Enter") respond($dialogState.choices.at(-1)?.value);
     }
 
     function onBackdropClick(e: MouseEvent) {
-        if (e.target === e.currentTarget) respond(false);
+        if (e.target === e.currentTarget) respond(null);
     }
 </script>
 
-{#if $confirmState}
-    {@const state = $confirmState}
+{#if $dialogState}
+    {@const state = $dialogState}
     <div
         bind:this={dialogEl}
         role="dialog"
@@ -34,11 +37,13 @@
             <p class="text-sm">{state.message}</p>
 
             <div class="flex justify-end gap-2">
-                <button class="btn btn-sm preset-tonal" onclick={() => respond(false)}>{state.cancelLabel}</button>
-                <button
-                    class={`btn btn-sm ${state.danger ? "preset-filled-error-500" : "preset-filled-primary-500"}`}
-                    onclick={() => respond(true)}
-                >{state.confirmLabel}</button>
+                {#each state.choices as choice, i (choice.label)}
+                    {@const isPrimary = i === state.choices.length - 1}
+                    <button
+                        class={`btn btn-sm ${isPrimary ? (choice.danger ? "preset-filled-error-500" : "preset-filled-primary-500") : "preset-tonal"}`}
+                        onclick={() => respond(choice.value)}
+                    >{choice.label}</button>
+                {/each}
             </div>
         </div>
     </div>

--- a/src/AppShell/src/components/ConfirmDialog.svelte
+++ b/src/AppShell/src/components/ConfirmDialog.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+    import { confirmState } from "$lib/confirm";
+
+    let dialogEl = $state<HTMLDivElement>();
+    $effect(() => { if ($confirmState) dialogEl?.focus(); });
+
+    function respond(result: boolean) {
+        $confirmState?.resolve(result);
+        confirmState.set(null);
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") respond(false);
+        if (e.key === "Enter") respond(true);
+    }
+
+    function onBackdropClick(e: MouseEvent) {
+        if (e.target === e.currentTarget) respond(false);
+    }
+</script>
+
+{#if $confirmState}
+    {@const state = $confirmState}
+    <div
+        bind:this={dialogEl}
+        role="dialog"
+        aria-modal="true"
+        tabindex="-1"
+        class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+        onclick={onBackdropClick}
+        onkeydown={handleKeydown}
+    >
+        <div class="card bg-white rounded-xl shadow-xl w-80 p-6 flex flex-col gap-4">
+            <p class="text-sm">{state.message}</p>
+
+            <div class="flex justify-end gap-2">
+                <button class="btn btn-sm preset-tonal" onclick={() => respond(false)}>{state.cancelLabel}</button>
+                <button
+                    class={`btn btn-sm ${state.danger ? "preset-filled-error-500" : "preset-filled-primary-500"}`}
+                    onclick={() => respond(true)}
+                >{state.confirmLabel}</button>
+            </div>
+        </div>
+    </div>
+{/if}

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-    import { selectNode, deleteChildElement, swapElements, createExit, getExitsData, createExitInDirection, createLookExitInDirection } from "$lib/editor-store";
-    import { confirmDialog } from "$lib/confirm";
+    import { selectNode, deleteChildElement, swapElements, createExit, getExitsData, createExitInDirection, createLookExitInDirection, scriptVersion } from "$lib/editor-store";
+    import { chooseDialog } from "$lib/confirm";
     import type { ExitsData, CompassDirectionInfo } from "$lib/types";
     import Combobox from "./Combobox.svelte";
 
@@ -16,7 +16,13 @@
     let createInverse = $state(true);
     let warning = $state<string | null>(null);
 
+    // scriptVersion bumps on undo/redo (see editor-store.ts) — this control's exits data is
+    // fetched separately from $selectedData, which refreshSelectedData() already handles on
+    // undo/redo, so without tracking scriptVersion here an undo that recreates/removes an exit
+    // wouldn't be reflected until switching tabs away and back (same pattern ScriptEditor.svelte
+    // uses for its own separately-fetched state).
     $effect(() => {
+        void $scriptVersion;
         refresh(elementKey);
     });
 
@@ -45,8 +51,13 @@
     async function deleteExit(exitKey: string, alias: string | null, to: string | null, lookOnly: boolean) {
         const reciprocalKey = findReciprocalExit(alias, to, lookOnly);
         if (reciprocalKey) {
-            const alsoDelete = await confirmDialog(`"${to}" has a matching return exit back to this room. Delete that one too?`, { confirmLabel: "Delete both", cancelLabel: "Just this one", danger: true });
-            if (alsoDelete) deleteChildElement(reciprocalKey);
+            const choice = await chooseDialog(`"${to}" has a matching return exit back to this room. Delete that one too?`, [
+                { label: "Cancel", value: "cancel" as const },
+                { label: "Just this one", value: "this" as const },
+                { label: "Delete both", value: "both" as const, danger: true },
+            ]);
+            if (choice === null || choice === "cancel") return;
+            if (choice === "both") deleteChildElement(reciprocalKey);
         }
         deleteChildElement(exitKey);
         refresh(elementKey);

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+    import { selectNode, deleteElement, swapElements, createExit, getExitsData, createExitInDirection, createLookExitInDirection } from "$lib/editor-store";
+    import type { ExitsData, CompassDirectionInfo } from "$lib/types";
+    import Combobox from "./Combobox.svelte";
+
+    interface Props {
+        elementKey: string;
+    }
+
+    let { elementKey }: Props = $props();
+
+    let data = $state<ExitsData | null>(null);
+    let openDirection = $state<string | null>(null);
+    let createTo = $state("");
+    let createInverse = $state(true);
+    let warning = $state<string | null>(null);
+
+    $effect(() => {
+        refresh(elementKey);
+    });
+
+    // Takes an explicit key rather than always reading the elementKey prop — deleteExit() below
+    // needs to keep operating on the room's key even after deleteElement() has (briefly) unmounted
+    // this component, at which point the live elementKey prop is no longer reliable.
+    function refresh(key: string) {
+        data = getExitsData(key);
+    }
+
+    // The deleted exit is always a child of elementKey (the currently-selected room), never the
+    // room itself — but deleteElement() unconditionally clears the current selection, which
+    // unmounts this component (PropertyEditor only renders it while $selectedKey is truthy). Capture
+    // the room key first so selectNode()/refresh() below don't run against a torn-down prop.
+    function deleteExit(exitKey: string) {
+        const roomKey = elementKey;
+        deleteElement(exitKey);
+        void selectNode(roomKey);
+        refresh(roomKey);
+    }
+
+    function moveUp(index: number) {
+        if (!data || index <= 0) return;
+        swapElements(data.allExits[index].key, data.allExits[index - 1].key);
+        refresh(elementKey);
+    }
+
+    function moveDown(index: number) {
+        if (!data || index >= data.allExits.length - 1) return;
+        swapElements(data.allExits[index].key, data.allExits[index + 1].key);
+        refresh(elementKey);
+    }
+
+    function toggleDirection(direction: string) {
+        if (openDirection === direction) {
+            openDirection = null;
+        } else {
+            openDirection = direction;
+            createTo = "";
+            createInverse = true;
+            warning = null;
+        }
+    }
+
+    function doCreate(direction: string) {
+        if (!createTo) return;
+        const result = createExitInDirection(elementKey, direction, createTo, createInverse);
+        if (result.startsWith("error:")) {
+            warning = result.slice("error:".length);
+            return;
+        }
+        if (result.startsWith("warning:")) {
+            warning = result.slice("warning:".length).split("|")[0];
+        } else {
+            openDirection = null;
+        }
+        refresh(elementKey);
+    }
+
+    function doCreateLook(direction: string) {
+        const result = createLookExitInDirection(elementKey, direction);
+        if (!result.startsWith("error:")) {
+            openDirection = null;
+        }
+        refresh(elementKey);
+    }
+
+    function addExit() {
+        createExit(elementKey);
+    }
+
+    const compassGrid = [0, 1, 2, 3, -1, 4, 5, 6, 7];
+    const directionGrid = [8, 10, 9, 11];
+</script>
+
+{#snippet directionCell(dir: CompassDirectionInfo | null | undefined)}
+    {#if !dir}
+        <div></div>
+    {:else if dir.exitKey !== null}
+        <div class="border border-surface-200-800 rounded p-1.5 bg-surface-50-950 min-h-14 flex flex-col gap-0.5">
+            <span class="text-[10px] uppercase text-surface-400-500">{dir.direction}</span>
+            <div class="flex items-center gap-1">
+                <button
+                    type="button"
+                    class="flex-1 text-left text-xs text-primary-600-400 hover:underline truncate"
+                    onclick={() => selectNode(dir.exitKey!)}
+                >{dir.lookOnly ? "(look)" : `→ ${dir.to}`}</button>
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-error-500 px-1 py-0 text-xs leading-none flex-shrink-0"
+                    title="Delete"
+                    onclick={() => deleteExit(dir.exitKey!)}
+                >×</button>
+            </div>
+        </div>
+    {:else}
+        <div class="border border-dashed border-surface-300-700 rounded p-1.5 min-h-14 flex flex-col gap-1">
+            <button
+                type="button"
+                class="text-xs text-surface-400-500 hover:text-primary-600-400 text-left"
+                onclick={() => toggleDirection(dir.direction)}
+            >+ {dir.direction}</button>
+            {#if openDirection === dir.direction && data}
+                <div class="flex flex-col gap-1 mt-1">
+                    <Combobox
+                        value={createTo}
+                        options={data.objects}
+                        onchange={(v) => { createTo = v; }}
+                        class="input text-xs py-0.5 px-1.5 w-full"
+                    />
+                    <label class="flex items-center gap-1.5 text-xs cursor-pointer">
+                        <input type="checkbox" class="checkbox size-3.5" bind:checked={createInverse} />
+                        Also create the return exit
+                    </label>
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                        disabled={!createTo}
+                        onclick={() => doCreate(dir.direction)}
+                    >Create exit</button>
+                    {#if data.allowLookExits}
+                        <button
+                            type="button"
+                            class="text-xs text-surface-400-500 hover:text-primary-600-400 underline text-left"
+                            onclick={() => doCreateLook(dir.direction)}
+                        >Create a look exit instead</button>
+                    {/if}
+                    {#if warning}
+                        <p class="text-xs text-warning-600-400">{warning}</p>
+                    {/if}
+                </div>
+            {/if}
+        </div>
+    {/if}
+{/snippet}
+
+<div class="flex flex-col w-full px-3 py-2 gap-3">
+    {#if data}
+        <div class="flex gap-4">
+            <div class="grid grid-cols-3 gap-1 w-48">
+                {#each compassGrid as idx (idx)}
+                    {@render directionCell(idx === -1 ? null : data.compass[idx])}
+                {/each}
+            </div>
+            <div class="grid grid-cols-2 gap-1 w-32">
+                {#each directionGrid as idx (idx)}
+                    {@render directionCell(data.compass[idx])}
+                {/each}
+            </div>
+        </div>
+
+        <div class="flex flex-col">
+            <div class="flex items-center gap-1 mb-2">
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                    onclick={addExit}
+                >+ Add Exit</button>
+            </div>
+
+            {#if data.allExits.length === 0}
+                <p class="text-xs text-surface-400-500 italic">No exits.</p>
+            {:else}
+                {#each data.allExits as exit, i (exit.key)}
+                    <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-center">
+                        <button
+                            type="button"
+                            class="flex-1 text-left text-xs px-1.5 py-1 pr-20 text-primary-600-400 hover:underline truncate"
+                            onclick={() => selectNode(exit.key)}
+                        >{exit.alias ?? "(none)"} → {exit.lookOnly ? "(look)" : (exit.to ?? "(nowhere)")}</button>
+                        <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                                title="Move up"
+                                disabled={i === 0}
+                                onclick={() => moveUp(i)}
+                            >↑</button>
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                                title="Move down"
+                                disabled={i === data.allExits.length - 1}
+                                onclick={() => moveDown(i)}
+                            >↓</button>
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
+                                title="Delete"
+                                onclick={() => deleteExit(exit.key)}
+                            >×</button>
+                        </div>
+                    </div>
+                {/each}
+            {/if}
+        </div>
+    {/if}
+</div>

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -23,11 +23,29 @@
         data = getExitsData(key);
     }
 
+    // Exits aren't stored as linked pairs — "also create the return exit" is a one-time
+    // convenience at creation time, not a persisted relationship — so the best a "return exit"
+    // can do is match by shape: the destination room having its own exit aliased to the inverse
+    // direction that points back to this room. Returns null for non-directional aliases (no
+    // inverse to look for) and for look exits (one-way by definition, no return exit possible).
+    function findReciprocalExit(alias: string | null, to: string | null, lookOnly: boolean): string | null {
+        if (!data || lookOnly || !alias || !to) return null;
+        const inverseDirection = data.compass.find(d => d.direction === alias)?.inverseDirection;
+        if (!inverseDirection) return null;
+        const destData = getExitsData(to);
+        const reciprocal = destData?.allExits.find(e => e.alias === inverseDirection && e.to === elementKey && !e.lookOnly);
+        return reciprocal?.key ?? null;
+    }
+
     // deleteChildElement() leaves the current selection alone (unlike deleteElement(), which
     // always clears it) — the exit being deleted here is always a child of elementKey (the room),
     // never the room itself, so there's nothing to reselect, and the room's own tabs/attributes
     // don't depend on which exits it has.
-    function deleteExit(exitKey: string) {
+    function deleteExit(exitKey: string, alias: string | null, to: string | null, lookOnly: boolean) {
+        const reciprocalKey = findReciprocalExit(alias, to, lookOnly);
+        if (reciprocalKey && confirm(`"${to}" has a matching return exit back to this room. Delete that one too?`)) {
+            deleteChildElement(reciprocalKey);
+        }
         deleteChildElement(exitKey);
         refresh(elementKey);
     }
@@ -103,7 +121,7 @@
                     type="button"
                     class="btn btn-sm preset-outlined-error-500 px-1 py-0 text-xs leading-none flex-shrink-0"
                     title="Delete"
-                    onclick={() => deleteExit(dir.exitKey!)}
+                    onclick={() => deleteExit(dir.exitKey!, dir.direction, dir.to, dir.lookOnly)}
                 >×</button>
             </div>
         </div>
@@ -216,7 +234,7 @@
                                 type="button"
                                 class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
                                 title="Delete"
-                                onclick={() => deleteExit(exit.key)}
+                                onclick={() => deleteExit(exit.key, exit.alias, exit.to, exit.lookOnly)}
                             >×</button>
                         </div>
                     </div>

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -95,12 +95,13 @@
     {#if !dir}
         <div></div>
     {:else if dir.exitKey !== null}
-        <div class="border border-surface-200-800 rounded p-1.5 bg-surface-50-950 min-h-14 flex flex-col gap-0.5">
-            <span class="text-[10px] uppercase text-surface-400-500">{dir.direction}</span>
-            <div class="flex items-center gap-1">
+        <div class="border border-surface-200-800 rounded p-1.5 bg-surface-50-950 min-h-14 min-w-0 flex flex-col gap-0.5">
+            <span class="text-[10px] uppercase text-surface-400-500 truncate">{dir.direction}</span>
+            <div class="flex items-center gap-1 min-w-0">
                 <button
                     type="button"
-                    class="flex-1 text-left text-xs text-primary-600-400 hover:underline truncate"
+                    class="flex-1 min-w-0 text-left text-xs text-primary-600-400 hover:underline truncate"
+                    title={dir.lookOnly ? undefined : (dir.to ?? undefined)}
                     onclick={() => selectNode(dir.exitKey!)}
                 >{dir.lookOnly ? "(look)" : `→ ${dir.to}`}</button>
                 <button
@@ -112,12 +113,12 @@
             </div>
         </div>
     {:else}
-        <div class="border border-dashed border-surface-300-700 rounded p-1.5 min-h-14 flex flex-col gap-1">
+        <div class="border border-dashed border-surface-300-700 rounded p-1.5 min-h-14 min-w-0 flex flex-col gap-1">
             <button
                 type="button"
-                class="text-xs text-surface-400-500 hover:text-primary-600-400 text-left"
+                class="text-xs text-surface-400-500 hover:text-primary-600-400 text-left truncate"
                 onclick={() => toggleDirection(dir.direction)}
-            >+ {dir.direction}</button>
+            >{dir.direction}</button>
             {#if openDirection === dir.direction && data}
                 <div class="flex flex-col gap-1 mt-1">
                     <Combobox
@@ -154,13 +155,13 @@
 
 <div class="flex flex-col w-full px-3 py-2 gap-3">
     {#if data}
-        <div class="flex gap-4">
-            <div class="grid grid-cols-3 gap-1 w-48">
+        <div class="flex gap-4 w-full max-w-xl">
+            <div class="grid grid-cols-3 gap-1.5 flex-[3] min-w-0">
                 {#each compassGrid as idx (idx)}
                     {@render directionCell(idx === -1 ? null : data.compass[idx])}
                 {/each}
             </div>
-            <div class="grid grid-cols-2 gap-1 w-32">
+            <div class="grid grid-cols-2 gap-1.5 flex-[2] min-w-0">
                 {#each directionGrid as idx (idx)}
                     {@render directionCell(data.compass[idx])}
                 {/each}

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -3,6 +3,7 @@
     import { chooseDialog } from "$lib/confirm";
     import type { ExitsData, CompassDirectionInfo } from "$lib/types";
     import Combobox from "./Combobox.svelte";
+    import Pencil from "@lucide/svelte/icons/pencil";
 
     interface Props {
         elementKey: string;
@@ -128,14 +129,26 @@
         <div></div>
     {:else if dir.exitKey !== null}
         <div class="border border-surface-200-800 rounded p-1.5 bg-surface-50-950 min-h-14 min-w-0 flex flex-col gap-0.5">
-            <span class="text-[10px] uppercase text-surface-400-500 truncate">{dir.direction}</span>
-            <div class="flex items-center gap-1 min-w-0">
+            <div class="flex items-center justify-between gap-1 min-w-0">
+                <span class="text-[10px] uppercase text-surface-400-500 truncate">{dir.direction}</span>
                 <button
                     type="button"
-                    class="flex-1 min-w-0 text-left text-xs text-primary-600-400 hover:underline truncate"
-                    title={dir.lookOnly ? undefined : (dir.to ?? undefined)}
+                    class="text-surface-400-500 hover:text-primary-600-400 flex-shrink-0"
+                    title="Edit exit"
                     onclick={() => selectNode(dir.exitKey!)}
-                >{dir.lookOnly ? "(look)" : `→ ${dir.to}`}</button>
+                ><Pencil size={11} /></button>
+            </div>
+            <div class="flex items-center gap-1 min-w-0">
+                {#if dir.lookOnly}
+                    <span class="flex-1 min-w-0 text-xs text-surface-500-400 truncate">(look)</span>
+                {:else}
+                    <button
+                        type="button"
+                        class="flex-1 min-w-0 text-left text-xs text-primary-600-400 hover:underline truncate"
+                        title={dir.to ?? undefined}
+                        onclick={() => selectNode(dir.to!)}
+                    >→ {dir.to}</button>
+                {/if}
                 <button
                     type="button"
                     class="btn btn-sm preset-outlined-error-500 px-1 py-0 text-xs leading-none flex-shrink-0"
@@ -229,12 +242,22 @@
             {:else}
                 {#each data.allExits as exit, i (exit.key)}
                     <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-center">
-                        <button
-                            type="button"
-                            class="flex-1 text-left text-xs px-1.5 py-1 pr-20 text-primary-600-400 hover:underline truncate"
-                            onclick={() => selectNode(exit.key)}
-                        >{exit.alias ?? "(none)"} → {exit.lookOnly ? "(look)" : (exit.to ?? "(nowhere)")}</button>
+                        {#if !exit.lookOnly && exit.to}
+                            <button
+                                type="button"
+                                class="flex-1 text-left text-xs px-1.5 py-1 pr-28 text-primary-600-400 hover:underline truncate"
+                                onclick={() => selectNode(exit.to!)}
+                            >{exit.alias ?? "(none)"} → {exit.to}</button>
+                        {:else}
+                            <span class="flex-1 text-xs px-1.5 py-1 pr-28 text-surface-500-400 truncate">{exit.alias ?? "(none)"} → {exit.lookOnly ? "(look)" : "(nowhere)"}</span>
+                        {/if}
                         <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none flex items-center"
+                                title="Edit exit"
+                                onclick={() => selectNode(exit.key)}
+                            ><Pencil size={12} /></button>
                             <button
                                 type="button"
                                 class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectNode, deleteChildElement, swapElements, createExit, getExitsData, createExitInDirection, createLookExitInDirection, scriptVersion } from "$lib/editor-store";
+    import { selectNode, deleteChildElement, deleteChildElements, swapElements, createExit, getExitsData, createExitInDirection, createLookExitInDirection, scriptVersion } from "$lib/editor-store";
     import { chooseDialog } from "$lib/confirm";
     import type { ExitsData, CompassDirectionInfo } from "$lib/types";
     import Combobox from "./Combobox.svelte";
@@ -44,10 +44,10 @@
         return reciprocal?.key ?? null;
     }
 
-    // deleteChildElement() leaves the current selection alone (unlike deleteElement(), which
-    // always clears it) — the exit being deleted here is always a child of elementKey (the room),
-    // never the room itself, so there's nothing to reselect, and the room's own tabs/attributes
-    // don't depend on which exits it has.
+    // deleteChildElement()/deleteChildElements() leave the current selection alone (unlike
+    // deleteElement(), which always clears it) — the exit being deleted here is always a child of
+    // elementKey (the room), never the room itself, so there's nothing to reselect, and the room's
+    // own tabs/attributes don't depend on which exits it has.
     async function deleteExit(exitKey: string, alias: string | null, to: string | null, lookOnly: boolean) {
         const reciprocalKey = findReciprocalExit(alias, to, lookOnly);
         if (reciprocalKey) {
@@ -57,7 +57,13 @@
                 { label: "Delete both", value: "both" as const, danger: true },
             ]);
             if (choice === null || choice === "cancel") return;
-            if (choice === "both") deleteChildElement(reciprocalKey);
+            // One call, one transaction — deleting each separately would open/close its own
+            // transaction, so a single Undo would only bring back the last of the two.
+            if (choice === "both") {
+                deleteChildElements([reciprocalKey, exitKey]);
+                refresh(elementKey);
+                return;
+            }
         }
         deleteChildElement(exitKey);
         refresh(elementKey);

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectNode, deleteElement, swapElements, createExit, getExitsData, createExitInDirection, createLookExitInDirection } from "$lib/editor-store";
+    import { selectNode, deleteChildElement, swapElements, createExit, getExitsData, createExitInDirection, createLookExitInDirection } from "$lib/editor-store";
     import type { ExitsData, CompassDirectionInfo } from "$lib/types";
     import Combobox from "./Combobox.svelte";
 
@@ -19,22 +19,17 @@
         refresh(elementKey);
     });
 
-    // Takes an explicit key rather than always reading the elementKey prop — deleteExit() below
-    // needs to keep operating on the room's key even after deleteElement() has (briefly) unmounted
-    // this component, at which point the live elementKey prop is no longer reliable.
     function refresh(key: string) {
         data = getExitsData(key);
     }
 
-    // The deleted exit is always a child of elementKey (the currently-selected room), never the
-    // room itself — but deleteElement() unconditionally clears the current selection, which
-    // unmounts this component (PropertyEditor only renders it while $selectedKey is truthy). Capture
-    // the room key first so selectNode()/refresh() below don't run against a torn-down prop.
+    // deleteChildElement() leaves the current selection alone (unlike deleteElement(), which
+    // always clears it) — the exit being deleted here is always a child of elementKey (the room),
+    // never the room itself, so there's nothing to reselect, and the room's own tabs/attributes
+    // don't depend on which exits it has.
     function deleteExit(exitKey: string) {
-        const roomKey = elementKey;
-        deleteElement(exitKey);
-        void selectNode(roomKey);
-        refresh(roomKey);
+        deleteChildElement(exitKey);
+        refresh(elementKey);
     }
 
     function moveUp(index: number) {

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -113,43 +113,15 @@
             </div>
         </div>
     {:else}
-        <div class="border border-dashed border-surface-300-700 rounded p-1.5 min-h-14 min-w-0 flex flex-col gap-1">
-            <button
-                type="button"
-                class="text-xs text-surface-400-500 hover:text-primary-600-400 text-left truncate"
-                onclick={() => toggleDirection(dir.direction)}
-            >{dir.direction}</button>
-            {#if openDirection === dir.direction && data}
-                <div class="flex flex-col gap-1 mt-1">
-                    <Combobox
-                        value={createTo}
-                        options={data.objects}
-                        onchange={(v) => { createTo = v; }}
-                        class="input text-xs py-0.5 px-1.5 w-full"
-                    />
-                    <label class="flex items-center gap-1.5 text-xs cursor-pointer">
-                        <input type="checkbox" class="checkbox size-3.5" bind:checked={createInverse} />
-                        Also create the return exit
-                    </label>
-                    <button
-                        type="button"
-                        class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
-                        disabled={!createTo}
-                        onclick={() => doCreate(dir.direction)}
-                    >Create exit</button>
-                    {#if data.allowLookExits}
-                        <button
-                            type="button"
-                            class="text-xs text-surface-400-500 hover:text-primary-600-400 underline text-left"
-                            onclick={() => doCreateLook(dir.direction)}
-                        >Create a look exit instead</button>
-                    {/if}
-                    {#if warning}
-                        <p class="text-xs text-warning-600-400">{warning}</p>
-                    {/if}
-                </div>
-            {/if}
-        </div>
+        {@const isOpen = openDirection === dir.direction}
+        <button
+            type="button"
+            class="border rounded p-1.5 min-h-14 min-w-0 flex items-center text-left text-xs transition-colors
+                {isOpen
+                    ? 'border-primary-500 bg-primary-50-950 text-primary-600-400'
+                    : 'border-dashed border-surface-300-700 text-surface-400-500 hover:border-primary-400 hover:text-primary-600-400'}"
+            onclick={() => toggleDirection(dir.direction)}
+        ><span class="truncate">{dir.direction}</span></button>
     {/if}
 {/snippet}
 
@@ -167,6 +139,49 @@
                 {/each}
             </div>
         </div>
+
+        <!-- Rendered as a separate block below the grids (rather than expanding the clicked cell
+             in place) so opening/closing it never changes the grid's own layout. -->
+        {#if openDirection}
+            <div class="border border-primary-300-700 rounded p-2.5 flex flex-col gap-1.5 bg-surface-50-950 w-full max-w-xl">
+                <div class="flex items-center justify-between">
+                    <span class="text-xs font-medium text-surface-600-400">Create exit: {openDirection}</span>
+                    <button
+                        type="button"
+                        class="text-xs text-surface-400-500 hover:text-surface-600-400"
+                        onclick={() => { openDirection = null; }}
+                    >✕</button>
+                </div>
+                <Combobox
+                    value={createTo}
+                    options={data.objects}
+                    onchange={(v) => { createTo = v; }}
+                    class="input text-xs py-0.5 px-1.5 w-full"
+                />
+                <label class="flex items-center gap-1.5 text-xs cursor-pointer">
+                    <input type="checkbox" class="checkbox size-3.5" bind:checked={createInverse} />
+                    Also create the return exit
+                </label>
+                <div class="flex items-center gap-3">
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                        disabled={!createTo}
+                        onclick={() => doCreate(openDirection!)}
+                    >Create exit</button>
+                    {#if data.allowLookExits}
+                        <button
+                            type="button"
+                            class="text-xs text-surface-400-500 hover:text-primary-600-400 underline text-left"
+                            onclick={() => doCreateLook(openDirection!)}
+                        >Create a look exit instead</button>
+                    {/if}
+                </div>
+                {#if warning}
+                    <p class="text-xs text-warning-600-400">{warning}</p>
+                {/if}
+            </div>
+        {/if}
 
         <div class="flex flex-col">
             <div class="flex items-center gap-1 mb-2">

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { selectNode, deleteChildElement, swapElements, createExit, getExitsData, createExitInDirection, createLookExitInDirection } from "$lib/editor-store";
+    import { confirmDialog } from "$lib/confirm";
     import type { ExitsData, CompassDirectionInfo } from "$lib/types";
     import Combobox from "./Combobox.svelte";
 
@@ -41,10 +42,11 @@
     // always clears it) — the exit being deleted here is always a child of elementKey (the room),
     // never the room itself, so there's nothing to reselect, and the room's own tabs/attributes
     // don't depend on which exits it has.
-    function deleteExit(exitKey: string, alias: string | null, to: string | null, lookOnly: boolean) {
+    async function deleteExit(exitKey: string, alias: string | null, to: string | null, lookOnly: boolean) {
         const reciprocalKey = findReciprocalExit(alias, to, lookOnly);
-        if (reciprocalKey && confirm(`"${to}" has a matching return exit back to this room. Delete that one too?`)) {
-            deleteChildElement(reciprocalKey);
+        if (reciprocalKey) {
+            const alsoDelete = await confirmDialog(`"${to}" has a matching return exit back to this room. Delete that one too?`, { confirmLabel: "Delete both", cancelLabel: "Just this one", danger: true });
+            if (alsoDelete) deleteChildElement(reciprocalKey);
         }
         deleteChildElement(exitKey);
         refresh(elementKey);
@@ -121,7 +123,7 @@
                     type="button"
                     class="btn btn-sm preset-outlined-error-500 px-1 py-0 text-xs leading-none flex-shrink-0"
                     title="Delete"
-                    onclick={() => deleteExit(dir.exitKey!, dir.direction, dir.to, dir.lookOnly)}
+                    onclick={() => void deleteExit(dir.exitKey!, dir.direction, dir.to, dir.lookOnly)}
                 >×</button>
             </div>
         </div>
@@ -131,8 +133,8 @@
             type="button"
             class="border rounded p-1.5 min-h-14 min-w-0 flex items-center text-left text-xs transition-colors
                 {isOpen
-                    ? 'border-primary-500 bg-primary-50-950 text-primary-600-400'
-                    : 'border-dashed border-surface-300-700 text-surface-400-500 hover:border-primary-400 hover:text-primary-600-400'}"
+                    ? "border-primary-500 bg-primary-50-950 text-primary-600-400"
+                    : "border-dashed border-surface-300-700 text-surface-400-500 hover:border-primary-400 hover:text-primary-600-400"}"
             onclick={() => toggleDirection(dir.direction)}
         ><span class="truncate">{dir.direction}</span></button>
     {/if}
@@ -234,7 +236,7 @@
                                 type="button"
                                 class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
                                 title="Delete"
-                                onclick={() => deleteExit(exit.key, exit.alias, exit.to, exit.lookOnly)}
+                                onclick={() => void deleteExit(exit.key, exit.alias, exit.to, exit.lookOnly)}
                             >×</button>
                         </div>
                     </div>

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -7,6 +7,7 @@
     import ListEditor from "./ListEditor.svelte";
     import ElementsList from "./ElementsList.svelte";
     import AssetPicker from "./AssetPicker.svelte";
+    import ExitsEditor from "./ExitsEditor.svelte";
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
@@ -395,6 +396,8 @@
             objectType={ctrl.objectType}
             listFilter={ctrl.listFilter}
         />
+    {:else if ctrl.controlType === "exits" && $selectedKey}
+        <ExitsEditor elementKey={$selectedKey} />
     {:else if ctrl.attribute !== null}
         {#if ctrl.controlType === "checkbox"}
             <label class="flex items-center gap-2 px-3 py-1.5 min-h-8 cursor-pointer">

--- a/src/AppShell/src/lib/confirm.ts
+++ b/src/AppShell/src/lib/confirm.ts
@@ -1,29 +1,45 @@
 import { writable } from "svelte/store";
 
+export interface DialogChoice<T> {
+    label: string;
+    value: T;
+    danger?: boolean;
+}
+
+interface DialogState {
+    message: string;
+    choices: DialogChoice<unknown>[];
+    resolve: (result: unknown) => void;
+}
+
+export const dialogState = writable<DialogState | null>(null);
+
+// General N-choice prompt rendered through ConfirmDialog.svelte (mounted once in +layout.svelte).
+// Resolves with the chosen value, or null if dismissed via Escape/backdrop click without choosing.
+// The store itself is untyped (a single instance is shared across every call site, each with its
+// own T) — type safety lives at the call site via this function's generic parameter.
+export function chooseDialog<T>(message: string, choices: DialogChoice<T>[]): Promise<T | null> {
+    return new Promise(resolve => {
+        dialogState.set({
+            message,
+            choices: choices as DialogChoice<unknown>[],
+            resolve: resolve as (result: unknown) => void,
+        });
+    });
+}
+
 export interface ConfirmOptions {
     confirmLabel?: string;
     cancelLabel?: string;
     danger?: boolean;
 }
 
-interface ConfirmState extends Required<ConfirmOptions> {
-    message: string;
-    resolve: (result: boolean) => void;
-}
-
-export const confirmState = writable<ConfirmState | null>(null);
-
-// Promise-based stand-in for window.confirm() — resolves true/false the same way, but renders
-// through ConfirmDialog.svelte (mounted once in +layout.svelte) so it looks like the rest of the
-// app instead of the browser's native dialog chrome.
-export function confirmDialog(message: string, options?: ConfirmOptions): Promise<boolean> {
-    return new Promise(resolve => {
-        confirmState.set({
-            message,
-            confirmLabel: options?.confirmLabel ?? "OK",
-            cancelLabel: options?.cancelLabel ?? "Cancel",
-            danger: options?.danger ?? false,
-            resolve,
-        });
-    });
+// Two-choice convenience wrapper — promise-based stand-in for window.confirm(), resolving
+// true/false the same way (Escape/backdrop dismissal counts as false, i.e. "cancel").
+export async function confirmDialog(message: string, options?: ConfirmOptions): Promise<boolean> {
+    const result = await chooseDialog(message, [
+        { label: options?.cancelLabel ?? "Cancel", value: false },
+        { label: options?.confirmLabel ?? "OK", value: true, danger: options?.danger },
+    ]);
+    return result ?? false;
 }

--- a/src/AppShell/src/lib/confirm.ts
+++ b/src/AppShell/src/lib/confirm.ts
@@ -1,0 +1,29 @@
+import { writable } from "svelte/store";
+
+export interface ConfirmOptions {
+    confirmLabel?: string;
+    cancelLabel?: string;
+    danger?: boolean;
+}
+
+interface ConfirmState extends Required<ConfirmOptions> {
+    message: string;
+    resolve: (result: boolean) => void;
+}
+
+export const confirmState = writable<ConfirmState | null>(null);
+
+// Promise-based stand-in for window.confirm() — resolves true/false the same way, but renders
+// through ConfirmDialog.svelte (mounted once in +layout.svelte) so it looks like the rest of the
+// app instead of the browser's native dialog chrome.
+export function confirmDialog(message: string, options?: ConfirmOptions): Promise<boolean> {
+    return new Promise(resolve => {
+        confirmState.set({
+            message,
+            confirmLabel: options?.confirmLabel ?? "OK",
+            cancelLabel: options?.cancelLabel ?? "Cancel",
+            danger: options?.danger ?? false,
+            resolve,
+        });
+    });
+}

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -6,7 +6,7 @@ import type { AssetInfo, FileAdapter } from "./filesystem/types";
 import { LocalDraftAdapter, shouldShowBackupBanner, markBackupBannerResolved } from "./filesystem/local-adapter";
 import { ServerFileAdapter } from "./filesystem/server-adapter";
 import { triggerDownload } from "./filesystem/download";
-import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData } from "./types";
+import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData, ExitsData } from "./types";
 
 export type AddElementModalState = { type: "room" | "object" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
 
@@ -908,5 +908,35 @@ export function swapElements(key1: string, key2: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SwapElements(key1, key2);
     if (result === "ok") refreshTree();
+    return result;
+}
+
+// ── Exits editor ─────────────────────────────────────────────────────────────
+
+export function getExitsData(roomKey: string): ExitsData | null {
+    if (!_bridge) return null;
+    const json = _bridge.GetExitsData(roomKey);
+    return json ? JSON.parse(json) : null;
+}
+
+// Deliberately doesn't call selectNode() (unlike the create* helpers above via afterCreate) —
+// quick-creating a directional exit should keep the room itself selected/in view.
+export function createExitInDirection(roomKey: string, direction: string, to: string, createInverse: boolean): string {
+    if (!_bridge) return "error:not loaded";
+    const result = _bridge.CreateExitInDirection(roomKey, direction, to, createInverse);
+    if (!result.startsWith("error:")) {
+        refreshTree();
+        refreshUndoRedo();
+    }
+    return result;
+}
+
+export function createLookExitInDirection(roomKey: string, direction: string): string {
+    if (!_bridge) return "error:not loaded";
+    const result = _bridge.CreateLookExitInDirection(roomKey, direction);
+    if (!result.startsWith("error:")) {
+        refreshTree();
+        refreshUndoRedo();
+    }
     return result;
 }

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -917,6 +917,16 @@ export function deleteChildElement(key: string) {
     refreshUndoRedo();
 }
 
+// Same as deleteChildElement(), but wraps every deletion in one transaction — deleting them one
+// at a time would each open/close their own transaction, so a single Undo would only restore the
+// last of them.
+export function deleteChildElements(keys: string[]) {
+    if (!_bridge) return;
+    _bridge.DeleteElements(JSON.stringify(keys));
+    refreshTree();
+    refreshUndoRedo();
+}
+
 export function swapElements(key1: string, key2: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SwapElements(key1, key2);

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -904,6 +904,19 @@ export function deleteElement(key: string) {
     refreshUndoRedo();
 }
 
+// For deleting a child of the currently-selected node (e.g. a room's exit) where the parent's own
+// tabs/attributes don't depend on that child's existence — leaves selectedKey/selectedData alone
+// so the parent stays selected and PropertyEditor's active tab doesn't reset. deleteElement() above
+// always clears the selection, which is right when the deleted item might itself be selected, but
+// briefly nulling it out here would make PropertyEditor treat the reselect as a "different node"
+// and jump back to its first tab.
+export function deleteChildElement(key: string) {
+    if (!_bridge) return;
+    _bridge.DeleteElement(key);
+    refreshTree();
+    refreshUndoRedo();
+}
+
 export function swapElements(key1: string, key2: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SwapElements(key1, key2);

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -44,6 +44,30 @@ export interface EditorDataResponse {
   controls: ControlInfo[]
 }
 
+export interface CompassDirectionInfo {
+  direction: string
+  typeKey: string
+  inverseDirection: string
+  inverseTypeKey: string
+  exitKey: string | null
+  to: string | null
+  lookOnly: boolean
+}
+
+export interface ExitRowInfo {
+  key: string
+  alias: string | null
+  to: string | null
+  lookOnly: boolean
+}
+
+export interface ExitsData {
+  compass: CompassDirectionInfo[]
+  allExits: ExitRowInfo[]
+  objects: ControlOption[]
+  allowLookExits: boolean
+}
+
 export interface ScriptControlData {
   controlType: string
   caption: string | null

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -78,6 +78,7 @@ export interface WasmBridge {
   CreateIncludedLibrary(): string
   CreateJavascript(): string
   DeleteElement(key: string): void
+  DeleteElements(keysJson: string): void
   SwapElements(key1: string, key2: string): string
   // New game
   GetGameTemplates(): string

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -65,6 +65,9 @@ export interface WasmBridge {
   CreateFunction(name: string): string
   CreateTimer(name: string): string
   CreateExit(parent: string): string
+  GetExitsData(roomKey: string): string
+  CreateExitInDirection(roomKey: string, direction: string, to: string, createInverse: boolean): string
+  CreateLookExitInDirection(roomKey: string, direction: string): string
   CreateTurnScript(parent: string): string
   CreateCommand(parent: string): string
   CreateVerb(parent: string): string

--- a/src/AppShell/src/routes/+layout.svelte
+++ b/src/AppShell/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
     import { isElectron } from "$lib/runtime";
     import HomeHeader from "$components/HomeHeader.svelte";
     import HomeTabs from "$components/HomeTabs.svelte";
+    import ConfirmDialog from "$components/ConfirmDialog.svelte";
 
     let { children }: { children: Snippet } = $props();
 
@@ -122,3 +123,4 @@
     </div>
 {/if}
 {@render children()}
+<ConfirmDialog />

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -5,6 +5,7 @@
     import { base } from "$app/paths";
     import { PUBLIC_HAS_SERVER } from "$env/static/public";
     import { openGame, loadingStatus } from "$lib/editor-store";
+    import { confirmDialog } from "$lib/confirm";
     import { hasFSA, openDirectory, loadFileFromDirectory, createLocalGame } from "$lib/filesystem/browser-adapter";
     import {
         openElectronFile, loadElectronFile, createElectronGame, getDefaultGamesDir, pickGameLocation,
@@ -326,7 +327,8 @@
     }
 
     async function handleDeleteDraft(gameId: string, filename: string) {
-        if (!confirm(`Delete the local draft "${filename}"? This can't be undone.`)) return;
+        const confirmed = await confirmDialog(`Delete the local draft "${filename}"? This can't be undone.`, { confirmLabel: "Delete", danger: true });
+        if (!confirmed) return;
         await deleteLocalDraft(gameId);
         await refreshDrafts();
     }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -1970,6 +1970,32 @@ public partial class WasmEditorBridge
         _controller?.DeleteElement(key, true);
     }
 
+    // Wraps every deletion in a single transaction (mirrors v5's ExitsControl.xaml.cs
+    // toolbar_DeleteClicked) so one Undo reverts all of them together — calling DeleteElement()
+    // once per key instead would open/close its own transaction each time, so Undo would only
+    // restore the last one.
+    [JSExport]
+    public static void DeleteElements(string keysJson)
+    {
+        if (_controller == null)
+        {
+            return;
+        }
+
+        var keys = JsonSerializer.Deserialize(keysJson, WasmEditorJsonContext.Default.ListString);
+        if (keys == null || keys.Count == 0)
+        {
+            return;
+        }
+
+        _controller.StartTransaction($"Delete {keys.Count} elements");
+        foreach (var key in keys)
+        {
+            _controller.DeleteElement(key, false);
+        }
+        _controller.EndTransaction();
+    }
+
     [JSExport]
     public static string SwapElements(string key1, string key2)
     {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -106,6 +106,23 @@ internal record FullAttributeData(List<AttributeDataItem> Attributes, List<Attri
 
 internal record GameTemplateInfo(string Id, string Label, string Type);
 
+internal record CompassDirectionInfo(
+    string Direction,
+    string TypeKey,
+    string InverseDirection,
+    string InverseTypeKey,
+    string? ExitKey,
+    string? To,
+    bool LookOnly);
+
+internal record ExitRowInfo(string Key, string? Alias, string? To, bool LookOnly);
+
+internal record ExitsData(
+    List<CompassDirectionInfo> Compass,
+    List<ExitRowInfo> AllExits,
+    List<ControlOption> Objects,
+    bool AllowLookExits);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
 [JsonSerializable(typeof(EditorDataResponse))]
@@ -118,6 +135,7 @@ internal record GameTemplateInfo(string Id, string Label, string Type);
 [JsonSerializable(typeof(List<ListItemData>))]
 [JsonSerializable(typeof(FullAttributeData))]
 [JsonSerializable(typeof(List<GameTemplateInfo>))]
+[JsonSerializable(typeof(ExitsData))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext
 {
 }
@@ -1595,6 +1613,167 @@ public partial class WasmEditorBridge
         try
         {
             return _controller.CreateNewExit(parent);
+        }
+        catch (Exception ex)
+        {
+            return $"error:{ex.Message}";
+        }
+    }
+
+    // Index-based opposite-direction lookup into the 12-entry compass list
+    // (NW,N,NE,W,E,SW,S,SE,Up,Down,In,Out) — ported from v5's ExitsControl.xaml.cs so it stays
+    // correct regardless of the localized caption text.
+    private static readonly int[] OppositeDirs = [7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 11, 10];
+
+    private static IEditorControl? FindExitsControl(string roomKey)
+    {
+        if (_controller == null)
+        {
+            return null;
+        }
+
+        var editorName = _controller.GetElementEditorName(roomKey);
+        if (editorName == null)
+        {
+            return null;
+        }
+
+        var def = _controller.GetEditorDefinition(editorName);
+        return def.Tabs.Values.SelectMany(t => t.Controls)
+            .FirstOrDefault(c => c.ControlType == "exits");
+    }
+
+    [JSExport]
+    public static string GetExitsData(string roomKey)
+    {
+        var empty = new ExitsData([], [], [], false);
+        if (_controller == null)
+        {
+            return JsonSerializer.Serialize(empty, WasmEditorJsonContext.Default.ExitsData);
+        }
+
+        var exitsControl = FindExitsControl(roomKey);
+        if (exitsControl == null)
+        {
+            return JsonSerializer.Serialize(empty, WasmEditorJsonContext.Default.ExitsData);
+        }
+
+        var directions = exitsControl.GetListString("compass").ToList();
+        var types = exitsControl.GetDictionary("compasstypes");
+
+        var compass = directions.Select((d, i) => new CompassDirectionInfo(
+            d, types[d], directions[OppositeDirs[i]], types[directions[OppositeDirs[i]]],
+            null, null, false)).ToList();
+
+        var allExits = new List<ExitRowInfo>();
+        foreach (var exitKey in _controller.GetObjectNames("exit", roomKey, true))
+        {
+            var data = _controller.GetEditorData(exitKey);
+            var to = data.GetAttribute("to") as IEditableObjectReference;
+            var alias = data.GetAttribute("alias") as string;
+            var lookOnly = data.GetAttribute("lookonly") as bool? == true;
+            allExits.Add(new ExitRowInfo(exitKey, alias, to?.Reference, lookOnly));
+
+            var dirIndex = alias != null ? directions.IndexOf(alias) : -1;
+            if (dirIndex >= 0)
+            {
+                compass[dirIndex] = compass[dirIndex] with
+                {
+                    ExitKey = exitKey, To = to?.Reference, LookOnly = lookOnly
+                };
+            }
+        }
+
+        var objects = _controller.GetObjectNames("object")
+            .Where(n => n != roomKey)
+            .OrderBy(n => n, StringComparer.CurrentCultureIgnoreCase)
+            .Select(n => new ControlOption(n, n)).ToList();
+
+        var gameData = _controller.GetEditorData("game");
+        var allowLookExits = gameData?.GetAttribute("allowlookdirections") as bool? ?? false;
+
+        var result = new ExitsData(compass, allExits, objects, allowLookExits);
+        return JsonSerializer.Serialize(result, WasmEditorJsonContext.Default.ExitsData);
+    }
+
+    [JSExport]
+    public static string CreateExitInDirection(string roomKey, string direction, string to, bool createInverse)
+    {
+        if (_controller == null)
+        {
+            return "error:Not initialised";
+        }
+
+        var exitsControl = FindExitsControl(roomKey);
+        if (exitsControl == null)
+        {
+            return "error:No exits control found";
+        }
+
+        var directions = exitsControl.GetListString("compass").ToList();
+        var types = exitsControl.GetDictionary("compasstypes");
+        var dirIndex = directions.IndexOf(direction);
+        if (dirIndex < 0)
+        {
+            return "error:Unknown direction";
+        }
+
+        var type = types[direction];
+
+        try
+        {
+            if (!createInverse)
+            {
+                return _controller.CreateNewExit(roomKey, to, direction, type, false);
+            }
+
+            var inverseDirection = directions[OppositeDirs[dirIndex]];
+            var inverseType = types[inverseDirection];
+
+            var inverseAlreadyExists = _controller.GetObjectNames("exit", to, true).Any(exitKey =>
+            {
+                var data = _controller.GetEditorData(exitKey);
+                var lookOnly = data.GetAttribute("lookonly") as bool? == true;
+                return !lookOnly && data.GetAttribute("alias") as string == inverseDirection;
+            });
+
+            if (inverseAlreadyExists)
+            {
+                var newExit = _controller.CreateNewExit(roomKey, to, direction, type, false);
+                return $"warning:An exit already exists in that direction from the destination room|{newExit}";
+            }
+
+            return _controller.CreateNewExit(roomKey, to, direction, inverseDirection, type, inverseType);
+        }
+        catch (Exception ex)
+        {
+            return $"error:{ex.Message}";
+        }
+    }
+
+    [JSExport]
+    public static string CreateLookExitInDirection(string roomKey, string direction)
+    {
+        if (_controller == null)
+        {
+            return "error:Not initialised";
+        }
+
+        var exitsControl = FindExitsControl(roomKey);
+        if (exitsControl == null)
+        {
+            return "error:No exits control found";
+        }
+
+        var types = exitsControl.GetDictionary("compasstypes");
+        if (!types.TryGetValue(direction, out var type))
+        {
+            return "error:Unknown direction";
+        }
+
+        try
+        {
+            return _controller.CreateNewExit(roomKey, null, direction, type, true);
         }
         catch (Exception ex)
         {

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -108,14 +108,16 @@ async function run() {
     await listRow.hover();
     await listRow.locator('button[title="Delete"]').click();
 
-    // Deleting resets the active tab to the first one (Setup) — same pre-existing behavior as
-    // ElementsList's delete-then-reselect-parent elsewhere in the app, not specific to this
-    // feature. Room One itself must still be the selected tree node throughout, though.
+    // Room One must stay selected AND the Exits tab must stay active — deleting an exit doesn't
+    // touch the current selection at all (unlike the generic deleteElement() used elsewhere,
+    // which always clears it), so there's no reselect for PropertyEditor to mistake for switching
+    // to a different node and reset the active tab.
     await page.waitForSelector('[data-value="Room One"][data-selected]', { timeout: 10000 });
-    await page.click('button:has-text("Exits")');
     await page.getByRole('button', { name: 'north', exact: true }).waitFor({ timeout: 10000 });
     await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
-    console.log('PASS: deleting an exit removes it and keeps Room One selected');
+    const exitsTabStillActive = await page.locator('button:has-text("Exits")').getAttribute('class');
+    if (!exitsTabStillActive?.includes('border-primary-500')) throw new Error('Expected Exits tab to remain the active tab after deleting an exit');
+    console.log('PASS: deleting an exit removes it, keeps Room One selected, and stays on the Exits tab');
 
     console.log('PASS: all checks passed');
 }

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -11,15 +11,15 @@ const page = await browser.newPage();
 page.on('pageerror', err => console.log('[pageerror]', err.message));
 page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
 
-// Deleting an exit that has a matching return exit prompts via a native confirm() dialog —
-// default to dismissing it (keep the reciprocal) unless a specific check below wants to accept.
-let lastDialogMessage = null;
-let dialogAction = 'dismiss';
-page.on('dialog', async dialog => {
-    lastDialogMessage = dialog.message();
-    if (dialogAction === 'accept') await dialog.accept();
-    else await dialog.dismiss();
-});
+// Deleting an exit that has a matching return exit prompts via ConfirmDialog.svelte (a custom
+// styled stand-in for window.confirm(), not a native browser dialog).
+async function respondToReciprocalPrompt(accept) {
+    const dialog = page.locator('[role="dialog"]').filter({ hasText: 'matching return exit' });
+    await dialog.waitFor({ timeout: 10000 });
+    const message = await dialog.locator('p').textContent();
+    await dialog.getByRole('button', { name: accept ? 'Delete both' : 'Just this one' }).click();
+    return message;
+}
 
 async function addRoom(name) {
     await page.click('button[title="Add element"]');
@@ -127,11 +127,10 @@ async function run() {
     await rowButton.waitFor({ timeout: 10000 });
     const listRow = rowButton.locator('..');
     await listRow.hover();
-    dialogAction = 'dismiss';
-    lastDialogMessage = null;
     await listRow.locator('button[title="Delete"]').click();
+    const dismissMessage = await respondToReciprocalPrompt(false);
     await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
-    if (!lastDialogMessage?.includes('Room Two')) throw new Error(`Expected a "delete the return exit" prompt mentioning Room Two, got: ${lastDialogMessage}`);
+    if (!dismissMessage?.includes('Room Two')) throw new Error(`Expected a "delete the return exit" prompt mentioning Room Two, got: ${dismissMessage}`);
     console.log('PASS: deleting an exit with a reciprocal prompts to also delete the return exit');
 
     // Room One must stay selected AND the Exits tab must stay active — deleting an exit doesn't
@@ -161,11 +160,10 @@ async function run() {
     await page.click('button:has-text("Create exit")');
     await page.waitForSelector('text=→ Room Two', { timeout: 10000 });
 
-    dialogAction = 'accept';
-    lastDialogMessage = null;
     await page.getByRole('button', { name: '→ Room Two', exact: true }).locator('..').locator('button[title="Delete"]').click();
+    const acceptMessage = await respondToReciprocalPrompt(true);
     await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
-    if (!lastDialogMessage) throw new Error('Expected a "delete the return exit" prompt for the west/east pair');
+    if (!acceptMessage) throw new Error('Expected a "delete the return exit" prompt for the west/east pair');
 
     // Check specifically the "east" cell went back to empty — Room Two's still-alive south exit
     // (from the dismissed prompt above) also reads "→ Room One", so that text alone is ambiguous.

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -11,6 +11,16 @@ const page = await browser.newPage();
 page.on('pageerror', err => console.log('[pageerror]', err.message));
 page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
 
+// Deleting an exit that has a matching return exit prompts via a native confirm() dialog —
+// default to dismissing it (keep the reciprocal) unless a specific check below wants to accept.
+let lastDialogMessage = null;
+let dialogAction = 'dismiss';
+page.on('dialog', async dialog => {
+    lastDialogMessage = dialog.message();
+    if (dialogAction === 'accept') await dialog.accept();
+    else await dialog.dismiss();
+});
+
 async function addRoom(name) {
     await page.click('button[title="Add element"]');
     await page.click('.add-dropdown button:has-text("Add Room")', { timeout: 5000 });
@@ -18,6 +28,16 @@ async function addRoom(name) {
     await page.fill('#element-name', name);
     await page.click('[role="dialog"] button:has-text("Add")');
     await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+// A leaf node's clickable row is [data-part="item"], but once it gains a child it becomes a
+// branch whose OWN [role="treeitem"] wrapper also (confusingly) carries the same data-value on
+// its nested (always-visible) [data-part="branch-control"] AND on its hidden-when-collapsed
+// [data-part="branch-content"] — a plain [data-value="X"] selector can resolve to any of those
+// three and occasionally lands on the hidden one. Match only the two parts that are ever the
+// actual clickable row.
+async function selectTreeNode(name) {
+    await page.locator(`[data-value="${name}"][data-part="item"], [data-value="${name}"][data-part="branch-control"]`).first().click();
 }
 
 async function run() {
@@ -44,7 +64,7 @@ async function run() {
     console.log('PASS: created Room One and Room Two');
 
     // Select Room One in the tree and open its Exits tab.
-    await page.click('[data-value="Room One"]');
+    await selectTreeNode('Room One');
     await page.waitForSelector('button:has-text("Exits")', { timeout: 10000 });
     await page.click('button:has-text("Exits")');
     await page.getByRole('button', { name: 'north', exact: true }).waitFor({ timeout: 10000 });
@@ -76,7 +96,7 @@ async function run() {
     console.log('PASS: Room One stays selected after quick-create (no unwanted navigation)');
 
     // Switch to Room Two and confirm the reciprocal South exit was created.
-    await page.click('[data-value="Room Two"]');
+    await selectTreeNode('Room Two');
     await page.waitForSelector('button:has-text("Exits")', { timeout: 10000 });
     await page.click('button:has-text("Exits")');
     await page.waitForSelector('text=→ Room One', { timeout: 10000 });
@@ -92,7 +112,7 @@ async function run() {
     console.log('PASS: clicking an existing exit navigates to its own working editor page');
 
     // Back on Room One, create a "look" exit (east) — no destination room, one-way.
-    await page.click('[data-value="Room One"]');
+    await selectTreeNode('Room One');
     await page.waitForSelector('button:has-text("Exits")', { timeout: 10000 });
     await page.click('button:has-text("Exits")');
     await page.getByRole('button', { name: 'east', exact: true }).click();
@@ -100,13 +120,19 @@ async function run() {
     await page.waitForSelector('text=(look)', { timeout: 10000 });
     console.log('PASS: "Create a look exit instead" creates a one-way look exit with no destination');
 
-    // Go back to Room One and delete the north exit via the full list, room should stay selected.
+    // Go back to Room One and delete the north exit via the full list, dismissing the "delete the
+    // return exit too?" prompt (north/Room Two has a matching reciprocal — south/Room One).
     await page.click('button:has-text("Exits")');
     const rowButton = page.getByRole('button', { name: 'north → Room Two', exact: true });
     await rowButton.waitFor({ timeout: 10000 });
     const listRow = rowButton.locator('..');
     await listRow.hover();
+    dialogAction = 'dismiss';
+    lastDialogMessage = null;
     await listRow.locator('button[title="Delete"]').click();
+    await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
+    if (!lastDialogMessage?.includes('Room Two')) throw new Error(`Expected a "delete the return exit" prompt mentioning Room Two, got: ${lastDialogMessage}`);
+    console.log('PASS: deleting an exit with a reciprocal prompts to also delete the return exit');
 
     // Room One must stay selected AND the Exits tab must stay active — deleting an exit doesn't
     // touch the current selection at all (unlike the generic deleteElement() used elsewhere,
@@ -114,10 +140,39 @@ async function run() {
     // to a different node and reset the active tab.
     await page.waitForSelector('[data-value="Room One"][data-selected]', { timeout: 10000 });
     await page.getByRole('button', { name: 'north', exact: true }).waitFor({ timeout: 10000 });
-    await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
     const exitsTabStillActive = await page.locator('button:has-text("Exits")').getAttribute('class');
     if (!exitsTabStillActive?.includes('border-primary-500')) throw new Error('Expected Exits tab to remain the active tab after deleting an exit');
     console.log('PASS: deleting an exit removes it, keeps Room One selected, and stays on the Exits tab');
+
+    // Dismissing the prompt must leave the reciprocal (south/Room One) alone in Room Two.
+    await selectTreeNode('Room Two');
+    await page.click('button:has-text("Exits")');
+    await page.getByRole('button', { name: '→ Room One', exact: true }).waitFor({ timeout: 10000 });
+    console.log('PASS: dismissing the prompt leaves the return exit (south → Room One) in place');
+
+    // Now create a fresh west/east pair and accept the prompt this time — both ends should go.
+    await selectTreeNode('Room One');
+    await page.click('button:has-text("Exits")');
+    await page.getByRole('button', { name: 'west', exact: true }).click();
+    await combobox.click();
+    await combobox.fill('Room Two');
+    await page.waitForSelector('[role="option"]:has-text("Room Two")', { timeout: 5000 });
+    await page.click('[role="option"]:has-text("Room Two")');
+    await page.click('button:has-text("Create exit")');
+    await page.waitForSelector('text=→ Room Two', { timeout: 10000 });
+
+    dialogAction = 'accept';
+    lastDialogMessage = null;
+    await page.getByRole('button', { name: '→ Room Two', exact: true }).locator('..').locator('button[title="Delete"]').click();
+    await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
+    if (!lastDialogMessage) throw new Error('Expected a "delete the return exit" prompt for the west/east pair');
+
+    // Check specifically the "east" cell went back to empty — Room Two's still-alive south exit
+    // (from the dismissed prompt above) also reads "→ Room One", so that text alone is ambiguous.
+    await selectTreeNode('Room Two');
+    await page.click('button:has-text("Exits")');
+    await page.getByRole('button', { name: 'east', exact: true }).waitFor({ timeout: 10000 });
+    console.log('PASS: accepting the prompt deletes both the exit and its return exit');
 
     console.log('PASS: all checks passed');
 }

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -174,7 +174,22 @@ async function run() {
     await page.getByRole('button', { name: 'east', exact: true }).waitFor({ timeout: 10000 });
     console.log('PASS: accepting the prompt deletes both the exit and its return exit');
 
+    // "Delete both" must be a single undo transaction — deleting the pair one call at a time would
+    // each open/close their own transaction, so a single Undo would only restore the second one.
+    // Check the "east" ghost button is gone (populated again) rather than "→ Room One" text, which
+    // is now ambiguous — Room Two's still-alive south exit (from the earlier dismissed prompt)
+    // reads the same.
+    await page.click('button[title="Undo"]');
+    const eastStillGhost = await page.getByRole('button', { name: 'east', exact: true }).count();
+    if (eastStillGhost !== 0) throw new Error('Expected Room Two\'s east exit to be restored by the single Undo');
+    await selectTreeNode('Room One');
+    await page.click('button:has-text("Exits")');
+    await page.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 10000 });
+    console.log('PASS: a single Undo after "Delete both" restores both exits, not just one');
+
     // Create one more fresh pair (northeast/southwest) to check Cancel and Undo separately.
+    // Scoped to the "northeast" cell specifically from here on — the restored west exit above
+    // also points to Room Two, so a plain "→ Room Two" match is now ambiguous between cells.
     await selectTreeNode('Room One');
     await page.click('button:has-text("Exits")');
     await page.getByRole('button', { name: 'northeast', exact: true }).click();
@@ -183,21 +198,22 @@ async function run() {
     await page.waitForSelector('[role="option"]:has-text("Room Two")', { timeout: 5000 });
     await page.click('[role="option"]:has-text("Room Two")');
     await page.click('button:has-text("Create exit")');
-    await page.waitForSelector('text=→ Room Two', { timeout: 10000 });
+    const northeastCell = page.getByText('northeast', { exact: true }).locator('..');
+    await northeastCell.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 10000 });
 
     // Cancel must delete nothing at all — not even the exit that was clicked on.
-    await page.getByRole('button', { name: '→ Room Two', exact: true }).locator('..').locator('button[title="Delete"]').click();
+    await northeastCell.locator('button[title="Delete"]').click();
     await respondToReciprocalPrompt('cancel');
-    await page.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 5000 });
+    await northeastCell.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 5000 });
     console.log('PASS: Cancel on the reciprocal prompt deletes nothing');
 
     // Now actually delete it ("Just this one"), then Undo via the toolbar — the compass grid and
     // full list must reflect the restored exit without switching tabs away and back.
-    await page.getByRole('button', { name: '→ Room Two', exact: true }).locator('..').locator('button[title="Delete"]').click();
+    await northeastCell.locator('button[title="Delete"]').click();
     await respondToReciprocalPrompt('this');
     await page.getByRole('button', { name: 'northeast', exact: true }).waitFor({ timeout: 10000 });
     await page.click('button[title="Undo"]');
-    await page.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 10000 });
+    await northeastCell.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 10000 });
     await page.waitForSelector('text=northeast → Room Two', { timeout: 5000 });
     console.log('PASS: Undo restores a deleted exit without needing to switch tabs away and back');
 

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -1,0 +1,131 @@
+// Ad-hoc manual verification for the new Room Exits editor tab: previously the
+// "exits" controltype rendered nothing (only the "Exits list prefix" textbox
+// showed). This checks the compass-grid quick-create (with reciprocal exit),
+// the full exit list, delete, and navigating into an exit's own editor page.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function addRoom(name) {
+    await page.click('button[title="Add element"]');
+    await page.click('.add-dropdown button:has-text("Add Room")', { timeout: 5000 });
+    await page.waitForSelector('#element-name');
+    await page.fill('#element-name', name);
+    await page.click('[role="dialog"] button:has-text("Add")');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Exits Editor Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    // Enable "look" exits at the game level so the compass cell's "Create a look exit instead"
+    // shortcut is offered (it's gated on game.allowlookdirections, off by default). The "game"
+    // node is already selected by default right after load, so no tree click needed here — its
+    // bounding box spans its (already-expanded) Verbs/Commands children too, which made an
+    // explicit click on it land on the wrong row.
+    await page.click('button:has-text("Features")');
+    await page.waitForSelector('text=Directional exits can be look only', { timeout: 10000 });
+    await page.click('label:has-text("Directional exits can be look only") input[type="checkbox"]');
+    console.log('PASS: enabled "look" exits at the game level');
+
+    await addRoom('Room One');
+    await addRoom('Room Two');
+    console.log('PASS: created Room One and Room Two');
+
+    // Select Room One in the tree and open its Exits tab.
+    await page.click('[data-value="Room One"]');
+    await page.waitForSelector('button:has-text("Exits")', { timeout: 10000 });
+    await page.click('button:has-text("Exits")');
+    await page.waitForSelector('text=+ north', { timeout: 10000 });
+    console.log('PASS: Exits tab renders the compass grid (previously rendered nothing)');
+
+    // Quick-create a North exit from Room One to Room Two, with the reciprocal exit.
+    // Directions are lowercase captions ("north", "northwest", ...) — use exact-match role
+    // queries throughout since plain text= substring matching would match "northwest" too.
+    await page.getByRole('button', { name: '+ north', exact: true }).click();
+    const combobox = page.locator('[role="combobox"]');
+    await combobox.click();
+    await combobox.fill('Room Two');
+    await page.waitForSelector('[role="option"]:has-text("Room Two")', { timeout: 5000 });
+    await page.click('[role="option"]:has-text("Room Two")');
+    const inverseCheckbox = page.locator('text=Also create the return exit').locator('..').locator('input[type="checkbox"]');
+    if (!(await inverseCheckbox.isChecked())) throw new Error('Expected "create return exit" to default to checked');
+    await page.click('button:has-text("Create exit")');
+    await page.waitForSelector('text=→ Room Two', { timeout: 10000 });
+    console.log('PASS: North compass cell now shows the created exit to Room Two');
+
+    // The full exit list below should also show the new exit.
+    await page.waitForSelector('text=north → Room Two', { timeout: 5000 });
+    console.log('PASS: full exit list shows the new exit');
+
+    // Room stays selected/in-view after the quick-create (no navigation away) — the "Exits list
+    // prefix" field only renders on the room's own Exits tab, so its continued presence proves
+    // selection didn't jump elsewhere.
+    await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
+    console.log('PASS: Room One stays selected after quick-create (no unwanted navigation)');
+
+    // Switch to Room Two and confirm the reciprocal South exit was created.
+    await page.click('[data-value="Room Two"]');
+    await page.waitForSelector('button:has-text("Exits")', { timeout: 10000 });
+    await page.click('button:has-text("Exits")');
+    await page.waitForSelector('text=→ Room One', { timeout: 10000 });
+    console.log('PASS: Room Two automatically got the reciprocal South exit to Room One');
+
+    // Click into the exit from the compass grid — should navigate to the exit's own editor.
+    // Exact match: the full list row below also contains "→ Room One" as a substring ("south →
+    // Room One"), which a plain text= substring locator would ambiguously match too.
+    await page.getByRole('button', { name: '→ Room One', exact: true }).click();
+    await page.waitForSelector('text=Exit', { timeout: 10000 });
+    const toValue = await page.locator('[role="combobox"]').first().inputValue();
+    if (toValue !== 'Room One') throw new Error(`Expected exit's own editor "To" field to show Room One, got "${toValue}"`);
+    console.log('PASS: clicking an existing exit navigates to its own working editor page');
+
+    // Back on Room One, create a "look" exit (east) — no destination room, one-way.
+    await page.click('[data-value="Room One"]');
+    await page.waitForSelector('button:has-text("Exits")', { timeout: 10000 });
+    await page.click('button:has-text("Exits")');
+    await page.getByRole('button', { name: '+ east', exact: true }).click();
+    await page.click('text=Create a look exit instead');
+    await page.waitForSelector('text=(look)', { timeout: 10000 });
+    console.log('PASS: "Create a look exit instead" creates a one-way look exit with no destination');
+
+    // Go back to Room One and delete the north exit via the full list, room should stay selected.
+    await page.click('button:has-text("Exits")');
+    const rowButton = page.getByRole('button', { name: 'north → Room Two', exact: true });
+    await rowButton.waitFor({ timeout: 10000 });
+    const listRow = rowButton.locator('..');
+    await listRow.hover();
+    await listRow.locator('button[title="Delete"]').click();
+
+    // Deleting resets the active tab to the first one (Setup) — same pre-existing behavior as
+    // ElementsList's delete-then-reselect-parent elsewhere in the app, not specific to this
+    // feature. Room One itself must still be the selected tree node throughout, though.
+    await page.waitForSelector('[data-value="Room One"][data-selected]', { timeout: 10000 });
+    await page.click('button:has-text("Exits")');
+    await page.getByRole('button', { name: '+ north', exact: true }).waitFor({ timeout: 10000 });
+    await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
+    console.log('PASS: deleting an exit removes it and keeps Room One selected');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-exits-editor-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -104,14 +104,23 @@ async function run() {
     await page.waitForSelector('text=→ Room One', { timeout: 10000 });
     console.log('PASS: Room Two automatically got the reciprocal South exit to Room One');
 
-    // Click into the exit from the compass grid — should navigate to the exit's own editor.
-    // Exact match: the full list row below also contains "→ Room One" as a substring ("south →
-    // Room One"), which a plain text= substring locator would ambiguously match too.
+    // The destination hyperlink navigates to the destination ROOM (matching v5's WPF/WebEditor
+    // behavior), not the exit itself — exact match since the full list row below also contains
+    // "→ Room One" as a substring ("south → Room One").
     await page.getByRole('button', { name: '→ Room One', exact: true }).click();
+    await page.waitForSelector('text=Setup', { timeout: 10000 });
+    const roomNameValue = await page.locator('input[type="text"]').first().inputValue();
+    if (roomNameValue !== 'Room One') throw new Error(`Expected the destination link to navigate to Room One, got "${roomNameValue}"`);
+    console.log('PASS: clicking the destination hyperlink navigates to the destination room');
+
+    // The separate pencil "Edit exit" button navigates to the exit's own editor instead.
+    await selectTreeNode('Room Two');
+    await page.click('button:has-text("Exits")');
+    await page.click('button[title="Edit exit"]');
     await page.waitForSelector('text=Exit', { timeout: 10000 });
     const toValue = await page.locator('[role="combobox"]').first().inputValue();
     if (toValue !== 'Room One') throw new Error(`Expected exit's own editor "To" field to show Room One, got "${toValue}"`);
-    console.log('PASS: clicking an existing exit navigates to its own working editor page');
+    console.log('PASS: clicking the pencil Edit button navigates to the exit\'s own working editor page');
 
     // Back on Room One, create a "look" exit (east) — no destination room, one-way.
     await selectTreeNode('Room One');
@@ -198,7 +207,10 @@ async function run() {
     await page.waitForSelector('[role="option"]:has-text("Room Two")', { timeout: 5000 });
     await page.click('[role="option"]:has-text("Room Two")');
     await page.click('button:has-text("Create exit")');
-    const northeastCell = page.getByText('northeast', { exact: true }).locator('..');
+    // Two levels up: the label span's immediate parent is now just the top row (label + pencil
+    // edit button); the outer cell div containing both rows (label row + destination/delete row)
+    // is its parent's parent.
+    const northeastCell = page.getByText('northeast', { exact: true }).locator('..').locator('..');
     await northeastCell.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 10000 });
 
     // Cancel must delete nothing at all — not even the exit that was clicked on.

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -47,13 +47,13 @@ async function run() {
     await page.click('[data-value="Room One"]');
     await page.waitForSelector('button:has-text("Exits")', { timeout: 10000 });
     await page.click('button:has-text("Exits")');
-    await page.waitForSelector('text=+ north', { timeout: 10000 });
+    await page.getByRole('button', { name: 'north', exact: true }).waitFor({ timeout: 10000 });
     console.log('PASS: Exits tab renders the compass grid (previously rendered nothing)');
 
     // Quick-create a North exit from Room One to Room Two, with the reciprocal exit.
     // Directions are lowercase captions ("north", "northwest", ...) — use exact-match role
     // queries throughout since plain text= substring matching would match "northwest" too.
-    await page.getByRole('button', { name: '+ north', exact: true }).click();
+    await page.getByRole('button', { name: 'north', exact: true }).click();
     const combobox = page.locator('[role="combobox"]');
     await combobox.click();
     await combobox.fill('Room Two');
@@ -95,7 +95,7 @@ async function run() {
     await page.click('[data-value="Room One"]');
     await page.waitForSelector('button:has-text("Exits")', { timeout: 10000 });
     await page.click('button:has-text("Exits")');
-    await page.getByRole('button', { name: '+ east', exact: true }).click();
+    await page.getByRole('button', { name: 'east', exact: true }).click();
     await page.click('text=Create a look exit instead');
     await page.waitForSelector('text=(look)', { timeout: 10000 });
     console.log('PASS: "Create a look exit instead" creates a one-way look exit with no destination');
@@ -113,7 +113,7 @@ async function run() {
     // feature. Room One itself must still be the selected tree node throughout, though.
     await page.waitForSelector('[data-value="Room One"][data-selected]', { timeout: 10000 });
     await page.click('button:has-text("Exits")');
-    await page.getByRole('button', { name: '+ north', exact: true }).waitFor({ timeout: 10000 });
+    await page.getByRole('button', { name: 'north', exact: true }).waitFor({ timeout: 10000 });
     await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
     console.log('PASS: deleting an exit removes it and keeps Room One selected');
 

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -12,12 +12,14 @@ page.on('pageerror', err => console.log('[pageerror]', err.message));
 page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
 
 // Deleting an exit that has a matching return exit prompts via ConfirmDialog.svelte (a custom
-// styled stand-in for window.confirm(), not a native browser dialog).
-async function respondToReciprocalPrompt(accept) {
+// styled stand-in for window.confirm(), not a native browser dialog) with three choices: Cancel
+// (delete nothing), "Just this one", or "Delete both".
+async function respondToReciprocalPrompt(choice) {
     const dialog = page.locator('[role="dialog"]').filter({ hasText: 'matching return exit' });
     await dialog.waitFor({ timeout: 10000 });
     const message = await dialog.locator('p').textContent();
-    await dialog.getByRole('button', { name: accept ? 'Delete both' : 'Just this one' }).click();
+    const label = choice === 'both' ? 'Delete both' : choice === 'this' ? 'Just this one' : 'Cancel';
+    await dialog.getByRole('button', { name: label }).click();
     return message;
 }
 
@@ -128,7 +130,7 @@ async function run() {
     const listRow = rowButton.locator('..');
     await listRow.hover();
     await listRow.locator('button[title="Delete"]').click();
-    const dismissMessage = await respondToReciprocalPrompt(false);
+    const dismissMessage = await respondToReciprocalPrompt('this');
     await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
     if (!dismissMessage?.includes('Room Two')) throw new Error(`Expected a "delete the return exit" prompt mentioning Room Two, got: ${dismissMessage}`);
     console.log('PASS: deleting an exit with a reciprocal prompts to also delete the return exit');
@@ -161,7 +163,7 @@ async function run() {
     await page.waitForSelector('text=→ Room Two', { timeout: 10000 });
 
     await page.getByRole('button', { name: '→ Room Two', exact: true }).locator('..').locator('button[title="Delete"]').click();
-    const acceptMessage = await respondToReciprocalPrompt(true);
+    const acceptMessage = await respondToReciprocalPrompt('both');
     await page.waitForSelector('text=Exits list prefix', { timeout: 3000 });
     if (!acceptMessage) throw new Error('Expected a "delete the return exit" prompt for the west/east pair');
 
@@ -171,6 +173,33 @@ async function run() {
     await page.click('button:has-text("Exits")');
     await page.getByRole('button', { name: 'east', exact: true }).waitFor({ timeout: 10000 });
     console.log('PASS: accepting the prompt deletes both the exit and its return exit');
+
+    // Create one more fresh pair (northeast/southwest) to check Cancel and Undo separately.
+    await selectTreeNode('Room One');
+    await page.click('button:has-text("Exits")');
+    await page.getByRole('button', { name: 'northeast', exact: true }).click();
+    await combobox.click();
+    await combobox.fill('Room Two');
+    await page.waitForSelector('[role="option"]:has-text("Room Two")', { timeout: 5000 });
+    await page.click('[role="option"]:has-text("Room Two")');
+    await page.click('button:has-text("Create exit")');
+    await page.waitForSelector('text=→ Room Two', { timeout: 10000 });
+
+    // Cancel must delete nothing at all — not even the exit that was clicked on.
+    await page.getByRole('button', { name: '→ Room Two', exact: true }).locator('..').locator('button[title="Delete"]').click();
+    await respondToReciprocalPrompt('cancel');
+    await page.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 5000 });
+    console.log('PASS: Cancel on the reciprocal prompt deletes nothing');
+
+    // Now actually delete it ("Just this one"), then Undo via the toolbar — the compass grid and
+    // full list must reflect the restored exit without switching tabs away and back.
+    await page.getByRole('button', { name: '→ Room Two', exact: true }).locator('..').locator('button[title="Delete"]').click();
+    await respondToReciprocalPrompt('this');
+    await page.getByRole('button', { name: 'northeast', exact: true }).waitFor({ timeout: 10000 });
+    await page.click('button[title="Undo"]');
+    await page.getByRole('button', { name: '→ Room Two', exact: true }).waitFor({ timeout: 10000 });
+    await page.waitForSelector('text=northeast → Room Two', { timeout: 5000 });
+    console.log('PASS: Undo restores a deleted exit without needing to switch tabs away and back');
 
     console.log('PASS: all checks passed');
 }


### PR DESCRIPTION
## Summary
- Adds the missing Exits editor tab for rooms — previously only the "Exits list prefix" textbox rendered; the compass-based `exits` control had no Svelte counterpart at all.
- Compass grid (NW/N/NE/W/E/SW/S/SE + Up/Down/In/Out) for quick-creating exits, optionally with a reciprocal return exit or a one-way "look" exit (gated on `game.allowlookdirections`), plus a full reorderable exit list below it for anything not on a compass direction.
- Destination hyperlinks navigate to the destination room (matching v5's WPF/WebEditor behavior); a separate pencil "Edit exit" button opens the exit's own editor.
- Deleting a directional exit detects a likely reciprocal (destination room's exit aliased to the inverse direction, pointing back here) and offers Cancel / "Just this one" / "Delete both" — "Delete both" is a single undo transaction.
- Adds a small reusable `ConfirmDialog`/`chooseDialog()` (styled like the existing `AddElementModal`, not Skeleton's unused headless Dialog primitive) and migrates the one other native `confirm()` call (local draft delete) to it too.
- Backend: new thin `WasmEditorBridge` JSExports (`GetExitsData`, `CreateExitInDirection`, `CreateLookExitInDirection`, `DeleteElements`) that reuse existing `EditorController` primitives (`CreateNewExit` overloads, `DeleteElement`, `SwapElements`) — no EditorCore/Engine changes.

## Test plan
- [x] `dotnet build src/WasmEditor/WasmEditor.csproj` — no warnings/errors
- [x] `npm run check` / `npm run lint` in `src/AppShell` — clean
- [x] `npm run build` in `src/AppShell` — production build succeeds
- [x] `node tests/e2e/verify-appshell-exits-editor.mjs` (checked in) — 17 Playwright checks covering: compass grid create/edit/delete, reciprocal exit creation, look exits, the Cancel/"Just this one"/"Delete both" prompt (including single-undo restoring both), destination-link vs. Edit-button navigation, and tab/selection stability across deletes and undo/redo
- [x] Manually verified in a running dev server (screenshots reviewed) at each iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)