### PR TITLE
feat(AppShell): add object Verbs editor tab

### DIFF
--- a/src/AppShell/src/components/Combobox.svelte
+++ b/src/AppShell/src/components/Combobox.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
     import type { ControlOption } from "$lib/types";
 
-    let { value, options, onchange, class: className = "" }: {
+    let { value, options, onchange, oninput, class: className = "" }: {
         value: string;
         options: ControlOption[];
         onchange: (value: string) => void;
+        // Fires on every keystroke, unlike onchange (which only commits on blur/select/Enter) —
+        // for callers that need the live typed text, e.g. to drive a submit button's disabled
+        // state without waiting for the field to lose focus.
+        oninput?: (value: string) => void;
         class?: string;
     } = $props();
 
@@ -15,8 +19,21 @@
     let inputValue = $state("");
     let activeIndex = $state(-1);
     let listboxEl = $state<HTMLDivElement | null>(null);
+    let inputEl = $state<HTMLInputElement | null>(null);
+    // Defaults to opening downward, but flips upward when there isn't room below — otherwise a
+    // combobox pinned near the bottom of a panel (e.g. VerbsEditor's "Add Verb" row) renders its
+    // suggestion list past the bottom of the screen/scroll container, invisible.
+    let openUpward = $state(false);
 
     let hasEmptyOption = $derived(options.some(o => o.value === ""));
+
+    function updateOpenDirection() {
+        if (!inputEl) return;
+        const rect = inputEl.getBoundingClientRect();
+        const spaceBelow = window.innerHeight - rect.bottom;
+        const spaceAbove = rect.top;
+        openUpward = spaceBelow < 200 && spaceAbove > spaceBelow;
+    }
 
     $effect(() => {
         if (!open) inputValue = value;
@@ -58,12 +75,14 @@
 
     function handleFocus() {
         inputValue = "";
+        updateOpenDirection();
         open = true;
     }
 
     function handleClick() {
         if (!open) {
             inputValue = "";
+            updateOpenDirection();
             open = true;
         }
     }
@@ -81,12 +100,13 @@
     function handleInput(e: Event) {
         inputValue = (e.target as HTMLInputElement).value;
         open = true;
+        oninput?.(inputValue);
     }
 
     function handleKeydown(e: KeyboardEvent) {
         if (e.key === "ArrowDown") {
             e.preventDefault();
-            if (!open) { open = true; activeIndex = 0; return; }
+            if (!open) { updateOpenDirection(); open = true; activeIndex = 0; return; }
             activeIndex = Math.min(activeIndex + 1, filtered.length - 1);
         } else if (e.key === "ArrowUp") {
             e.preventDefault();
@@ -113,6 +133,7 @@
 
 <div class="relative">
     <input
+        bind:this={inputEl}
         type="text"
         autocapitalize="off"
         role="combobox"
@@ -134,7 +155,7 @@
             bind:this={listboxEl}
             id="{uid}-listbox"
             role="listbox"
-            class="absolute z-50 top-full left-0 mt-0.5 min-w-full max-h-48 overflow-y-auto rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-md"
+            class="absolute z-50 left-0 min-w-full max-h-48 overflow-y-auto rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-md {openUpward ? "bottom-full mb-0.5" : "top-full mt-0.5"}"
         >
             {#each filtered as opt, i (opt.value)}
                 <div

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -8,6 +8,7 @@
     import ElementsList from "./ElementsList.svelte";
     import AssetPicker from "./AssetPicker.svelte";
     import ExitsEditor from "./ExitsEditor.svelte";
+    import VerbsEditor from "./VerbsEditor.svelte";
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
@@ -398,6 +399,8 @@
         />
     {:else if ctrl.controlType === "exits" && $selectedKey}
         <ExitsEditor elementKey={$selectedKey} />
+    {:else if ctrl.controlType === "verbs" && $selectedKey}
+        <VerbsEditor elementKey={$selectedKey} />
     {:else if ctrl.attribute !== null}
         {#if ctrl.controlType === "checkbox"}
             <label class="flex items-center gap-2 px-3 py-1.5 min-h-8 cursor-pointer">

--- a/src/AppShell/src/components/ScriptDictionaryEditor.svelte
+++ b/src/AppShell/src/components/ScriptDictionaryEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { SvelteSet } from "svelte/reactivity";
-    import { addScriptDictItem, removeScriptDictItem, makeScriptDictEditable } from "$lib/editor-store";
+    import { addScriptDictItem, removeScriptDictItem, makeScriptDictEditable, getObjectNames } from "$lib/editor-store";
     import ScriptEditor from "./ScriptEditor.svelte";
 
     interface Props {
@@ -8,9 +8,15 @@
         attribute: string;
         value: string | null;
         isLocked?: boolean;
+        // "object" swaps the free-text "Add entry key" field for a dropdown of the game's
+        // objects — used by VerbsEditor's "Require another object" behaviour, where the key
+        // must be a real object name for the interpreter to match against. Generic attribute
+        // dictionaries (AttributesEditor) keep free-text keys, since those aren't necessarily
+        // object names.
+        keySource?: "text" | "object";
     }
 
-    let { elementKey, attribute, value, isLocked = false }: Props = $props();
+    let { elementKey, attribute, value, isLocked = false, keySource = "text" }: Props = $props();
 
     let items = $derived.by<{key: string, value: string}[]>(() => {
         try {
@@ -22,6 +28,16 @@
 
     const expandedKeys = new SvelteSet<string>();
     let newKey = $state("");
+
+    let allObjectNames = $state<string[]>([]);
+    $effect(() => {
+        if (keySource === "object") allObjectNames = getObjectNames() ?? [];
+    });
+    // Excludes the object itself (a verb requiring itself doesn't make sense) and objects
+    // already added as entries.
+    let availableObjectNames = $derived(
+        allObjectNames.filter(n => n !== elementKey && !keys.includes(n))
+    );
 
     function onAdd() {
         const k = newKey.trim();
@@ -77,18 +93,34 @@
             </div>
         {/each}
         <div class="flex items-center gap-1 mt-0.5">
-            <input
-                type="text"
-                autocapitalize="off"
-                class="input text-xs py-0.5 px-1.5 flex-1"
-                placeholder="Add entry key…"
-                data-staging
-                bind:value={newKey}
-                onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
-            />
+            {#if keySource === "object"}
+                <select
+                    class="select text-xs py-0.5 px-1.5 flex-1"
+                    aria-label="Add entry key"
+                    data-staging
+                    bind:value={newKey}
+                >
+                    <option value="">Select object…</option>
+                    {#each availableObjectNames as name (name)}
+                        <option value={name}>{name}</option>
+                    {/each}
+                </select>
+            {:else}
+                <input
+                    type="text"
+                    autocapitalize="off"
+                    class="input text-xs py-0.5 px-1.5 flex-1"
+                    placeholder="Add entry key…"
+                    aria-label="Add entry key"
+                    data-staging
+                    bind:value={newKey}
+                    onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}
+                />
+            {/if}
             <button
                 type="button"
                 class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0"
+                disabled={!newKey.trim()}
                 onclick={onAdd}
             >Add</button>
         </div>

--- a/src/AppShell/src/components/VerbsEditor.svelte
+++ b/src/AppShell/src/components/VerbsEditor.svelte
@@ -225,7 +225,7 @@
                             <ScriptEditor elementKey={elementKey} attribute={attr.name} />
                         </div>
                     {:else if attr.type === "scriptdictionary"}
-                        <ScriptDictionaryEditor elementKey={elementKey} attribute={attr.name} value={attr.value} />
+                        <ScriptDictionaryEditor elementKey={elementKey} attribute={attr.name} value={attr.value} keySource="object" />
                     {:else}
                         <textarea
                             autocapitalize="off"

--- a/src/AppShell/src/components/VerbsEditor.svelte
+++ b/src/AppShell/src/components/VerbsEditor.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+    import { fullAttributeData, scriptVersion, setAttribute, removeAttribute, changeAttributeType, getVerbAttributesInfo, addVerb } from "$lib/editor-store";
+    import type { AttributeDataItem } from "$lib/types";
+    import ScriptEditor from "./ScriptEditor.svelte";
+    import ScriptDictionaryEditor from "./ScriptDictionaryEditor.svelte";
+    import Combobox from "./Combobox.svelte";
+
+    interface Props {
+        elementKey: string;
+    }
+
+    let { elementKey }: Props = $props();
+
+    const TYPE_OPTIONS = [
+        { value: "string",           label: "Print a message" },
+        { value: "script",           label: "Run a script" },
+        { value: "scriptdictionary", label: "Require another object" },
+    ];
+
+    // Property name -> friendly display pattern for every verb in the game. Game-wide (not
+    // scoped to this object), so it only needs refreshing when the verb list itself could have
+    // changed — on undo/redo (scriptVersion) or when a verb was just added to this object.
+    let verbInfo = $state<{attribute: string, displayPattern: string}[]>([]);
+
+    $effect(() => {
+        void $scriptVersion;
+        void elementKey;
+        verbInfo = getVerbAttributesInfo();
+    });
+
+    let verbPatternByAttribute = $derived(new Map(verbInfo.map(v => [v.attribute, v.displayPattern])));
+
+    // Only the object's own (non-inherited) attributes that happen to be verbs — matches the
+    // Attributes tab's own "added to this object" semantics.
+    let verbs = $derived(
+        ($fullAttributeData?.attributes ?? []).filter(a => !a.isInherited && verbPatternByAttribute.has(a.name))
+    );
+
+    let availableVerbPatterns = $derived(
+        Array.from(new Set(verbInfo.map(v => v.displayPattern)))
+            .sort((a, b) => a.localeCompare(b))
+            .map(p => ({ value: p, label: p }))
+    );
+
+    let selectedAttrName = $state<string | null>(null);
+    let selectedAttr = $derived(
+        selectedAttrName ? (verbs.find(v => v.name === selectedAttrName) ?? null) : null
+    );
+
+    let prevElementKey = $state<string | null>(null);
+    $effect(() => {
+        if (elementKey !== prevElementKey) {
+            prevElementKey = elementKey;
+            selectedAttrName = null;
+            newVerbPattern = "";
+            addError = null;
+        }
+    });
+
+    // The "Print a message" value buffer. Deliberately NOT kept in sync via a $effect watching
+    // selectedAttr — that reactive chain (selectedAttr -> verbs -> fullAttributeData store, plus
+    // verbPatternByAttribute derived from the separately-fetched verbInfo) re-runs far more often
+    // than selectedAttr actually changes, which was stomping the buffer back to the committed
+    // value on every keystroke and made the textarea appear uneditable. Set explicitly instead,
+    // at the three points where the edited value actually should change.
+    let editingMessage = $state("");
+    let editingMessageOriginal = $state("");
+
+    function syncMessageBuffer(attr: AttributeDataItem | null) {
+        editingMessage = attr && attr.type === "string" ? (attr.value ?? "") : "";
+        editingMessageOriginal = editingMessage;
+    }
+
+    function commitMessage() {
+        if (!selectedAttr || editingMessage === editingMessageOriginal) return;
+        setAttribute(elementKey, selectedAttr.name, "textbox", editingMessage);
+        editingMessageOriginal = editingMessage;
+    }
+
+    function onSelectVerb(attr: AttributeDataItem) {
+        selectedAttrName = attr.name;
+        syncMessageBuffer(attr);
+    }
+
+    function onDeleteVerb(attr: AttributeDataItem, e: MouseEvent) {
+        e.stopPropagation();
+        removeAttribute(elementKey, attr.name);
+        if (selectedAttrName === attr.name) selectedAttrName = null;
+    }
+
+    function onChangeType(newType: string) {
+        if (!selectedAttrName) return;
+        changeAttributeType(elementKey, selectedAttrName, newType);
+        // ChangeAttributeType resets the backing attribute to a fresh empty string for "string" —
+        // reflect that immediately rather than waiting on the async refreshSelectedData() round trip.
+        if (newType === "string") {
+            editingMessage = "";
+            editingMessageOriginal = "";
+        }
+    }
+
+    let newVerbPattern = $state("");
+    let addError = $state<string | null>(null);
+
+    function onAddVerb() {
+        const pattern = newVerbPattern.trim();
+        if (!pattern) return;
+        const result = addVerb(elementKey, pattern);
+        if (result.startsWith("error:")) {
+            addError = result.slice("error:".length);
+            return;
+        }
+        addError = null;
+        newVerbPattern = "";
+        verbInfo = getVerbAttributesInfo();
+        if (result.startsWith("ok:")) {
+            selectedAttrName = result.slice("ok:".length);
+            // AddVerb always sets the new verb's value to an empty string ("Print a message").
+            editingMessage = "";
+            editingMessageOriginal = "";
+        }
+    }
+</script>
+
+<div class="flex text-xs">
+    <!-- Left: verbs list, with "Add Verb" directly beneath it. Deliberately NOT stretched to
+         fill the tab's height (unlike AttributesEditor, which is normally packed with rows) —
+         verbs lists are usually short or empty, and forcing this column to fill all available
+         height pinned "Add Verb" far below the list under a wall of blank space. This sizes to
+         content instead, scrolling with the rest of the tab if the list ever gets long. -->
+    <div class="flex flex-col flex-1 min-w-0">
+        <div class="px-3 py-1.5 border-b border-surface-100-900">
+            <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Verbs</span>
+        </div>
+        <div>
+            <table class="w-full">
+                <thead class="sticky top-0 bg-surface-50-950 z-10">
+                    <tr class="text-surface-400-500 border-b border-surface-200-800">
+                        <th class="text-left py-1 px-3 font-medium">Verb</th>
+                        <th class="text-left py-1 px-3 font-medium">Behaviour</th>
+                        <th class="w-6"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each verbs as attr (attr.name)}
+                        {@const isSelected = selectedAttrName === attr.name}
+                        {@const display = verbPatternByAttribute.get(attr.name) ?? attr.name}
+                        <tr
+                            class="border-b border-surface-100-900 cursor-pointer
+                                {isSelected ? "bg-primary-100-900" : "hover:bg-surface-100-900"}"
+                            onclick={() => onSelectVerb(attr)}
+                        >
+                            <td class="py-0.5 px-3 font-medium truncate max-w-36" title={display}>{display}</td>
+                            <td class="py-0.5 px-3 text-surface-400-500">
+                                {TYPE_OPTIONS.find(t => t.value === attr.type)?.label ?? attr.type}
+                            </td>
+                            <td class="py-0.5 pr-2 text-right">
+                                <button
+                                    type="button"
+                                    class="text-error-500 hover:text-error-700"
+                                    onclick={(e) => onDeleteVerb(attr, e)}
+                                    title="Remove verb"
+                                >✕</button>
+                            </td>
+                        </tr>
+                    {:else}
+                        <tr><td colspan="3" class="py-2 px-3 text-surface-400-500 italic">No verbs added yet</td></tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Add verb -->
+        <div class="px-3 py-1.5 flex-shrink-0 border-t border-surface-200-800 flex flex-col gap-1">
+            <div class="flex items-center gap-2">
+                <Combobox
+                    value={newVerbPattern}
+                    options={availableVerbPatterns}
+                    onchange={(v) => { newVerbPattern = v; }}
+                    oninput={(v) => { newVerbPattern = v; }}
+                    class="input text-xs py-0.5 px-1.5 flex-1"
+                />
+                <button
+                    type="button"
+                    disabled={!newVerbPattern.trim()}
+                    onclick={onAddVerb}
+                    class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 flex-shrink-0"
+                >Add Verb</button>
+            </div>
+            {#if addError}
+                <p class="text-xs text-error-500">{addError}</p>
+            {/if}
+        </div>
+    </div>
+
+    <!-- Right: selected verb's behaviour -->
+    <div class="w-80 flex-shrink-0 flex flex-col overflow-hidden border-l border-surface-200-800">
+        <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-500-400 uppercase tracking-wide flex-shrink-0">
+            Behaviour
+        </div>
+        {#if selectedAttr}
+            {@const attr = selectedAttr}
+            <div class="p-3 flex flex-col gap-2 overflow-y-auto">
+                <div class="font-medium text-surface-700-300 truncate flex-shrink-0" title={verbPatternByAttribute.get(attr.name) ?? attr.name}>
+                    {verbPatternByAttribute.get(attr.name) ?? attr.name}
+                </div>
+
+                <div class="flex flex-col gap-1 flex-shrink-0">
+                    <span class="text-surface-400-500 uppercase tracking-wide text-xs">Type</span>
+                    <select
+                        class="select text-xs py-0 px-1.5 h-7"
+                        value={attr.type}
+                        onchange={(e) => onChangeType((e.target as HTMLSelectElement).value)}
+                    >
+                        {#each TYPE_OPTIONS as opt (opt.value)}
+                            <option value={opt.value}>{opt.label}</option>
+                        {/each}
+                    </select>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <span class="text-surface-400-500 uppercase tracking-wide text-xs flex-shrink-0">Value</span>
+                    {#if attr.type === "script"}
+                        <div class="min-h-48">
+                            <ScriptEditor elementKey={elementKey} attribute={attr.name} />
+                        </div>
+                    {:else if attr.type === "scriptdictionary"}
+                        <ScriptDictionaryEditor elementKey={elementKey} attribute={attr.name} value={attr.value} />
+                    {:else}
+                        <textarea
+                            autocapitalize="off"
+                            class="input text-xs py-1 px-1.5 w-full resize-none"
+                            rows="4"
+                            value={editingMessage}
+                            oninput={(e) => { editingMessage = (e.target as HTMLTextAreaElement).value; }}
+                            onblur={commitMessage}
+                            onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commitMessage(); } }}
+                        ></textarea>
+                    {/if}
+                </div>
+            </div>
+        {:else}
+            <p class="p-3 text-surface-400-500 italic">Select a verb to edit its behaviour.</p>
+        {/if}
+    </div>
+</div>

--- a/src/AppShell/src/components/VerbsEditor.svelte
+++ b/src/AppShell/src/components/VerbsEditor.svelte
@@ -99,6 +99,35 @@
         }
     }
 
+    // Resizable splitter (matches AttributesEditor's) — defaults wider than that one since the
+    // verbs list only needs a couple of narrow columns, so most of the width is better spent on
+    // the Behaviour panel (script/dictionary editors) rather than left as blank space.
+    let panelWidth = $state(480);
+    let isDragging = $state(false);
+    let dragStartX = 0;
+    let dragStartWidth = 0;
+
+    function onSplitterMousedown(e: MouseEvent) {
+        isDragging = true;
+        dragStartX = e.clientX;
+        dragStartWidth = panelWidth;
+        e.preventDefault();
+    }
+
+    $effect(() => {
+        if (!isDragging) return;
+        function onMousemove(e: MouseEvent) {
+            panelWidth = Math.max(180, Math.min(900, dragStartWidth + (dragStartX - e.clientX)));
+        }
+        function onMouseup() { isDragging = false; }
+        window.addEventListener("mousemove", onMousemove);
+        window.addEventListener("mouseup", onMouseup);
+        return () => {
+            window.removeEventListener("mousemove", onMousemove);
+            window.removeEventListener("mouseup", onMouseup);
+        };
+    });
+
     let newVerbPattern = $state("");
     let addError = $state<string | null>(null);
 
@@ -193,8 +222,15 @@
         </div>
     </div>
 
+    <!-- Splitter -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+        class="w-1 flex-shrink-0 cursor-col-resize bg-surface-200-800 hover:bg-primary-400 transition-colors"
+        onmousedown={onSplitterMousedown}
+    ></div>
+
     <!-- Right: selected verb's behaviour -->
-    <div class="w-80 flex-shrink-0 flex flex-col overflow-hidden border-l border-surface-200-800">
+    <div class="flex-shrink-0 flex flex-col overflow-hidden border-l border-surface-200-800" style="width: {panelWidth}px">
         <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-500-400 uppercase tracking-wide flex-shrink-0">
             Behaviour
         </div>
@@ -244,3 +280,8 @@
         {/if}
     </div>
 </div>
+
+<!-- Drag overlay: keeps col-resize cursor while dragging over other elements -->
+{#if isDragging}
+    <div class="fixed inset-0 z-50 cursor-col-resize select-none"></div>
+{/if}

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -6,7 +6,7 @@ import type { AssetInfo, FileAdapter } from "./filesystem/types";
 import { LocalDraftAdapter, shouldShowBackupBanner, markBackupBannerResolved } from "./filesystem/local-adapter";
 import { ServerFileAdapter } from "./filesystem/server-adapter";
 import { triggerDownload } from "./filesystem/download";
-import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData, ExitsData } from "./types";
+import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData, ExitsData, VerbInfo } from "./types";
 
 export type AddElementModalState = { type: "room" | "object" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
 
@@ -959,6 +959,27 @@ export function createLookExitInDirection(roomKey: string, direction: string): s
     const result = _bridge.CreateLookExitInDirection(roomKey, direction);
     if (!result.startsWith("error:")) {
         refreshTree();
+        refreshUndoRedo();
+    }
+    return result;
+}
+
+// ── Verbs editor ─────────────────────────────────────────────────────────────
+
+export function getVerbAttributesInfo(): VerbInfo[] {
+    if (!_bridge) return [];
+    try { return JSON.parse(_bridge.GetVerbAttributesInfo()); }
+    catch { return []; }
+}
+
+// A new custom verb also creates a game-wide command element (visible under the Commands tree
+// node), so unlike createExitInDirection() this needs refreshTree() too, not just refreshSelectedData().
+export function addVerb(elementKey: string, verbPattern: string): string {
+    if (!_bridge) return "error:not loaded";
+    const result = _bridge.AddVerb(elementKey, verbPattern);
+    if (result.startsWith("ok:")) {
+        refreshTree();
+        refreshSelectedData();
         refreshUndoRedo();
     }
     return result;

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -68,6 +68,11 @@ export interface ExitsData {
   allowLookExits: boolean
 }
 
+export interface VerbInfo {
+  attribute: string
+  displayPattern: string
+}
+
 export interface ScriptControlData {
   controlType: string
   caption: string | null

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -68,6 +68,9 @@ export interface WasmBridge {
   GetExitsData(roomKey: string): string
   CreateExitInDirection(roomKey: string, direction: string, to: string, createInverse: boolean): string
   CreateLookExitInDirection(roomKey: string, direction: string): string
+  // Verbs editor API
+  GetVerbAttributesInfo(): string
+  AddVerb(elementKey: string, verbPattern: string): string
   CreateTurnScript(parent: string): string
   CreateCommand(parent: string): string
   CreateVerb(parent: string): string

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -123,6 +123,8 @@ internal record ExitsData(
     List<ControlOption> Objects,
     bool AllowLookExits);
 
+internal record VerbInfo(string Attribute, string DisplayPattern);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
 [JsonSerializable(typeof(EditorDataResponse))]
@@ -136,6 +138,7 @@ internal record ExitsData(
 [JsonSerializable(typeof(FullAttributeData))]
 [JsonSerializable(typeof(List<GameTemplateInfo>))]
 [JsonSerializable(typeof(ExitsData))]
+[JsonSerializable(typeof(List<VerbInfo>))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext
 {
 }
@@ -2023,6 +2026,129 @@ public partial class WasmEditorBridge
         }
 
         return "ok";
+    }
+
+    // ── Verbs editor API ─────────────────────────────────────────────────────
+
+    private static IEditorControl? FindVerbsControl(string elementKey)
+    {
+        if (_controller == null)
+        {
+            return null;
+        }
+
+        var editorName = _controller.GetElementEditorName(elementKey);
+        if (editorName == null)
+        {
+            return null;
+        }
+
+        var def = _controller.GetEditorDefinition(editorName);
+        return def.Tabs.Values.SelectMany(t => t.Controls)
+            .FirstOrDefault(c => c.ControlType == "verbs");
+    }
+
+    // Property name -> friendly display pattern (e.g. "lookin" -> "look in") for every verb
+    // defined anywhere in the game (library verbs plus any custom ones already added to any
+    // object) — used both to identify which of an object's attributes are verbs, and to build
+    // the autocomplete list when adding a new one.
+    [JSExport]
+    public static string GetVerbAttributesInfo()
+    {
+        if (_controller == null)
+        {
+            return "[]";
+        }
+
+        var verbs = _controller.GetVerbProperties()
+            .Select(kv => new VerbInfo(kv.Key, kv.Value))
+            .ToList();
+
+        return JsonSerializer.Serialize(verbs, WasmEditorJsonContext.Default.ListVerbInfo);
+    }
+
+    [JSExport]
+    public static string AddVerb(string elementKey, string verbPattern)
+    {
+        if (_controller == null)
+        {
+            return "error:Not initialised";
+        }
+
+        verbPattern = verbPattern.Trim().ToLowerInvariant();
+        if (verbPattern.Length == 0)
+        {
+            return "error:Enter a verb";
+        }
+
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null)
+        {
+            return "error:No data";
+        }
+
+        var verbsControl = FindVerbsControl(elementKey);
+        var verbAttribute = _controller.GetVerbAttributeForPattern(verbPattern);
+        var isExistingVerb = _controller.IsVerbAttribute(verbAttribute);
+
+        if (!isExistingVerb)
+        {
+            var canAdd = _controller.CanAddVerb(verbPattern);
+            if (!canAdd.CanAdd)
+            {
+                var message = $"Verb would clash with the '{canAdd.ClashingCommandDisplay}' command";
+                var clashMessages = verbsControl?.GetDictionary("clashmessages");
+                if (clashMessages != null && canAdd.ClashingCommand != null &&
+                    clashMessages.TryGetValue(canAdd.ClashingCommand, out var extra))
+                {
+                    message += ". " + extra;
+                }
+
+                return $"error:{message}";
+            }
+        }
+
+        if (data.GetAttribute(verbAttribute) != null)
+        {
+            return "error:This verb has already been added";
+        }
+
+        _controller.StartTransaction($"Add '{verbPattern}' verb");
+        try
+        {
+            if (!isExistingVerb)
+            {
+                // A custom verb doesn't exist as a game-wide command yet, so create it (this is
+                // what makes the pattern actually get parsed by the player at runtime) before
+                // recording that this object handles it.
+                var newVerbId = _controller.CreateNewVerb(null, false);
+                var verbData = _controller.GetEditorData(newVerbId);
+                verbData.SetAttribute("property", verbAttribute);
+                if (verbData.GetAttribute("pattern") is IEditableCommandPattern pattern)
+                {
+                    pattern.Pattern = verbPattern;
+                }
+
+                var defaultExpressionTemplate = verbsControl?.GetString("defaultexpression");
+                if (!string.IsNullOrEmpty(defaultExpressionTemplate))
+                {
+                    verbData.SetAttribute("defaultexpression",
+                        defaultExpressionTemplate.Replace("#verb#", verbPattern));
+                }
+            }
+
+            var result = data.SetAttribute(verbAttribute, string.Empty);
+            if (!result.Valid)
+            {
+                return $"error:{result.Message}";
+            }
+
+            return $"ok:{verbAttribute}";
+        }
+        finally
+        {
+            _controller.EndTransaction();
+        }
     }
 
     // ── Attributes editor API ──────────────────────────────────────────────────

--- a/tests/e2e/verify-appshell-verbs-editor.mjs
+++ b/tests/e2e/verify-appshell-verbs-editor.mjs
@@ -1,0 +1,158 @@
+// Ad-hoc manual verification for the new object Verbs editor tab: previously it rendered
+// nothing. Checks adding a custom verb (default "Print a message" behaviour), switching its
+// behaviour to "Run a script" and "Require another object", the clash-message shown when a
+// pattern collides with a built-in command, delete, and undo.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function addRoom(name) {
+    await page.click('button[title="Add element"]');
+    await page.click('.add-dropdown button:has-text("Add Room")', { timeout: 5000 });
+    await page.waitForSelector('#element-name');
+    await page.fill('#element-name', name);
+    await page.click('[role="dialog"] button:has-text("Add")');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+// Objects can only be added under a room/object (there's no bare top-level "Add Object"), so a
+// room must be selected first — the toolbar's Add menu then offers "Add Object in <room>".
+async function addObjectIn(parentRoom, name) {
+    await selectTreeNode(parentRoom);
+    await page.click('button[title="Add element"]');
+    await page.click(`.add-dropdown button:has-text("Add Object in")`, { timeout: 5000 });
+    await page.waitForSelector('#element-name');
+    await page.fill('#element-name', name);
+    await page.click('[role="dialog"] button:has-text("Add")');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+async function selectTreeNode(name) {
+    await page.locator(`[data-value="${name}"][data-part="item"], [data-value="${name}"][data-part="branch-control"]`).first().click();
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Verbs Editor Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    await addRoom('Room One');
+    await addObjectIn('Room One', 'Statue');
+    console.log('PASS: created Room One and a Statue object inside it');
+
+    await selectTreeNode('Statue');
+    await page.waitForSelector('button:has-text("Verbs")', { timeout: 10000 });
+    await page.click('button:has-text("Verbs")');
+    await page.waitForSelector('text=No verbs added yet', { timeout: 10000 });
+    console.log('PASS: Verbs tab renders (previously rendered nothing) and starts empty');
+
+    // Typing a pattern that clashes with a built-in command ("take") must surface the
+    // game-specific clash message wired through from CoreEditorObjectVerbs.aslx's
+    // <clashmessages>, not just a generic error.
+    const comboInput = page.locator('[role="combobox"]');
+    await comboInput.click();
+    await comboInput.fill('take');
+    await page.keyboard.press('Tab'); // blur commits the Combobox's free-typed value
+    await page.click('button:has-text("Add Verb")');
+    await page.waitForSelector('text=Use the Inventory tab', { timeout: 10000 });
+    console.log('PASS: adding a verb that clashes with a built-in command shows the specific clash message');
+
+    // Add a genuine custom verb.
+    await comboInput.click();
+    await comboInput.fill('smell');
+    await page.keyboard.press('Tab');
+    await page.click('button:has-text("Add Verb")');
+    await page.waitForSelector('table >> text=smell', { timeout: 10000 });
+    console.log('PASS: adding a new custom verb ("smell") succeeds');
+
+    // New verb defaults to "Print a message" and is auto-selected in the behaviour panel.
+    await page.waitForSelector('text=Print a message', { timeout: 5000 });
+    const typeSelect = page.locator('select').first();
+    if (await typeSelect.inputValue() !== 'string') throw new Error('Expected new verb to default to the "string" (Print a message) type');
+    console.log('PASS: new verb defaults to "Print a message" behaviour, auto-selected for editing');
+
+    // Regression check: typing real keystrokes into the message box must actually accumulate —
+    // a reactive effect previously re-synced this buffer from the committed value on every
+    // keystroke (not just on selection changes), which silently discarded everything typed.
+    const messageBox = page.locator('textarea');
+    await messageBox.click();
+    await page.keyboard.type('You give it a sniff. Nothing.', { delay: 20 });
+    const typedValue = await messageBox.inputValue();
+    if (typedValue !== 'You give it a sniff. Nothing.') throw new Error(`Expected typed keystrokes to accumulate in the message box, got: ${JSON.stringify(typedValue)}`);
+    console.log('PASS: message text field accepts real keystrokes without resetting itself');
+
+    // And it must actually commit (on blur) — reselecting the verb should show the saved text.
+    await page.click('text=Behaviour');
+    const smellListRow = page.locator('tr', { hasText: 'smell' });
+    await smellListRow.click();
+    await messageBox.waitFor({ timeout: 5000 });
+    const persistedValue = await messageBox.inputValue();
+    if (persistedValue !== 'You give it a sniff. Nothing.') throw new Error(`Expected the message to persist after reselecting the verb, got: ${JSON.stringify(persistedValue)}`);
+    console.log('PASS: message commits on blur and persists across reselection');
+
+    // Switch behaviour to "Run a script".
+    await typeSelect.selectOption('script');
+    await page.waitForSelector('button:has-text("Add script")', { timeout: 10000 });
+    console.log('PASS: switching behaviour to "Run a script" shows the script editor');
+
+    // Switch behaviour to "Require another object".
+    await typeSelect.selectOption('scriptdictionary');
+    await page.waitForSelector('input[placeholder="Add entry key…"]', { timeout: 10000 });
+    console.log('PASS: switching behaviour to "Require another object" shows the script-dictionary editor');
+
+    // Scoped to the entry-key input's own row — a bare "Add" text match would also hit the
+    // toolbar's "+ Add" dropdown trigger and the "Add Verb" button.
+    const entryKeyInput = page.locator('input[placeholder="Add entry key…"]');
+    await entryKeyInput.fill('key');
+    await entryKeyInput.locator('..').getByRole('button', { name: 'Add', exact: true }).click();
+    await page.getByRole('button', { name: 'key' }).waitFor({ timeout: 10000 });
+    console.log('PASS: can add an object-keyed entry under "Require another object"');
+
+    // Delete the verb.
+    const smellRow = page.locator('tr', { hasText: 'smell' });
+    await smellRow.locator('button[title="Remove verb"]').click();
+    await page.waitForSelector('text=No verbs added yet', { timeout: 10000 });
+    console.log('PASS: deleting a verb removes it from the list');
+
+    // Undo restores it.
+    await page.click('button[title="Undo"]');
+    await page.waitForSelector('table >> text=smell', { timeout: 10000 });
+    console.log('PASS: Undo restores the deleted verb');
+
+    // "smell" above matched an existing library verb, so it never exercised AddVerb's other
+    // branch: a genuinely novel pattern (no existing match) creates a brand-new verb command
+    // element (visible under the game's Commands tree node) as well as setting the attribute.
+    await comboInput.click();
+    await comboInput.fill('juggle');
+    await page.keyboard.press('Tab');
+    await page.click('button:has-text("Add Verb")');
+    await page.waitForSelector('table >> text=juggle', { timeout: 10000 });
+    console.log('PASS: adding a genuinely novel verb pattern ("juggle") succeeds');
+
+    // The new verb command element lands under the game's synthetic "Verbs" tree node (key
+    // "_gameVerbs" — see EditorController's k_verbs), alongside any library-defined verbs.
+    await selectTreeNode('_gameVerbs');
+    await page.waitForSelector('text=juggle', { timeout: 10000 });
+    console.log('PASS: the novel verb also created a new command element under the Verbs tree node');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-verbs-editor-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}

--- a/tests/e2e/verify-appshell-verbs-editor.mjs
+++ b/tests/e2e/verify-appshell-verbs-editor.mjs
@@ -104,18 +104,35 @@ async function run() {
     await page.waitForSelector('button:has-text("Add script")', { timeout: 10000 });
     console.log('PASS: switching behaviour to "Run a script" shows the script editor');
 
-    // Switch behaviour to "Require another object".
+    // Switch behaviour to "Require another object" — the entry-key field must be an object
+    // picker (not free text), since the dictionary key has to be a real object name.
     await typeSelect.selectOption('scriptdictionary');
-    await page.waitForSelector('input[placeholder="Add entry key…"]', { timeout: 10000 });
-    console.log('PASS: switching behaviour to "Require another object" shows the script-dictionary editor');
+    const entryKeySelect = page.getByLabel('Add entry key');
+    await entryKeySelect.waitFor({ timeout: 10000 });
+    if ((await entryKeySelect.evaluate(el => el.tagName)) !== 'SELECT') throw new Error('Expected "Require another object" to offer an object-picker dropdown, not a free-text field');
+    console.log('PASS: switching behaviour to "Require another object" shows an object-picker dropdown');
 
-    // Scoped to the entry-key input's own row — a bare "Add" text match would also hit the
+    const objectOptions = await entryKeySelect.locator('option').allTextContents();
+    if (!objectOptions.includes('Room One')) throw new Error(`Expected the object picker to list "Room One", got: ${JSON.stringify(objectOptions)}`);
+    if (objectOptions.includes('Statue')) throw new Error('Expected the object picker to exclude the object itself ("Statue")');
+    console.log('PASS: object picker lists other objects and excludes the object itself');
+
+    // Scoped to the entry-key select's own row — a bare "Add" text match would also hit the
     // toolbar's "+ Add" dropdown trigger and the "Add Verb" button.
-    const entryKeyInput = page.locator('input[placeholder="Add entry key…"]');
-    await entryKeyInput.fill('key');
-    await entryKeyInput.locator('..').getByRole('button', { name: 'Add', exact: true }).click();
-    await page.getByRole('button', { name: 'key' }).waitFor({ timeout: 10000 });
+    const addEntryButton = entryKeySelect.locator('..').getByRole('button', { name: 'Add', exact: true });
+    if (!(await addEntryButton.isDisabled())) throw new Error('Expected "Add" to be disabled before an object is chosen');
+    await entryKeySelect.selectOption('Room One');
+    if (await addEntryButton.isDisabled()) throw new Error('Expected "Add" to enable once an object is chosen');
+    await addEntryButton.click();
+    // Scoped to the dictionary editor's own container (two levels up from the entry-key select)
+    // — a bare "Room One" role match also hits its tree node, which has the same accessible name.
+    const dictEditor = entryKeySelect.locator('..').locator('..');
+    await dictEditor.getByRole('button', { name: 'Room One' }).waitFor({ timeout: 10000 });
     console.log('PASS: can add an object-keyed entry under "Require another object"');
+
+    const objectOptionsAfterAdd = await entryKeySelect.locator('option').allTextContents();
+    if (objectOptionsAfterAdd.includes('Room One')) throw new Error('Expected the object picker to exclude "Room One" now that it has been added');
+    console.log('PASS: object picker excludes objects already added as entries');
 
     // Delete the verb.
     const smellRow = page.locator('tr', { hasText: 'smell' });


### PR DESCRIPTION
## Summary
- Adds a Verbs editor tab for objects (previously empty) — list of the object's own verbs plus a "Behaviour" panel to switch each between "Print a message" / "Run a script" / "Require another object", mirroring the existing Attributes editor. Backed by new `WasmEditorBridge` `GetVerbAttributesInfo`/`AddVerb` endpoints that port v5 WebEditor's `VerbsAdd` logic (clash detection against built-in commands, custom verb command creation).
- "Require another object" now offers an object-picker dropdown for the dictionary key instead of free text (opt-in via a new `ScriptDictionaryEditor` `keySource` prop, so the generic Attributes-tab usage is unaffected), matching v5's desktop editor.
- Adds a drag-resizable splitter for the Behaviour panel, matching Attributes' assignment panel, defaulting wider (480px) since the verbs list only needs a couple of narrow columns.
- Along the way: fixed `Combobox`'s suggestion dropdown to flip upward when pinned near the bottom of a panel (previously rendered off-screen/clipped), and added a live `oninput` callback so dependent button-disabled checks don't lag behind typed text.

## Test plan
- [x] `tests/e2e/verify-appshell-verbs-editor.mjs` (new) — empty state, built-in-command clash message, adding a library verb and a genuinely novel one (creates a command element under the tree's Verbs node), switching between all three behaviour types, message persistence across reselection, object-picker exclusions, delete, undo
- [x] `tests/e2e/verify-appshell-exits-editor.mjs` rerun clean (touched shared `PropertyEditor`/`Combobox`)
- [x] `npm run check` / `eslint` clean
- [x] `dotnet test tests/EditorCoreTests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)