### PR TITLE
fix(Engine): always allow creating look-only exits

### DIFF
--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -214,13 +214,11 @@
                         disabled={!createTo}
                         onclick={() => doCreate(openDirection!)}
                     >Create exit</button>
-                    {#if data.allowLookExits}
-                        <button
-                            type="button"
-                            class="text-xs text-surface-400-500 hover:text-primary-600-400 underline text-left"
-                            onclick={() => doCreateLook(openDirection!)}
-                        >Create a look exit instead</button>
-                    {/if}
+                    <button
+                        type="button"
+                        class="text-xs text-surface-400-500 hover:text-primary-600-400 underline text-left"
+                        onclick={() => doCreateLook(openDirection!)}
+                    >Create a look exit instead</button>
                 </div>
                 {#if warning}
                     <p class="text-xs text-warning-600-400">{warning}</p>

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -65,7 +65,6 @@ export interface ExitsData {
   compass: CompassDirectionInfo[]
   allExits: ExitRowInfo[]
   objects: ControlOption[]
-  allowLookExits: boolean
 }
 
 export interface ScriptControlData {

--- a/src/Engine/Core/CoreEditorExit.aslx
+++ b/src/Engine/Core/CoreEditorExit.aslx
@@ -111,7 +111,6 @@
         <controltype>title</controltype>
         <caption>[EditorExitLookinthis]</caption>
         <advanced/>
-        <onlydisplayif>game.allowlookdirections</onlydisplayif>
       </control>
 
       <control>
@@ -119,7 +118,6 @@
         <controltype>checkbox</controltype>
         <attribute>lookonly</attribute>
         <advanced/>
-        <onlydisplayif>game.allowlookdirections</onlydisplayif>
       </control>
 
       <control>
@@ -133,7 +131,6 @@
           string=textbox
         </editors>
         <advanced/>
-        <onlydisplayif>game.allowlookdirections</onlydisplayif>
       </control>
 
     </tab>

--- a/src/Engine/Core/CoreEditorGame.aslx
+++ b/src/Engine/Core/CoreEditorGame.aslx
@@ -157,12 +157,6 @@
 
       <control>
         <controltype>checkbox</controltype>
-        <caption>[EditorGameAllowLookDirections]</caption>
-        <attribute>allowlookdirections</attribute>
-      </control>	  
-
-      <control>
-        <controltype>checkbox</controltype>
         <caption>[EditorGameMultipleCommands]</caption>
         <attribute>multiplecommands</attribute>
       </control>

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -149,7 +149,6 @@
   <template name="EditorGameAnnotations">Notizen: Eine Registerkarte für "Notizen" wird jedem Raum hinzugefügt (Nicht sichtbar für den Spieler)</template>
   <template name="EditorGamePrices">Preise: Ein Nummernfeld zur Angabe eines Artikelpreises wird der Registerkarte "Inventar" hinzugefügt</template>
   <template name="EditorGameInroomdescriptions">Beschreibungen im Raum: Zu jedem Objekt kann eine zusätzliche Beschreibung in den Räumen angezeigt werden</template>
-  <template name="EditorGameAllowLookDirections">Die Ausgänge können in Richtungen nur zum Betrachten umgewandelt werden</template>
   <template name="EditorGameMultipleCommands">Eingabe mehrerer Kommandos in einem Kommandofeld erlauben (Getrennt durch einen Punkt)</template>
   <template name="EditorGameHideSaveButton">Speichern-Schaltfläche im Webplayer entfernen</template>
   <template name="EditorGameDisplay">Oberfläche</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -146,7 +146,6 @@
   <template name="EditorGameAnnotations">Annotations: adds a tab to rooms where authors notes can be made, not seen by players</template>
   <template name="EditorGamePrices">Prices: adds a number box to the Inventory tab for the price of the item</template>
   <template name="EditorGameInroomdescriptions">In-room descriptions: additional text which each object contributes to a room description</template>
-  <template name="EditorGameAllowLookDirections">Directional exits can be look only</template>
   <template name="EditorGameMultipleCommands">Allow input of multiple commands in one line separated by "."</template>
   <template name="EditorGameHideSaveButton">Hide the Save button on the web player</template>
   <template name="EditorGameDisplay">Display</template>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -120,8 +120,7 @@ internal record ExitRowInfo(string Key, string? Alias, string? To, bool LookOnly
 internal record ExitsData(
     List<CompassDirectionInfo> Compass,
     List<ExitRowInfo> AllExits,
-    List<ControlOption> Objects,
-    bool AllowLookExits);
+    List<ControlOption> Objects);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
@@ -1646,7 +1645,7 @@ public partial class WasmEditorBridge
     [JSExport]
     public static string GetExitsData(string roomKey)
     {
-        var empty = new ExitsData([], [], [], false);
+        var empty = new ExitsData([], [], []);
         if (_controller == null)
         {
             return JsonSerializer.Serialize(empty, WasmEditorJsonContext.Default.ExitsData);
@@ -1689,10 +1688,7 @@ public partial class WasmEditorBridge
             .OrderBy(n => n, StringComparer.CurrentCultureIgnoreCase)
             .Select(n => new ControlOption(n, n)).ToList();
 
-        var gameData = _controller.GetEditorData("game");
-        var allowLookExits = gameData?.GetAttribute("allowlookdirections") as bool? ?? false;
-
-        var result = new ExitsData(compass, allExits, objects, allowLookExits);
+        var result = new ExitsData(compass, allExits, objects);
         return JsonSerializer.Serialize(result, WasmEditorJsonContext.Default.ExitsData);
     }
 

--- a/tests/e2e/verify-appshell-exits-editor.mjs
+++ b/tests/e2e/verify-appshell-exits-editor.mjs
@@ -51,16 +51,6 @@ async function run() {
     await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     console.log('PASS: local draft created and opened in the editor');
 
-    // Enable "look" exits at the game level so the compass cell's "Create a look exit instead"
-    // shortcut is offered (it's gated on game.allowlookdirections, off by default). The "game"
-    // node is already selected by default right after load, so no tree click needed here — its
-    // bounding box spans its (already-expanded) Verbs/Commands children too, which made an
-    // explicit click on it land on the wrong row.
-    await page.click('button:has-text("Features")');
-    await page.waitForSelector('text=Directional exits can be look only', { timeout: 10000 });
-    await page.click('label:has-text("Directional exits can be look only") input[type="checkbox"]');
-    console.log('PASS: enabled "look" exits at the game level');
-
     await addRoom('Room One');
     await addRoom('Room Two');
     console.log('PASS: created Room One and Room Two');


### PR DESCRIPTION
## Summary
- Removes the "Directional exits can be look only" game feature toggle (`allowlookdirections`). Tracing through the git history back to 2011-era Quest 5, this setting only ever gated a few advanced fields on an individual exit's own editor tab (`CoreEditorExit.aslx`, added 2017). The compass-grid "Exits" UI — the actual, normal way authors create exits, in both the old v5 desktop (WPF) and web editors as well as the new AppShell editor — never checked it, so look-only exits could always be created regardless of the toggle. It was dead weight from day one.
- The "Create a look exit instead" option in the new AppShell Exits tab is now always shown (previously gated on this same toggle via `game.allowlookdirections`).

## Test plan
- [x] `dotnet build --configuration Release` — full solution builds clean
- [x] `dotnet test --configuration Release` — all 327 tests pass across EngineTests/EditorCoreTests/PlayerCoreTests/LegacyTests/WebPlayerTests
- [x] `npx tsc --noEmit` in `src/AppShell` — no type errors
- [x] `node tests/e2e/verify-appshell-exits-editor.mjs` against a running AppShell dev server — all checks pass, including creating a look-only exit with no prior toggle step

🤖 Generated with [Claude Code](https://claude.com/claude-code)