### PR TITLE
fix(Engine): remove dead "write log to file" feature

### DIFF
--- a/src/Engine/Core/CoreEditorGame.aslx
+++ b/src/Engine/Core/CoreEditorGame.aslx
@@ -167,11 +167,6 @@
         <attribute>multiplecommands</attribute>
       </control>
     
-      <control>
-        <controltype>checkbox</controltype>
-        <caption>[EditorGameWriteLogToFile]</caption>
-        <attribute>writelogtofile</attribute>
-      </control>
     </tab>
 
     <tab>

--- a/src/Engine/Core/CoreOutput.aslx
+++ b/src/Engine/Core/CoreOutput.aslx
@@ -884,10 +884,6 @@
       text = "[" + TypeOf(text) + "]"
     }
     request (Log, text)
-    if (GetBoolean(game, "writelogtofile")){
-      text = Replace(text, "\"", "''")
-      JS.WriteToLog(text)
-    }
     ]]>
   </function>
 

--- a/src/Engine/Core/CoreTypes.aslx
+++ b/src/Engine/Core/CoreTypes.aslx
@@ -94,7 +94,6 @@
     <showmenuresponses type="boolean">false</showmenuresponses>
     <multiplecommands type="boolean">false</multiplecommands>
     <publishfileextensions>*.jpg;*.jpeg;*.png;*.gif;*.js;*.wav;*.mp3;*.htm;*.html;*.svg;*.ogg;*.ogv</publishfileextensions>
-    <writelogtofile type="boolean">false</writelogtofile>
     <notranscript type="boolean">false</notranscript>
     <savetranscript type="boolean">false</savetranscript>
     <changedsavetranscript type="script">

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -916,5 +916,4 @@
   <template name="EditorScriptObjectsHide">Hide</template>
   <template name="EditorScriptObjectsPrint">Print</template>
   <template name="EditorScriptObjectsIf">If</template>
-  <template name="EditorGameWriteLogToFile">Save log entries to a file in "Documents\Quest Logs"</template>
 </library>

--- a/src/PlayerCore/Resources/player.js
+++ b/src/PlayerCore/Resources/player.js
@@ -202,10 +202,6 @@ function addExternalScript(url) {
     });
 }
 
-function WriteToLog(data) {
-    // Do nothing.
-}
-
 function WriteToTranscript(data) {
     if (noTranscript) {
         // Do nothing.


### PR DESCRIPTION
## Summary
- The Features tab's "Save log entries to a file in \"Documents\Quest Logs\"" checkbox (`writelogtofile`) is a leftover from the old Windows desktop Quest player and no longer does anything in either web player:
  - **WebPlayer/Electron**: `WriteToLog` in `PlayerCore/Resources/player.js` was already a no-op stub (`// Do nothing.`)
  - **WasmPlayer**: never defined `WriteToLog` at all — the call throws a `ReferenceError` that's caught and silently logged to the console
  - Neither player runs anywhere with a writable `Documents\Quest Logs` folder (WebPlayer is server-hosted, WasmPlayer is browser-sandboxed)
- Removes the editor checkbox, the `writelogtofile` attribute default, the dead branch in `Log()`, the caption template, and the now-orphaned JS stub.

## Test plan
- [x] `dotnet build --configuration Release` succeeds
- [x] `dotnet test` passes for EngineTests, EditorCoreTests, PlayerCoreTests
- [x] Confirmed no other references to `writelogtofile`/`WriteToLog` remain in tracked source

🤖 Generated with [Claude Code](https://claude.com/claude-code)