### PR TITLE
fix(Engine): remove "Hide the Save button" game option

### DIFF
--- a/src/Engine/Core/Core.aslx
+++ b/src/Engine/Core/Core.aslx
@@ -143,9 +143,6 @@
     if (HasString(game, "marginscolour")) {
       JS.setCss ("body", "background-color:" + game.marginscolour)
     }
-    if (game.turnoffsavebutton) {
-      JS.setCss ("#controlButtons", "display:none")
-    }
     if (game.turnoffcompass) {
       JS.setCss ("#compassLabel", "display:none;")
       JS.setCss ("#compassAccordion", "display:none;")

--- a/src/Engine/Core/CoreEditorGame.aslx
+++ b/src/Engine/Core/CoreEditorGame.aslx
@@ -626,14 +626,6 @@
       </control>
       
       <control>
-        <controltype>checkbox</controltype>
-        <caption>[EditorGameHideSaveButton]</caption>
-        <attribute>turnoffsavebutton</attribute>
-        <onlydisplayif>game.showlocation</onlydisplayif>
-      </control>	  
-      
-      
-      <control>
         <controltype>title</controltype>
         <caption>[EditorGameBorderCaption]</caption>
       </control>

--- a/src/Engine/Core/CoreTypes.aslx
+++ b/src/Engine/Core/CoreTypes.aslx
@@ -45,7 +45,6 @@
     <commandcursor>&gt;</commandcursor>
     <moneyformat>$!</moneyformat>
     <classiclocation/>
-    <turnoffsavebutton type="boolean">false</turnoffsavebutton>
     <mapexitwidth type="int">1</mapexitwidth>
     <mapexitcolour>Black</mapexitcolour>
     

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -150,7 +150,6 @@
   <template name="EditorGamePrices">Preise: Ein Nummernfeld zur Angabe eines Artikelpreises wird der Registerkarte "Inventar" hinzugefügt</template>
   <template name="EditorGameInroomdescriptions">Beschreibungen im Raum: Zu jedem Objekt kann eine zusätzliche Beschreibung in den Räumen angezeigt werden</template>
   <template name="EditorGameMultipleCommands">Eingabe mehrerer Kommandos in einem Kommandofeld erlauben (Getrennt durch einen Punkt)</template>
-  <template name="EditorGameHideSaveButton">Speichern-Schaltfläche im Webplayer entfernen</template>
   <template name="EditorGameDisplay">Oberfläche</template>
   <template name="EditorGameTheme">Thema</template>
   <template name="EditorGameFont">Schriftart</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -147,7 +147,6 @@
   <template name="EditorGamePrices">Prices: adds a number box to the Inventory tab for the price of the item</template>
   <template name="EditorGameInroomdescriptions">In-room descriptions: additional text which each object contributes to a room description</template>
   <template name="EditorGameMultipleCommands">Allow input of multiple commands in one line separated by "."</template>
-  <template name="EditorGameHideSaveButton">Hide the Save button on the web player</template>
   <template name="EditorGameDisplay">Display</template>
   <template name="EditorGameTheme">Theme</template>
   <template name="EditorGameFont">Text</template>


### PR DESCRIPTION
## Summary
- Removes the Features-tab checkbox "Hide the Save button on the web player" (`turnoffsavebutton` attribute), its `Core.aslx` handling, and the English/German editor translation strings.
- The option has been mislabeled since it was added in Quest 5.7 (2017): it hides the whole `#controlButtons` div, which contains the Debug and panes-toggle hamburger buttons alongside Save, not just Save. On narrow/mobile layouts the hamburger button is the only way to show/hide the sidebar panes, and `#cmdSave`'s click handler now opens the multi-slot save/load dialog — so enabling this option silently breaks more UI than it advertises and blocks saving entirely.

## Test plan
- [x] `dotnet build --configuration Release` succeeds
- [x] `dotnet test --configuration Release` — all 327 tests pass across EngineTests, PlayerCoreTests, EditorCoreTests, WebPlayerTests, LegacyTests

🤖 Generated with [Claude Code](https://claude.com/claude-code)