### PR TITLE
fix(AppShell): surface clearer validation errors when renaming an object

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -35,7 +35,7 @@
 
     function recordResult(attribute: string, result: string) {
         const error = result.startsWith("error:") ? result.slice("error:".length) : "";
-        attributeErrors = {...attributeErrors, [attribute]: error};
+        attributeErrors = { ...attributeErrors, [attribute]: error };
         // The inline error below the field only stays visible while this element/tab is in
         // view — a toast survives switching to a different tab or element entirely.
         if (error) showToast(error, "error");

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { selectedKey, selectedData, setAttribute, setDropdownType, setMultiType, setObjectReference, addDictItem, removeDictItem, updateDictItem } from "$lib/editor-store";
+    import { showToast } from "$lib/toast";
     import type { ControlInfo, TextProcessorCommand } from "$lib/types";
     import ScriptEditor from "./ScriptEditor.svelte";
     import Combobox from "./Combobox.svelte";
@@ -14,12 +15,14 @@
     let lastKey = $state<string | null>(null);
     let editingItem = $state<{attribute: string, key: string, value: string} | null>(null);
     let newDictItems = $state<Record<string, {key: string, value: string}>>({});
+    let attributeErrors = $state<Record<string, string>>({});
 
     $effect(() => {
         const key = $selectedKey;
         const data = $selectedData;
         if (key !== lastKey) {
             lastKey = key;
+            attributeErrors = {};
             activeTab = (data && data.tabs.length > 0) ? data.tabs[0].caption : null;
         } else if (activeTab !== null) {
             // Keep activeTab valid after a data refresh (tab list is stable for the same node)
@@ -30,20 +33,28 @@
         }
     });
 
+    function recordResult(attribute: string, result: string) {
+        const error = result.startsWith("error:") ? result.slice("error:".length) : "";
+        attributeErrors = {...attributeErrors, [attribute]: error};
+        // The inline error below the field only stays visible while this element/tab is in
+        // view — a toast survives switching to a different tab or element entirely.
+        if (error) showToast(error, "error");
+    }
+
     function onTextChange(attribute: string, controlType: string, value: string) {
-        if ($selectedKey) setAttribute($selectedKey, attribute, controlType, value);
+        if ($selectedKey) recordResult(attribute, setAttribute($selectedKey, attribute, controlType, value));
     }
 
     function onCheckboxChange(attribute: string, checked: boolean) {
-        if ($selectedKey) setAttribute($selectedKey, attribute, "checkbox", checked.toString());
+        if ($selectedKey) recordResult(attribute, setAttribute($selectedKey, attribute, "checkbox", checked.toString()));
     }
 
     function onNumberChange(attribute: string, controlType: string, value: string) {
-        if ($selectedKey) setAttribute($selectedKey, attribute, controlType, value);
+        if ($selectedKey) recordResult(attribute, setAttribute($selectedKey, attribute, controlType, value));
     }
 
     function onDropdownChange(attribute: string, value: string) {
-        if ($selectedKey) setAttribute($selectedKey, attribute, "dropdown", value);
+        if ($selectedKey) recordResult(attribute, setAttribute($selectedKey, attribute, "dropdown", value));
     }
 
     function getControlsForView(): ControlInfo[] {
@@ -204,7 +215,7 @@
         <input
             type="text"
             autocapitalize="off"
-            class="input text-xs py-0.5 px-1.5 w-full"
+            class={"input text-xs py-0.5 px-1.5 w-full" + (ctrl.attribute && attributeErrors[ctrl.attribute] ? " !border-error-500" : "")}
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value)}
         />
@@ -470,11 +481,19 @@
                 <div class="flex flex-col gap-1 px-3 py-1.5">
                     <span class="text-xs text-surface-600-400">{label}:</span>
                     {@render controlOnly(ctrl)}
+                    {#if ctrl.attribute && attributeErrors[ctrl.attribute]}
+                        <p class="text-xs text-error-500">{attributeErrors[ctrl.attribute]}</p>
+                    {/if}
                 </div>
             {:else}
-                <div class="flex {isMultiline ? "items-start" : "items-center"} gap-2 px-3 py-1.5 min-h-8">
-                    <span class="text-xs text-surface-600-400 w-32 flex-shrink-0 {isMultiline ? "pt-0.5" : ""}">{label}:</span>
-                    {@render controlOnly(ctrl)}
+                <div class="flex flex-col gap-1 px-3 py-1.5">
+                    <div class="flex {isMultiline ? "items-start" : "items-center"} gap-2 min-h-8">
+                        <span class="text-xs text-surface-600-400 w-32 flex-shrink-0 {isMultiline ? "pt-0.5" : ""}">{label}:</span>
+                        {@render controlOnly(ctrl)}
+                    </div>
+                    {#if ctrl.attribute && attributeErrors[ctrl.attribute]}
+                        <p class="text-xs text-error-500">{attributeErrors[ctrl.attribute]}</p>
+                    {/if}
                 </div>
             {/if}
         {/if}

--- a/src/AppShell/src/components/Toast.svelte
+++ b/src/AppShell/src/components/Toast.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import { toasts, dismissToast } from "$lib/toast";
+</script>
+
+<div class="fixed bottom-4 right-4 z-[60] flex flex-col gap-2 items-end pointer-events-none">
+    {#each $toasts as toast (toast.id)}
+        <div
+            role="alert"
+            class={"pointer-events-auto shadow-lg rounded-lg px-4 py-2 text-sm max-w-sm flex items-start gap-2 " + (toast.kind === "error" ? "preset-filled-error-500" : "preset-filled-surface-500")}
+        >
+            <span class="flex-1">{toast.text}</span>
+            <button
+                type="button"
+                class="opacity-80 hover:opacity-100 leading-none"
+                aria-label="Dismiss"
+                onclick={() => dismissToast(toast.id)}
+            >✕</button>
+        </div>
+    {/each}
+</div>

--- a/src/AppShell/src/lib/toast.ts
+++ b/src/AppShell/src/lib/toast.ts
@@ -15,7 +15,7 @@ let nextId = 0;
 // to a specific control, which disappears the moment the user navigates away from it).
 export function showToast(text: string, kind: ToastMessage["kind"] = "error", durationMs = 6000): void {
     const id = ++nextId;
-    toasts.update(list => [...list, {id, text, kind}]);
+    toasts.update(list => [...list, { id, text, kind }]);
     setTimeout(() => {
         toasts.update(list => list.filter(t => t.id !== id));
     }, durationMs);

--- a/src/AppShell/src/lib/toast.ts
+++ b/src/AppShell/src/lib/toast.ts
@@ -1,0 +1,26 @@
+import { writable } from "svelte/store";
+
+export interface ToastMessage {
+    id: number;
+    text: string;
+    kind: "error" | "info";
+}
+
+export const toasts = writable<ToastMessage[]>([]);
+
+let nextId = 0;
+
+// Fire-and-forget notification rendered through Toast.svelte (mounted once in +layout.svelte,
+// so it survives whatever tab/element/route is currently active — unlike an inline error tied
+// to a specific control, which disappears the moment the user navigates away from it).
+export function showToast(text: string, kind: ToastMessage["kind"] = "error", durationMs = 6000): void {
+    const id = ++nextId;
+    toasts.update(list => [...list, {id, text, kind}]);
+    setTimeout(() => {
+        toasts.update(list => list.filter(t => t.id !== id));
+    }, durationMs);
+}
+
+export function dismissToast(id: number): void {
+    toasts.update(list => list.filter(t => t.id !== id));
+}

--- a/src/AppShell/src/routes/+layout.svelte
+++ b/src/AppShell/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
     import HomeHeader from "$components/HomeHeader.svelte";
     import HomeTabs from "$components/HomeTabs.svelte";
     import ConfirmDialog from "$components/ConfirmDialog.svelte";
+    import Toast from "$components/Toast.svelte";
 
     let { children }: { children: Snippet } = $props();
 
@@ -124,3 +125,4 @@
 {/if}
 {@render children()}
 <ConfirmDialog />
+<Toast />

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -70,7 +70,7 @@ public sealed class EditorController : IDisposable
         {ValidationMessage.ExceptionOccurred, "An error occurred: {1}"},
         {
             ValidationMessage.InvalidElementName,
-            "Invalid element name. {1} cannot be used — element names can only contain letters, numbers, underscores and spaces."
+            "Invalid element name. {1} cannot be used - element names can only contain letters, numbers, underscores and spaces."
         },
         {ValidationMessage.InvalidElementNameEmpty, "Element name cannot be empty."},
         {ValidationMessage.CircularTypeReference, "Circular type reference"},

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -25,6 +25,7 @@ public enum ValidationMessage
     InvalidAttributeName,
     ExceptionOccurred,
     InvalidElementName,
+    InvalidElementNameEmpty,
     CircularTypeReference,
     InvalidElementNameMultipleSpaces,
     InvalidElementNameInvalidWord,
@@ -67,7 +68,11 @@ public sealed class EditorController : IDisposable
         {ValidationMessage.ElementAlreadyExists, "An element called '{0}' already exists in this game"},
         {ValidationMessage.InvalidAttributeName, "Invalid attribute name"},
         {ValidationMessage.ExceptionOccurred, "An error occurred: {1}"},
-        {ValidationMessage.InvalidElementName, "Invalid element name"},
+        {
+            ValidationMessage.InvalidElementName,
+            "Invalid element name. {1} cannot be used — element names can only contain letters, numbers, underscores and spaces."
+        },
+        {ValidationMessage.InvalidElementNameEmpty, "Element name cannot be empty."},
         {ValidationMessage.CircularTypeReference, "Circular type reference"},
         {
             ValidationMessage.InvalidElementNameMultipleSpaces,
@@ -1813,9 +1818,19 @@ public sealed class EditorController : IDisposable
 
     private ValidationResult ValidateElementName(string name)
     {
-        if (string.IsNullOrEmpty(name) || !s_validNameRegex.IsMatch(name))
+        if (string.IsNullOrEmpty(name))
         {
-            return new ValidationResult {Valid = false, Message = ValidationMessage.InvalidElementName};
+            return new ValidationResult {Valid = false, Message = ValidationMessage.InvalidElementNameEmpty};
+        }
+
+        if (!s_validNameRegex.IsMatch(name))
+        {
+            var invalidChars = Regex.Matches(name, "[^\\w ]").Select(m => m.Value).Distinct().ToList();
+            return new ValidationResult
+            {
+                Valid = false, Message = ValidationMessage.InvalidElementName,
+                MessageData = FormatInvalidCharacterList(invalidChars)
+            };
         }
 
         if (name.StartsWith(" ") || name.EndsWith(" ") || name.Contains("  "))
@@ -1839,6 +1854,15 @@ public sealed class EditorController : IDisposable
         }
 
         return new ValidationResult {Valid = true};
+    }
+
+    // e.g. ["-"] -> "'-'", ["-", "."] -> "'-' and '.'", ["-", ".", "!"] -> "'-', '.' and '!'"
+    private static string FormatInvalidCharacterList(List<string> chars)
+    {
+        var quoted = chars.Select(c => $"'{c}'").ToList();
+        return quoted.Count == 1
+            ? quoted[0]
+            : string.Join(", ", quoted.Take(quoted.Count - 1)) + " and " + quoted[^1];
     }
 
     public ValidationResult CanAddTemplate(string name)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -321,7 +321,7 @@ public partial class WasmEditorBridge
             var result = data.SetAttribute(attribute, typedValue);
             if (!result.Valid)
             {
-                return result.Message.ToString();
+                return $"error:{EditorController.GetValidationError(result, typedValue)}";
             }
 
             return _pendingRenameNewKey != null ? $"renamed:{_pendingRenameNewKey}" : "ok";

--- a/tests/e2e/verify-rename-invalid-name.mjs
+++ b/tests/e2e/verify-rename-invalid-name.mjs
@@ -58,10 +58,13 @@ async function run() {
     await nameInput.fill('new-thing');
     await nameInput.blur();
 
-    // Should show an inline validation error instead of silently accepting/discarding it.
+    // Should show an inline validation error instead of silently accepting/discarding it, and it
+    // should call out the specific offending character rather than a generic "invalid name".
     const errorText = page.locator('p.text-error-500', { hasText: /invalid/i });
     await errorText.waitFor({ timeout: 5000 });
-    console.log(`PASS: inline error shown: "${await errorText.textContent()}"`);
+    const errorMessage = await errorText.textContent();
+    if (!errorMessage?.includes("'-'")) throw new Error(`Expected the error to call out the '-' character specifically, got: "${errorMessage}"`);
+    console.log(`PASS: inline error shown, naming the specific bad character: "${errorMessage}"`);
 
     const borderClass = await nameInput.getAttribute('class');
     if (!borderClass?.includes('border-error-500')) throw new Error('Expected name input to get an error border');

--- a/tests/e2e/verify-rename-invalid-name.mjs
+++ b/tests/e2e/verify-rename-invalid-name.mjs
@@ -1,0 +1,119 @@
+// Ad-hoc manual verification: renaming an object to an invalid name (e.g. containing a dash)
+// used to silently fail — PropertyEditor.svelte discarded the ValidationResult returned by
+// setAttribute(), and WasmEditorBridge.SetAttribute returned the raw C# enum name instead of a
+// friendly message. This checks that an inline error now appears (and a toast that survives
+// switching to a different tree node, unlike the tab-scoped inline error) and the rename doesn't
+// stick.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function addRoom(name) {
+    await page.click('button[title="Add element"]');
+    await page.click('.add-dropdown button:has-text("Add Room")', { timeout: 5000 });
+    await page.waitForSelector('#element-name');
+    await page.fill('#element-name', name);
+    await page.click('[role="dialog"] button:has-text("Add")');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+async function selectTreeNode(name) {
+    await page.locator(`[data-value="${name}"][data-part="item"], [data-value="${name}"][data-part="branch-control"]`).first().click();
+}
+
+async function addObjectIn(roomName, name) {
+    await selectTreeNode(roomName);
+    await page.click('button[title="Add element"]');
+    await page.click(`.add-dropdown button:has-text("Add Object in")`, { timeout: 5000 });
+    await page.waitForSelector('#element-name');
+    await page.fill('#element-name', name);
+    await page.click('[role="dialog"] button:has-text("Add")');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Rename Invalid Name Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    await addRoom('Room One');
+    console.log('PASS: created Room One');
+    await addObjectIn('Room One', 'thing');
+    console.log('PASS: created object "thing"');
+
+    // The name field is the first textbox control on the object's properties panel.
+    const nameInput = page.locator('input[type="text"]').first();
+    const before = await nameInput.inputValue();
+    if (before !== 'thing') throw new Error(`Expected name field to show "thing", got "${before}"`);
+
+    await nameInput.fill('new-thing');
+    await nameInput.blur();
+
+    // Should show an inline validation error instead of silently accepting/discarding it.
+    const errorText = page.locator('p.text-error-500', { hasText: /invalid/i });
+    await errorText.waitFor({ timeout: 5000 });
+    console.log(`PASS: inline error shown: "${await errorText.textContent()}"`);
+
+    const borderClass = await nameInput.getAttribute('class');
+    if (!borderClass?.includes('border-error-500')) throw new Error('Expected name input to get an error border');
+    console.log('PASS: name input gets an error border');
+
+    // A toast should also have fired, rendered at the layout level.
+    const toast = page.locator('[role="alert"]', { hasText: /invalid/i });
+    await toast.waitFor({ timeout: 5000 });
+    console.log(`PASS: toast notification shown: "${await toast.textContent()}"`);
+
+    // The tree label must NOT have changed to the invalid name.
+    const treeStillThing = await page.locator('[data-value="thing"]').count();
+    if (treeStillThing === 0) throw new Error('Expected tree to still show "thing" (rename should have been rejected)');
+    const treeGotBadName = await page.locator('[data-value="new-thing"]').count();
+    if (treeGotBadName !== 0) throw new Error('Tree picked up the invalid name — rename incorrectly succeeded');
+    console.log('PASS: tree label unchanged ("thing"), invalid rename was rejected');
+
+    // Navigating away to a DIFFERENT node and back should show the field reverted to the real
+    // name, not the stale typed text (this matches the original repro: reselecting the SAME
+    // already-selected node is a no-op and doesn't exercise the bug). The inline error (tied to
+    // the "thing" node's property panel) is expected to disappear once we leave that node — but
+    // the toast must still be showing, since it's the whole point of not being tab/element-scoped.
+    await selectTreeNode('Room One');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 5000 });
+    if ((await toast.count()) === 0) throw new Error('Expected the toast to still be visible after switching to a different tree node');
+    console.log('PASS: toast survives navigating to a different tree node');
+
+    await selectTreeNode('thing');
+    const afterRevisit = await page.locator('input[type="text"]').first().inputValue();
+    if (afterRevisit !== 'thing') throw new Error(`Expected name field to revert to "thing" after reselecting, got "${afterRevisit}"`);
+    console.log('PASS: name field correctly reverted to "thing" after navigating away and back');
+
+    // Now do a VALID rename and confirm it still works (no regression).
+    await nameInput.fill('renamed thing');
+    await nameInput.blur();
+    await page.waitForSelector('[data-value="renamed thing"]', { timeout: 5000 });
+    console.log('PASS: valid rename to "renamed thing" still works');
+
+    // The toast's dismiss button should close it manually rather than waiting out the timeout.
+    await toast.locator('button[aria-label="Dismiss"]').click();
+    await toast.waitFor({ state: 'detached', timeout: 2000 });
+    console.log('PASS: toast dismiss button closes it');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/rename-invalid-name-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Renaming an object to an invalid name (e.g. containing a dash) used to fail silently: `PropertyEditor.svelte` discarded the `ValidationResult` returned by `setAttribute()`, and `WasmEditorBridge.SetAttribute` returned the raw C# enum name instead of a human-readable message.
- Invalid edits now show an inline error plus a global toast (new `Toast.svelte`/`toast.ts`, mounted in `+layout.svelte`) that survives switching tabs or tree nodes, unlike the tab-scoped inline error alone.
- The validation message itself is now specific about what's wrong, e.g. `Invalid element name. '-' cannot be used - element names can only contain letters, numbers, underscores and spaces.`, and an empty name gets its own distinct message instead of sharing the generic one.

## Test plan
- [x] `dotnet test tests/EditorCoreTests` passes
- [x] Full solution `dotnet build --configuration Release` passes
- [x] `npm run check` (svelte-check) passes with 0 errors
- [x] New Playwright script `tests/e2e/verify-rename-invalid-name.mjs` run against the built AppShell dev server: inline error + red border shown, toast fires and survives navigating to a different tree node, name reverts correctly on reselect, valid rename still works, toast dismiss button works
- [x] Manually checked multi-character (`'.', '-' and '!'`) and empty-name messages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)