### PR TITLE
fix(AppShell): list named exits, not objects, in exit-targeted script pickers

### DIFF
--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -25,6 +25,7 @@
         removeElseIf,
         getScriptCommandCategories,
         getObjectNames,
+        getExitNames,
         getIfExpressionTemplates,
         getIfExpressionTemplateData,
         makeScriptEditable,
@@ -70,6 +71,7 @@
     // overriding the default simple-mode detection based on value shape.
     const expressionOverrides = new SvelteSet<string>();
     let objectNames = $state<string[]>([]);
+    let exitNames = $state<string[]>([]);
     let ifTemplates = $state<IfExpressionTemplate[]>([]);
 
     // Load on mount and whenever scriptVersion bumps (undo/redo)
@@ -89,6 +91,10 @@
         if (objectNames.length === 0) {
             const names = getObjectNames();
             if (names && names.length > 0) objectNames = names;
+        }
+        if (exitNames.length === 0) {
+            const names = getExitNames();
+            if (names && names.length > 0) exitNames = names;
         }
         if (ifTemplates.length === 0) {
             const templates = getIfExpressionTemplates();
@@ -121,6 +127,10 @@
 
     function exprKey(scriptIndex: number, attr: string): string {
         return `${containerPath}/${scriptIndex}/${attr}`;
+    }
+
+    function namesForControl(ctrl: ScriptControlData): string[] {
+        return ctrl.objectType === "exit" ? exitNames : objectNames;
     }
 
     function isSimpleValue(ctrl: ScriptControlData): boolean {
@@ -578,7 +588,7 @@
                         onchange={(e) => onSimpleValueChange(scriptIndex, ctrl, (e.target as HTMLSelectElement).value)}
                     >
                         <option value=""></option>
-                        {#each objectNames as name (name)}
+                        {#each namesForControl(ctrl) as name (name)}
                             <option value={name}>{name}</option>
                         {/each}
                     </select>

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -774,6 +774,13 @@ export function getObjectNames(): string[] | null {
     } catch { return null; }
 }
 
+export function getExitNames(): string[] | null {
+    if (!_bridge) return null;
+    try {
+        return JSON.parse(_bridge.GetExitNames());
+    } catch { return null; }
+}
+
 export function getIfExpressionTemplates(): IfExpressionTemplate[] | null {
     if (!_bridge) return null;
     try {

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -82,6 +82,7 @@ export interface ScriptControlData {
   source: string | null
   options: ControlOption[] | null
   scripts: ScriptNodeData[] | null
+  objectType?: string | null
 }
 
 export interface ElseIfClauseData {

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -36,6 +36,7 @@ export interface WasmBridge {
   RemoveElseIf(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, elseIfIndex: number): string
   GetScriptCommandCategories(): Promise<string>
   GetObjectNames(): string
+  GetExitNames(): string
   GetIfExpressionTemplates(): string
   GetIfExpressionTemplateData(expression: string): string | null
   // List editor API

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -52,7 +52,8 @@ internal record ScriptControlData(
     string? SimpleLabel,
     string? Source,
     List<ControlOption>? Options,
-    List<ScriptNodeData>? Scripts
+    List<ScriptNodeData>? Scripts,
+    string? ObjectType = null
 );
 
 internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
@@ -1382,6 +1383,18 @@ public partial class WasmEditorBridge
         }
 
         var names = _controller.GetObjectNames("object", false).ToList();
+        return JsonSerializer.Serialize(names, WasmEditorJsonContext.Default.ListString);
+    }
+
+    [JSExport]
+    public static string GetExitNames()
+    {
+        if (_controller == null)
+        {
+            return "[]";
+        }
+
+        var names = _controller.GetObjectNames("exit", false).ToList();
         return JsonSerializer.Serialize(names, WasmEditorJsonContext.Default.ListString);
     }
 
@@ -2869,6 +2882,7 @@ public partial class WasmEditorBridge
 
         string? simpleLabel = null;
         string? source = null;
+        string? objectType = null;
 
         if (ctrl.ControlType == "expression")
         {
@@ -2877,6 +2891,7 @@ public partial class WasmEditorBridge
             // If <simpleeditor> is absent but <simple> is set, default simple editor is a textbox
             simpleEditor = simpleEditorTag ?? (simpleLabel != null ? "textbox" : null);
             source = ctrl.GetString("source");
+            objectType = ctrl.GetString("objecttype");
 
             if (simpleEditor == "dropdown")
             {
@@ -2921,7 +2936,8 @@ public partial class WasmEditorBridge
             simpleLabel,
             source,
             options,
-            nestedScripts
+            nestedScripts,
+            objectType
         );
     }
 

--- a/tests/e2e/verify-appshell-unlock-exit-picker.mjs
+++ b/tests/e2e/verify-appshell-unlock-exit-picker.mjs
@@ -1,0 +1,102 @@
+// Ad-hoc manual verification for the "unlock exit" (and lock/make-visible/make-invisible exit)
+// script command: its object picker used <objecttype>exit</objecttype> in the .aslx editor
+// definition, but ScriptEditor.svelte's "objects" simpleeditor always listed plain object names
+// (rooms/objects), never named exits, because the objecttype tag was silently dropped when
+// building ScriptControlData for script parameters (it was only wired up for the unrelated
+// PropertyEditor "objects"/"elementslist" controls). Fixed by threading objecttype through to
+// the frontend and loading a separate exit-names list for objecttype="exit" controls.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function addRoom(name) {
+    await page.click('button[title="Add element"]');
+    await page.click('.add-dropdown button:has-text("Add Room")', { timeout: 5000 });
+    await page.waitForSelector('#element-name');
+    await page.fill('#element-name', name);
+    await page.click('[role="dialog"] button:has-text("Add")');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+async function selectTreeNode(name) {
+    await page.locator(`[data-value="${name}"][data-part="item"], [data-value="${name}"][data-part="branch-control"]`).first().click();
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Unlock Exit Picker Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    await addRoom('Room One');
+    await addRoom('Room Two');
+    console.log('PASS: created Room One and Room Two');
+
+    // Create a north exit from Room One to Room Two via the compass grid, then open its own
+    // editor page and give it a name — only named, non-anonymous exits are eligible to be
+    // referenced from a script (matches the "you must name this exit to unlock it" hint on the
+    // exit's own editor page).
+    await selectTreeNode('Room One');
+    await page.click('button:has-text("Exits")');
+    await page.getByRole('button', { name: 'north', exact: true }).click();
+    const combobox = page.locator('[role="combobox"]');
+    await combobox.click();
+    await combobox.fill('Room Two');
+    await page.waitForSelector('[role="option"]:has-text("Room Two")', { timeout: 5000 });
+    await page.click('[role="option"]:has-text("Room Two")');
+    await page.click('button:has-text("Create exit")');
+    await page.waitForSelector('text=→ Room Two', { timeout: 10000 });
+    await page.click('button[title="Edit exit"]');
+    await page.waitForSelector('text=Name:', { timeout: 10000 });
+    // The property editor renders "Name:" as a plain <span> label sibling of the input, not a
+    // <label for=...> — locate the input via their shared container.
+    const nameField = page.locator('span:has-text("Name:")').locator('..').locator('input[type="text"]');
+    await nameField.fill('gate');
+    await nameField.blur();
+    await page.waitForSelector('[data-value="gate"]', { timeout: 10000 });
+    console.log('PASS: named the north exit "gate"');
+
+    // Add an "Unlock exit" script to Room One's "before entering" script and open its parameter.
+    await selectTreeNode('Room One');
+    await page.waitForSelector('button:has-text("Script")', { timeout: 10000 });
+    await page.click('button:has-text("Script")');
+    await page.waitForSelector('button:has-text("Add script")', { timeout: 10000 });
+    await page.click('button:has-text("Add script")');
+    const addScriptDialog = page.locator('[role="dialog"]').filter({ hasText: 'Add Script Command' });
+    await addScriptDialog.waitFor({ timeout: 10000 });
+    await addScriptDialog.getByRole('button', { name: 'Objects', exact: true }).click();
+    await addScriptDialog.getByRole('button', { name: 'Unlock exit' }).click();
+    await addScriptDialog.getByRole('button', { name: 'OK', exact: true }).click();
+    console.log('PASS: added an "Unlock exit" script command');
+
+    // The exit picker is the first <select> in the newly-added script row.
+    const exitSelect = page.locator('select').last();
+    const options = await exitSelect.locator('option').allTextContents();
+    if (!options.includes('gate')) {
+        throw new Error(`Expected the Unlock exit picker to list the named exit "gate", got: ${JSON.stringify(options)}`);
+    }
+    if (options.includes('Room One') || options.includes('Room Two')) {
+        throw new Error(`Expected the Unlock exit picker to exclude plain object names, got: ${JSON.stringify(options)}`);
+    }
+    console.log('PASS: Unlock exit picker lists the named exit ("gate") and excludes room/object names');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-unlock-exit-picker-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- The `Lock exit` / `Unlock exit` / `Make exit visible` / `Make exit invisible` script commands declare `<objecttype>exit</objecttype>` in their `.aslx` editor definitions, but the script editor's "objects" picker always rendered the fixed object/room name list regardless of that tag — `objecttype` was never read for script (`expression`) controls in `WasmEditorBridge.cs`.
- Threaded `objecttype` through `ScriptControlData` (bridge → `types.ts`), added a `GetExitNames()` bridge method (named, non-anonymous exits only), and had `ScriptEditor.svelte`'s picker choose `exitNames` vs `objectNames` based on `ctrl.objectType`, matching the v5 editors.
- Checked all `<simpleeditor>objects</simpleeditor>` controls in the core library: `exit` is the only non-default `objecttype` ever paired with this picker, so this closes the only gap.

## Test plan
- [x] `dotnet build src/WasmEditor/WasmEditor.csproj` (Release and Debug)
- [x] `npm run check` (svelte-check, 0 errors)
- [x] New Playwright script `tests/e2e/verify-appshell-unlock-exit-picker.mjs`: names an exit, adds an "Unlock exit" script, confirms the picker lists the named exit and excludes rooms/objects
- [x] Manual regression check that a plain object picker (e.g. "Make object visible") still lists rooms/objects unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)