### PR TITLE
fix: bigger Electron preview window, resizable editor tree pane

### DIFF
--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -9,6 +9,8 @@
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
 
+    let { width }: { width: number } = $props();
+
     interface HierNode {
         id: string
         text: string
@@ -182,7 +184,7 @@
     }
 </script>
 
-<div class="flex flex-col w-60 min-w-[180px] border-r border-surface-200-800 bg-surface-50-950">
+<div class="flex flex-col shrink-0 border-r border-surface-200-800 bg-surface-50-950" style="width: {width}px">
     <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800">
         Game Objects
     </div>

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -16,6 +16,34 @@
 
     let serverLoadError = $state<string | null>(null);
 
+    // Session-only (not persisted across reloads), same tradeoff as
+    // WasmPlayer's debugger splitter: a panel width isn't worth the
+    // complexity of persisting, but should survive for the life of the tab.
+    let treeWidth = $state(240); // matches TreePanel's old fixed w-60
+    const TREE_MIN_WIDTH = 180;
+    const TREE_MAX_WIDTH = 600;
+
+    function handleSplitterPointerDown(e: PointerEvent) {
+        e.preventDefault();
+        const startX = e.clientX;
+        const startWidth = treeWidth;
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
+
+        function onMove(moveEvent: PointerEvent) {
+            const next = startWidth + (moveEvent.clientX - startX);
+            treeWidth = Math.min(TREE_MAX_WIDTH, Math.max(TREE_MIN_WIDTH, next));
+        }
+        function onUp() {
+            document.removeEventListener("pointermove", onMove);
+            document.removeEventListener("pointerup", onUp);
+            document.body.style.cursor = "";
+            document.body.style.userSelect = "";
+        }
+        document.addEventListener("pointermove", onMove);
+        document.addEventListener("pointerup", onUp);
+    }
+
     // Delegated at the panel level so every field-editing component (property
     // panel, script editor, nested dictionary/list editors, ...) is covered
     // without each one having to wire this up itself. "input"/"focusout" both
@@ -107,7 +135,13 @@
         <Toolbar />
         <BackupBanner />
         <div class="flex flex-1 overflow-hidden" oninput={handleFieldInput} onfocusout={clearFieldEditing}>
-            <TreePanel />
+            <TreePanel width={treeWidth} />
+            <div
+                role="separator"
+                aria-orientation="vertical"
+                class="w-1 shrink-0 cursor-col-resize hover:bg-primary-500/50 active:bg-primary-500/70 transition-colors"
+                onpointerdown={handleSplitterPointerDown}
+            ></div>
             <PropertyEditor />
         </div>
     </div>

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -353,6 +353,13 @@ function createEditorWindow(port: number, initialPath?: string | null): void {
                 // autoplayPolicy explicit for the same reason as
                 // createEditorWindow's own webPreferences above.
                 overrideBrowserWindowOptions: {
+                    // Electron's BrowserWindow default (800x600) is narrower
+                    // than playercore.js's 950px gameWidth threshold, so the
+                    // side panes would start collapsed behind the
+                    // cmdShowPanes toggle button instead of docked. Wide
+                    // enough to clear that threshold with margin to spare.
+                    width: 1050,
+                    height: 850,
                     webPreferences: {
                         contextIsolation: true,
                         nodeIntegration: false,

--- a/tests/e2e/verify-appshell-tree-splitter.mjs
+++ b/tests/e2e/verify-appshell-tree-splitter.mjs
@@ -1,0 +1,77 @@
+// Ad-hoc manual verification for the new draggable splitter between TreePanel
+// (element tree, left) and PropertyEditor (right) on the /edit page — the
+// tree pane used to be a fixed w-60 (240px) with no way to widen it to see
+// long room/object names.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Splitter Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    const separator = page.locator('[role="separator"][aria-orientation="vertical"]');
+    await separator.waitFor({ timeout: 10000 });
+
+    const treePanel = page.locator('div.border-r.border-surface-200-800.bg-surface-50-950').first();
+    const startBox = await treePanel.boundingBox();
+    if (!startBox) throw new Error('Could not find TreePanel bounding box');
+    if (Math.abs(startBox.width - 240) > 2) throw new Error(`Expected default tree width ~240px, got ${startBox.width}`);
+    console.log(`PASS: TreePanel starts at default width (${startBox.width}px)`);
+    await page.screenshot({ path: '/tmp/appshell-splitter-before.png' });
+
+    // Drag the splitter to the right by 150px.
+    const sepBox = await separator.boundingBox();
+    await page.mouse.move(sepBox.x + sepBox.width / 2, sepBox.y + sepBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(sepBox.x + sepBox.width / 2 + 150, sepBox.y + sepBox.height / 2, { steps: 10 });
+    await page.screenshot({ path: '/tmp/appshell-splitter-during.png' });
+    await page.mouse.up();
+
+    const widerBox = await treePanel.boundingBox();
+    if (widerBox.width < startBox.width + 100) throw new Error(`Expected tree panel to widen by ~150px, got ${widerBox.width - startBox.width}px delta`);
+    console.log(`PASS: dragging right widened TreePanel to ${widerBox.width}px`);
+    await page.screenshot({ path: '/tmp/appshell-splitter-after.png' });
+
+    // Drag far left, past the min clamp (180px).
+    const sepBox2 = await separator.boundingBox();
+    await page.mouse.move(sepBox2.x + sepBox2.width / 2, sepBox2.y + sepBox2.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(sepBox2.x + sepBox2.width / 2 - 400, sepBox2.y + sepBox2.height / 2, { steps: 10 });
+    await page.mouse.up();
+    const minBox = await treePanel.boundingBox();
+    if (minBox.width < 178 || minBox.width > 182) throw new Error(`Expected width to clamp at ~180px, got ${minBox.width}`);
+    console.log(`PASS: dragging far left clamps at min width (${minBox.width}px)`);
+
+    // Drag far right, past the max clamp (600px).
+    const sepBox3 = await separator.boundingBox();
+    await page.mouse.move(sepBox3.x + sepBox3.width / 2, sepBox3.y + sepBox3.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(sepBox3.x + sepBox3.width / 2 + 1000, sepBox3.y + sepBox3.height / 2, { steps: 10 });
+    await page.mouse.up();
+    const maxBox = await treePanel.boundingBox();
+    if (maxBox.width < 598 || maxBox.width > 602) throw new Error(`Expected width to clamp at ~600px, got ${maxBox.width}`);
+    console.log(`PASS: dragging far right clamps at max width (${maxBox.width}px)`);
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-splitter-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- ElectronApp: the editor's Preview button opened a popup at Electron's 800x600 default, narrower than playercore.js's 950px pane-collapse threshold — its side panes started hidden behind the show-panes toggle instead of docked. Sized the popup to 1050x850.
- AppShell editor: added a draggable splitter between the element tree and property editor, replacing the tree's fixed 240px width (clamped 180px-600px).

## Test plan
- [x] `dotnet build`/typecheck n/a for these two frontend-only projects; ran `npm run check` and `npm run lint` in AppShell (clean)
- [x] `tsc --noEmit` in ElectronApp (clean)
- [x] New Playwright script `tests/e2e/verify-appshell-tree-splitter.mjs` against the AppShell dev server: default width, drag-to-widen, min-clamp, max-clamp all pass
- [x] Screenshots confirm smooth reflow with no overlap between panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)