### PR TITLE
feat(AppShell): add filter textbox to the elements tree

### DIFF
--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { untrack } from "svelte";
     import { TreeView, createTreeViewCollection } from "@skeletonlabs/skeleton-svelte";
+    import Search from "@lucide/svelte/icons/search";
+    import X from "@lucide/svelte/icons/x";
     import {
         treeNodes, selectedKey, selectNode,
         openAddModal, createExit, createTurnScript, createCommand, createVerb,
@@ -45,6 +47,51 @@
         return (byParent.get(null) ?? []).map(build);
     }
 
+    // ── Filtering ──────────────────────────────────────────────────────────────
+
+    let filterText = $state("");
+    let filterInputEl = $state<HTMLInputElement | undefined>();
+
+    // Keep a node if its own text matches, or one of its descendants does. A node
+    // that matches directly keeps its full, unfiltered subtree so authors can still
+    // browse into e.g. a matched room and see everything inside it.
+    function filterHierTree(nodes: HierNode[], query: string): HierNode[] {
+        const result: HierNode[] = [];
+        for (const node of nodes) {
+            const selfMatch = node.text.toLowerCase().includes(query);
+            if (node.children) {
+                const filteredChildren = selfMatch ? node.children : filterHierTree(node.children, query);
+                if (selfMatch || filteredChildren.length > 0) {
+                    result.push({ ...node, children: filteredChildren });
+                }
+            } else if (selfMatch) {
+                result.push(node);
+            }
+        }
+        return result;
+    }
+
+    function collectBranchIds(nodes: HierNode[]): string[] {
+        const ids: string[] = [];
+        for (const node of nodes) {
+            if (node.children) {
+                ids.push(node.id, ...collectBranchIds(node.children));
+            }
+        }
+        return ids;
+    }
+
+    let isFiltering = $derived(filterText.trim().length > 0);
+    let rawHierTree = $derived(buildHierTree($treeNodes));
+    let filteredHierTree = $derived(
+        isFiltering ? filterHierTree(rawHierTree, filterText.trim().toLowerCase()) : rawHierTree
+    );
+
+    function clearFilter() {
+        filterText = "";
+        filterInputEl?.focus();
+    }
+
     // ── Expansion state ────────────────────────────────────────────────────────
 
     let expandedIds = $state<string[]>([]);
@@ -61,6 +108,9 @@
     });
 
     function toggleExpand(id: string) {
+        // While filtering, all matching branches are force-expanded so results stay
+        // visible; manual collapse would have no visible effect, so ignore it.
+        if (isFiltering) return;
         if (expandedIds.includes(id)) {
             // If the selected node is inside this branch, select the branch itself first
             const nodeMap = new Map($treeNodes.map(n => [n.key, n]));
@@ -99,8 +149,12 @@
         createTreeViewCollection<HierNode>({
             nodeToValue: (n) => n.id,
             nodeToString: (n) => n.text,
-            rootNode: { id: "__root__", text: "", nodeType: "header", children: buildHierTree($treeNodes) },
+            rootNode: { id: "__root__", text: "", nodeType: "header", children: filteredHierTree },
         })
+    );
+
+    let effectiveExpandedIds = $derived(
+        isFiltering ? collectBranchIds(filteredHierTree) : expandedIds
     );
 
     // ── Add / delete ───────────────────────────────────────────────────────────
@@ -188,12 +242,36 @@
     <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800">
         Game Objects
     </div>
+    <div class="p-1.5 border-b border-surface-200-800 relative">
+        <Search class="absolute left-3.5 top-1/2 -translate-y-1/2 size-3.5 text-surface-400 pointer-events-none" />
+        <input
+            bind:this={filterInputEl}
+            type="text"
+            autocapitalize="off"
+            bind:value={filterText}
+            placeholder="Filter..."
+            aria-label="Filter game objects"
+            class="input text-xs py-1 pl-7 pr-6 w-full"
+            onkeydown={(e) => { if (e.key === "Escape" && filterText) { e.stopPropagation(); clearFilter(); } }}
+        />
+        {#if filterText}
+            <button
+                type="button"
+                class="absolute right-3 top-1/2 -translate-y-1/2 size-4 flex items-center justify-center text-surface-400 hover:text-surface-900-50"
+                onclick={clearFilter}
+                aria-label="Clear filter"
+            ><X class="size-3.5" /></button>
+        {/if}
+    </div>
+    {#if isFiltering && (collection.rootNode.children ?? []).length === 0}
+        <div class="px-3 py-2 text-xs text-surface-400">No matches</div>
+    {/if}
     <div class="flex-1 overflow-y-auto p-1 text-xs">
         <TreeView
             {collection}
             selectionMode="single"
             expandOnClick={false}
-            expandedValue={expandedIds}
+            expandedValue={effectiveExpandedIds}
             selectedValue={$selectedKey ? [$selectedKey] : []}
             onSelectionChange={(e) => { if (e.selectedValue[0]) selectNode(e.selectedValue[0]); }}
         >
@@ -238,9 +316,9 @@
                     <button
                         type="button"
                         tabindex="-1"
-                        class="flex-shrink-0 size-4 flex items-center justify-center transition-transform duration-150 {expandedIds.includes(node.id) ? "rotate-90" : ""}"
+                        class="flex-shrink-0 size-4 flex items-center justify-center transition-transform duration-150 {effectiveExpandedIds.includes(node.id) ? "rotate-90" : ""}"
                         onclick={(e) => { e.stopPropagation(); toggleExpand(node.id); }}
-                        aria-label={expandedIds.includes(node.id) ? "Collapse" : "Expand"}
+                        aria-label={effectiveExpandedIds.includes(node.id) ? "Collapse" : "Expand"}
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="size-4"><polyline points="9 18 15 12 9 6" /></svg>
                     </button>

--- a/tests/e2e/verify-appshell-tree-filter.mjs
+++ b/tests/e2e/verify-appshell-tree-filter.mjs
@@ -1,0 +1,107 @@
+// Ad-hoc manual verification for the new filter textbox at the top of
+// TreePanel (element tree, left) on the /edit page — lets authors with lots
+// of objects narrow the tree down to matching names instead of scrolling.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function addViaToolbar(menuLabel, name) {
+    await page.click('button[title="Add element"]');
+    await page.locator('.add-dropdown button', { hasText: menuLabel }).click();
+    await page.fill('#element-name', name);
+    await page.keyboard.press('Enter');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Tree Filter Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    const filterInput = page.getByPlaceholder('Filter...');
+    await filterInput.waitFor({ timeout: 10000 });
+    console.log('PASS: filter input is present');
+
+    // Build up a small tree: two top-level rooms, each with an object inside.
+    await addViaToolbar('Add Room', 'Kitchen');
+    await addViaToolbar('Add Room', 'Garden');
+
+    await page.click('span:text-is("Kitchen")');
+    await addViaToolbar('Add Object in "Kitchen"', 'Table');
+
+    await page.click('span:text-is("Garden")');
+    await addViaToolbar('Add Object in "Garden"', 'Flower');
+    console.log('PASS: built Kitchen(Table) / Garden(Flower) tree');
+
+    const treePanel = page.locator('div.border-r.border-surface-200-800.bg-surface-50-950').first();
+
+    // Filtering for "table" should show Kitchen (ancestor) + Table, but hide Garden/Flower.
+    await filterInput.fill('table');
+    await page.waitForTimeout(200);
+    let text = await treePanel.innerText();
+    if (!text.includes('Kitchen')) throw new Error('Expected ancestor "Kitchen" to stay visible while filtering for "table"');
+    if (!text.includes('Table')) throw new Error('Expected "Table" to be visible while filtering for "table"');
+    if (text.includes('Garden')) throw new Error('Expected "Garden" to be hidden while filtering for "table"');
+    if (text.includes('Flower')) throw new Error('Expected "Flower" to be hidden while filtering for "table"');
+    console.log('PASS: filtering for "table" shows only Kitchen > Table');
+
+    // Filtering for a room name should show that room's full subtree (Table).
+    await filterInput.fill('kitchen');
+    await page.waitForTimeout(200);
+    text = await treePanel.innerText();
+    if (!text.includes('Kitchen') || !text.includes('Table')) throw new Error('Expected matched room "Kitchen" to show its full subtree ("Table")');
+    if (text.includes('Garden')) throw new Error('Expected "Garden" to stay hidden while filtering for "kitchen"');
+    console.log('PASS: filtering for "kitchen" shows the matched room\'s full subtree');
+
+    // Filtering is case-insensitive.
+    await filterInput.fill('KITCHEN');
+    await page.waitForTimeout(200);
+    text = await treePanel.innerText();
+    if (!text.includes('Kitchen')) throw new Error('Expected filter to be case-insensitive');
+    console.log('PASS: filtering is case-insensitive');
+
+    // No matches.
+    await filterInput.fill('zzz-nonexistent');
+    await page.waitForTimeout(200);
+    await page.waitForSelector('text=No matches', { timeout: 5000 });
+    console.log('PASS: "No matches" message shown for a query with no results');
+
+    // Clear button resets the filter and restores the full tree.
+    await page.locator('button[aria-label="Clear filter"]').click();
+    await page.waitForTimeout(200);
+    text = await treePanel.innerText();
+    if (await filterInput.inputValue() !== '') throw new Error('Expected clear button to empty the filter input');
+    if (!text.includes('Garden') || !text.includes('Flower')) throw new Error('Expected full tree to be restored after clearing the filter');
+    console.log('PASS: clear button restores the full tree');
+
+    // Escape clears the filter too.
+    await filterInput.fill('table');
+    await page.waitForTimeout(200);
+    await filterInput.press('Escape');
+    await page.waitForTimeout(200);
+    if (await filterInput.inputValue() !== '') throw new Error('Expected Escape to clear the filter input');
+    text = await treePanel.innerText();
+    if (!text.includes('Garden')) throw new Error('Expected full tree to be restored after pressing Escape');
+    console.log('PASS: Escape clears the filter');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-tree-filter-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Adds a filter textbox at the top of the left-hand elements tree (`TreePanel.svelte`), similar to the Quest 5 desktop editor's tree filter, so authors with lots of objects can quickly find what they're looking for.
- Matching is case-insensitive substring on element name; matches keep their ancestor chain visible (so you can see which room an object lives in) and force-expand so results aren't hidden behind a collapsed branch. A node that matches directly (e.g. a room name) keeps its full unfiltered subtree so you can browse into it.
- Shows a "No matches" message when nothing matches; clearing the filter (✕ button or Escape) restores the tree and the exact expand/collapse state it had before filtering.

## Test plan
- [x] `svelte-check` / ESLint clean
- [x] `npm run build` (production static build) succeeds
- [x] New Playwright script `tests/e2e/verify-appshell-tree-filter.mjs` run against a live dev server: builds a two-room tree, verifies filtering by object/room name, ancestor visibility, case-insensitivity, "No matches" state, and both clear paths (✕ button + Escape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)