### PR TITLE
feat(AppShell): add filter textbox and keyboard nav to the script command adder

### DIFF
--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -292,7 +292,7 @@
                 <div
                     class="flex-1 overflow-y-auto pb-2"
                     role="listbox"
-                    aria-label="Script commands in {selectedCategory?.name ?? ''}"
+                    aria-label="Script commands in {selectedCategory?.name ?? ""}"
                     tabindex="-1"
                     onkeydown={onCategoryCommandListKeydown}
                 >

--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
     import type { ScriptCategoryInfo, ScriptCommandInfo } from "$lib/types";
+    import Search from "@lucide/svelte/icons/search";
+    import X from "@lucide/svelte/icons/x";
 
     interface Props {
         categories: ScriptCategoryInfo[];
@@ -10,7 +12,6 @@
     let { categories, onAdd, onClose }: Props = $props();
 
     let dialogEl: HTMLDivElement;
-    $effect(() => { dialogEl?.focus(); });
 
     const SHORTCUT_KEYWORDS: string[] = [
         "msg",
@@ -44,11 +45,100 @@
 
     const selectedCategory = $derived(categories[selectedCategoryIndex] ?? null);
 
-    // Auto-select first command when category changes
-    $effect(() => {
-        const cat = selectedCategory;
-        selectedCommand = cat && cat.commands.length > 0 ? cat.commands[0] : null;
+    // ── Filtering ──────────────────────────────────────────────────────────────
+    // While the box has text, the category sidebar + single-category list is
+    // replaced by one flat list of matches across every category, each tagged
+    // with its category name, so authors don't need to know where to look.
+
+    let filterText = $state("");
+    let filterInputEl = $state<HTMLInputElement | undefined>();
+    $effect(() => { filterInputEl?.focus(); });
+    const isFiltering = $derived(filterText.trim().length > 0);
+
+    interface MatchedCommand extends ScriptCommandInfo {
+        categoryName: string;
+    }
+
+    const filteredCommands = $derived.by((): MatchedCommand[] => {
+        const query = filterText.trim().toLowerCase();
+        if (!query) return [];
+        const matches: MatchedCommand[] = [];
+        for (const cat of categories) {
+            for (const cmd of cat.commands) {
+                if (cmd.add.toLowerCase().includes(query)) {
+                    matches.push({ ...cmd, categoryName: cat.name });
+                }
+            }
+        }
+        return matches;
     });
+
+    // Auto-select first command whenever the active list changes (category
+    // switch, or entering/leaving/typing further into the filter)
+    $effect(() => {
+        if (isFiltering) {
+            selectedCommand = filteredCommands[0] ?? null;
+        } else {
+            const cat = selectedCategory;
+            selectedCommand = cat && cat.commands.length > 0 ? cat.commands[0] : null;
+        }
+    });
+
+    function clearFilter() {
+        filterText = "";
+        filterInputEl?.focus();
+    }
+
+    // ── Keyboard navigation ────────────────────────────────────────────────────
+    // Both the flat filtered list and the per-category list are custom listboxes
+    // (plain buttons, not a native <select>), so Up/Down to move the selection
+    // isn't free — wire it up here rather than only supporting mouse clicks.
+
+    const activeList = $derived<ScriptCommandInfo[]>(isFiltering ? filteredCommands : (selectedCategory?.commands ?? []));
+    const selectedIndex = $derived(
+        selectedCommand ? activeList.findIndex((c) => c.createString === selectedCommand!.createString) : -1
+    );
+
+    let rowEls = $state<(HTMLButtonElement | undefined)[]>([]);
+
+    function moveSelection(delta: number) {
+        const list = activeList;
+        if (list.length === 0) return;
+        const nextIndex = Math.min(Math.max(selectedIndex + delta, 0), list.length - 1);
+        selectedCommand = list[nextIndex];
+        rowEls[nextIndex]?.scrollIntoView({ block: "nearest" });
+    }
+
+    // Up/Down while focus is inside the category sidebar moves between categories instead of
+    // between commands — otherwise it's indistinguishable from being focused on the command
+    // list, since both are plain buttons and the general handler below can't tell them apart.
+    let categoryButtonEls = $state<(HTMLButtonElement | undefined)[]>([]);
+
+    function onCategoryListKeydown(e: KeyboardEvent) {
+        if (e.key === "ArrowRight") {
+            // Jump across to the command list, landing on whichever row is already selected.
+            e.preventDefault();
+            e.stopPropagation();
+            rowEls[selectedIndex]?.focus();
+            return;
+        }
+        if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+        e.preventDefault();
+        e.stopPropagation();
+        const delta = e.key === "ArrowDown" ? 1 : -1;
+        const nextIndex = Math.min(Math.max(selectedCategoryIndex + delta, 0), categories.length - 1);
+        selectedCategoryIndex = nextIndex;
+        categoryButtonEls[nextIndex]?.focus();
+    }
+
+    // Left, with focus in the (non-filtered) command list, jumps back to the category sidebar —
+    // there's no equivalent list to jump to from the flat filtered list, since it has no sidebar.
+    function onCategoryCommandListKeydown(e: KeyboardEvent) {
+        if (e.key !== "ArrowLeft") return;
+        e.preventDefault();
+        e.stopPropagation();
+        categoryButtonEls[selectedCategoryIndex]?.focus();
+    }
 
     function onShortcutClick(createString: string) {
         onAdd(createString);
@@ -63,8 +153,17 @@
     }
 
     function onKeydown(e: KeyboardEvent) {
-        if (e.key === "Escape") onClose();
+        if (e.key === "Escape") {
+            if (filterText) {
+                e.stopPropagation();
+                clearFilter();
+                return;
+            }
+            onClose();
+        }
         if (e.key === "Enter" && selectedCommand) onOk();
+        if (e.key === "ArrowDown") { e.preventDefault(); moveSelection(1); }
+        if (e.key === "ArrowUp") { e.preventDefault(); moveSelection(-1); }
     }
 
     function onBackdropClick(e: MouseEvent) {
@@ -108,30 +207,46 @@
             </div>
         {/if}
 
-        <!-- Body: categories + commands -->
-        <div class="flex flex-1 min-h-0">
-            <!-- Category sidebar -->
-            <div class="w-40 border-r border-surface-200-800 overflow-y-auto flex-shrink-0">
-                {#each categories as cat, ci (ci)}
+        <!-- Filter box -->
+        <div class="px-5 py-2 border-b border-surface-200-800 flex-shrink-0">
+            <div class="relative">
+                <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-surface-400 pointer-events-none" />
+                <input
+                    bind:this={filterInputEl}
+                    type="text"
+                    autocapitalize="off"
+                    bind:value={filterText}
+                    placeholder="Filter commands..."
+                    aria-label="Filter script commands"
+                    class="input text-sm py-1.5 pl-8 pr-7 w-full"
+                />
+                {#if filterText}
                     <button
                         type="button"
-                        onclick={() => { selectedCategoryIndex = ci; }}
-                        class="w-full text-left px-4 py-2.5 text-sm transition-colors {
-                            selectedCategoryIndex === ci
-                                ? "font-semibold text-primary-600-400 bg-primary-100 dark:bg-primary-900/40"
-                                : "text-surface-700-300 hover:bg-surface-100-900"
-                        }"
-                    >{cat.name}</button>
-                {/each}
+                        class="absolute right-2 top-1/2 -translate-y-1/2 size-4 flex items-center justify-center text-surface-400 hover:text-surface-900-50"
+                        onclick={clearFilter}
+                        aria-label="Clear filter"
+                    ><X class="size-3.5" /></button>
+                {/if}
             </div>
+        </div>
 
-            <!-- Commands list -->
-            <div class="flex-1 overflow-y-auto pb-2">
-                {#if selectedCategory}
-                    {#each selectedCategory.commands as cmd (cmd.createString)}
+        <!-- Body: categories + commands, or a flat filtered list -->
+        <div class="flex flex-1 min-h-0">
+            {#if isFiltering}
+                <!-- Flat filtered list across all categories -->
+                <div class="flex-1 overflow-y-auto pb-2" role="listbox" aria-label="Matching script commands">
+                    {#if filteredCommands.length === 0}
+                        <div class="px-5 py-3 text-sm text-surface-400">No matching commands</div>
+                    {/if}
+                    {#each filteredCommands as cmd, idx (cmd.createString)}
                         {@const isSelected = selectedCommand?.createString === cmd.createString}
                         <button
+                            bind:this={rowEls[idx]}
                             type="button"
+                            role="option"
+                            aria-selected={isSelected}
+                            tabindex={isSelected ? 0 : -1}
                             onclick={() => (selectedCommand = cmd)}
                             ondblclick={() => { selectedCommand = cmd; onOk(); }}
                             class="w-full text-left px-5 py-2 text-sm flex items-center gap-3 transition-colors {
@@ -141,11 +256,70 @@
                             }"
                         >
                             <span class="w-4 flex-shrink-0 text-primary-500 {isSelected ? "opacity-100" : "opacity-0"}">●</span>
-                            {cmd.add}
+                            <span class="flex-1">{cmd.add}</span>
+                            <span class="flex-shrink-0 text-xs text-surface-400">{cmd.categoryName}</span>
                         </button>
                     {/each}
-                {/if}
-            </div>
+                </div>
+            {:else}
+                <!-- Category sidebar -->
+                <div
+                    class="w-40 border-r border-surface-200-800 overflow-y-auto flex-shrink-0"
+                    role="listbox"
+                    aria-label="Script command categories"
+                    tabindex="-1"
+                    onkeydown={onCategoryListKeydown}
+                >
+                    {#each categories as cat, ci (ci)}
+                        {@const isSelected = selectedCategoryIndex === ci}
+                        <button
+                            bind:this={categoryButtonEls[ci]}
+                            type="button"
+                            role="option"
+                            aria-selected={isSelected}
+                            tabindex={isSelected ? 0 : -1}
+                            onclick={() => { selectedCategoryIndex = ci; }}
+                            class="w-full text-left px-4 py-2.5 text-sm transition-colors {
+                                isSelected
+                                    ? "font-semibold text-primary-600-400 bg-primary-100 dark:bg-primary-900/40"
+                                    : "text-surface-700-300 hover:bg-surface-100-900"
+                            }"
+                        >{cat.name}</button>
+                    {/each}
+                </div>
+
+                <!-- Commands list -->
+                <div
+                    class="flex-1 overflow-y-auto pb-2"
+                    role="listbox"
+                    aria-label="Script commands in {selectedCategory?.name ?? ''}"
+                    tabindex="-1"
+                    onkeydown={onCategoryCommandListKeydown}
+                >
+                    {#if selectedCategory}
+                        {#each selectedCategory.commands as cmd, idx (cmd.createString)}
+                            {@const isSelected = selectedCommand?.createString === cmd.createString}
+                            <button
+                                bind:this={rowEls[idx]}
+                                type="button"
+                                role="option"
+                                aria-selected={isSelected}
+                                tabindex={isSelected ? 0 : -1}
+                                onclick={() => (selectedCommand = cmd)}
+                                ondblclick={() => { selectedCommand = cmd; onOk(); }}
+                                class="w-full text-left px-5 py-2 text-sm flex items-center gap-3 transition-colors {
+                                    isSelected
+                                        ? "bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300 font-medium"
+                                        : "text-surface-700-300 hover:bg-surface-100-900"
+                                }"
+                            >
+                                <span class="w-4 flex-shrink-0 text-primary-500 {isSelected ? "opacity-100" : "opacity-0"}">●</span>
+                                {cmd.add}
+                            </button>
+                        {/each}
+                    {/if}
+                </div>
+            {/if}
         </div>
 
         <!-- Footer -->

--- a/tests/e2e/verify-appshell-script-adder-filter.mjs
+++ b/tests/e2e/verify-appshell-script-adder-filter.mjs
@@ -1,0 +1,263 @@
+// Ad-hoc manual verification for the new filter textbox in the "Add Script Command" modal
+// (AddScriptModal.svelte). Unlike the elements tree filter (TreePanel.svelte), the script adder
+// is a two-pane category-sidebar + command-list, so filtering can't just narrow a single tree —
+// while the filter box has text, it replaces that view with one flat list of matches across
+// every category (each tagged with its category name), then reverts to the normal per-category
+// browsing view when cleared. Also covers Up/Down arrow-key selection, added afterwards since
+// the command list is a custom listbox (plain buttons) with no keyboard nav for free.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Script Adder Filter Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    // Open the game's own "before entering"-style top-level script editor via the tree root,
+    // which is simplest: use the "Script" tab on the root game object.
+    await page.locator('[data-value]').first().click();
+    await page.waitForSelector('button:has-text("Script")', { timeout: 10000 });
+    await page.click('button:has-text("Script")');
+    await page.waitForSelector('button:has-text("Add script")', { timeout: 10000 });
+    await page.click('button:has-text("Add script")');
+    const dialog = page.locator('[role="dialog"]').filter({ hasText: 'Add Script Command' });
+    await dialog.waitFor({ timeout: 10000 });
+    console.log('PASS: opened Add Script Command modal');
+
+    // Baseline: two-pane category view, sidebar visible with multiple categories.
+    const categoryButtons = dialog.locator('button:has-text("Objects")');
+    await categoryButtons.first().waitFor({ timeout: 5000 });
+    console.log('PASS: category sidebar visible before filtering');
+
+    const filterInput = dialog.getByPlaceholder('Filter commands...');
+    await filterInput.waitFor({ timeout: 5000 });
+
+    const isOptionSelected = async (row) => (await row.getAttribute('aria-selected')) === 'true';
+
+    // Arrow-key nav should also work in the plain (non-filtered) per-category command list, not
+    // just the flattened filtered one — same underlying custom listbox, same lack of free
+    // keyboard nav. Scope to the commands listbox specifically, since the category sidebar is
+    // now *also* a listbox of options (see the category-nav check further down) and a bare
+    // `[role="listbox"] [role="option"]` would match both.
+    await categoryButtons.first().click();
+    const commandRowsInCategory = dialog.locator('[role="listbox"][aria-label^="Script commands in"] [role="option"]');
+    const commandRowCount = await commandRowsInCategory.count();
+    if (commandRowCount < 2) {
+        throw new Error(`Expected the "Objects" category to have at least 2 commands to test navigation, got ${commandRowCount}`);
+    }
+    if (!(await isOptionSelected(commandRowsInCategory.nth(0)))) {
+        throw new Error('Expected the first command in the category to be selected by default');
+    }
+    await filterInput.press('ArrowDown');
+    if (await isOptionSelected(commandRowsInCategory.nth(0)) || !(await isOptionSelected(commandRowsInCategory.nth(1)))) {
+        throw new Error('Expected ArrowDown to move selection within the non-filtered category list');
+    }
+    console.log('PASS: ArrowDown moves the selection within the non-filtered category list too');
+    await filterInput.press('ArrowUp');
+
+    // Up/Down while focus is on the category sidebar itself should switch categories, not move
+    // through commands — this is the thing that was missing (both are plain buttons, so without
+    // explicit wiring the general Up/Down handler can't tell them apart).
+    const categoryOptions = dialog.locator('[role="listbox"][aria-label="Script command categories"] [role="option"]');
+    const categoryCount = await categoryOptions.count();
+    if (categoryCount < 2) {
+        throw new Error(`Expected at least 2 categories to test navigation, got ${categoryCount}`);
+    }
+    // Click (not just focus) the first category button so it becomes both the selected category
+    // and the DOM focus target — a plain .focus() wouldn't update selectedCategoryIndex, since
+    // that's driven by the click handler, not focus.
+    await categoryOptions.first().click();
+    if (!(await isOptionSelected(categoryOptions.nth(0)))) {
+        throw new Error('Expected the first category to be selected once clicked');
+    }
+    const commandsLabelBefore = await dialog.locator('[role="listbox"][aria-label^="Script commands in"]').getAttribute('aria-label');
+    await page.keyboard.press('ArrowDown');
+    if (await isOptionSelected(categoryOptions.nth(0)) || !(await isOptionSelected(categoryOptions.nth(1)))) {
+        throw new Error('Expected ArrowDown, with focus on the category sidebar, to move to the next category');
+    }
+    const commandsLabelAfter = await dialog.locator('[role="listbox"][aria-label^="Script commands in"]').getAttribute('aria-label');
+    if (commandsLabelAfter === commandsLabelBefore) {
+        throw new Error('Expected the command list to switch to the newly-selected category');
+    }
+    const focusedIsSecondCategory = await categoryOptions.nth(1).evaluate((el) => el === document.activeElement);
+    if (!focusedIsSecondCategory) {
+        throw new Error('Expected DOM focus to move to the newly-selected category button');
+    }
+    console.log(`PASS: ArrowDown on the category sidebar moves category selection and focus (now "${commandsLabelAfter}")`);
+
+    await page.keyboard.press('ArrowUp');
+    if (!(await isOptionSelected(categoryOptions.nth(0)))) {
+        throw new Error('Expected ArrowUp, with focus on the category sidebar, to move back to the first category');
+    }
+    console.log('PASS: ArrowUp on the category sidebar moves back to the previous category');
+
+    // Roving tabindex: only the selected option in each listbox should be a tab stop, not every
+    // row — otherwise Tab has to step through every category (and every command) individually.
+    const tabIndicesOf = (locator) => locator.evaluateAll((els) => els.map((el) => el.tabIndex));
+    const categoryTabIndices = await tabIndicesOf(categoryOptions);
+    if (categoryTabIndices.filter((t) => t === 0).length !== 1) {
+        throw new Error(`Expected exactly one category with tabIndex 0, got ${JSON.stringify(categoryTabIndices)}`);
+    }
+    console.log('PASS: only the selected category is a tab stop (roving tabindex)');
+
+    const commandTabIndices = await tabIndicesOf(commandRowsInCategory);
+    if (commandTabIndices.filter((t) => t === 0).length !== 1) {
+        throw new Error(`Expected exactly one command row with tabIndex 0, got ${JSON.stringify(commandTabIndices)}`);
+    }
+    console.log('PASS: only the selected command row is a tab stop (roving tabindex)');
+
+    // ArrowRight, with focus on the category sidebar, should jump to the (already-selected) row
+    // in the command list; ArrowLeft from there should jump back.
+    await page.keyboard.press('ArrowRight');
+    const focusedIsCommandRow = await commandRowsInCategory.nth(0).evaluate((el) => el === document.activeElement);
+    if (!focusedIsCommandRow) {
+        throw new Error('Expected ArrowRight from the category sidebar to move focus into the command list');
+    }
+    console.log('PASS: ArrowRight moves focus from the category sidebar into the command list');
+
+    await page.keyboard.press('ArrowLeft');
+    const focusedIsCategoryAgain = await categoryOptions.nth(0).evaluate((el) => el === document.activeElement);
+    if (!focusedIsCategoryAgain) {
+        throw new Error('Expected ArrowLeft from the command list to move focus back to the category sidebar');
+    }
+    console.log('PASS: ArrowLeft moves focus from the command list back to the category sidebar');
+
+    // Filtering should surface a match ("move" appears in commands from multiple categories,
+    // e.g. Objects' "Move object to..." and other move-related commands) and stop showing the
+    // category sidebar.
+    await filterInput.fill('move');
+    await page.waitForTimeout(200);
+
+    // The category sidebar is the only "w-40" column in the modal; check its absence rather than
+    // any specific category name, since matched rows are now tagged with their category name too
+    // (e.g. "Variables" legitimately appears as a result's category tag, not just a sidebar button).
+    const sidebarStillThere = await dialog.locator('div.w-40').count();
+    if (sidebarStillThere > 0) {
+        throw new Error('Expected the category sidebar to be replaced by a flat list while filtering');
+    }
+    console.log('PASS: category sidebar hidden while filtering');
+
+    // Scope past the "Move" quick-add shortcut pill, which also matches /move/i, to just the
+    // flat results list (identified by its category-tag rows using text-surface-400).
+    const matchRows = dialog.locator('.flex-1.overflow-y-auto button', { hasText: /move/i });
+    const matchCount = await matchRows.count();
+    if (matchCount === 0) {
+        throw new Error('Expected at least one match for "move"');
+    }
+    console.log(`PASS: found ${matchCount} matching command row(s) for "move"`);
+
+    // Each result row should be tagged with its source category name so authors know where it
+    // lives even though the sidebar is gone.
+    const firstRowText = await matchRows.first().textContent();
+    if (!firstRowText || firstRowText.trim().length === 0) {
+        throw new Error('Expected matching row to have visible text (command + category tag)');
+    }
+    console.log(`PASS: first match row reads "${firstRowText.trim()}"`);
+
+    // Arrow keys should move the highlighted (aria-selected) row without needing a mouse click —
+    // these are custom listboxes (plain buttons), so this doesn't come for free.
+    const isRowSelected = async (row) => (await row.getAttribute('aria-selected')) === 'true';
+    if (!(await isRowSelected(matchRows.nth(0)))) {
+        throw new Error('Expected the first match to be selected by default');
+    }
+    await filterInput.press('ArrowDown');
+    if (await isRowSelected(matchRows.nth(0)) || !(await isRowSelected(matchRows.nth(1)))) {
+        throw new Error('Expected ArrowDown to move selection from the first match to the second');
+    }
+    console.log('PASS: ArrowDown moves the selection to the next match');
+
+    await filterInput.press('ArrowUp');
+    if (!(await isRowSelected(matchRows.nth(0)))) {
+        throw new Error('Expected ArrowUp to move selection back to the first match');
+    }
+    console.log('PASS: ArrowUp moves the selection back to the previous match');
+
+    // A nonsense query should show the empty state, not stale results.
+    await filterInput.fill('zzz_no_such_command_zzz');
+    await page.waitForTimeout(200);
+    await dialog.locator('text=No matching commands').waitFor({ timeout: 5000 });
+    console.log('PASS: "No matching commands" empty state shown for a non-matching query');
+
+    // Clearing the filter (the × button) should restore the category sidebar.
+    await dialog.getByLabel('Clear filter').click();
+    await categoryButtons.first().waitFor({ timeout: 5000 });
+    const filterValueAfterClear = await filterInput.inputValue();
+    if (filterValueAfterClear !== '') {
+        throw new Error('Expected filter box to be empty after clicking clear');
+    }
+    console.log('PASS: clearing the filter restores the category sidebar');
+
+    // Escape while the filter has text should clear it rather than closing the modal.
+    await filterInput.fill('move');
+    await page.waitForTimeout(200);
+    await filterInput.press('Escape');
+    await dialog.waitFor({ timeout: 2000 });
+    const filterValueAfterEscape = await filterInput.inputValue();
+    if (filterValueAfterEscape !== '') {
+        throw new Error('Expected Escape to clear a non-empty filter rather than closing the modal');
+    }
+    console.log('PASS: Escape clears a non-empty filter instead of closing the modal');
+
+    // Escape again (now empty) should close the modal.
+    await filterInput.press('Escape');
+    await dialog.waitFor({ state: 'hidden', timeout: 5000 });
+    console.log('PASS: Escape with an empty filter closes the modal');
+
+    // Round-trip proof that Enter adds whichever row is *currently selected*, not always the
+    // first: add the plain default match, then add again after ArrowDown, and confirm the two
+    // resulting script rows are different commands.
+    async function addedRowTexts() {
+        return page.locator('[role="region"] > div.group').allTextContents();
+    }
+
+    await page.click('button:has-text("Add script")');
+    await dialog.waitFor({ timeout: 10000 });
+    await dialog.getByPlaceholder('Filter commands...').fill('move');
+    await page.waitForTimeout(200);
+    await dialog.getByPlaceholder('Filter commands...').press('Enter');
+    await dialog.waitFor({ state: 'hidden', timeout: 5000 });
+    const rowsAfterFirstAdd = await addedRowTexts();
+    if (rowsAfterFirstAdd.length !== 1) {
+        throw new Error(`Expected exactly one script row after the first add, got ${rowsAfterFirstAdd.length}`);
+    }
+    console.log(`PASS: plain Enter added the default (first) match: "${rowsAfterFirstAdd[0].trim()}"`);
+
+    await page.click('button:has-text("Add script")');
+    await dialog.waitFor({ timeout: 10000 });
+    await dialog.getByPlaceholder('Filter commands...').fill('move');
+    await page.waitForTimeout(200);
+    await dialog.getByPlaceholder('Filter commands...').press('ArrowDown');
+    await dialog.getByPlaceholder('Filter commands...').press('Enter');
+    await dialog.waitFor({ state: 'hidden', timeout: 5000 });
+    const rowsAfterSecondAdd = await addedRowTexts();
+    if (rowsAfterSecondAdd.length !== 2) {
+        throw new Error(`Expected two script rows after the second add, got ${rowsAfterSecondAdd.length}`);
+    }
+    const secondAddedText = rowsAfterSecondAdd[1].trim();
+    if (secondAddedText === rowsAfterFirstAdd[0].trim()) {
+        throw new Error('Expected ArrowDown + Enter to add a different command than plain Enter did');
+    }
+    console.log(`PASS: ArrowDown + Enter added a different match: "${secondAddedText}" (confirms keyboard-moved selection, not just the default, drives Enter)`);
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-script-adder-filter-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Adds a filter textbox to the "Add Script Command" modal, matching the elements-tree filter (#1929) in spirit. Since the adder is a two-pane category-sidebar + command-list (not a tree), filtering replaces both panes with one flat list of matches across every category, each tagged with its source category name.
- Adds keyboard navigation the custom listbox UI didn't have for free: Up/Down moves the selection within whichever list is focused (with auto-scroll into view), Left/Right jumps focus between the category sidebar and the command list, and both lists now use roving tabindex (only the selected row/category is a tab stop) instead of every row being individually tabbable.

## Test plan
- [x] `npm run check` (svelte-check) clean
- [x] `node tests/e2e/verify-appshell-script-adder-filter.mjs` against a local dev server — covers: filter flattening/clearing/Escape behavior, empty-state, Up/Down in both list modes, roving tabindex, Left/Right cross-list focus, and a round-trip proof that Enter adds whichever row is keyboard-selected (not just the default first match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)