### PR TITLE
fix: resolve e2e failures across WasmPlayer restart, AppShell autosave, and Electron

### DIFF
--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -259,9 +259,19 @@ export function persistNow(): Promise<void> {
     return _saveInFlight;
 }
 
+// A local draft's OPFS write is often fast enough (small game, no network)
+// that isSaving flips true then false within ~10ms — well under a frame in
+// practice, so the "Saving…" pill can go completely unseen (confirmed via
+// rAF-precision polling: the class changes, but nothing ever gets painted in
+// between). Same category of issue as wasm-player.js's nextPaint() calls
+// elsewhere in this codebase — hold the visible state open for a minimum
+// stretch so it's perceptible rather than a silent flicker.
+const MIN_SAVING_VISIBLE_MS = 300;
+
 async function doPersist(): Promise<void> {
     if (!_bridge || !_adapter) return;
     isSaving.set(true);
+    const startedAt = performance.now();
     try {
         await rekeyIfGameIdChanged();
         await _adapter.saveFile(_bridge.Save()); // Save() clears _isDirty in the bridge
@@ -279,6 +289,10 @@ async function doPersist(): Promise<void> {
         saveError.set(err instanceof Error ? err.message : "Save failed");
         scheduleRetry();
     } finally {
+        const elapsed = performance.now() - startedAt;
+        if (elapsed < MIN_SAVING_VISIBLE_MS) {
+            await new Promise(resolve => setTimeout(resolve, MIN_SAVING_VISIBLE_MS - elapsed));
+        }
         isSaving.set(false);
     }
 }

--- a/src/PlayerCore/Resources/player.js
+++ b/src/PlayerCore/Resources/player.js
@@ -176,15 +176,29 @@ function saveGame() {
     }, 100);
 }
 
-// A restart (Start from the beginning / Load) re-runs Initialise() on the
-// same live document rather than a fresh page load, and Initialise()
-// unconditionally re-registers the game's external scripts. A real <script
-// src> only ever runs once per document, so re-adding the same URL here would
-// re-execute the game's setup code against DOM it already set up on the
-// previous run (e.g. a custom sidebar pane), producing duplicates. Dedupe by
-// URL so each script tag still only truly executes once per document, same
-// as normal page-load semantics.
+// Initialise() unconditionally re-registers the game's external scripts every
+// time it runs, including on a mid-session restart (Start from the beginning
+// / Load) — but a real <script src> only ever runs once per document, so
+// re-adding the same URL against the *same* live DOM would re-execute the
+// game's setup code against elements it already set up on the previous run
+// (e.g. a custom sidebar pane), producing duplicates. Dedupe by URL so each
+// script tag still only truly executes once per document, same as normal
+// page-load semantics.
+//
+// A restart also wipes and rebuilds the whole player chrome first (see
+// WasmPlayer's swapInPlayerUi() / WebPlayer's resetPlayerUi()), so by the
+// time Initialise() re-registers scripts against that fresh DOM, the
+// "already set up on the previous run" premise above no longer holds — the
+// old elements are gone, and the dedupe would wrongly skip re-running setup
+// code against the new ones, silently dropping anything the script injects
+// (confirmed via a real game's custom sidebar pane vanishing after restart).
+// Both chrome-reset call sites clear the set via clearLoadedExternalScripts()
+// so a restart's re-registration is treated as a genuinely fresh page load.
 var _loadedExternalScripts = new Set();
+
+function clearLoadedExternalScripts() {
+    _loadedExternalScripts.clear();
+}
 
 function addExternalScript(url) {
     if (_loadedExternalScripts.has(url)) return Promise.resolve();

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -287,6 +287,11 @@ function swapInPlayerUi() {
     if (savesDialogEl) document.body.appendChild(savesDialogEl);
     if (debuggerDialogEl) document.body.appendChild(debuggerDialogEl);
     if (restartingEl) document.body.appendChild(restartingEl);
+    // This is a genuinely fresh chrome (see above) — addExternalScript's
+    // dedupe-by-URL (player.js) must not carry over, or the game's external
+    // scripts silently no-op against it on the very next Initialise() call
+    // and never re-inject whatever they set up (e.g. that sidebar pane).
+    clearLoadedExternalScripts();
     return startScreenEl;
 }
 

--- a/src/WebPlayer/wwwroot/playerweb.js
+++ b/src/WebPlayer/wwwroot/playerweb.js
@@ -60,6 +60,9 @@ class WebPlayer {
     // session and it adds another one.
     static resetPlayerUi(html) {
         document.getElementById("qv-player-chrome").innerHTML = html;
+        // Fresh chrome — see clearLoadedExternalScripts (player.js) and
+        // WasmPlayer's swapInPlayerUi for why this must follow the reset.
+        clearLoadedExternalScripts();
     }
 
     static async downloadSaveAsFile(filename) {

--- a/tests/e2e/verify-appshell-autosave.mjs
+++ b/tests/e2e/verify-appshell-autosave.mjs
@@ -33,7 +33,11 @@ async function run() {
     // Select the game node (already selected on load) and edit its
     // description via the PropertyEditor, then blur it — this should commit
     // into the WASM model (onchange) and kick off the debounced autosave.
-    const descBox = page.locator('textarea, input[type="text"]').first();
+    // Excludes the elements-tree filter box (added after this test was
+    // written, and first in DOM order): an unscoped "first text input on the
+    // page" locator silently fills that instead, so the edit never reaches
+    // the WASM bridge — isDirty never flips and "Saving…" never appears.
+    const descBox = page.locator('textarea, input[type="text"]:not([placeholder="Filter..."])').first();
     await descBox.waitFor({ timeout: 10000 });
     const marker = `Autosave marker ${Date.now()}`;
     await descBox.fill(marker);
@@ -54,7 +58,7 @@ async function run() {
     await page.click('button:has-text("Autosave Test.aslx")');
     await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     await page.waitForSelector('text=Saved', { timeout: 10000 });
-    const persistedValue = await page.locator('textarea, input[type="text"]').first().inputValue();
+    const persistedValue = await page.locator('textarea, input[type="text"]:not([placeholder="Filter..."])').first().inputValue();
     console.log('value after reload:', persistedValue);
     if (persistedValue !== marker) throw new Error(`Edit did not survive reload — expected "${marker}", got "${persistedValue}"`);
     console.log('PASS: autosaved edit survived a full page reload (persisted to OPFS)');

--- a/tests/e2e/verify-appshell-drafts-rekey-backup.mjs
+++ b/tests/e2e/verify-appshell-drafts-rekey-backup.mjs
@@ -73,10 +73,16 @@ try {
     await download.saveAs(zipPath);
     console.log('backup zip saved to', zipPath);
 
-    // Delete the draft, then re-import the backed-up zip.
+    // Delete the draft, then re-import the backed-up zip. Deletion is
+    // confirmed through the app's own ConfirmDialog.svelte (a promise-based
+    // in-page modal — see lib/confirm.ts), not a native window.confirm(), so
+    // there's no browser "dialog" event to auto-accept; the confirm button
+    // (also labelled "Delete", as the primary/danger action) must be clicked
+    // directly, scoped to the dialog to avoid matching a different draft
+    // row's own "Delete" button.
     await page.goto(`${baseUrl}/open`);
-    page.once('dialog', d => d.accept());
     await page.click('button:has-text("Delete")');
+    await page.locator('div[role="dialog"] button:has-text("Delete")').click();
     await page.waitForTimeout(500);
 
     const [fileChooser2] = await Promise.all([

--- a/tests/e2e/verify-electron-new-game-folder.mjs
+++ b/tests/e2e/verify-electron-new-game-folder.mjs
@@ -85,7 +85,7 @@ try {
     // rather than silently pass.
     await win.waitForSelector('text=Text adventure', { timeout: 10000 });
     await win.click('button:has-text("Create")');
-    await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
+    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
 
     const questGamesDir = join(fakeDocumentsDir, 'Quest Games');
     const gameAAslx = join(questGamesDir, 'Game A', 'Game A.aslx');
@@ -120,7 +120,7 @@ try {
     );
     await win.fill('input[placeholder="Game name"]', 'Game B');
     await win.click('button:has-text("Create")');
-    await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
+    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     const gameBAslx = join(customLocationDir, 'Game B', 'Game B.aslx');
     const gameBCreated = existsSync(gameBAslx);
     console.log('PASS: Game B created at the chosen custom location instead of Quest Games:', gameBCreated);

--- a/tests/e2e/verify-electron-open-file.mjs
+++ b/tests/e2e/verify-electron-open-file.mjs
@@ -74,7 +74,7 @@ try {
     await win.click('button:has-text("Change location…")');
     await win.waitForFunction((dir) => document.body.innerText.includes(dir), gamesRoot, { timeout: 10000 });
     await win.click('button:has-text("Create")');
-    await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
+    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
 
     const gameDir = join(gamesRoot, 'First');
     const firstAslx = join(gameDir, 'First.aslx');
@@ -89,7 +89,7 @@ try {
     await win.waitForSelector('button:has-text("Open game…")', { timeout: 10000 });
     await stubPicker(secondAslx);
     await win.click('button:has-text("Open game…")');
-    await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
+    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     const multiFileScreenShown = await win.isVisible('text=Multiple game files found');
     console.log('PASS: "Second.aslx" opened directly with no multi-file disambiguation screen:', !multiFileScreenShown);
     if (multiFileScreenShown) throw new Error('Unexpected multi-file disambiguation screen for Electron');
@@ -100,7 +100,7 @@ try {
     await win.waitForSelector('button:has-text("Open game…")', { timeout: 10000 });
     await stubPicker(firstAslx);
     await clickMenuItem('File', 'Open Game…');
-    await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
+    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     console.log('PASS: native "Open Game…" menu item opens "First.aslx" directly');
 
     console.log('PASS: all checks passed');

--- a/tests/e2e/verify-electron-recent-games.mjs
+++ b/tests/e2e/verify-electron-recent-games.mjs
@@ -90,7 +90,7 @@ try {
         await win.fill('input[placeholder="Game name"]', name);
         await win.waitForSelector('text=Text adventure', { timeout: 10000 });
         await win.click('button:has-text("Create")');
-        await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
+        await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     }
 
     // 1. Fresh app, no recent games yet. Root lands on the Play tab by
@@ -128,13 +128,13 @@ try {
     await clickMenuItem('File', 'New Game…');
     await win.waitForSelector('text=Game B.aslx', { timeout: 10000 });
     await win.click('button:has-text("Game A.aslx")');
-    await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
+    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     console.log('PASS: clicking Game A in Recent reopened it directly');
 
     // 5. Native "Open Recent" submenu click loads a game too (the nonce/query-
     // string path from +layout.svelte's onOpenRecent, not the /open page button).
     await clickMenuItem('File', 'Open Recent', 'Game B.aslx — Game B');
-    await win.waitForSelector('button:has-text("Assets")', { timeout: 30000 });
+    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     console.log('PASS: native "Open Recent" menu entry reopened Game B directly');
 
     // 6. Remove one entry from the /open page, confirm it's gone from both

--- a/tests/e2e/verify-wasmplayer-restart-sidebar-dup.mjs
+++ b/tests/e2e/verify-wasmplayer-restart-sidebar-dup.mjs
@@ -24,8 +24,17 @@ const restart = async () => {
     await page.click('#cmdSave');
     await page.waitForSelector('#qv-saves', { state: 'visible', timeout: 10000 });
     await page.click('#qv-saves-start-new');
-    await page.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
-    await page.waitForTimeout(500);
+    // #txtCommand is part of the static chrome swapInPlayerUi() puts back
+    // immediately, so it's visible well before Initialise()/Begin() (which
+    // re-parses the whole Core library XML from scratch) actually finish —
+    // not a safe readiness signal, and on a loaded CI runner that work can
+    // easily outlast a flat waitForTimeout, reading the pane count before
+    // the game's StartGame (which adds it) has even run. #qv-restarting is
+    // an opaque, z-index:9999 full-viewport overlay shown for exactly the
+    // duration of that work (wasm-player.js's restartGameCore) — wait for it
+    // to appear and then disappear, which brackets the restart precisely.
+    await page.waitForSelector('#qv-restarting', { state: 'visible', timeout: 5000 });
+    await page.waitForSelector('#qv-restarting', { state: 'hidden', timeout: 30000 });
 };
 
 const initial = await countPanes();


### PR DESCRIPTION
## Summary

Traced and fixed the four independent failures from a manual `e2e` workflow run against `main` (run 30030561437) — every job failed, but for unrelated reasons, so each is a separate fix:

- **WasmPlayer restart (`wasmplayer_chromium`)** — real regression: `addExternalScript`'s dedupe-by-URL (added alongside the full-chrome DOM reset in #1833) is never cleared on a mid-session restart, so a game's external `<javascript>` resource never re-runs its setup code after the very first restart (e.g. a custom sidebar pane vanishes for good). Cleared it from both WasmPlayer's `swapInPlayerUi()` and WebPlayer's `resetPlayerUi()`, since both already rebuild the chrome from scratch each time. Also fixed the test itself: it read pane counts using `#txtCommand`'s visibility as a "restart is done" signal, but that element is part of the static chrome that's back in the DOM instantly — well before `Bridge.Initialise()`/`Begin()` (which reparses the whole Core library XML) actually finish. Now brackets the restart on the `#qv-restarting` overlay's visible→hidden transition instead.

- **AppShell autosave (`appshell_chromium`)** — two bugs: the test's `input[type="text"]).first()` locator started matching the elements-tree filter box (added in a later PR) instead of the description field, so the edit never reached the WASM model at all. Separately, even once targeting the right field, the "Saving…" pill can be visible for as little as ~10ms on a fast local-draft write (confirmed via frame-precise polling) — added a 300ms minimum visible duration in `editor-store.ts` so it's reliably perceptible to users and tests alike, same pattern as the existing `nextPaint()` calls elsewhere in this codebase.

- **AppShell drafts backup (`appshell_opfs_firefox`)** — draft deletion moved from `window.confirm()` to an in-app `ConfirmDialog` a while back; the test still waited on a native `dialog` event that never fires, so the confirm modal sat open and silently blocked the rest of the flow.

- **Electron (`electron`)** — three scripts waited on a text-labelled `button:has-text("Assets")`, but a toolbar cleanup made that button icon-only (`title="Manage assets"`, no visible text).

## Test plan

- [x] Reproduced each of the 4 original CI failures locally against the same builds
- [x] Fixed each root cause and re-ran the *specific* failing script until green
- [x] Re-ran every script in each affected job's full suite (not just the one that failed) to check for collateral regressions — all pass:
  - `appshell_chromium`: opfs-default, autosave, play-open-file, play-refresh
  - `appshell_opfs_firefox`: local-drafts, drafts-rekey-backup, multi-aslx-zip
  - `wasmplayer_chromium`: restart-sidebar-dup, debugger
  - `electron`: open-file, new-game-folder, recent-games (x3 for flake-check), play-local-file
- [ ] CI `e2e` workflow is manual-dispatch only — trigger a run on this branch/PR to confirm in the real CI environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)