### PR TITLE
feat(AppShell): fold advanced controls into a collapsed expander

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -75,6 +75,14 @@
         return data.controls;
     }
 
+    function partitionControls(controls: ControlInfo[]): { main: ControlInfo[]; advanced: ControlInfo[] } {
+        const advanced = controls.filter(c => c.advanced);
+        if (advanced.length === 0 || advanced.length === controls.length) {
+            return { main: controls, advanced: [] };
+        }
+        return { main: controls.filter(c => !c.advanced), advanced };
+    }
+
     function attrValue(attribute: string): string | null {
         return $selectedData?.attributes[attribute] ?? null;
     }
@@ -144,20 +152,24 @@
         {@const viewControls = getControlsForView()}
         {@const hasAttributesPanel = viewControls.some(c => c.controlType === "attributes")}
         {#if hasAttributesPanel}
+            {@const { main, advanced } = partitionControls(viewControls.filter(c => c.controlType !== "attributes"))}
             <div class="flex-1 overflow-hidden flex flex-col min-h-0">
                 <AttributesEditor>
                     {#snippet extraControls()}
-                        {#each viewControls.filter(c => c.controlType !== "attributes") as ctrl, i (i)}
+                        {#each main as ctrl, i (i)}
                             {@render controlRow(ctrl)}
                         {/each}
+                        {@render advancedExpander(advanced)}
                     {/snippet}
                 </AttributesEditor>
             </div>
         {:else}
+            {@const { main, advanced } = partitionControls(viewControls)}
             <div class="flex-1 overflow-y-auto">
-                {#each viewControls as ctrl, i (i)}
+                {#each main as ctrl, i (i)}
                     {@render controlRow(ctrl)}
                 {/each}
+                {@render advancedExpander(advanced)}
             </div>
         {/if}
     {/if}
@@ -407,6 +419,19 @@
         {:else}
             <em class="text-xs text-surface-400-500">null</em>
         {/if}
+    {/if}
+{/snippet}
+
+{#snippet advancedExpander(controls: ControlInfo[])}
+    {#if controls.length > 0}
+        <details class="border-t border-surface-200-800">
+            <summary class="px-3 py-1.5 text-xs font-semibold uppercase text-surface-500-400 cursor-pointer select-none">
+                Advanced
+            </summary>
+            {#each controls as ctrl, i (i)}
+                {@render controlRow(ctrl)}
+            {/each}
+        </details>
     {/if}
 {/snippet}
 

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -31,6 +31,7 @@ export interface ControlInfo {
   objectType?: string | null
   listFilter?: string | null
   source?: string | null
+  advanced: boolean
 }
 
 export interface TabInfo {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -34,7 +34,8 @@ internal record ControlInfo(
     string? ElementType = null,
     string? ObjectType = null,
     string? ListFilter = null,
-    string? Source = null);
+    string? Source = null,
+    bool Advanced = false);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -3075,14 +3076,15 @@ public partial class WasmEditorBridge
 
             var caption = ctrl.Caption ?? ctrl.GetString("selfcaption");
             return new ControlInfo(ctrl.Id, ctrl.ControlType, caption, options, subEditors, ctrl.Attribute,
-                multiTpCommands);
+                multiTpCommands, Advanced: !ctrl.IsControlVisibleInSimpleMode);
         }
         else if (ctrl.ControlType == "elementslist")
         {
             return new ControlInfo(null, "elementslist", null, null, null, null, null, null,
                 ctrl.GetString("elementtype"),
                 ctrl.GetString("objecttype"),
-                ctrl.GetString("listfilter"));
+                ctrl.GetString("listfilter"),
+                Advanced: !ctrl.IsControlVisibleInSimpleMode);
         }
 
         List<TextProcessorCommand>? textProcessorCommands = null;
@@ -3095,7 +3097,8 @@ public partial class WasmEditorBridge
         var source = ctrl.ControlType == "file" ? ctrl.GetString("source") : null;
 
         return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
-            null, null, textProcessorCommands, addPrompt, Source: source);
+            null, null, textProcessorCommands, addPrompt, Source: source,
+            Advanced: !ctrl.IsControlVisibleInSimpleMode);
     }
 
     [JSExport]

--- a/tests/e2e/verify-appshell-advanced-controls.mjs
+++ b/tests/e2e/verify-appshell-advanced-controls.mjs
@@ -1,0 +1,86 @@
+// Verifies workstream 1 of docs/editor-progressive-disclosure.md: controls
+// flagged <advanced/> in the ASLX editor definitions are folded into a
+// collapsed "Advanced" expander at the bottom of their tab instead of being
+// rendered inline, and still round-trip edits once expanded.
+//
+// Target: the game element's "Interface" tab, whose "Set a custom display
+// width" checkbox (EditorGameSetacustom) is <advanced/> with no onlydisplayif,
+// so it's always present without extra game setup.
+//
+// Run: node src/WasmEditor... build first (Debug), then
+//   node tests/e2e/verify-appshell-advanced-controls.mjs [baseUrl]
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+try {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Advanced Controls Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+
+    // "game" is auto-selected on load but that doesn't push into the mobile
+    // properties pane on narrow viewports; tap it explicitly to be safe.
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+
+    await page.getByRole('button', { name: 'Interface', exact: true }).click();
+
+    const advancedCheckbox = page.getByText('Set a custom display width', { exact: true });
+    const nonAdvancedCheckbox = page.getByText('Show border', { exact: true });
+
+    await nonAdvancedCheckbox.waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: non-advanced control ("Show border") renders inline');
+
+    const isAdvancedVisibleBeforeExpand = await advancedCheckbox.isVisible().catch(() => false);
+    if (isAdvancedVisibleBeforeExpand) throw new Error('Advanced control should be hidden until the expander is opened');
+    console.log('PASS: advanced control is not visible before expanding');
+
+    const summary = page.locator('summary', { hasText: 'Advanced' });
+    await summary.waitFor({ state: 'visible', timeout: 5000 });
+    await summary.click();
+
+    await advancedCheckbox.waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: advanced control appears after expanding "Advanced"');
+
+    // Round-trip: toggle the checkbox and confirm the attribute is persisted.
+    const checkboxInput = advancedCheckbox.locator('xpath=ancestor::label').locator('input[type=checkbox]');
+    const wasChecked = await checkboxInput.isChecked();
+    await checkboxInput.click();
+    await page.waitForTimeout(200);
+    const nowChecked = await checkboxInput.isChecked();
+    if (nowChecked === wasChecked) throw new Error('Checkbox state did not toggle');
+
+    // Switch tabs away and back, then re-open the expander, to confirm the edit persisted.
+    await page.getByRole('button', { name: 'Setup', exact: true }).click();
+    await page.getByRole('button', { name: 'Interface', exact: true }).click();
+    const summary2 = page.locator('summary', { hasText: 'Advanced' });
+    await summary2.waitFor({ state: 'visible', timeout: 5000 });
+    // The <details> DOM node is reused (not recreated) across this tab-away-and-back,
+    // so it's still open from the earlier expand — only click if it isn't.
+    const alreadyOpen = await summary2.evaluate(el => el.closest('details')?.open);
+    if (!alreadyOpen) await summary2.click();
+    await advancedCheckbox.waitFor({ state: 'visible', timeout: 5000 });
+    const persistedChecked = await checkboxInput.isChecked();
+    if (persistedChecked !== nowChecked) throw new Error('Checkbox edit did not persist after tab switch');
+    console.log('PASS: advanced control edit round-trips after tab switch');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+    try {
+        const pages = browser.contexts().flatMap(c => c.pages());
+        if (pages[0]) await pages[0].screenshot({ path: '/tmp/advanced-controls-failure.png' });
+    } catch { /* best-effort */ }
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Workstream 1 of `docs/editor-progressive-disclosure.md`: controls flagged `<advanced/>` in the Core ASLX editor definitions now fold into a collapsed "Advanced" expander at the bottom of their tab instead of rendering inline.
- `WasmEditorBridge.ControlInfo` gains `Advanced` (from `IEditorControl.IsControlVisibleInSimpleMode`, inverted), applied to both tab and top-level controls.
- `PropertyEditor.svelte` partitions each tab's controls into main + advanced, preserving relative order within each partition. Tabs with no advanced controls, or where every control is advanced, render unchanged (no expander).

## Test plan
- [x] `dotnet build` (Release) for WasmEditor
- [x] `npm run check` (svelte-check) clean
- [x] New Playwright script `tests/e2e/verify-appshell-advanced-controls.mjs`: non-advanced control renders inline, advanced control hidden until expanded, edit round-trips after switching tabs away and back
- [x] Re-ran `verify-appshell-attributes-panel-pinned.mjs` and `verify-appshell-game-status-attributes-scroll.mjs` — no regressions in the attributes-panel rendering path

🤖 Generated with [Claude Code](https://claude.com/claude-code)