### PR TITLE
feat(AppShell): demote advanced categories in the script adder

### DIFF
--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -54,6 +54,15 @@
 
     const selectedCategory = $derived(categories[selectedCategoryIndex] ?? null);
 
+    // Within a mixed category (not already-entirely-advanced, which already got its own
+    // category-level divider above), commands are pre-sorted non-advanced-first by the
+    // bridge — find where the advanced tail starts so a divider can mark it.
+    const firstAdvancedCommandIndex = $derived(
+        selectedCategory && !selectedCategory.advanced
+            ? selectedCategory.commands.findIndex((c) => c.advanced)
+            : -1
+    );
+
     // ── Filtering ──────────────────────────────────────────────────────────────
     // While the box has text, the category sidebar + single-category list is
     // replaced by one flat list of matches across every category, each tagged
@@ -315,6 +324,9 @@
                     {#if selectedCategory}
                         {#each selectedCategory.commands as cmd, idx (cmd.createString)}
                             {@const isSelected = selectedCommand?.createString === cmd.createString}
+                            {#if idx === firstAdvancedCommandIndex && idx > 0}
+                                <div class="px-5 py-1 text-[10px] font-semibold uppercase tracking-wide text-surface-400-500 border-t border-surface-200-800 mt-1 pt-2">Advanced</div>
+                            {/if}
                             <button
                                 bind:this={rowEls[idx]}
                                 type="button"

--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -9,7 +9,16 @@
         onClose: () => void;
     }
 
-    let { categories, onAdd, onClose }: Props = $props();
+    let { categories: unorderedCategories, onAdd, onClose }: Props = $props();
+
+    // Keep every command reachable, but stop presenting advanced-only categories as
+    // peers of everyday ones — order non-advanced categories first, then the advanced
+    // ones after a divider. The filter box searches all categories regardless.
+    const categories = $derived([
+        ...unorderedCategories.filter((c) => !c.advanced),
+        ...unorderedCategories.filter((c) => c.advanced),
+    ]);
+    const firstAdvancedIndex = $derived(categories.findIndex((c) => c.advanced));
 
     let dialogEl: HTMLDivElement;
 
@@ -276,6 +285,9 @@
                 >
                     {#each categories as cat, ci (ci)}
                         {@const isSelected = selectedCategoryIndex === ci}
+                        {#if ci === firstAdvancedIndex && ci > 0}
+                            <div class="px-4 py-1 text-[10px] font-semibold uppercase tracking-wide text-surface-400-500 border-t border-surface-200-800 mt-1 pt-2">Advanced</div>
+                        {/if}
                         <button
                             bind:this={categoryButtonEls[ci]}
                             type="button"

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -112,6 +112,7 @@ export interface ScriptCommandInfo {
   display: string
   add: string
   createString: string
+  advanced: boolean
 }
 
 export interface ScriptCategoryInfo {

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -116,6 +116,7 @@ export interface ScriptCommandInfo {
 export interface ScriptCategoryInfo {
   name: string
   commands: ScriptCommandInfo[]
+  advanced: boolean
 }
 
 export interface ScriptCommandCategoriesData {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -72,7 +72,7 @@ internal record ScriptNodeData(
 
 internal record ScriptBlockData(List<ScriptNodeData> Scripts);
 
-internal record ScriptCommandInfo(string Keyword, string Display, string Add, string CreateString);
+internal record ScriptCommandInfo(string Keyword, string Display, string Add, string CreateString, bool Advanced);
 
 internal record ScriptCategoryInfo(string Name, List<ScriptCommandInfo> Commands, bool Advanced);
 
@@ -1363,12 +1363,17 @@ public partial class WasmEditorBridge
             .GroupBy(kv => kv.Value.Category)
             .Select(g => new ScriptCategoryInfo(
                 g.Key,
-                g.OrderBy(kv => kv.Value.Order).Select(kv => new ScriptCommandInfo(
-                    kv.Key,
-                    kv.Value.DisplayString ?? kv.Key,
-                    kv.Value.AdderDisplayString ?? kv.Key,
-                    kv.Value.CreateString!
-                )).ToList(),
+                // Non-advanced commands first (in declared order), then advanced ones
+                // (also in declared order) — keeps a mixed category's everyday commands
+                // together at the top instead of interleaved with advanced ones.
+                g.OrderBy(kv => !kv.Value.IsVisibleInSimpleMode).ThenBy(kv => kv.Value.Order)
+                    .Select(kv => new ScriptCommandInfo(
+                        kv.Key,
+                        kv.Value.DisplayString ?? kv.Key,
+                        kv.Value.AdderDisplayString ?? kv.Key,
+                        kv.Value.CreateString!,
+                        !kv.Value.IsVisibleInSimpleMode
+                    )).ToList(),
                 g.All(kv => !kv.Value.IsVisibleInSimpleMode)
             ))
             .ToList();

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -73,7 +73,7 @@ internal record ScriptBlockData(List<ScriptNodeData> Scripts);
 
 internal record ScriptCommandInfo(string Keyword, string Display, string Add, string CreateString);
 
-internal record ScriptCategoryInfo(string Name, List<ScriptCommandInfo> Commands);
+internal record ScriptCategoryInfo(string Name, List<ScriptCommandInfo> Commands, bool Advanced);
 
 internal record ScriptCommandCategoriesData(List<ScriptCategoryInfo> Categories);
 
@@ -1367,7 +1367,8 @@ public partial class WasmEditorBridge
                     kv.Value.DisplayString ?? kv.Key,
                     kv.Value.AdderDisplayString ?? kv.Key,
                     kv.Value.CreateString!
-                )).ToList()
+                )).ToList(),
+                g.All(kv => !kv.Value.IsVisibleInSimpleMode)
             ))
             .ToList();
         var data = new ScriptCommandCategoriesData(grouped);

--- a/tests/e2e/verify-appshell-scriptadder-advanced-categories.mjs
+++ b/tests/e2e/verify-appshell-scriptadder-advanced-categories.mjs
@@ -32,8 +32,11 @@ try {
     await page.locator('[data-value="game"][data-part="branch-control"]').click();
 
     // Enable "Lightness and darkness" on the Features tab so the (entirely-advanced)
-    // Darkness script category actually has visible commands.
+    // Darkness script category actually has visible commands. The checkbox is itself
+    // <advanced/>, so (since workstream 1, #1934) it's folded into the property
+    // editor's own "Advanced" expander — open that first.
     await page.getByRole('button', { name: 'Features', exact: true }).click();
+    await page.locator('summary', { hasText: 'Advanced' }).click();
     await page.getByText('Lightness and darkness', { exact: false }).click();
 
     await page.getByRole('button', { name: 'Scripts', exact: true }).click();

--- a/tests/e2e/verify-appshell-scriptadder-advanced-categories.mjs
+++ b/tests/e2e/verify-appshell-scriptadder-advanced-categories.mjs
@@ -1,0 +1,109 @@
+// Verifies workstream 3 of docs/editor-progressive-disclosure.md: script
+// command categories where *every* visible command is <advanced/> (mirroring
+// v5's GetCategories filter in reverse) are demoted below a divider in
+// AddScriptModal's category sidebar, instead of presented as peers of
+// everyday categories like "Output". Every command stays reachable — the
+// filter box searches all categories regardless of the divider.
+//
+// "Darkness" (CoreEditorScriptsDarkness.aslx) is entirely <advanced/> but
+// gated behind game.feature_lightdark, off by default — enable it via the
+// Features tab so the category actually has visible commands and appears at
+// all (a category with zero visible commands doesn't show up either way).
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+try {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `ScriptAdder Advanced Cats Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+
+    // "game" is auto-selected but doesn't push into the mobile properties pane; tap it.
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+
+    // Enable "Lightness and darkness" on the Features tab so the (entirely-advanced)
+    // Darkness script category actually has visible commands.
+    await page.getByRole('button', { name: 'Features', exact: true }).click();
+    await page.getByText('Lightness and darkness', { exact: false }).click();
+
+    await page.getByRole('button', { name: 'Scripts', exact: true }).click();
+    await page.getByText('+ Add script', { exact: false }).first().click();
+
+    const sidebar = page.locator('[role="listbox"][aria-label="Script command categories"]');
+    await sidebar.getByText('Output', { exact: true }).waitFor({ state: 'visible', timeout: 5000 });
+
+    const categoryLabels = await sidebar.locator('button').allTextContents();
+    const divider = sidebar.getByText('Advanced', { exact: true });
+    await divider.waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: "Advanced" divider is present once an entirely-advanced category has visible commands');
+
+    const dividerBox = await divider.boundingBox();
+    const outputIndex = categoryLabels.indexOf('Output');
+    const darknessIndex = categoryLabels.indexOf('Darkness');
+    if (outputIndex === -1 || darknessIndex === -1) {
+        throw new Error(`Expected both "Output" and "Darkness" categories, got: ${categoryLabels.join(', ')}`);
+    }
+    if (!(outputIndex < darknessIndex)) {
+        throw new Error(`Expected "Output" before "Darkness", got order: ${categoryLabels.join(', ')}`);
+    }
+    console.log('PASS: non-advanced "Output" is ordered before advanced "Darkness"');
+
+    const outputBox = await sidebar.getByText('Output', { exact: true }).boundingBox();
+    const darknessBox = await sidebar.getByText('Darkness', { exact: true }).boundingBox();
+    if (!(outputBox.y < dividerBox.y && dividerBox.y < darknessBox.y)) {
+        throw new Error('Expected the divider to sit visually between "Output" and "Darkness"');
+    }
+    console.log('PASS: divider sits visually between non-advanced and advanced categories');
+
+    // Every command is still reachable: select Darkness and confirm it has commands,
+    // then create one.
+    await sidebar.getByText('Darkness', { exact: true }).click();
+    const commandList = page.locator('[role="listbox"][aria-label^="Script commands in Darkness"]');
+    const commandCount = await commandList.locator('button').count();
+    if (commandCount === 0) throw new Error('Darkness category should list its commands');
+    console.log(`PASS: Darkness category lists ${commandCount} command(s)`);
+
+    const startScriptSection = page.locator('text=Start script:').locator('..');
+    const selectCountBefore = await startScriptSection.locator('select').count();
+    await commandList.locator('button').first().click();
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
+    await page.getByRole('dialog').waitFor({ state: 'hidden', timeout: 3000 });
+    // Adding "Make <object> dark" inserts a new object-picker <select> into the
+    // previously-empty Start script — its presence confirms the command was added.
+    await page.waitForFunction(
+        (before) => document.querySelectorAll('select').length > before,
+        selectCountBefore,
+        { timeout: 5000 }
+    );
+    console.log('PASS: an advanced-category command can still be added and appears in the script');
+
+    // The filter box searches everything regardless of the divider.
+    await page.getByText('+ Add script', { exact: false }).first().click();
+    await page.fill('input[placeholder="Filter commands..."]', 'dark');
+    await page.waitForTimeout(200);
+    const filteredMatches = page.locator('[role="listbox"][aria-label="Matching script commands"] button');
+    const filteredCount = await filteredMatches.count();
+    if (filteredCount === 0) throw new Error('Filtering for "dark" should still surface Darkness commands');
+    console.log(`PASS: filter box surfaces ${filteredCount} advanced-category match(es) regardless of the divider`);
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+    try {
+        const pages = browser.contexts().flatMap(c => c.pages());
+        if (pages[0]) await pages[0].screenshot({ path: '/tmp/scriptadder-advanced-categories-failure.png' });
+    } catch { /* best-effort */ }
+} finally {
+    await browser.close();
+}

--- a/tests/e2e/verify-appshell-scriptadder-advanced-commands.mjs
+++ b/tests/e2e/verify-appshell-scriptadder-advanced-commands.mjs
@@ -1,0 +1,71 @@
+// Follow-up to workstream 3 of docs/editor-progressive-disclosure.md: the
+// category-level divider (verify-appshell-scriptadder-advanced-categories.mjs)
+// only demotes categories where *every* command is advanced — Darkness/Drawing,
+// both gated behind off-by-default features, so the effect was invisible on a
+// stock game. This extends the same idea one level down: within a mixed
+// category, advanced commands sort after a divider too, e.g. "Scripts" (If,
+// First time non-advanced; Comment/For/For each/Switch/While/etc. advanced) —
+// visible on any fresh game, no feature flags required.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+try {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `ScriptAdder Advanced Cmds Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+    await page.getByRole('button', { name: 'Scripts', exact: true }).click();
+    await page.getByText('+ Add script', { exact: false }).first().click();
+    await page.getByRole('option', { name: 'Scripts', exact: true }).waitFor({ state: 'visible', timeout: 5000 });
+    await page.getByRole('option', { name: 'Scripts', exact: true }).click();
+
+    const commandList = page.locator('[role="listbox"][aria-label^="Script commands in Scripts"]');
+    await commandList.getByText('If...', { exact: false }).waitFor({ state: 'visible', timeout: 5000 });
+
+    const rowTexts = await commandList.locator('button, div').allTextContents();
+    const cleaned = rowTexts.map(t => t.replace('●', '').trim()).filter(Boolean);
+    const dividerIndex = cleaned.indexOf('Advanced');
+    const ifIndex = cleaned.indexOf('If...');
+    const forIndex = cleaned.indexOf('For...');
+    if (dividerIndex === -1) throw new Error(`Expected an "Advanced" divider within the mixed "Scripts" category, got: ${cleaned.join(', ')}`);
+    if (!(ifIndex < dividerIndex && dividerIndex < forIndex)) {
+        throw new Error(`Expected order If... < divider < For..., got: ${cleaned.join(', ')}`);
+    }
+    console.log('PASS: "Scripts" category shows non-advanced commands (If...) before the divider and advanced ones (For...) after');
+
+    // The category itself must NOT be demoted below the category-level divider —
+    // "Scripts" has non-advanced commands, so it's not an all-advanced category.
+    const sidebar = page.locator('[role="listbox"][aria-label="Script command categories"]');
+    const categoryDividerVisible = await sidebar.getByText('Advanced', { exact: true }).isVisible().catch(() => false);
+    if (categoryDividerVisible) throw new Error('No category should be fully-advanced with default game content — the category-level divider should not appear here');
+    console.log('PASS: mixed categories like "Scripts" stay out of the category-level divider');
+
+    // Advanced commands are still directly clickable/addable, not hidden behind anything.
+    await commandList.getByText('For...', { exact: false }).click();
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
+    await page.getByRole('dialog').waitFor({ state: 'hidden', timeout: 3000 });
+    console.log('PASS: an advanced command below the divider is still directly clickable and addable');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+    try {
+        const pages = browser.contexts().flatMap(c => c.pages());
+        if (pages[0]) await pages[0].screenshot({ path: '/tmp/scriptadder-advanced-commands-failure.png' });
+    } catch { /* best-effort */ }
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Workstream 3 of `docs/editor-progressive-disclosure.md`: script command categories where *every* visible command is `<advanced/>` (mirroring v5's `GetCategories` filter in reverse) now sort below a divider in `AddScriptModal`'s category sidebar, instead of appearing as peers of everyday categories like "Output".
- `WasmEditorBridge.ScriptCategoryInfo` gains `Advanced`, computed per category from `EditableScriptData.IsVisibleInSimpleMode`.
- Every command stays reachable — the filter box searches all categories regardless of the divider.

## Test plan
- [x] `dotnet build` (Release) for WasmEditor
- [x] `npm run check` (svelte-check) clean
- [x] New Playwright script `tests/e2e/verify-appshell-scriptadder-advanced-categories.mjs`: enables the (off-by-default) "Lightness and darkness" feature so the entirely-advanced "Darkness" category has visible commands, confirms it sorts after non-advanced categories with a divider between them, confirms its commands are still addable, and confirms the filter box still surfaces them regardless of the divider
- [x] Re-ran `verify-appshell-addscript-modal-mobile.mjs`, `verify-appshell-script-adder-filter.mjs`, `verify-appshell-script-label-stacks-below.mjs`, `verify-appshell-scripteditor-row-buttons.mjs`, `verify-appshell-scripteditor-selection-toolbar.mjs` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)