### PR TITLE
feat(Engine): revise advanced-flag metadata after progressive disclosure audit

### DIFF
--- a/docs/editor-progressive-disclosure.md
+++ b/docs/editor-progressive-disclosure.md
@@ -1,0 +1,53 @@
+# Editor progressive disclosure (Simple Mode successor)
+
+Decision record. The work described here shipped in PRs #1934 (property-editor
+Advanced expanders), #1935 (hide empty advanced tree categories), #1936 (script-adder
+Advanced demotion), and a follow-up metadata audit of the `<advanced/>` flags.
+
+## Background
+
+Quest 5 had a global "Simple Mode" toggle aimed at beginners and classrooms: it hid
+advanced tree categories entirely, hid any editor tab or control flagged `<advanced/>`
+in the Core `.aslx` editor definitions, and filtered the script command adder to
+non-advanced categories.
+
+## Decision: disclosure, not a mode
+
+We did **not** port Simple Mode as a global toggle:
+
+- Modes fork the docs/tutorials and double the manual/e2e test surface.
+- v5's version could make existing content invisible: open a game that uses functions
+  with Simple Mode on and the Functions category simply wasn't there.
+- Quest Viva already covers much of the same ground per-game rather than per-user: the
+  Features tab (`game.feature_*` + `onlydisplayif`) hides whole tabs until a game opts
+  in, and the tree/script-adder filter textboxes address findability.
+
+Instead the `<advanced/>` metadata (throughout `src/Engine/Core/*.aslx`) drives
+**disclosure**: advanced controls fold into a collapsed "Advanced" expander at the
+bottom of each property-editor tab, and the script adder orders non-advanced categories
+first with the rest below an "Advanced" divider (and, within mixed categories, sorts
+advanced commands into an "Advanced" tail). Everything stays reachable and editable.
+
+Two conventions for the flags themselves, established by the audit:
+
+- **Feature-gated content is not also advanced-flagged.** If a command or control is
+  already behind a `game.feature_*` opt-in (`onlydisplayif`), the feature toggle is the
+  disclosure — flagging it advanced too would demote it for exactly the games that
+  opted in. (The Player score/health/money commands are the model; darkness and frame
+  picture commands were fixed to match.) Exception: the Drawing category stays
+  advanced — most grid-map users never touch the custom drawing layer.
+- **Tab-level `<advanced/>` is ignored.** Hiding or demoting whole tabs re-introduces
+  the "where did X go" problem; the Features tab already gates the noisiest ones.
+
+## Dormant EditorCore plumbing — keep it
+
+EditorCore still carries the full v5 Simple Mode plumbing, all deliberately dormant:
+`SimpleMode` / `SimpleModeChanged` on `EditorController`, the `m_advancedTypes` tree
+filtering, `IsTabVisibleInSimpleMode` (`EditorTab.cs`), `IsControlVisibleInSimpleMode`
+(`EditorControl.cs` — this one *is* consulted, inverted, by `WasmEditorBridge` to
+populate the `Advanced` flags above), `IsVisibleInSimpleMode`
+(`EditableScriptFactory.cs`), and `GetCategories(simpleModeOnly, showAll)`.
+
+Don't remove it. If a locked-down classroom deployment is ever wanted, this makes a
+global toggle cheap to add later (a bridge property plus UI conditionals, defaulted
+per-deployment via query param rather than per-user). Wait for actual demand.

--- a/src/Engine/Core/CoreEditorExit.aslx
+++ b/src/Engine/Core/CoreEditorExit.aslx
@@ -89,7 +89,6 @@
         <controltype>checkbox</controltype>
         <attribute>runscript</attribute>
         <onlydisplayif>not this.lookonly</onlydisplayif>
-        <advanced/>
       </control>
   
       <control>
@@ -97,7 +96,6 @@
         <controltype>script</controltype>
         <attribute>script</attribute>
         <onlydisplayif>this.runscript</onlydisplayif>
-        <advanced/>
       </control>
 
       <control>

--- a/src/Engine/Core/CoreEditorGame.aslx
+++ b/src/Engine/Core/CoreEditorGame.aslx
@@ -122,7 +122,6 @@
         <controltype>checkbox</controltype>
         <caption>[EditorGameLightnessand]</caption>
         <attribute>feature_lightdark</attribute>
-        <advanced/>
       </control>
 
       <control>

--- a/src/Engine/Core/CoreEditorObjectSetup.aslx
+++ b/src/Engine/Core/CoreEditorObjectSetup.aslx
@@ -21,7 +21,6 @@
       <caption>[EditorObjectSetupAlias]</caption>
       <controltype>textbox</controltype>
       <attribute>alias</attribute>
-      <advanced/>
       <nullable/>
     </control>
 

--- a/src/Engine/Core/CoreEditorScriptsDarkness.aslx
+++ b/src/Engine/Core/CoreEditorScriptsDarkness.aslx
@@ -5,7 +5,6 @@
     <category>[EditorScriptsDarknessDarkness]</category>
     <create>SetDark()</create>
     <add>[EditorScriptsDarknessMakeroomdark]</add>
-    <advanced/>
     <onlydisplayif>game.feature_lightdark</onlydisplayif>
   
     <control>
@@ -27,7 +26,6 @@
     <category>[EditorScriptsDarknessDarkness]</category>
     <create>SetLight()</create>
     <add>[EditorScriptsDarknessMakeroomlight]</add>
-    <advanced/>
     <onlydisplayif>game.feature_lightdark</onlydisplayif>
   
     <control>
@@ -49,7 +47,6 @@
     <category>[EditorScriptsDarknessDarkness]</category>
     <create>SetObjectLightstrength (,"")</create>
     <add>[EditorScriptsDarknessSetobjectbrightness]</add>
-    <advanced/>
     <onlydisplayif>game.feature_lightdark</onlydisplayif>
   
     <control>
@@ -86,7 +83,6 @@
     <category>[EditorScriptsDarknessDarkness]</category>
     <create>SetExitLightstrength (,"")</create>
     <add>[EditorScriptsDarknessSetexitbrightness]</add>
-    <advanced/>
     <onlydisplayif>game.feature_lightdark</onlydisplayif>
   
     <control>

--- a/src/Engine/Core/CoreEditorScriptsObjects.aslx
+++ b/src/Engine/Core/CoreEditorScriptsObjects.aslx
@@ -144,7 +144,6 @@
     <category>[EditorScriptsObjectsObjects]</category>
     <create>RemoveObject ()</create>
     <add>[EditorScriptsObjectsRemoveobject]</add>
-    <advanced/>
 
     <control>
       <controltype>label</controltype>

--- a/src/Engine/Core/CoreEditorScriptsOutput.aslx
+++ b/src/Engine/Core/CoreEditorScriptsOutput.aslx
@@ -124,7 +124,6 @@
     <category>[EditorScriptsOutputOutput]</category>
     <create>SetFramePicture ("")</create>
     <add>[EditorScriptsOutputSetframepicture]</add>
-    <advanced/>
     <onlydisplayif>GetString(game, "_editorstyle") = null and GetBoolean(game, "feature_pictureframe")</onlydisplayif>
 
     <control>
@@ -149,7 +148,6 @@
     <category>[EditorScriptsOutputOutput]</category>
     <create>ClearFramePicture</create>
     <add>[EditorScriptsOutputClearframe]</add>
-    <advanced/>
     <onlydisplayif>GetString(game, "_editorstyle") = null and GetBoolean(game, "feature_pictureframe")</onlydisplayif>
 
     <control>
@@ -347,7 +345,6 @@
     <category>[EditorScriptsOutputOutput]</category>
     <create>stop sound</create>
     <add>[EditorScriptsOutputStopsound]</add>
-    <advanced/>
 
     <control>
       <controltype>label</controltype>
@@ -604,7 +601,6 @@
     <category>[EditorScriptsOutputOutput]</category>
     <create>ShowMenu ("",,true) { }</create>
     <add>[EditorScriptsOutputShowamenu]</add>
-    <advanced/>
 
     <control>
       <controltype>label</controltype>
@@ -679,7 +675,6 @@
     <category>[EditorScriptsOutputOutput]</category>
     <create>Ask ("") { }</create>
     <add>[EditorScriptsOutputAskaquestion]</add>
-    <advanced/>
     <onlydisplayif>GetString(game, "_editorstyle") = null</onlydisplayif>
 
     <control>

--- a/src/Engine/Core/CoreEditorScriptsScripts.aslx
+++ b/src/Engine/Core/CoreEditorScriptsScripts.aslx
@@ -22,7 +22,6 @@
     <category>[EditorScriptsScriptsScripts]</category>
     <add>[EditorScriptsScriptsComment]</add>
     <create>// Type comment</create>
-    <advanced/>
 
     <control>
       <controltype>textbox</controltype>

--- a/src/Engine/Core/CoreEditorScriptsTurnScripts.aslx
+++ b/src/Engine/Core/CoreEditorScriptsTurnScripts.aslx
@@ -176,6 +176,7 @@
     <category>[EditorScriptsTurnScriptsTurnScripts]</category>
     <create>SuppressTurnscripts</create>
     <add>[EditorScriptsTurnScriptsSuppressturnscripts]</add>
+    <advanced/>
 
     <control>
       <controltype>label</controltype>

--- a/src/Engine/Core/CoreEditorScriptsVariables.aslx
+++ b/src/Engine/Core/CoreEditorScriptsVariables.aslx
@@ -258,7 +258,6 @@
     <category>[EditorScriptsVariablesVariables]</category>
     <add>[EditorScriptsVariablesSetavariable]</add>
     <create>=</create>
-    <advanced/>
 
     <control>
       <controltype>label</controltype>


### PR DESCRIPTION
Follow-up to #1934/#1935/#1936: the `<advanced/>` flags in `src/Engine/Core/*.aslx` were curated for Quest 5's Simple Mode circa 2011 and had never been reviewed against the new disclosure UI. This audits them and adjusts 17 flags (data only, no code).

**Unflagged (moved out of Advanced):**
- Feature-gated content that was double-gated — the feature opt-in is already the disclosure, so demoting these punished exactly the games that opted in (the Player score/health/money commands were the existing model for this): all 4 Darkness commands, Set/Clear frame picture, and the light/dark checkbox on the Features tab itself.
- Commonly needed items: Alias on the object Setup tab, the exit "Run a script" checkbox + script (locked doors are a first-tutorial pattern), Comment, Stop sound (Play sound wasn't advanced), Set a variable or attribute (`=`), Show a menu, Ask a question, Remove object.

**Flagged (moved into Advanced):**
- Suppress turn scripts.

The Drawing category deliberately stays all-advanced: it's feature-gated too, but most grid-map users never touch the custom drawing layer.

Also lands `docs/editor-progressive-disclosure.md` (from the old `simple-mode` branch) trimmed from a plan to a decision record: why there's no global Simple Mode toggle, the two flag conventions above, and why EditorCore's dormant SimpleMode plumbing is kept. The `simple-mode` branch can be deleted once this merges.

Verified with EditorCoreTests (19/19) and a script that inventories every `<advanced/>` flag by category before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)