### PR TITLE
fix(AppShell): reset script command scroll on category switch

### DIFF
--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -118,6 +118,14 @@
     );
 
     let rowEls = $state<(HTMLButtonElement | undefined)[]>([]);
+    let commandListEl = $state<HTMLDivElement | undefined>();
+
+    // Switching categories reuses the same scrollable panel, so without this the
+    // command list would keep whatever scroll offset the previous category left behind.
+    $effect(() => {
+        selectedCategoryIndex;
+        commandListEl?.scrollTo(0, 0);
+    });
 
     function moveSelection(delta: number) {
         const list = activeList;
@@ -315,6 +323,7 @@
 
                 <!-- Commands list -->
                 <div
+                    bind:this={commandListEl}
                     class="flex-1 overflow-y-auto pb-2"
                     role="listbox"
                     aria-label="Script commands in {selectedCategory?.name ?? ""}"

--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -123,7 +123,7 @@
     // Switching categories reuses the same scrollable panel, so without this the
     // command list would keep whatever scroll offset the previous category left behind.
     $effect(() => {
-        selectedCategoryIndex;
+        void selectedCategoryIndex;
         commandListEl?.scrollTo(0, 0);
     });
 


### PR DESCRIPTION
## Summary
- Switching categories in the script adder modal reused the previous category's scroll position, so a long scroll in one category carried over to the next category's command list instead of starting at the top.
- Bind the command-list container and reset its scroll offset whenever the selected category changes.

## Test plan
- [x] Open the script adder, scroll down within a category's command list, switch to a different category, and confirm the list starts at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)