### PR TITLE
feat(AppShell): move rare element adders into the Advanced tree node

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectedKey, selectedData, treeNodes, setAttribute, setDropdownType, setMultiType, setObjectReference, addDictItem, removeDictItem, updateDictItem } from "$lib/editor-store";
+    import { selectedKey, selectedData, treeNodes, setAttribute, setDropdownType, setMultiType, setObjectReference, addDictItem, removeDictItem, updateDictItem, openAddModal, createIncludedLibrary, createJavascript } from "$lib/editor-store";
     import { showToast } from "$lib/toast";
     import type { ControlInfo, TextProcessorCommand } from "$lib/types";
     import type { TreeNode } from "$lib/types";
@@ -19,6 +19,24 @@
     let selectedNode = $derived<TreeNode | null>(
         $treeNodes.find(n => n.key === $selectedKey) ?? null
     );
+
+    // The "_advanced" tree header has no elementType of its own (EditorController
+    // registers it with type: null), so $selectedData is always null for it and it
+    // would otherwise fall into the generic "No properties available" state below.
+    // It still needs to be a real entry point — its sub-category headers (Functions,
+    // Timers, Library, ...) stay hidden from the tree until they have their first
+    // element (TreePanel's HIDE_WHEN_EMPTY), so this is the only place to add the
+    // first one of each.
+    const ADVANCED_ADDERS: { label: string; action: () => void }[] = [
+        { label: "Add Function", action: () => openAddModal("function", null) },
+        { label: "Add Timer", action: () => openAddModal("timer", null) },
+        { label: "Add Walkthrough", action: () => openAddModal("walkthrough", null) },
+        { label: "Add Library", action: () => createIncludedLibrary() },
+        { label: "Add Template", action: () => openAddModal("template", null) },
+        { label: "Add Dynamic Template", action: () => openAddModal("dynamictemplate", null) },
+        { label: "Add Type", action: () => openAddModal("type", null) },
+        { label: "Add JavaScript", action: () => createJavascript() },
+    ];
 
     let activeTab = $state<string | null>(null);
     let lastKey = $state<string | null>(null);
@@ -132,6 +150,16 @@
 
     {#if $selectedKey === null}
         <p class="px-3 py-4 text-sm text-surface-400-500">Select an object to view its properties.</p>
+    {:else if $selectedKey === "_advanced"}
+        <div class="flex flex-col items-start gap-1.5 px-3 py-3">
+            {#each ADVANCED_ADDERS as adder (adder.label)}
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                    onclick={adder.action}
+                >+ {adder.label}</button>
+            {/each}
+        </div>
     {:else if $selectedData === null}
         <p class="px-3 py-4 text-sm text-surface-400-500">No properties available.</p>
     {:else}

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -11,7 +11,6 @@
         undo, redo, canUndo, canRedo,
         treeNodes, selectedKey, openAddModal,
         createExit, createTurnScript, createCommand, createVerb,
-        createIncludedLibrary, createJavascript,
         deleteElement,
         assetManagerOpen,
     } from "$lib/editor-store";
@@ -90,19 +89,14 @@
         nt !== "" && nt !== "header" && nt !== "game" && nt !== "other"
     );
 
-    // Context-sensitive add options
+    // Context-sensitive add options. Function/Timer/Walkthrough/Library/Template/
+    // Dynamic Template/Type/JavaScript live under the "Advanced" tree node instead
+    // (see PropertyEditor's ADVANCED_ADDERS) — they're rare enough that they don't
+    // earn a slot in this always-visible dropdown.
     type AddOption = { label: string; action: () => void };
     let addOptions = $derived<AddOption[]>([
         // Always available
         { label: "Add Room", action: () => openAddModal("room", null) },
-        { label: "Add Function", action: () => openAddModal("function", null) },
-        { label: "Add Timer", action: () => openAddModal("timer", null) },
-        { label: "Add Walkthrough", action: () => openAddModal("walkthrough", null) },
-        { label: "Add Template", action: () => openAddModal("template", null) },
-        { label: "Add Dynamic Template", action: () => openAddModal("dynamictemplate", null) },
-        { label: "Add Type", action: () => openAddModal("type", null) },
-        { label: "Add Library", action: () => createIncludedLibrary() },
-        { label: "Add JavaScript", action: () => createJavascript() },
         // Context-sensitive: when a room or object is selected
         ...(nt === "room" || nt === "object" ? [
             { label: `Add Object in "${selectedNode!.text}"`, action: () => openAddModal("object", selectedNode!.key) },

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -52,13 +52,15 @@
     // Advanced category headers are always present in the tree data (added
     // unconditionally by EditorController.AddTreeHeader) even when nothing of that
     // type exists yet. An empty header is noise for everyone, not just beginners —
-    // hide these (and the "_advanced" group header itself once all of its children
-    // are hidden) until the author adds one via the Toolbar "+" menu, which doesn't
-    // depend on the header being visible. "_objects" is never hidden.
+    // hide these until the author adds one via that category's own "+ Add" button
+    // (ElementsList), reached by expanding "_advanced". "_advanced" itself is
+    // never hidden even when all its children are — it's the only entry point for
+    // adding the first function/timer/walkthrough/etc. in a fresh game, so it must
+    // stay clickable regardless of what it currently contains. "_objects" is never
+    // hidden either.
     const HIDE_WHEN_EMPTY = new Set([
         "_functions", "_timers", "_walkthrough",
         "_include", "_template", "_dynamictemplate", "_objecttype", "_javascript",
-        "_advanced",
     ]);
 
     function pruneEmptyAdvancedCategories(nodes: HierNode[]): HierNode[] {

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -513,11 +513,11 @@ public sealed class EditorController : IDisposable
 
         AddTreeHeader(EditorStyle.TextAdventure, ElementType.Object, "_objects", "Objects", null, false);
         AddTreeHeader(EditorStyle.GameBook, ElementType.Object, "_objects", "Pages", null, false);
-        AddTreeHeader(null, ElementType.Function, "_functions", "Functions", null, false);
-
-        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Timer, "_timers", "Timers", null, false);
-        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Walkthrough, "_walkthrough", "Walkthrough", null, false);
         AddTreeHeader(null, null, "_advanced", "Advanced", null, false);
+        AddTreeHeader(null, ElementType.Function, "_functions", "Functions", "_advanced", false);
+        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Timer, "_timers", "Timers", "_advanced", false);
+        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Walkthrough, "_walkthrough", "Walkthrough", "_advanced",
+            false);
         AddTreeHeader(null, ElementType.IncludedLibrary, "_include", "Included Libraries", "_advanced", false);
         AddTreeHeader(EditorStyle.TextAdventure, ElementType.Template, "_template", "Templates", "_advanced", false);
         AddTreeHeader(EditorStyle.TextAdventure, ElementType.DynamicTemplate, "_dynamictemplate", "Dynamic Templates",

--- a/tests/e2e/verify-advanced-tree.mjs
+++ b/tests/e2e/verify-advanced-tree.mjs
@@ -1,0 +1,44 @@
+import { chromium } from "playwright";
+
+const BASE = "http://localhost:5174";
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on("console", msg => console.log("[console]", msg.type(), msg.text()));
+page.on("pageerror", err => console.log("[pageerror]", err));
+
+await page.goto(`${BASE}/open`, { waitUntil: "networkidle" });
+await page.getByPlaceholder("Game name").fill("Advanced Tree Test");
+await page.waitForSelector("select");
+await page.waitForTimeout(1000);
+await page.getByText("Create local draft").click();
+await page.waitForSelector("text=Advanced", { timeout: 15000 });
+await page.waitForTimeout(500);
+await page.screenshot({ path: "/tmp/1-editor.png", fullPage: true });
+
+// Toolbar Add dropdown should now be trimmed down.
+await page.locator('button[title="Add element"]').click();
+await page.waitForTimeout(300);
+await page.screenshot({ path: "/tmp/2-add-menu.png" });
+console.log("--- Add menu items ---");
+console.log(await page.locator("body").innerText());
+await page.keyboard.press("Escape");
+
+// Click the Advanced tree node.
+await page.getByRole("button", { name: "Expand Advanced" }).click();
+await page.waitForTimeout(500);
+await page.screenshot({ path: "/tmp/3-advanced-panel.png", fullPage: true });
+console.log("--- Advanced panel ---");
+console.log(await page.locator("body").innerText());
+
+// Click "+ Add Function" and confirm it lands under Advanced > Functions in the tree.
+await page.getByRole("button", { name: "+ Add Function" }).click();
+await page.waitForTimeout(300);
+await page.getByLabel("Name").fill("MyTestFunction");
+await page.getByRole("button", { name: "Add Function", exact: true }).last().click();
+await page.waitForTimeout(500);
+await page.screenshot({ path: "/tmp/4-after-add-function.png", fullPage: true });
+console.log("--- After Add Function ---");
+console.log(await page.locator("body").innerText());
+
+await browser.close();


### PR DESCRIPTION
## Summary
- Function/Timer/Walkthrough now live under the tree's `_advanced` header alongside Library/Template/Dynamic Template/Type/JavaScript (`EditorController.cs`), matching how they're already grouped for SimpleMode.
- `_advanced` no longer disappears from the tree when empty — it's the entry point for adding the first of any of these on a fresh game, so it has to stay clickable regardless of content (`TreePanel.svelte`).
- Selecting the Advanced node now shows a vertical list of "+ Add X" quick-add buttons instead of "No properties available" (`PropertyEditor.svelte`).
- The Toolbar Add dropdown is trimmed down to just Add Room + the context-sensitive items (Object/Room/Exit/Command/Verb/Turn Script in selection) — the eight advanced adders are gone from there (`Toolbar.svelte`).

Follows on from #1934–#1937's progressive-disclosure work; addresses the Add menu being cluttered with rarely-used items like "Add Dynamic Template".

## Test plan
- [x] `dotnet build` (EditorCore) and `dotnet test tests/EditorCoreTests` pass
- [x] `svelte-check` clean
- [x] Manually verified via Playwright against the AppShell dev server (`tests/e2e/verify-advanced-tree.mjs`, kept for regression reruns): fresh game shows "Advanced" in the tree with no children, selecting it renders the eight add buttons, clicking "+ Add Function" creates and correctly nests the function under Advanced → Functions, and the Toolbar Add dropdown only shows "Add Room"

🤖 Generated with [Claude Code](https://claude.com/claude-code)