### PR TITLE
fix(AppShell): stop file-upload picker overflowing on mobile

### DIFF
--- a/src/AppShell/src/components/AssetPicker.svelte
+++ b/src/AppShell/src/components/AssetPicker.svelte
@@ -2,11 +2,16 @@
     import { assets, uploadAsset, resolveAssetUrl, parseAssetSource } from "$lib/editor-store";
     import Combobox from "./Combobox.svelte";
 
-    let { value, source = null, onchange, class: className = "input text-xs py-0.5 px-1.5 w-auto min-w-24" }: {
+    let { value, source = null, onchange, class: className = "input text-xs py-0.5 px-1.5 w-full min-w-0", containerClass = "" }: {
         value: string;
         source?: string | null;
         onchange: (value: string) => void;
         class?: string;
+        // Applied to the row div alongside the default shrink-safe layout — pass "w-full" when
+        // the caller's row has no other flexible sibling and wants this control to fill it
+        // (e.g. PropertyEditor), and leave unset for inline/wrapping layouts (e.g. ScriptEditor)
+        // where growing to fill would force everything else in the row onto the next line.
+        containerClass?: string;
     } = $props();
 
     let filter = $derived(parseAssetSource(source));
@@ -45,7 +50,7 @@
     }
 </script>
 
-<div class="flex items-center gap-1.5">
+<div class="flex items-center gap-1.5 min-w-0 {containerClass}">
     {#if filter.kind === "image" && value}
         {#if thumbUrl}
             <img src={thumbUrl} alt="" class="h-6 w-6 object-cover rounded border border-surface-200-800 shrink-0" />
@@ -55,7 +60,7 @@
     {:else if value}
         <span class="text-xs shrink-0" title={value}>📄</span>
     {/if}
-    <Combobox {value} {options} {onchange} class={className} />
+    <Combobox {value} {options} {onchange} class={className} wrapperClass="flex-1 min-w-0" />
     <button
         type="button"
         class="btn btn-sm preset-outlined-primary-500 text-xs px-1.5 py-0.5 whitespace-nowrap shrink-0"

--- a/src/AppShell/src/components/Combobox.svelte
+++ b/src/AppShell/src/components/Combobox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { ControlOption } from "$lib/types";
 
-    let { value, options, onchange, oninput, class: className = "" }: {
+    let { value, options, onchange, oninput, class: className = "", wrapperClass = "" }: {
         value: string;
         options: ControlOption[];
         onchange: (value: string) => void;
@@ -10,6 +10,10 @@
         // state without waiting for the field to lose focus.
         oninput?: (value: string) => void;
         class?: string;
+        // Applied to the root wrapper rather than the <input> — needed when a caller's flex
+        // row relies on this component itself (not just the input inside it) to grow/shrink,
+        // since flex sizing classes on the input don't affect its own wrapping element.
+        wrapperClass?: string;
     } = $props();
 
     // Unique ID prefix for ARIA references
@@ -131,7 +135,7 @@
     }
 </script>
 
-<div class="relative">
+<div class="relative {wrapperClass}">
     <input
         bind:this={inputEl}
         type="text"

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -304,6 +304,7 @@
             value={attrValue(ctrl.attribute!) ?? ""}
             source={ctrl.source}
             onchange={(v) => onTextChange(ctrl.attribute!, ctrl.controlType, v)}
+            containerClass="w-full"
         />
     {:else if ctrl.controlType === "list" && ctrl.attribute && $selectedKey}
         <ListEditor elementKey={$selectedKey} attribute={ctrl.attribute} value={attrValue(ctrl.attribute)} addPrompt={ctrl.addPrompt ?? undefined} />

--- a/tests/e2e/verify-appshell-assetpicker-mobile-overflow.mjs
+++ b/tests/e2e/verify-appshell-assetpicker-mobile-overflow.mjs
@@ -1,0 +1,90 @@
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+const browser = await chromium.launch();
+
+async function createDraftAndGetPage(context) {
+    const page = await context.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `AssetPicker Fix Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+    return page;
+}
+
+try {
+    // --- Mobile: PropertyEditor's "Cover art" file field must not overflow the viewport ---
+    const mobileCtx = await browser.newContext({ viewport: { width: 375, height: 812 }, hasTouch: true });
+    const mobilePage = await createDraftAndGetPage(mobileCtx);
+
+    // "game" is auto-selected at load without pushing the mobile detail pane; select "room" first
+    // then back to "game" so tapping it actually triggers navigation.
+    await mobilePage.click('text=room');
+    await mobilePage.waitForSelector('button:has-text("room")', { timeout: 5000 });
+    await mobilePage.click('button:has-text("room")'); // back to tree
+    await mobilePage.waitForSelector('text=GAME OBJECTS', { timeout: 5000 });
+    // Exact match — "text=game" (substring) also matches the "GAME OBJECTS" heading.
+    await mobilePage.click('text="game"');
+    await mobilePage.waitForSelector('button:has-text("Setup")', { timeout: 5000 });
+
+    const scrollWidth = await mobilePage.evaluate(() => document.documentElement.scrollWidth);
+    const clientWidth = await mobilePage.evaluate(() => document.documentElement.clientWidth);
+    if (scrollWidth > clientWidth) {
+        throw new Error(`Page overflows horizontally before opening Cover art: scrollWidth=${scrollWidth} clientWidth=${clientWidth}`);
+    }
+
+    const coverArtLabel = await mobilePage.locator('text=Cover art:').elementHandle();
+    await coverArtLabel.scrollIntoViewIfNeeded();
+    const uploadBtn = mobilePage.locator('button:has-text("Upload…")').first();
+    await uploadBtn.waitFor({ state: 'visible', timeout: 5000 });
+    const box = await uploadBtn.boundingBox();
+    if (!box) throw new Error('Upload button not found');
+    if (box.x + box.width > 375) {
+        throw new Error(`Upload button overflows viewport: right edge at ${box.x + box.width}px (viewport is 375px)`);
+    }
+    console.log('PASS: Cover art Upload button fits within 375px mobile viewport (right edge at ' + (box.x + box.width).toFixed(1) + 'px)');
+
+    const scrollWidthAfter = await mobilePage.evaluate(() => document.documentElement.scrollWidth);
+    if (scrollWidthAfter > 375) {
+        throw new Error(`Page overflows horizontally with Cover art visible: scrollWidth=${scrollWidthAfter}`);
+    }
+    console.log('PASS: no horizontal overflow on mobile with the file-upload control visible');
+
+    await mobileCtx.close();
+
+    // --- Desktop: ScriptEditor's inline AssetPicker (Show picture) must stay compact, not stretch full-width ---
+    const desktopCtx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    const desktopPage = await createDraftAndGetPage(desktopCtx);
+    await desktopPage.click('button:has-text("Scripts")').catch(() => {});
+    // "game" node's own tabs: Setup/Features/.../Scripts - click via text since node already selected on desktop by default.
+    await desktopPage.waitForSelector('button:has-text("Scripts")', { timeout: 5000 });
+    await desktopPage.click('button:has-text("Scripts")');
+    await desktopPage.click('button:has-text("+ Add script")');
+    await desktopPage.waitForSelector('text=Add Script Command', { timeout: 5000 });
+    await desktopPage.click('text=Show a picture');
+    await desktopPage.click('button:has-text("OK")');
+    await desktopPage.waitForSelector('text=Show picture', { timeout: 5000 });
+
+    const assetPickerRow = desktopPage.locator('button:has-text("Upload…")').first();
+    await assetPickerRow.waitFor({ state: 'visible', timeout: 5000 });
+    const rowBox = await assetPickerRow.boundingBox();
+    console.log(`INFO: ScriptEditor Upload button box: x=${rowBox.x.toFixed(0)} width=${rowBox.width.toFixed(0)}`);
+    // A regression would force this control (and thus the button) to the full width of the
+    // script row (>800px); the compact/inline width should be well under that.
+    if (rowBox.width > 400) {
+        throw new Error(`ScriptEditor's AssetPicker appears stretched full-width (button x=${rowBox.x}), inline layout regressed`);
+    }
+    console.log('PASS: ScriptEditor inline "Show picture" control stays compact, no full-width regression');
+
+    await desktopCtx.close();
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- File-upload fields in the editor (e.g. a game's Cover art, a room's Picture) forced the whole page to scroll horizontally on mobile viewports, because `AssetPicker`'s combobox wrapper div wasn't sizable independently of its inner `<input>`.
- `Combobox` gains a `wrapperClass` prop so callers can size its actual root element, not just the input inside it.
- `AssetPicker` uses that plus a new `containerClass` prop so `PropertyEditor`'s row can fill available width on mobile, while `ScriptEditor`'s inline/wrapping usage (e.g. the "Show picture" script command) is left compact and unaffected.

## Test plan
- [x] Manually verified in the AppShell dev server at a 375px mobile viewport: the "Cover art" field no longer overflows (`document.documentElement.scrollWidth` matches `clientWidth`, Upload button fully on-screen).
- [x] Manually verified at desktop width that `ScriptEditor`'s inline "Show picture" control still renders compactly (no full-width regression).
- [x] Added `tests/e2e/verify-appshell-assetpicker-mobile-overflow.mjs` (Playwright, run via `node`) covering both cases — passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)