### PR TITLE
feat(ElectronApp): clean up native Edit/View menus, reserve DevTools for Player windows

### DIFF
--- a/src/AppShell/src/routes/+layout.svelte
+++ b/src/AppShell/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
     import { base } from "$app/paths";
     import { page } from "$app/state";
     import { PUBLIC_APPSHELL_VERSION, PUBLIC_SHOW_HOME } from "$env/static/public";
-    import { isLoaded, saveGame, saveGameAs } from "$lib/editor-store";
+    import { isLoaded, saveGame, saveGameAs, undo, redo, canUndo, canRedo } from "$lib/editor-store";
     import { isElectron } from "$lib/runtime";
     import HomeHeader from "$components/HomeHeader.svelte";
     import HomeTabs from "$components/HomeTabs.svelte";
@@ -85,6 +85,18 @@
                     break;
                 case "save-as":
                     if (get(isLoaded)) void saveGameAs();
+                    break;
+                // Guarded on canUndo/canRedo rather than sent unconditionally
+                // like the actions above: EditorCore's UndoLogger throws on
+                // an empty undo/redo stack (there's no "NothingToRedo"
+                // template fallback the way Undo has), so the native menu
+                // item can't just forward blindly the way Toolbar.svelte's
+                // buttons don't — they're `disabled` on the same flags.
+                case "undo":
+                    if (get(canUndo)) void undo();
+                    break;
+                case "redo":
+                    if (get(canRedo)) void redo();
                     break;
             }
         });

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -296,8 +296,35 @@ function buildAppMenu(recentGames: RecentGame[]): Menu {
                 { role: "resetZoom" },
                 { role: "zoomIn" },
                 { role: "zoomOut" },
-                { type: "separator" },
-                { role: "togglefullscreen" },
+                // mac only: omitted here rather than included unconditionally
+                // because of an Electron regression (39.1+) where AppKit's
+                // own automatic "Enter Full Screen" injection into any menu
+                // titled "View" no longer detects our item and skips adding
+                // its own — it used to, so before this regression an
+                // explicit item here was the only one; now it'd double up.
+                // electron/electron#49048 tracked the original report and
+                // was closed as fixed (electron/electron#49074, backported
+                // to 38.x–41.x), but electron/electron#50531 reproduced the
+                // same duplicate afterwards on 41.1.0 and is still open/
+                // unresolved as of this writing — so this workaround stays
+                // until someone confirms on a newer Electron that the
+                // official fix actually holds. Letting AppKit's automatic
+                // item be the only one sidesteps the mechanism entirely
+                // rather than depending on it. Windows/Linux have no such
+                // auto-injection, so they still need an explicit item.
+                ...(isMac ? [] : [{ type: "separator" as const }, { role: "togglefullscreen" as const }]),
+                // Hidden (visible: false) rather than left off entirely:
+                // accelerators in Electron are only live when a matching
+                // menu item exists (there's no unconditional Chromium-level
+                // F12/DevTools binding independent of the Menu), so dropping
+                // role: "toggleDevTools" outright — as an earlier pass here
+                // did — silently killed the shortcut everywhere, including
+                // in Player/Preview windows where it's supposed to work.
+                // Both common bindings are listed so either works. Safe
+                // no-op on the editor window regardless, since
+                // createEditorWindow sets devTools: false there.
+                { role: "toggleDevTools", visible: false, accelerator: "F12" },
+                { role: "toggleDevTools", visible: false, accelerator: isMac ? "Alt+Cmd+I" : "Ctrl+Shift+I" },
             ],
         },
         { role: "windowMenu" },

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, dialog, shell, type MenuItemConstructorOptions } from "electron";
+import { app, BrowserWindow, Menu, MenuItem, dialog, shell, type MenuItemConstructorOptions } from "electron";
 import path from "node:path";
 import { startStaticServer, type StaticServerHandle } from "./static-server";
 import { registerFsHandlers } from "./ipc/fs";
@@ -92,7 +92,7 @@ if (process.platform === "darwin") {
 // Mirrors the union AppShell's src/routes/+layout.svelte switches on (see
 // window.electronApp.menu.onAction in preload.ts) — the two sides can't share
 // a type since they're separate npm projects, so keep them in sync by hand.
-type MenuAction = "new-game" | "open-file" | "save" | "save-as";
+type MenuAction = "new-game" | "open-file" | "save" | "save-as" | "undo" | "redo";
 
 // Every File-menu editor action is reachable even while a player window (or,
 // on mac, no window at all) is frontmost — mac has one shared app-level menu
@@ -120,6 +120,28 @@ function broadcastRecentChanged(kind: RecentKind): void {
 function sendMenuAction(action: MenuAction): void {
     focusEditorWindow();
     editorWindow?.webContents.send("menu-action", action);
+}
+
+// Undo/Redo can't just forward blindly like sendMenuAction does for File
+// actions: the editor has its own app-level undo stack (EditorCore's
+// UndoLogger, exposed via editor-store's canUndo/canRedo) with no native
+// equivalent, but Cmd+Z/Cmd+Shift+Z is a single app-wide accelerator on mac
+// shared by every window. Forcing focus to the editor here (the way
+// sendMenuAction does) would mean reflexively hitting Cmd+Z while playing a
+// game in a player window yanks that window's focus away and undoes an
+// unrelated editor edit. Instead: forward to the editor only when it's
+// already the focused window; otherwise fall back to the focused window's
+// own native text-field undo/redo (e.g. text typed into the player's command
+// box), exactly like Electron's default 'undo'/'redo' roles would.
+function editorUndoRedo(action: "undo" | "redo") {
+    return (_item: MenuItem, focusedWindow: Electron.BaseWindow | undefined): void => {
+        if (focusedWindow === editorWindow) {
+            editorWindow?.webContents.send("menu-action", action);
+        } else if (focusedWindow instanceof BrowserWindow) {
+            if (action === "undo") focusedWindow.webContents.undo();
+            else focusedWindow.webContents.redo();
+        }
+    };
 }
 
 // Renderer has no fixed "open this specific game" action string (unlike
@@ -244,8 +266,40 @@ function buildAppMenu(recentGames: RecentGame[]): Menu {
                 ...(isMac ? [] : [{ type: "separator" as const }, { role: "quit" as const }]),
             ],
         },
-        { role: "editMenu" },
-        { role: "viewMenu" },
+        {
+            label: "Edit",
+            submenu: [
+                // Undo/Redo replace the role-based defaults (which only ever
+                // undo native text-field edits) with the editor's real
+                // command-stack undo — see editorUndoRedo's comment. Cut/
+                // Copy/Paste stay as plain roles: there's no app-level
+                // clipboard concept for tree/canvas content, only ordinary
+                // text fields, which the native roles already handle
+                // correctly for whichever window/field is focused.
+                { label: "Undo", accelerator: "CmdOrCtrl+Z", click: editorUndoRedo("undo") },
+                { label: "Redo", accelerator: isMac ? "Shift+Cmd+Z" : "Ctrl+Y", click: editorUndoRedo("redo") },
+                { type: "separator" },
+                { role: "cut" },
+                { role: "copy" },
+                { role: "paste" },
+            ],
+        },
+        {
+            // Hand-rolled rather than role: "viewMenu" — the default template
+            // also includes Reload/Force Reload/Toggle Developer Tools, which
+            // don't make sense for the editor window (there's nothing to
+            // "reload" from a user's perspective, and DevTools is reserved
+            // for Player windows — see createEditorWindow's devTools: false
+            // and player.ts, which leaves it at Electron's default instead).
+            label: "View",
+            submenu: [
+                { role: "resetZoom" },
+                { role: "zoomIn" },
+                { role: "zoomOut" },
+                { type: "separator" },
+                { role: "togglefullscreen" },
+            ],
+        },
         { role: "windowMenu" },
         {
             role: "help",
@@ -308,6 +362,12 @@ function createEditorWindow(port: number, initialPath?: string | null): void {
             // other player-window surface, rather than relying on Electron's
             // already-permissive default.
             autoplayPolicy: "no-user-gesture-required",
+            // DevTools is reserved for Player windows (see player.ts, which
+            // leaves this at Electron's default true) — this blocks it
+            // outright at the webContents level, not just the menu item/F12
+            // accelerator, since `devTools: false` makes openDevTools()/
+            // toggleDevTools() no-ops too.
+            devTools: false,
         },
     });
 


### PR DESCRIPTION
## Summary
- Drops Reload/Force Reload from the app menu and reserves DevTools for Player/Preview windows only — the editor window sets `devTools: false` so the shortcut and menu item are inert there, while Player windows keep Electron's default.
- Replaces the default `editMenu` role with a custom one: Undo/Redo now forward to the editor's real command-stack (EditorCore's `UndoLogger` via `editor-store`'s `undo`/`redo`, guarded on `canUndo`/`canRedo` since the stack throws when empty) when the editor window is focused, and fall back to native text-field undo/redo otherwise — so Cmd+Z in a Player window doesn't yank focus to the editor and undo an unrelated edit. Cut/Copy/Paste keep native roles; Select All and mac's Paste-and-Match-Style/Delete/Speech items are dropped as clutter.
- Fixes a duplicate "Toggle Full Screen" entry on mac's View menu — a known Electron regression (electron/electron#49048, closed/fixed, but reproduced again afterwards in electron/electron#50531, which is still open) — by omitting our own item on mac and relying solely on AppKit's automatic one; Windows/Linux keep an explicit item.
- Restores the F12/Alt+Cmd+I/Ctrl+Shift+I DevTools shortcuts (as `visible: false` menu items) after discovering Electron only wires up accelerators when a matching menu item exists.

## Test plan
- [x] `tsc --noEmit` (ElectronApp) and `svelte-check` (AppShell) both pass
- [x] Built and ran the dev Electron app; menu builds and app runs without errors
- [x] Manually confirmed in the running dev app: single "Toggle Full Screen" entry on mac, DevTools shortcut works in Preview window and is inert in the editor window

🤖 Generated with [Claude Code](https://claude.com/claude-code)