### PR TITLE
fix(AppShell): add spacing above Advanced section in property editor

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -458,8 +458,8 @@
 
 {#snippet advancedExpander(controls: ControlInfo[])}
     {#if controls.length > 0}
-        <details class="border-t border-surface-200-800">
-            <summary class="px-3 py-1.5 text-xs font-semibold uppercase text-surface-500-400 cursor-pointer select-none">
+        <details class="mt-2 border-t border-surface-200-800">
+            <summary class="px-3 pt-2.5 pb-1.5 text-xs font-semibold uppercase text-surface-500-400 cursor-pointer select-none">
                 Advanced
             </summary>
             {#each controls as ctrl, i (i)}


### PR DESCRIPTION
## Summary
- Adds top margin above the collapsed "Advanced" `<details>` section in the property editor, and slightly increases the summary's top padding, so it doesn't sit flush against the content above it.

## Test plan
- [x] Open the AppShell editor, select an element with an Advanced section in its property editor, and confirm the extra spacing looks correct in both collapsed and expanded states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)