### PR TITLE
fix(PlayerCore): stop ShowMenu dialog throwing when no option is manually clicked

### DIFF
--- a/examples/test.aslx
+++ b/examples/test.aslx
@@ -150,6 +150,10 @@
         else if (command = "menu") {
             menu()
         }
+        else if (command = "menufn") {
+            options = Split("One,Two,Three,Four", ",")
+            msg ("You chose: " + ShowMenu("Please choose one of these...", options, true))
+        }
         else if (command = "event") {
             msg ("<a onclick=\"ASLEvent('FromJS','some parameter')\">Click me</a>")
         }

--- a/src/PlayerCore/Resources/player.js
+++ b/src/PlayerCore/Resources/player.js
@@ -40,10 +40,17 @@ var _menuSelection = "";
 
 function showMenu(title, options, allowCancel) {
     $("#dialogOptions").empty();
+    var firstOption = true;
     $.each(options, function (key, value) {
+        // Explicitly mark the first <option> selected - a <select> visually
+        // shows its first option as selected by default, but jQuery's .val()
+        // returns null (not that option's value) unless one is actually
+        // marked with the selected attribute, which broke dialogSelect() for
+        // anyone who clicked "Select" without first clicking an option.
         $("#dialogOptions").append(
-            $("<option/>").attr("value", key).text(value)
+            $("<option/>").attr("value", key).text(value).prop("selected", firstOption)
         );
+        firstOption = false;
     });
 
     $("#dialogCaption").html(title);

--- a/tests/e2e/verify-wasmplayer-showmenu-select-default.mjs
+++ b/tests/e2e/verify-wasmplayer-showmenu-select-default.mjs
@@ -19,34 +19,53 @@ const pageErrors = [];
 page.on('console', msg => console.log('[console]', msg.type(), msg.text()));
 page.on('pageerror', err => { pageErrors.push(err.message); console.log('[pageerror]', err.message); });
 
-await page.goto(`${baseUrl}/?url=/examples/test.aslx`);
-await page.waitForSelector('#txtCommand', { timeout: 30000 });
-console.log('Game booted.');
+async function run() {
+    await page.goto(`${baseUrl}/?url=/examples/test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000 });
+    console.log('PASS: game booted');
 
-// ExpressionOwner.ShowMenu() function form, via test.aslx's "menufn" command.
-await page.fill('#txtCommand', 'menufn');
-await page.press('#txtCommand', 'Enter');
-await page.waitForSelector('#dialogOptions option', { timeout: 10000 });
+    // ExpressionOwner.ShowMenu() function form, via test.aslx's "menufn" command.
+    await page.fill('#txtCommand', 'menufn');
+    await page.press('#txtCommand', 'Enter');
+    await page.waitForSelector('#dialogOptions option', { timeout: 10000 });
 
-const selectedBeforeClick = await page.$eval('#dialogOptions', el => el.value);
-console.log('Select value before clicking any option (expect non-empty, e.g. "One"):', selectedBeforeClick);
+    const selectedBeforeClick = await page.$eval('#dialogOptions', el => el.value);
+    if (!selectedBeforeClick) {
+        throw new Error(`Expected a non-empty default selection, got ${JSON.stringify(selectedBeforeClick)}`);
+    }
+    console.log(`PASS: first option is pre-selected ("${selectedBeforeClick}")`);
 
-// Reproduce the original bug: click "Select" WITHOUT first clicking an option,
-// exactly as a player would if they trusted the visually-shown default.
-await page.click('button:has-text("Select")');
-await page.waitForTimeout(300);
+    // Reproduce the original bug: click "Select" WITHOUT first clicking an option,
+    // exactly as a player would if they trusted the visually-shown default.
+    await page.click('button:has-text("Select")');
+    await page.waitForTimeout(300);
 
-console.log('Page errors after clicking Select with no manual option click (expect none):', pageErrors.length === 0 ? 'none' : pageErrors);
+    if (pageErrors.length > 0) {
+        throw new Error(`Page errors were thrown after clicking Select with no manual option click: ${pageErrors.join('; ')}`);
+    }
+    console.log('PASS: no page errors after clicking Select with no manual option click');
 
-const output = await page.$eval('#divOutput', el => el.textContent).catch(() => null);
-console.log('Output tail (expect "You chose: One"):', output?.slice(-60));
+    const output = await page.$eval('#divOutput', el => el.textContent).catch(() => null);
+    if (!output?.includes('You chose: One')) {
+        throw new Error(`Expected output to contain "You chose: One", got tail: ${output?.slice(-100)}`);
+    }
+    console.log('PASS: menu choice was submitted ("You chose: One")');
 
-const dialogStillOpen = await page.$eval('#dialog', el => $(el).dialog('isOpen')).catch(() => null);
-console.log('Dialog still open after Select (expect false):', dialogStillOpen);
+    const dialogStillOpen = await page.$eval('#dialog', el => $(el).dialog('isOpen')).catch(() => null);
+    if (dialogStillOpen !== false) {
+        throw new Error(`Expected dialog to be closed after Select, got isOpen=${dialogStillOpen}`);
+    }
+    console.log('PASS: dialog closed after Select');
 
-await browser.close();
+    console.log('PASS: all checks passed');
+}
 
-if (pageErrors.length > 0) {
-    console.log('FAILED: page errors were thrown');
-    process.exit(1);
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/wasmplayer-showmenu-select-default-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
 }

--- a/tests/e2e/verify-wasmplayer-showmenu-select-default.mjs
+++ b/tests/e2e/verify-wasmplayer-showmenu-select-default.mjs
@@ -1,0 +1,52 @@
+// Ad-hoc manual verification: showMenu() in player.js (shared by WasmPlayer
+// and WebPlayer) populates the menu dialog's <select> without marking any
+// <option> as selected. A <select> visually shows its first option as
+// selected by default, but jQuery's .val() returns null (not that option's
+// value) unless one is explicitly marked - so clicking "Select" without
+// first manually clicking an option threw
+// "TypeError: Cannot read properties of null (reading 'length')" in
+// dialogSelect() and silently did nothing. Fixed by explicitly marking the
+// first appended <option> selected.
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const pageErrors = [];
+page.on('console', msg => console.log('[console]', msg.type(), msg.text()));
+page.on('pageerror', err => { pageErrors.push(err.message); console.log('[pageerror]', err.message); });
+
+await page.goto(`${baseUrl}/?url=/examples/test.aslx`);
+await page.waitForSelector('#txtCommand', { timeout: 30000 });
+console.log('Game booted.');
+
+// ExpressionOwner.ShowMenu() function form, via test.aslx's "menufn" command.
+await page.fill('#txtCommand', 'menufn');
+await page.press('#txtCommand', 'Enter');
+await page.waitForSelector('#dialogOptions option', { timeout: 10000 });
+
+const selectedBeforeClick = await page.$eval('#dialogOptions', el => el.value);
+console.log('Select value before clicking any option (expect non-empty, e.g. "One"):', selectedBeforeClick);
+
+// Reproduce the original bug: click "Select" WITHOUT first clicking an option,
+// exactly as a player would if they trusted the visually-shown default.
+await page.click('button:has-text("Select")');
+await page.waitForTimeout(300);
+
+console.log('Page errors after clicking Select with no manual option click (expect none):', pageErrors.length === 0 ? 'none' : pageErrors);
+
+const output = await page.$eval('#divOutput', el => el.textContent).catch(() => null);
+console.log('Output tail (expect "You chose: One"):', output?.slice(-60));
+
+const dialogStillOpen = await page.$eval('#dialog', el => $(el).dialog('isOpen')).catch(() => null);
+console.log('Dialog still open after Select (expect false):', dialogStillOpen);
+
+await browser.close();
+
+if (pageErrors.length > 0) {
+    console.log('FAILED: page errors were thrown');
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

- `showMenu()` in the shared `src/PlayerCore/Resources/player.js` (used by both WasmPlayer and WebPlayer) populates the menu dialog's `<select>` with `<option>` elements but never marks any of them `selected`. A `<select>` visually shows its first option as selected by default, but jQuery's `.val()` returns `null` (not that option's value) unless one is actually marked with the `selected` attribute - so a player clicking "Select" without first manually clicking an option in the dropdown hit `TypeError: Cannot read properties of null (reading 'length')` in `dialogSelect()`, leaving the dialog open and silently doing nothing (no error shown to the player).
- Found incidentally while adding e2e coverage for `ExpressionOwner.ShowMenu()` in a separate PR, unrelated to that change.
- Fix: explicitly mark the first appended `<option>` selected, so `.val()` reliably returns a value even if the player never touches the dropdown before clicking "Select".

## Test plan

- [x] `dotnet build --configuration Release` / `dotnet test --configuration Release` - all 327 tests pass
- [x] New `tests/e2e/verify-wasmplayer-showmenu-select-default.mjs` + a `menufn` command added to `examples/test.aslx` (calling `ShowMenu()` directly, the function form that triggers this dialog): reproduces the original failure by clicking "Select" *without* first clicking an option - confirms zero page errors and the expected default choice is submitted, where previously this threw and did nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)