### PR TITLE
test: add real assertions to the last 2 e2e scripts missing them

### DIFF
--- a/tests/e2e/verify-advanced-tree.mjs
+++ b/tests/e2e/verify-advanced-tree.mjs
@@ -1,44 +1,88 @@
+// Ad-hoc manual verification for the Advanced-tree progressive-disclosure
+// change: the toolbar's "Add element" dropdown should be trimmed down to
+// just "Add Room" (the advanced element types - functions, timers, etc. -
+// moved under the "Advanced" tree node instead of cluttering the toolbar),
+// and adding a function via that Advanced panel should actually produce a
+// real, selected tree node under Advanced > Functions, not just a
+// silently-dropped click.
 import { chromium } from "playwright";
 
-const BASE = "http://localhost:5174";
+const BASE = process.argv[2] || "http://localhost:5174";
 
 const browser = await chromium.launch();
 const page = await browser.newPage();
-page.on("console", msg => console.log("[console]", msg.type(), msg.text()));
+page.on("console", msg => { if (msg.type() === "error") console.log("[console.error]", msg.text()); });
 page.on("pageerror", err => console.log("[pageerror]", err));
 
-await page.goto(`${BASE}/open`, { waitUntil: "networkidle" });
-await page.getByPlaceholder("Game name").fill("Advanced Tree Test");
-await page.waitForSelector("select");
-await page.waitForTimeout(1000);
-await page.getByText("Create local draft").click();
-await page.waitForSelector("text=Advanced", { timeout: 15000 });
-await page.waitForTimeout(500);
-await page.screenshot({ path: "/tmp/1-editor.png", fullPage: true });
+async function run() {
+    await page.goto(`${BASE}/open`, { waitUntil: "networkidle" });
+    await page.getByPlaceholder("Game name").fill("Advanced Tree Test");
+    await page.waitForSelector("select");
+    await page.waitForTimeout(1000);
+    await page.getByText("Create local draft").click();
+    await page.waitForSelector("text=Advanced", { timeout: 15000 });
+    await page.waitForTimeout(500);
+    console.log("PASS: local draft created, editor loaded");
 
-// Toolbar Add dropdown should now be trimmed down.
-await page.locator('button[title="Add element"]').click();
-await page.waitForTimeout(300);
-await page.screenshot({ path: "/tmp/2-add-menu.png" });
-console.log("--- Add menu items ---");
-console.log(await page.locator("body").innerText());
-await page.keyboard.press("Escape");
+    // The dropdown is a sibling <div> rendered immediately after the toggle
+    // button when open - scope the check to it, not the whole page, since
+    // "Add Function" etc. legitimately appear elsewhere (the Advanced panel).
+    const addToolbarBtn = page.locator('button[title="Add element"]');
+    await addToolbarBtn.click();
+    await page.waitForTimeout(300);
+    const addMenu = addToolbarBtn.locator("xpath=following-sibling::div[1]");
+    const addMenuText = (await addMenu.innerText()).trim();
+    if (addMenuText !== "Add Room") {
+        throw new Error(`Expected toolbar Add menu to contain only "Add Room", got: ${JSON.stringify(addMenuText)}`);
+    }
+    console.log('PASS: toolbar Add dropdown is trimmed to just "Add Room"');
+    await page.keyboard.press("Escape");
 
-// Click the Advanced tree node.
-await page.getByRole("button", { name: "Expand Advanced" }).click();
-await page.waitForTimeout(500);
-await page.screenshot({ path: "/tmp/3-advanced-panel.png", fullPage: true });
-console.log("--- Advanced panel ---");
-console.log(await page.locator("body").innerText());
+    // Expand the Advanced tree node and confirm its panel offers the element
+    // types that used to live directly in the toolbar dropdown.
+    await page.getByRole("button", { name: "Expand Advanced" }).click();
+    await page.waitForTimeout(500);
+    const addFunctionBtn = page.getByRole("button", { name: "+ Add Function" });
+    if (!(await addFunctionBtn.isVisible())) {
+        throw new Error('Expected "+ Add Function" button in the Advanced panel');
+    }
+    console.log('PASS: Advanced panel offers "+ Add Function"');
 
-// Click "+ Add Function" and confirm it lands under Advanced > Functions in the tree.
-await page.getByRole("button", { name: "+ Add Function" }).click();
-await page.waitForTimeout(300);
-await page.getByLabel("Name").fill("MyTestFunction");
-await page.getByRole("button", { name: "Add Function", exact: true }).last().click();
-await page.waitForTimeout(500);
-await page.screenshot({ path: "/tmp/4-after-add-function.png", fullPage: true });
-console.log("--- After Add Function ---");
-console.log(await page.locator("body").innerText());
+    // Add a function and confirm it actually lands as a real, selected tree
+    // node under Advanced > Functions.
+    await addFunctionBtn.click();
+    await page.waitForTimeout(300);
+    await page.getByLabel("Name").fill("MyTestFunction");
+    await page.getByRole("button", { name: "Add Function", exact: true }).last().click();
+    await page.waitForTimeout(500);
 
-await browser.close();
+    const treeNode = page.getByRole("treeitem", { name: /MyTestFunction/ });
+    if (!(await treeNode.isVisible())) {
+        throw new Error('Expected a "MyTestFunction" tree item to appear after adding it');
+    }
+    console.log('PASS: "MyTestFunction" appears as a tree item under Advanced > Functions');
+
+    // Confirm the properties panel actually opened on the new function (not
+    // some other stale/default panel) by checking its Name field's live value
+    // - Svelte sets the DOM property, not the "value" attribute, so read via
+    // evaluateAll rather than an attribute selector.
+    const nameValue = await page.locator("input").evaluateAll(
+        inputs => inputs.map(i => i.value).find(v => v === "MyTestFunction")
+    );
+    if (nameValue !== "MyTestFunction") {
+        throw new Error('Expected the properties panel Name field to show "MyTestFunction" after adding it');
+    }
+    console.log('PASS: properties panel shows the new function selected, named "MyTestFunction"');
+
+    console.log("PASS: all checks passed");
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error("FAIL:", err.message);
+    await page.screenshot({ path: "/tmp/appshell-advanced-tree-failure.png", fullPage: true });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}

--- a/tests/e2e/verify-preview-banner.mjs
+++ b/tests/e2e/verify-preview-banner.mjs
@@ -1,22 +1,44 @@
+// Ad-hoc manual verification: the editor's "in preview" warning banner
+// (PreviewBanner.svelte) shows on the /open screen and survives a reload.
+// Requires the AppShell dev server running locally:
+//   cd src/AppShell && npm run dev
 import { chromium } from "playwright";
 
-const BASE = "http://localhost:5180";
+const BASE = process.argv[2] || "http://localhost:5174";
 
 const browser = await chromium.launch();
 const page = await browser.newPage();
+page.on("console", msg => { if (msg.type() === "error") console.log("[console.error]", msg.text()); });
+page.on("pageerror", err => console.log("[pageerror]", err));
 
-await page.goto(`${BASE}/open`);
-await page.waitForSelector("text=Quest Viva Editor");
+async function run() {
+    await page.goto(`${BASE}/open`);
+    await page.waitForSelector("text=Quest Viva Editor");
 
-const banner = page.locator("text=Quest Viva's editor is still in preview");
-await banner.waitFor({ state: "visible" });
-console.log("Banner visible:", await banner.isVisible());
+    // The banner's exact wording has drifted before (this script used to look
+    // for "...editor is still in preview", which no longer matches
+    // PreviewBanner.svelte's "...editor is in preview" and made the whole
+    // script hang until a raw Playwright timeout) - match on a stable
+    // substring of the component's actual text instead of copying it in full,
+    // so a future copy-edit doesn't silently break this again.
+    const banner = page.locator("text=editor is in preview");
+    await banner.waitFor({ state: "visible", timeout: 10000 });
+    console.log("PASS: preview banner is visible on /open");
 
-await page.screenshot({ path: "/tmp/preview-banner.png", fullPage: true });
+    await page.reload();
+    await page.waitForSelector("text=Quest Viva Editor");
+    await banner.waitFor({ state: "visible", timeout: 10000 });
+    console.log("PASS: preview banner is still visible after a reload");
 
-await page.reload();
-await page.waitForSelector("text=Quest Viva Editor");
-await banner.waitFor({ state: "visible" });
-console.log("Banner still visible after reload:", await banner.isVisible());
+    console.log("PASS: all checks passed");
+}
 
-await browser.close();
+try {
+    await run();
+} catch (err) {
+    console.error("FAIL:", err.message);
+    await page.screenshot({ path: "/tmp/appshell-preview-banner-failure.png", fullPage: true });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary

Full audit of all 58 `tests/e2e/verify-*.mjs` scripts (prompted by the same issue caught in #1950/#1951) turned up two more with no real pass/fail signal:

- **`verify-advanced-tree.mjs`** was pure exploration - screenshots and `console.log(innerText)` dumps for a human to eyeball, despite its own comments claiming to "confirm" things. Rewrote it to actually assert: the toolbar's Add dropdown is trimmed to just "Add Room" (scoped to the dropdown's own container, since "Add Function" etc. legitimately appear elsewhere in the Advanced panel), and that adding a function produces a real, selected tree item plus a properties panel reflecting its name - not just a silently-dropped click.
- **`verify-preview-banner.mjs`** technically already failed loudly (a Playwright `waitFor()` throws on timeout), but it was actually broken: it looked for `"...editor is still in preview"` while `PreviewBanner.svelte`'s current text is `"...editor is in preview"` (no "still") - real drift this script should have been catching, not silently timing out with an unhelpful raw stack trace. Fixed the locator to match a stable substring of the actual copy, wrapped it in the same `run()`/try-catch/`exitCode` convention as its siblings, and fixed the base URL to the standard `5174` (it hardcoded `5180` with no CLI override, unlike every other AppShell script).

All other scripts in the directory were checked and confirmed to have real assertions already (some via `throw new Error`, some via plain `if (cond) { process.exit(1) }` - both legitimate, just different styles).

## Test plan

- [x] `dotnet test --configuration Release` - all 327 tests pass (no C# touched, included for completeness)
- [x] Ran both rewritten scripts against a live AppShell dev server - both pass cleanly
- [x] Verified each actually fails with a clear message when the thing it checks is broken (renamed the target tree item in one, broke the banner text match in the other), then confirmed both pass again after reverting

🤖 Generated with [Claude Code](https://claude.com/claude-code)