### PR TITLE
fix(AppShell): fix invisible text in modals in dark mode

### DIFF
--- a/src/AppShell/src/components/AddElementModal.svelte
+++ b/src/AppShell/src/components/AddElementModal.svelte
@@ -61,7 +61,7 @@
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
 >
-    <div class="card bg-white rounded-xl shadow-xl w-full max-w-80 p-6 flex flex-col gap-4">
+    <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-80 p-6 flex flex-col gap-4">
         <h2 class="text-base font-semibold">
             Add {labels[elementType]}{parent ? ` in "${parent}"` : ""}
         </h2>
@@ -72,7 +72,7 @@
                 id="element-name"
                 type="text"
                 autocapitalize="off"
-                class={"input bg-white px-2 py-1 text-sm" + (error ? " !border-error-500" : "")}
+                class={"input bg-surface-50-950 px-2 py-1 text-sm" + (error ? " !border-error-500" : "")}
                 bind:this={inputEl}
                 bind:value={name}
                 placeholder="Enter a name..."

--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -206,7 +206,7 @@
     onclick={onBackdropClick}
     onkeydown={onKeydown}
 >
-    <div class="bg-white rounded-xl shadow-xl w-full max-w-[600px] h-[min(520px,85dvh)] flex flex-col overflow-hidden ring-1 ring-surface-200-800">
+    <div class="bg-surface-50-950 rounded-xl shadow-xl w-full max-w-[600px] h-[min(520px,85dvh)] flex flex-col overflow-hidden ring-1 ring-surface-200-800">
 
         <!-- Header -->
         <div class="px-5 py-3 flex items-center justify-between flex-shrink-0 border-b border-surface-200-800">

--- a/src/AppShell/src/components/AssetManagerModal.svelte
+++ b/src/AppShell/src/components/AssetManagerModal.svelte
@@ -70,7 +70,7 @@
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
 >
-    <div class="card bg-white rounded-xl shadow-xl w-full max-w-[32rem] max-h-[85dvh] p-6 flex flex-col gap-4">
+    <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-[32rem] max-h-[85dvh] p-6 flex flex-col gap-4">
         <div class="flex items-center justify-between">
             <h2 class="text-base font-semibold">Assets</h2>
             <button class="btn btn-sm preset-tonal" onclick={oncancel}>Close</button>

--- a/src/AppShell/src/components/ConfirmDialog.svelte
+++ b/src/AppShell/src/components/ConfirmDialog.svelte
@@ -33,7 +33,7 @@
         onclick={onBackdropClick}
         onkeydown={handleKeydown}
     >
-        <div class="card bg-white rounded-xl shadow-xl w-80 p-6 flex flex-col gap-4">
+        <div class="card bg-surface-50-950 rounded-xl shadow-xl w-80 p-6 flex flex-col gap-4">
             <p class="text-sm">{state.message}</p>
 
             <div class="flex justify-end gap-2">

--- a/src/AppShell/src/components/PublishModal.svelte
+++ b/src/AppShell/src/components/PublishModal.svelte
@@ -40,7 +40,7 @@
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
 >
-    <div class="card bg-white rounded-xl shadow-xl w-full max-w-[28rem] p-6 flex flex-col gap-4">
+    <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-[28rem] p-6 flex flex-col gap-4">
         <div class="flex items-center justify-between">
             <h2 class="text-base font-semibold">Publish</h2>
             <button class="btn btn-sm preset-tonal" onclick={oncancel}>Close</button>


### PR DESCRIPTION
## Summary
- Every editor modal (Add Object/Room/etc, script picker, asset manager, confirm/delete dialogs, publish) hardcoded a `bg-white` panel background while its text relied on the app-wide body color, which Skeleton's `wintry` theme flips to near-white under `prefers-color-scheme: dark` — so the panel background never left white but the text turned white too, making it invisible.
- Replaced `bg-white` with Skeleton's paired adaptive token `bg-surface-50-950` in the 5 affected modal components, matching the convention already used elsewhere in the codebase (`text-surface-900-50`, `border-surface-200-800`, etc). No shared `Modal.svelte` wrapper exists — each file duplicated its own panel markup, which is how the bug was copy-pasted into all five.

## Files changed
- `AddElementModal.svelte` (generic "Add Room/Object/Page/..." modal — also fixed its name input's hardcoded white background)
- `AddScriptModal.svelte`
- `AssetManagerModal.svelte`
- `ConfirmDialog.svelte` (delete/rename confirmations)
- `PublishModal.svelte`

## Test plan
- [x] Ran the AppShell dev server with the browser forced to dark color scheme and opened the "Add Room" modal (shares the `AddElementModal` component with "Add Object") — panel is now dark with fully readable heading, label, input, and button text.
- [x] Confirmed no regression to components already using the adaptive Skeleton tokens correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)