### PR TITLE
fix(PlayerCore): cap map panel width to game width when panes are hidden

### DIFF
--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -202,7 +202,12 @@ function initPlayerUI() {
             gameContent.style.width = "initial";
             gamePanel.style.width = "100%";
             gridPanel.style.width = "100%";
-            if (window.paper && paper.view) paper.view.viewSize.width = window.innerWidth;
+            // "100%" here resolves to whichever is smaller: the actual window
+            // (narrow/mobile) or #gameBorder's max-width cap (a wide window with
+            // panes hidden, e.g. no places/inventory to show) — window.innerWidth
+            // alone ignored that cap and stretched the paper.js view past the
+            // visible (overflow: hidden) panel, throwing off its centering.
+            if (window.paper && paper.view) paper.view.viewSize.width = Math.min(window.innerWidth, gameWidth);
         }
 
         const newPanelImageMaxHeight = `${(window.innerHeight - 30) * 0.5}px`;


### PR DESCRIPTION
## Summary

- Fixes a moderator-reported bug: the in-game map (paper.js grid panel) isn't centered when it's shown without the sidebar panes (Inventory/Places/Status) — either on a narrow window, or because the game calls `panesVisible(false)` since it has nothing to show there (e.g. `sc-jtbvlk0cujvypsmpp1g`, "Find Andy").
- Root cause: in `doLayout()`'s panes-hidden branch, the paper.js view was sized to raw `window.innerWidth` instead of the width its container (`#gridPanel`, `width: 100%`) actually resolves to, which is capped by `#gameBorder`'s `max-width`. On a wide desktop browser this stretched the view past the panel's real (`overflow: hidden`) bounds, so the map's centered content rendered off to one side.
- Fix: cap the view width to `Math.min(window.innerWidth, gameWidth)`, matching what `100%` actually resolves to. Left the panes-visible branch untouched — it already used the equivalent formula (`gameWidth - 220`) and was never buggy.

An earlier version of this fix used `gridPanel.clientWidth` (a live DOM measurement) instead of a formula, gated behind a `> 0` guard. That regressed a second game (`vpf7vh9mfusdg4mta1u76g`, "Jacqueline, Jungle Queen!") that keeps its sidebar panes visible throughout — `doLayout()` only runs once early there, before the panel has settled into its final layout, so the guarded measurement could read `0` and never self-correct since nothing re-triggers layout afterward. The formula-based approach here has no such timing dependency.

## Test plan

- [x] Reproduced the original bug live against `play.questviva.com` with `sc-jtbvlk0cujvypsmpp1g`.
- [x] Built WasmPlayer locally with the fix; confirmed via the game's own map-drawing calls (`gridApi.drawGrid`/`drawPlayer`/`setCentre`) that the marker now renders centered in the panel, and reproduced the exact off-center bug by reverting to the old line, for a clean before/after.
- [x] Re-tested against `vpf7vh9mfusdg4mta1u76g` ("Jacqueline, Jungle Queen!", panes visible) to confirm no regression — view width matches production (`730`) exactly.
- [x] Re-confirmed the panes-hidden fix still holds after the revision (view width `950`, capped correctly, not the raw `1400`px window width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)