### PR TITLE
feat(AppShell): add move/cut/copy/paste for tree elements

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "AppShell",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5174
+    }
+  ]
+}

--- a/src/AppShell/src/components/MoveElementModal.svelte
+++ b/src/AppShell/src/components/MoveElementModal.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+    import { getMovePossibleParents } from "$lib/editor-store";
+    import Combobox from "$components/Combobox.svelte";
+    import type { ControlOption } from "$lib/types";
+
+    interface Props {
+        elementKey: string;
+        onconfirm: (parent: string) => void;
+        oncancel: () => void;
+    }
+
+    const { elementKey, onconfirm, oncancel }: Props = $props();
+
+    // "_objects" un-parents the element back to the top level (mirrors MoveElement's
+    // own special-case for that key) — always offered first regardless of what
+    // GetMovePossibleParents itself returns.
+    let options: ControlOption[] = $derived([
+        { value: "_objects", label: "(top level)" },
+        ...getMovePossibleParents(elementKey).map(name => ({ value: name, label: name })),
+    ]);
+
+    let target = $state("");
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter" && target) confirm();
+        if (e.key === "Escape") oncancel();
+    }
+
+    function onBackdropClick(e: MouseEvent) {
+        if (e.target === e.currentTarget) oncancel();
+    }
+
+    function confirm() {
+        if (!target) return;
+        onconfirm(target);
+    }
+</script>
+
+<div
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
+    onclick={onBackdropClick}
+    onkeydown={handleKeydown}
+>
+    <div class="card bg-white rounded-xl shadow-xl w-full max-w-80 p-6 flex flex-col gap-4">
+        <h2 class="text-base font-semibold">Move "{elementKey}"</h2>
+
+        <div class="flex flex-col gap-1">
+            <span class="text-xs text-surface-500-400">New parent</span>
+            <Combobox
+                {options}
+                value={target}
+                onchange={(v) => { target = v; }}
+                class="input bg-white px-2 py-1 text-sm w-full"
+            />
+        </div>
+
+        <div class="flex justify-end gap-2">
+            <button class="btn btn-sm preset-tonal" onclick={oncancel}>Cancel</button>
+            <button
+                class="btn btn-sm preset-filled-primary-500"
+                onclick={confirm}
+                disabled={!target}
+            >
+                Move
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -9,7 +9,7 @@
         createIncludedLibrary, createJavascript,
         deleteElement,
         canMoveElement, openMoveModal, copyElements, cutElements, canPasteElements, pasteElements,
-        clipboardVersion,
+        clipboardVersion, cutElementKeys,
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
 
@@ -415,7 +415,7 @@
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="size-4"><polyline points="9 18 15 12 9 6" /></svg>
                     </button>
-                    <TreeView.BranchText class="flex-1 min-w-0 truncate">{node.text}</TreeView.BranchText>
+                    <TreeView.BranchText class="flex-1 min-w-0 truncate {$cutElementKeys.has(node.id) ? "opacity-50 italic" : ""}">{node.text}</TreeView.BranchText>
                     <span class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100">
                         {@render nodeActions(node)}
                     </span>
@@ -429,7 +429,7 @@
             </TreeView.Branch>
         {:else}
             <TreeView.Item class="group flex items-center" onclick={() => activateIfAlreadySelected(node.id)}>
-                <span class="flex-1 min-w-0 truncate">{node.text}</span>
+                <span class="flex-1 min-w-0 truncate {$cutElementKeys.has(node.id) ? "opacity-50 italic" : ""}">{node.text}</span>
                 <span class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100">
                     {@render nodeActions(node)}
                 </span>

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -8,6 +8,8 @@
         openAddModal, createExit, createTurnScript, createCommand, createVerb,
         createIncludedLibrary, createJavascript,
         deleteElement,
+        canMoveElement, openMoveModal, copyElements, cutElements, canPasteElements, pasteElements,
+        clipboardVersion,
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
 
@@ -257,6 +259,10 @@
     }
 
     function nodeMenuOptions(node: HierNode): Array<{ label: string; action: () => void }> {
+        // Read (not used) so this function's callers re-run whenever the clipboard
+        // changes — canPasteElements() below reads server-side state that Svelte
+        // has no other reactive handle on.
+        void $clipboardVersion;
         const opts: Array<{ label: string; action: () => void }> = [];
         const { id, text, nodeType: nt } = node;
 
@@ -265,6 +271,9 @@
                 opts.push($isGamebook
                     ? { label: "Add Page", action: () => openAddModal("page", null) }
                     : { label: "Add Room", action: () => openAddModal("room", null) });
+                if (canPasteElements(id)) {
+                    opts.push({ label: "Paste", action: () => pasteElements(id) });
+                }
             }
             else if (id === "_functions") opts.push({ label: "Add Function", action: () => openAddModal("function", null) });
             else if (id === "_timers") opts.push({ label: "Add Timer", action: () => openAddModal("timer", null) });
@@ -291,6 +300,19 @@
                 { label: "Add Verb", action: () => createVerb(id) },
                 { label: "Add Turn Script", action: () => createTurnScript(id) },
             );
+        }
+
+        if (nt === "room" || nt === "object") {
+            if (canMoveElement(id)) {
+                opts.push(
+                    { label: "Move to…", action: () => openMoveModal(id) },
+                    { label: "Cut", action: () => cutElements([id]) },
+                    { label: "Copy", action: () => copyElements([id]) },
+                );
+            }
+            if (canPasteElements(id)) {
+                opts.push({ label: "Paste", action: () => pasteElements(id) });
+            }
         }
 
         if (isDeletable(nt)) {

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -302,7 +302,12 @@
             );
         }
 
-        if (nt === "room" || nt === "object") {
+        // Gamebook pages ("page") are plain ElementType.Object elements underneath —
+        // v5's own desktop editor wires Cut/Copy/Paste/drag-move generically off
+        // EditorController with no gamebook-vs-textadventure gating at all (only
+        // GetPasteParent special-cases gamebook, always pasting at the flat top
+        // level), so pages get the same menu entries as rooms/objects here.
+        if (nt === "room" || nt === "object" || nt === "page") {
             if (canMoveElement(id)) {
                 opts.push(
                     { label: "Move to…", action: () => openMoveModal(id) },

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -25,6 +25,11 @@ export const isGamebook = writable(false);
 export function openAddModal(type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type", parent: string | null) {
     addElementModal.set({ type, parent });
 }
+// Holds the key of the element currently being moved, or null when the modal is closed.
+export const moveElementModal = writable<string | null>(null);
+export function openMoveModal(key: string) {
+    moveElementModal.set(key);
+}
 export const gameFilename = writable<string | null>(null);
 export const canSaveAs = writable(false);
 export const canBackup = writable(false);
@@ -957,6 +962,59 @@ export function swapElements(key1: string, key2: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SwapElements(key1, key2);
     if (result === "ok") refreshTree();
+    return result;
+}
+
+// ── Move / cut / copy / paste ───────────────────────────────────────────────
+
+export function canMoveElement(key: string): boolean {
+    return _bridge?.CanMoveElement(key) ?? false;
+}
+
+export function getMovePossibleParents(key: string): string[] {
+    if (!_bridge) return [];
+    return JSON.parse(_bridge.GetMovePossibleParents(key));
+}
+
+export function moveElement(key: string, newParent: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.MoveElement(key, newParent);
+    if (result === "ok") {
+        refreshTree();
+        void selectNode(key);
+        refreshUndoRedo();
+    }
+    return result;
+}
+
+// Bumped by copyElements/cutElements so TreePanel's per-node "⋯" menus (computed
+// inline from nodeMenuOptions(), not driven by a store) know to recompute their
+// "Paste" entry — the clipboard lives entirely in EditorController and mutating it
+// doesn't touch treeNodes/selectedKey/anything else Svelte would already react to.
+export const clipboardVersion = writable(0);
+
+export function copyElements(keys: string[]) {
+    _bridge?.CopyElements(JSON.stringify(keys));
+    clipboardVersion.update(n => n + 1);
+}
+
+export function cutElements(keys: string[]) {
+    _bridge?.CutElements(JSON.stringify(keys));
+    clipboardVersion.update(n => n + 1);
+}
+
+export function canPasteElements(parentKey: string): boolean {
+    return _bridge?.CanPasteElements(parentKey) ?? false;
+}
+
+export function pasteElements(parentKey: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.PasteElements(parentKey);
+    if (result !== "error") {
+        refreshTree();
+        void selectNode(result);
+        refreshUndoRedo();
+    }
     return result;
 }
 

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -110,6 +110,7 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
         gameFilename.set(filename);
         refreshUndoRedo();
         scriptClipboardHasContent.set(false);
+        cutElementKeys.set(new Set());
         await refreshAssets();
         const gameNode = nodes.find(n => n.nodeType === "game");
         if (gameNode) await selectNode(gameNode.key);
@@ -993,13 +994,21 @@ export function moveElement(key: string, newParent: string): string {
 // doesn't touch treeNodes/selectedKey/anything else Svelte would already react to.
 export const clipboardVersion = writable(0);
 
+// Keys currently staged by Cut (not yet pasted) — TreePanel dims these rows so
+// a cut element doesn't look untouched. Mirrors EditorController's own
+// m_lastelementscutout flag: cleared by Copy (a fresh copy isn't a cut) and by
+// a completed Paste (the element has landed at its new parent), set by Cut.
+export const cutElementKeys = writable<Set<string>>(new Set());
+
 export function copyElements(keys: string[]) {
     _bridge?.CopyElements(JSON.stringify(keys));
+    cutElementKeys.set(new Set());
     clipboardVersion.update(n => n + 1);
 }
 
 export function cutElements(keys: string[]) {
     _bridge?.CutElements(JSON.stringify(keys));
+    cutElementKeys.set(new Set(keys));
     clipboardVersion.update(n => n + 1);
 }
 
@@ -1011,6 +1020,7 @@ export function pasteElements(parentKey: string): string {
     if (!_bridge) return "error";
     const result = _bridge.PasteElements(parentKey);
     if (result !== "error") {
+        cutElementKeys.set(new Set());
         refreshTree();
         void selectNode(result);
         refreshUndoRedo();

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -85,6 +85,14 @@ export interface WasmBridge {
   DeleteElement(key: string): void
   DeleteElements(keysJson: string): void
   SwapElements(key1: string, key2: string): string
+  // Move / cut / copy / paste
+  CanMoveElement(elementKey: string): boolean
+  GetMovePossibleParents(elementKey: string): string
+  MoveElement(elementKey: string, newParentKey: string): string
+  CopyElements(keysJson: string): void
+  CutElements(keysJson: string): void
+  CanPasteElements(parentKey: string): boolean
+  PasteElements(parentKey: string): string
   // New game
   GetGameTemplates(): string
   CreateGameFromTemplate(templateId: string, gameName: string): string

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -4,7 +4,7 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { get } from "svelte/store";
-    import { isLoaded, isDirty, isEditingField, markFieldEditing, clearFieldEditing, saveGame, loadingStatus, addElementModal, assetManagerOpen, publishModalOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType } from "$lib/editor-store";
+    import { isLoaded, isDirty, isEditingField, markFieldEditing, clearFieldEditing, saveGame, loadingStatus, addElementModal, assetManagerOpen, publishModalOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType, moveElementModal, moveElement } from "$lib/editor-store";
     import { loadFromServer } from "$lib/filesystem/server-adapter";
     import Toolbar from "$components/Toolbar.svelte";
     import BackupBanner from "$components/BackupBanner.svelte";
@@ -12,6 +12,7 @@
     import PropertyEditor from "$components/PropertyEditor.svelte";
     import { isNarrow } from "$lib/layout.svelte";
     import AddElementModal from "$components/AddElementModal.svelte";
+    import MoveElementModal from "$components/MoveElementModal.svelte";
     import AssetManagerModal from "$components/AssetManagerModal.svelte";
     import PublishModal from "$components/PublishModal.svelte";
 
@@ -172,6 +173,14 @@
             parent={$addElementModal.parent}
             onconfirm={handleAddConfirm}
             oncancel={() => addElementModal.set(null)}
+        />
+    {/if}
+
+    {#if $moveElementModal}
+        <MoveElementModal
+            elementKey={$moveElementModal}
+            onconfirm={(parent) => { moveElement($moveElementModal!, parent); moveElementModal.set(null); }}
+            oncancel={() => moveElementModal.set(null)}
         />
     {/if}
 

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -10,7 +10,7 @@
   <template name="EditorGBBackground">Hintergrund</template>
   <template name="EditorGBForeground">Vordergrund</template>
   <template name="EditorGBLinkForeground">Link-Vordergrund</template>
-  <template name="EditorGBYouCanChange">Du kannst den Anfang des Spiels verändern, indem du das Objekt "player" auf eine andere Seite ziehst.</template>
+  <template name="EditorGBYouCanChange">Du kannst den Anfang des Spiels verändern, indem du das Objekt "player" auf eine andere Seite verschiebst.</template>
   <template name="EditorGBPage">Seite</template>
   <template name="EditorGBName">Name</template>
   <template name="EditorGBPageType">Seitentyp</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -7,7 +7,7 @@
   <template name="EditorGBBackground">Background</template>
   <template name="EditorGBForeground">Foreground</template>
   <template name="EditorGBLinkForeground">Link foreground</template>
-  <template name="EditorGBYouCanChange">You can change where the game starts by dragging "player" to a different page.</template>
+  <template name="EditorGBYouCanChange">You can change where the game starts by moving "player" to a different page.</template>
   <template name="EditorGBPage">Page</template>
   <template name="EditorGBName">Name</template>
   <template name="EditorGBPageType">Page type</template>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -2055,6 +2055,84 @@ public partial class WasmEditorBridge
         return "ok";
     }
 
+    // ── Move / cut / copy / paste ───────────────────────────────────────────
+
+    [JSExport]
+    public static bool CanMoveElement(string elementKey)
+    {
+        return _controller?.CanMoveElement(elementKey) ?? false;
+    }
+
+    [JSExport]
+    public static string GetMovePossibleParents(string elementKey)
+    {
+        var parents = _controller?.GetMovePossibleParents(elementKey)?.ToList() ?? [];
+        return JsonSerializer.Serialize(parents, WasmEditorJsonContext.Default.ListString);
+    }
+
+    [JSExport]
+    public static string MoveElement(string elementKey, string newParentKey)
+    {
+        if (_controller == null || !_controller.CanMoveElement(elementKey, newParentKey))
+        {
+            return "error";
+        }
+
+        _controller.MoveElement(elementKey, newParentKey);
+        return "ok";
+    }
+
+    [JSExport]
+    public static void CopyElements(string keysJson)
+    {
+        if (_controller == null)
+        {
+            return;
+        }
+
+        var keys = JsonSerializer.Deserialize(keysJson, WasmEditorJsonContext.Default.ListString);
+        if (keys == null || keys.Count == 0)
+        {
+            return;
+        }
+
+        _controller.CopyElements(keys);
+    }
+
+    [JSExport]
+    public static void CutElements(string keysJson)
+    {
+        if (_controller == null)
+        {
+            return;
+        }
+
+        var keys = JsonSerializer.Deserialize(keysJson, WasmEditorJsonContext.Default.ListString);
+        if (keys == null || keys.Count == 0)
+        {
+            return;
+        }
+
+        _controller.CutElements(keys);
+    }
+
+    [JSExport]
+    public static bool CanPasteElements(string parentKey)
+    {
+        return _controller?.CanPaste(parentKey) ?? false;
+    }
+
+    [JSExport]
+    public static string PasteElements(string parentKey)
+    {
+        if (_controller == null || !_controller.CanPaste(parentKey))
+        {
+            return "error";
+        }
+
+        return _controller.PasteElements(parentKey) ?? "error";
+    }
+
     // ── Verbs editor API ─────────────────────────────────────────────────────
 
     private static IEditorControl? FindVerbsControl(string elementKey)


### PR DESCRIPTION
## Summary

- The editor's tree had no way to move an object/room to a different parent, or to cut/copy/paste an element — both existed in the old v5 editors (drag-and-drop in the desktop editor, a "Move" button in the WebEditor).
- `EditorController` already had this logic in full (`CanMoveElement`/`MoveElement`/`GetMovePossibleParents`, `CopyElements`/`CutElements`/`PasteElements`/`CanPaste`), carried over from v5 and never called by anything. Reparenting already propagates to the tree correctly via the existing `"parent"`-attribute field-changed handler, so this is pure bridging + UI — no `EditorCore`/`Engine` changes for the core feature.
- Adds 7 thin `[JSExport]` passthroughs in `WasmEditorBridge.cs`, wrapper functions + a `moveElementModal` store in `editor-store.ts`, a new `MoveElementModal.svelte` (modeled on `AddElementModal.svelte`, using the existing `Combobox` component), and "Move to…"/"Cut"/"Copy"/"Paste" entries in `TreePanel.svelte`'s per-row "⋯" menu.
- Applies to room/object/gamebook-page elements (matches what the underlying API supports — v5's own desktop editor wires the same `EditorController` methods generically with no gamebook-vs-textadventure gating), single-element only (matches the tree's current single-selection UI), no drag-and-drop yet (no DnD library in AppShell today, and neither `@zag-js/tree-view` nor `skeleton-svelte`'s `TreeView` wrapper have any built-in drag support to build on — real touch/mobile parity would need pointer-event-based custom dragging rather than native HTML5 DnD, so left as a possible follow-up).
- Cut elements now grey out in the tree until pasted, instead of sitting there looking untouched — see below.

## Bugs found and fixed during review/testing

- Cutting/copying an element doesn't touch any Svelte store, so the tree's per-row menus (computed inline in `nodeMenuOptions()`, not driven by a store) never noticed the clipboard had changed — "Paste" wouldn't appear until something else forced a re-render. Fixed with a `clipboardVersion` counter store that `nodeMenuOptions()` reads, following the same pattern as the existing `scriptVersion` counter used for the analogous script-clipboard case.
- Gamebook pages (`nodeType: "page"`) were initially excluded from the menu entirely by an overly-narrow `nt === "room" || nt === "object"` gate. Widened to include `"page"` after confirming v5's desktop editor supports copying pages too — `GetPasteParent` already special-cases gamebook correctly (always pastes at the flat top level).
- The player object's gamebook help text ("You can change where the game starts by dragging 'player' to a different page.") assumed drag-and-drop, which AppShell doesn't have. Reworded to "moving" in `EditorEnglish.aslx`/`EditorDeutsch.aslx` (the only two translations with this string) — accurate for both AppShell's new menu and v5's desktop drag. Checked the rest of the language files for similar right-click/double-click/toolbar/context-menu references; this was the only one. (Aside: traced how it could ever show up — the game's *content*-language template controls which `EditorXXX.aslx` gets `<include>`d, same list as the "Create new game" language dropdown — but `Gamebook.template` has always been English-only, in v5 too, so the German string has been unreachable since it was written.)
- Added the grey-out affordance for cut elements: a `cutElementKeys` store (mirrors `EditorController`'s own `m_lastelementscutout` — set by Cut, cleared by Copy or a completed Paste) dims the matching tree row(s). This finishes something SoonGames attempted in 2017 and left commented out in `EditorController.cs` ("I wanted to show the object to be cut out in gray. But it hasn't worked yet."). Deliberately *not* reverting to the pre-2017 behavior of deleting the original immediately on Cut (which is what a 2011 version of this code did) — immediate `DeleteElement` runs `RemoveReferences()`, which permanently clears any field elsewhere in the game pointing at the cut object (e.g. an Exit's `to`) before anything has been pasted. The current defer-until-paste design (re-materializing under the same name at paste time) avoids that data loss; this only adds the missing visual on top of it.

Also adds `.claude/launch.json` for the AppShell dev server (used to drive manual verification below), since none existed yet.

## Test plan

Verified manually against the AppShell dev server (`npm run dev`) with fresh local-draft games (text-adventure and gamebook):
- [x] "Move to…" reparents an object/room; target list excludes the element itself, its current parent, and its own descendants (cycle prevention)
- [x] Cut → Paste moves the element (same name, removed from old parent, no orphan/duplicate); the cut row appears dimmed until the paste completes, then returns to normal
- [x] Copy → Paste clones with a unique name; original untouched (and not dimmed, since Copy isn't a cut)
- [x] Undo reverts each of Move / Cut+Paste / Copy+Paste as a single step
- [x] None of the new menu items appear on non-object/page nodes (functions, timers, headers)
- [x] Gamebook: Copy → Paste on a page clones it at the flat top level with a unique name and preserved content/links; Move to… offers a sane target list; help text on the player object reads correctly
- [x] `npm run check`, `npm run lint`, and `dotnet build src/WasmEditor/WasmEditor.csproj` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)