### PR TITLE
feat(AppShell): add Code View with syntax highlighting for scripts and raw XML

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,6 +5,7 @@
       "name": "AppShell",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
+      "cwd": "src/AppShell",
       "port": 5174
     }
   ]

--- a/src/AppShell/package-lock.json
+++ b/src/AppShell/package-lock.json
@@ -124,10 +124,45 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -136,9 +171,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -214,9 +249,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -271,9 +306,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -285,30 +320,30 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "dev": true,
       "license": "MIT"
     },
@@ -470,9 +505,9 @@
       }
     },
     "node_modules/@lucide/svelte": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.25.0.tgz",
-      "integrity": "sha512-v9m+dD68jxVnqkU3K59mG/RSRFlPGzmKCGSyMfnXcaGv9jODDQMyQkcp1CGvk3Y/cUj9v7f8rw1n//K0B53xGQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.27.0.tgz",
+      "integrity": "sha512-qzNBHdqy/MKp2qxuy/DcYELuep6h19fjo+4ech8fZsS4GtZeBtg5jgCTRQvLvwhppt0mhRN6qt8Nt8rPb/J4Ag==",
       "license": "ISC",
       "peerDependencies": {
         "svelte": "^5"
@@ -485,28 +520,31 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^2.0.0-alpha.3",
+        "@emnapi/runtime": "^2.0.0-alpha.3"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -521,9 +559,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -538,9 +576,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -555,9 +593,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -572,9 +610,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -589,9 +627,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -606,9 +644,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -623,9 +661,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -640,9 +678,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -657,9 +695,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -674,9 +712,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -691,9 +729,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -708,9 +746,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -725,9 +763,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -735,41 +773,30 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -778,9 +805,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -795,9 +822,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -884,9 +911,9 @@
       "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
-      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+      "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -945,10 +972,20 @@
         }
       }
     },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.1.tgz",
+      "integrity": "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
-      "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.2.0.tgz",
+      "integrity": "sha512-1SpkuMSRLfugrVX+IrKfE1RUegzo8AQzKQ6qQPfVzbcWi5IhuTPaKb5ZrLpucleFznkc4/RTeSPoRnGWFxX+EQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -967,9 +1004,9 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -977,49 +1014,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
-        "jiti": "^2.6.1",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.4"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-x64": "4.2.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -1034,9 +1071,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -1051,9 +1088,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -1068,9 +1105,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -1085,9 +1122,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -1102,9 +1139,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -1119,9 +1156,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -1136,9 +1173,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -1153,9 +1190,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -1170,9 +1207,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1188,85 +1225,21 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
-        "@tybys/wasm-util": "^0.10.1",
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1281,9 +1254,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -1298,24 +1271,24 @@
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
-      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.2.4",
-        "@tailwindcss/oxide": "4.2.4",
-        "tailwindcss": "4.2.4"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1351,14 +1324,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -1368,17 +1341,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1391,15 +1364,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1407,17 +1380,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1433,14 +1406,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1455,14 +1428,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1473,9 +1446,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1490,15 +1463,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1515,9 +1488,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -1530,16 +1503,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1558,16 +1531,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1582,13 +1555,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2211,9 +2184,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -2279,16 +2252,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chokidar": {
@@ -2413,15 +2386,15 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
-      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
+      "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.2.tgz",
-      "integrity": "sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.4.tgz",
+      "integrity": "sha512-GVoi+ICHocoOIU7qVVM48wOJziRsqrsyqlI0Ce0LdowRn6v3bcH2zUa9kp85ncx0nwIb9/HOCOLS3fdThDG/XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2446,19 +2419,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2480,7 +2456,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2503,9 +2479,9 @@
       }
     },
     "node_modules/eslint-plugin-svelte": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.17.1.tgz",
-      "integrity": "sha512-NyiXHtS3Ni7e532RBwS9OXlMKDIrENg3gY+/+ODjZzQx2xhU3NlJ+nIl1a93iUUQeiJL3lS8KLmY+W8hklzweQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.22.0.tgz",
+      "integrity": "sha512-O3qn0NePTWta+1o25dIThqeEP/hEQ3VxDK2LVO8SQ5wG9umLMvulK+m1yQ4JGOb2Pkl8IB0G1lpRV/HXDXSLTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2518,7 +2494,7 @@
         "postcss-load-config": "^3.1.4",
         "postcss-safe-parser": "^7.0.0",
         "semver": "^7.6.3",
-        "svelte-eslint-parser": "^1.4.0"
+        "svelte-eslint-parser": "^1.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2606,9 +2582,9 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.6.tgz",
-      "integrity": "sha512-WN0clHt0a4mzC780UBVVBpsj4vSSjOFNRd2WjYtduB9HeKxm1sjHMNUwLEHVjI3FdCQD/Hurgz9ftbKEzP79Ow==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
+      "integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2745,9 +2721,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3233,13 +3209,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3302,15 +3278,18 @@
       "license": "MIT"
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3390,9 +3369,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3404,9 +3383,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3528,9 +3507,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3583,13 +3562,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.139.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3599,21 +3578,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/sade": {
@@ -3630,9 +3609,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3643,9 +3622,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3704,15 +3683,15 @@
       "license": "MIT"
     },
     "node_modules/svelte": {
-      "version": "5.55.7",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
-      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
+      "version": "5.56.8",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+      "integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
         "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
@@ -3721,7 +3700,7 @@
         "clsx": "^2.1.1",
         "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.4",
+        "esrap": "^2.2.12",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -3732,13 +3711,14 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
-      "integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.4.tgz",
+      "integrity": "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.1",
         "chokidar": "^4.0.1",
         "fdir": "^6.2.0",
         "picocolors": "^1.0.0",
@@ -3752,13 +3732,13 @@
       },
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "typescript": ">=5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/svelte-eslint-parser": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.6.1.tgz",
-      "integrity": "sha512-hhvSH6kRj46UzrBVO5TaotD+Iuvruj5ccKBcO4wAhVcPTLmIc/c32D8UllBTYO0on4LzYuM0rNzf1lM/gBlkSQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.0.tgz",
+      "integrity": "sha512-mikR1qwIVy3t5WthUoAXkMwxkXvabZP9FJgdx35Ei7EbGWmctva1Pih16Koeor/bdNNq8NXHlwKGS6NkYTawLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3772,7 +3752,7 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
-        "pnpm": "10.33.0"
+        "pnpm": "10.34.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
@@ -3835,9 +3815,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -3932,16 +3912,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3956,9 +3936,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3980,17 +3960,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -4007,7 +3987,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -4108,6 +4088,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/src/AppShell/package-lock.json
+++ b/src/AppShell/package-lock.json
@@ -8,6 +8,15 @@
       "name": "quest-app-shell",
       "version": "0.0.1",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.20.3",
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-xml": "^6.1.0",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/search": "^6.7.1",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.7",
+        "@lezer/common": "^1.5.2",
+        "@lezer/highlight": "^1.2.3",
         "@lucide/svelte": "^1.25.0",
         "fflate": "^0.8.3"
       },
@@ -31,39 +40,97 @@
         "vite": "^8.0.16"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
+      "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -317,6 +384,7 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -366,6 +434,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lucide/svelte": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.25.0.tgz",
@@ -374,6 +477,12 @@
       "peerDependencies": {
         "svelte": "^5"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -799,6 +908,7 @@
       "integrity": "sha512-nY9SPHGOZro3doud9vZXDBwl9tCZIouuJztjgSHs6PAIrv9M/z5O7eOhPV5xU7CgVHA976Jwu3BA1hIFvXztkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.9",
@@ -841,6 +951,7 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -1245,6 +1356,7 @@
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1300,6 +1412,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1407,6 +1520,7 @@
       "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2101,6 +2215,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2210,6 +2325,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2330,6 +2451,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3273,6 +3395,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3300,6 +3423,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -3573,11 +3697,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/svelte": {
       "version": "5.55.7",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3708,7 +3839,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -3790,6 +3922,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3852,6 +3985,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3943,6 +4077,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/src/AppShell/package.json
+++ b/src/AppShell/package.json
@@ -12,6 +12,15 @@
     "lint:fix": "eslint src --fix"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-xml": "^6.1.0",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/search": "^6.7.1",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.7",
+    "@lezer/common": "^1.5.2",
+    "@lezer/highlight": "^1.2.3",
     "@lucide/svelte": "^1.25.0",
     "fflate": "^0.8.3"
   },

--- a/src/AppShell/src/components/CodeEditor.svelte
+++ b/src/AppShell/src/components/CodeEditor.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+    import { untrack } from "svelte";
+    import { EditorState, Compartment } from "@codemirror/state";
+    import { EditorView, keymap, lineNumbers, highlightActiveLine } from "@codemirror/view";
+    import { history, defaultKeymap, historyKeymap, indentWithTab } from "@codemirror/commands";
+    import { bracketMatching, indentOnInput } from "@codemirror/language";
+    import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+    import { searchKeymap } from "@codemirror/search";
+    import { questScript } from "$lib/quest-script-lang";
+    import { xmlWithScript } from "$lib/xml-with-script-lang";
+    import { questEditorExtensions } from "$lib/codemirror-theme";
+    import { registerActiveCmView } from "$lib/code-editor-registry";
+
+    interface Props {
+        value: string;
+        language: "xml" | "quest-script";
+        readonly?: boolean;
+        onChange?: (value: string) => void;
+        minHeight?: string;
+        class?: string;
+    }
+
+    let { value, language, readonly = false, onChange, minHeight = "10rem", class: className = "" }: Props = $props();
+
+    let editorEl = $state<HTMLDivElement | null>(null);
+    let view: EditorView | null = null;
+
+    const languageCompartment = new Compartment();
+    const readonlyCompartment = new Compartment();
+
+    function languageExtension(lang: "xml" | "quest-script") {
+        return lang === "xml" ? xmlWithScript() : questScript();
+    }
+
+    function readonlyExtension(ro: boolean) {
+        return [EditorState.readOnly.of(ro), EditorView.editable.of(!ro)];
+    }
+
+    // Mounts once when the host element first appears, and never again — value/language/readonly
+    // are read via untrack() here so prop changes don't retrigger a full remount (which would
+    // otherwise wipe CodeMirror's own cursor position and undo history on every parent re-render).
+    // Later prop changes are instead applied surgically by the two $effects below.
+    $effect(() => {
+        if (!editorEl) return;
+
+        const initialValue = untrack(() => value);
+        const initialLanguage = untrack(() => language);
+        const initialReadonly = untrack(() => readonly);
+
+        view = new EditorView({
+            doc: initialValue,
+            parent: editorEl,
+            extensions: [
+                lineNumbers(),
+                highlightActiveLine(),
+                history(),
+                bracketMatching(),
+                closeBrackets(),
+                indentOnInput(),
+                EditorView.lineWrapping,
+                keymap.of([
+                    ...closeBracketsKeymap,
+                    ...defaultKeymap,
+                    ...historyKeymap,
+                    ...searchKeymap,
+                    indentWithTab,
+                    {
+                        key: "Mod-s",
+                        preventDefault: true,
+                        run: v => {
+                            onChange?.(v.state.doc.toString());
+                            return true;
+                        },
+                    },
+                ]),
+                EditorView.domEventHandlers({
+                    blur: (_event, v) => {
+                        onChange?.(v.state.doc.toString());
+                    },
+                }),
+                languageCompartment.of(languageExtension(initialLanguage)),
+                readonlyCompartment.of(readonlyExtension(initialReadonly)),
+                EditorView.theme({
+                    "&": { minHeight, height: "100%" },
+                    ".cm-scroller": { overflow: "auto" },
+                }),
+                ...questEditorExtensions,
+            ],
+        });
+
+        return () => {
+            registerActiveCmView(null);
+            view?.destroy();
+            view = null;
+        };
+    });
+
+    // Reconfigure language/readonly in place on prop change — avoids the remount above. Also
+    // (re)registers this view as the toolbar's active Undo/Redo target whenever it's editable, so
+    // those buttons operate on the text actually on screen instead of Quest's own undo stack —
+    // except while readonly (locked/inherited scripts), where there's nothing here to undo and
+    // the toolbar should keep acting on the real model as normal.
+    $effect(() => {
+        if (!view) return;
+        view.dispatch({
+            effects: [
+                languageCompartment.reconfigure(languageExtension(language)),
+                readonlyCompartment.reconfigure(readonlyExtension(readonly)),
+            ],
+        });
+        registerActiveCmView(readonly ? null : view);
+    });
+
+    // External value sync: only replace the doc when the incoming prop actually differs from
+    // what the editor already shows, so this doesn't fight in-progress typing or clobber
+    // CodeMirror's own undo stack every time onChange echoes the same text back through this prop.
+    $effect(() => {
+        if (!view) return;
+        if (value !== view.state.doc.toString()) {
+            view.dispatch({
+                changes: { from: 0, to: view.state.doc.length, insert: value },
+            });
+        }
+    });
+</script>
+
+<div bind:this={editorEl} class="code-editor rounded border border-surface-200-800 overflow-hidden h-full {className}"></div>

--- a/src/AppShell/src/components/CodeViewPanel.svelte
+++ b/src/AppShell/src/components/CodeViewPanel.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+    import { untrack } from "svelte";
+    import { getGameXml, setGameXml, codeViewCloseRequested } from "$lib/editor-store";
+    import { chooseDialog, confirmDialog } from "$lib/confirm";
+    import CodeEditor from "./CodeEditor.svelte";
+
+    interface Props {
+        onclose: () => void;
+    }
+
+    let { onclose }: Props = $props();
+
+    // Loaded once on open, not kept in sync with scriptVersion/undo-redo — re-syncing while the
+    // panel is open would fight whatever raw XML the user is mid-edit on.
+    const originalXml = getGameXml();
+    let xml = $state(originalXml);
+    let applying = $state(false);
+    let error = $state<string | null>(null);
+    let hasChanges = $derived(xml !== originalXml);
+
+    function handleChange(value: string) {
+        xml = value;
+        error = null;
+    }
+
+    // Applies without its own confirmation — callers (the Apply button, and the "Apply" choice
+    // from the unsaved-changes prompt below) are each responsible for confirming first, so a user
+    // routed through the prompt doesn't see a second "are you sure" right after choosing Apply.
+    async function applyChanges(): Promise<boolean> {
+        applying = true;
+        error = null;
+        try {
+            const result = await setGameXml(xml);
+            if (result === "ok") return true;
+            // Keep the panel open with the user's text intact so they can fix and retry —
+            // SetGameXml() never touched the live game on a failure like this.
+            error = result.startsWith("error:") ? result.slice("error:".length) : result;
+            return false;
+        } finally {
+            applying = false;
+        }
+    }
+
+    async function handleApplyButton() {
+        const confirmed = await confirmDialog(
+            "Applying reloads the whole game from this text and discards undo history. Continue?",
+            { confirmLabel: "Apply", danger: true }
+        );
+        if (!confirmed) return;
+        if (await applyChanges()) onclose();
+    }
+
+    // Shared by the Cancel button and the toolbar's toggle-to-close button (see the
+    // codeViewCloseRequested effect below) — asks before throwing away unapplied edits either way,
+    // rather than only guarding one of the two ways to leave this panel.
+    async function attemptClose() {
+        if (!hasChanges) {
+            onclose();
+            return;
+        }
+        const choice = await chooseDialog(
+            "You have unsaved raw XML changes. Applying reloads the game and discards undo history.",
+            [
+                { label: "Keep editing", value: "keep" as const },
+                { label: "Discard changes", value: "discard" as const },
+                { label: "Apply changes", value: "apply" as const },
+            ]
+        );
+        if (choice === "discard") {
+            onclose();
+        } else if (choice === "apply") {
+            if (await applyChanges()) onclose();
+        }
+    // Any other outcome ("keep", or Escape/backdrop which resolves null) — stay open.
+    }
+
+    // Reacts to the toolbar's toggle button being clicked while this panel is already open. Only
+    // treated as a genuine request when the counter changes *after* this component mounted —
+    // otherwise every fresh mount would immediately see a nonzero leftover count from some earlier
+    // session and try to close itself right away.
+    let lastCloseRequest = untrack(() => $codeViewCloseRequested);
+    $effect(() => {
+        if ($codeViewCloseRequested !== lastCloseRequest) {
+            lastCloseRequest = $codeViewCloseRequested;
+            void attemptClose();
+        }
+    });
+</script>
+
+{#if applying}
+    <!-- Matches the app's main "Loading game…" treatment (edit/+page.svelte) rather than a small
+         in-button spinner — reloading the whole model from raw XML is exactly that kind of
+         operation, and deserves to be at least as obvious as the initial load. -->
+    <main class="flex flex-col items-center justify-center flex-1 gap-6 p-8">
+        <div class="size-10 rounded-full border-4 border-surface-300-700 border-t-primary-500 animate-spin"></div>
+        <p class="text-surface-500-400 text-sm">Applying changes…</p>
+    </main>
+{:else}
+    <div class="flex flex-col flex-1 min-w-0 overflow-hidden">
+        {#if error}
+            <div class="px-4 py-2 bg-error-100-900 border-b border-error-300-700 text-sm text-error-600-400 whitespace-pre-wrap">{error}</div>
+        {/if}
+
+        <!-- data-staging: edits here are a local scratch buffer until Apply commits them — opt out
+             of the page-level isEditingField/"Unsaved" tracking that assumes input events mean an
+             edit already landed in the bridge, same as ListEditor/DictionaryEditor. -->
+        <div class="flex-1 min-h-0 p-2" data-staging>
+            <CodeEditor value={xml} language="xml" onChange={handleChange} class="h-full" />
+        </div>
+
+        <div class="flex items-center justify-end gap-2 px-4 py-2 border-t border-surface-200-800">
+            <button type="button" class="btn btn-sm preset-tonal" onclick={attemptClose}>Cancel</button>
+            <button type="button" class="btn btn-sm preset-filled-primary-500" onclick={handleApplyButton}>Apply</button>
+        </div>
+    </div>
+{/if}

--- a/src/AppShell/src/components/ConfirmDialog.svelte
+++ b/src/AppShell/src/components/ConfirmDialog.svelte
@@ -29,14 +29,14 @@
         role="dialog"
         aria-modal="true"
         tabindex="-1"
-        class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+        class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
         onclick={onBackdropClick}
         onkeydown={handleKeydown}
     >
-        <div class="card bg-surface-50-950 rounded-xl shadow-xl w-80 p-6 flex flex-col gap-4">
+        <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-sm p-6 flex flex-col gap-4">
             <p class="text-sm">{state.message}</p>
 
-            <div class="flex justify-end gap-2">
+            <div class="flex flex-wrap justify-end gap-2">
                 {#each state.choices as choice, i (choice.label)}
                     {@const isPrimary = i === state.choices.length - 1}
                     <button

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -3,6 +3,7 @@
     import ScriptEditor from "./ScriptEditor.svelte";
     import AddScriptModal from "./AddScriptModal.svelte";
     import AssetPicker from "./AssetPicker.svelte";
+    import CodeEditor from "./CodeEditor.svelte";
     import {
         scriptVersion,
         scriptClipboardHasContent,
@@ -368,14 +369,13 @@
         </div>
     {/if}
     {#if codeViewMode}
-        <textarea
-            autocapitalize="off"
-            class="textarea text-xs font-mono w-full"
-            rows={10}
-            readonly={isLocked}
+        <CodeEditor
             value={scriptCode}
-            onchange={(e) => onCodeViewSave((e.target as HTMLTextAreaElement).value)}
-        ></textarea>
+            language="quest-script"
+            readonly={isLocked}
+            onChange={onCodeViewSave}
+            minHeight="10rem"
+        />
     {:else}
         <div role="region" inert={isLocked || undefined} class={isLocked ? "opacity-60" : ""}>
             {#each scripts() as script, i (script.id)}

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -13,7 +13,10 @@
         createExit, createTurnScript, createCommand, createVerb,
         deleteElement,
         assetManagerOpen,
+        codeViewPanelOpen,
+        codeViewCloseRequested,
     } from "$lib/editor-store";
+    import { hasActiveCmView, cmUndo, cmRedo } from "$lib/code-editor-registry";
     import type { TreeNode } from "$lib/types";
     import Home from "@lucide/svelte/icons/home";
     import ImageIcon from "@lucide/svelte/icons/image";
@@ -31,6 +34,7 @@
     import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
     import Circle from "@lucide/svelte/icons/circle";
     import Ellipsis from "@lucide/svelte/icons/ellipsis";
+    import FileCode from "@lucide/svelte/icons/file-code";
     import DiscordIcon from "$components/DiscordIcon.svelte";
     import GithubIcon from "$components/GithubIcon.svelte";
     import DropdownMenu from "$components/DropdownMenu.svelte";
@@ -76,7 +80,36 @@
     }
 
     async function handlePreview() {
+        // Without this, a field the author is still mid-typing in (not yet blurred) never
+        // commits into the bridge at all — Preview would open showing stale content, since text
+        // inputs commit on blur/change, not on every keystroke. Same flush saveGame() already
+        // does before navigating home/away; Preview just never called it.
+        await saveGame();
         await previewInWasmPlayer(wasmPlayerUrl);
+    }
+
+    // While a CodeEditor (per-script Code view, or the raw XML panel) is on screen and editable,
+    // Undo/Redo act on its own CodeMirror history instead of Quest's model — otherwise these
+    // buttons would silently undo/redo the last applied model change in the background while the
+    // author is still looking at unrelated, not-yet-committed text.
+    function handleUndo() {
+        if (get(hasActiveCmView)) { cmUndo(); return; }
+        undo();
+    }
+    function handleRedo() {
+        if (get(hasActiveCmView)) { cmRedo(); return; }
+        redo();
+    }
+
+    // Acts as a toggle: opens the raw XML panel if closed, or — if it's already open — asks it to
+    // attempt closing (CodeViewPanel prompts to Apply/Discard first when there are unsaved edits,
+    // rather than this just forcing it shut).
+    function handleToggleCodeView() {
+        if (get(codeViewPanelOpen)) {
+            codeViewCloseRequested.update(n => n + 1);
+        } else {
+            codeViewPanelOpen.set(true);
+        }
     }
 
     // Derive the currently selected tree node
@@ -143,10 +176,11 @@
         links[0] = { ...links[0], divider: true };
 
         return [
-            { label: "Delete", action: () => selectedNode && deleteElement(selectedNode.key), icon: Trash2, disabled: !canDelete },
+            { label: "Delete", action: () => selectedNode && deleteElement(selectedNode.key), icon: Trash2, disabled: $codeViewPanelOpen || !canDelete },
             { label: "Manage assets", action: () => assetManagerOpen.set(true), icon: ImageIcon, divider: true },
-            { label: "Undo", action: undo, icon: Undo2, disabled: !$canUndo },
-            { label: "Redo", action: redo, icon: Redo2, disabled: !$canRedo },
+            { label: $hasActiveCmView ? "Undo (in code editor)" : "Undo", action: handleUndo, icon: Undo2, disabled: $hasActiveCmView ? false : !$canUndo },
+            { label: $hasActiveCmView ? "Redo (in code editor)" : "Redo", action: handleRedo, icon: Redo2, disabled: $hasActiveCmView ? false : !$canRedo },
+            { label: "Raw XML code view", action: handleToggleCodeView, icon: FileCode },
             ...fileItems,
             ...links,
         ];
@@ -191,31 +225,36 @@
         </AppBar.Lead>
         <AppBar.Trail>
             <div class="flex gap-1.5 items-center">
-                <!-- Add dropdown: icon-only below md -->
+                <!-- Add dropdown: icon-only below md. Disabled while the raw XML panel is open —
+                     there's no tree selection context there, and the tree itself isn't even
+                     mounted (see edit/+page.svelte), so these actions have nothing to act on. -->
                 <DropdownMenu items={addOptions}>
                     {#snippet trigger(toggle)}
                         <button
                             type="button"
                             class="btn btn-sm preset-outlined-primary-500"
                             onclick={toggle}
+                            disabled={$codeViewPanelOpen}
                             title="Add element"
                         ><Plus size={14} /> <span class="hidden md:inline">Add</span> <ChevronDown size={12} class="hidden md:inline" /></button>
                     {/snippet}
                 </DropdownMenu>
                 <!-- Delete button: always rendered, disabled when nothing deletable is
-                     selected, so surrounding buttons don't shift as selection changes.
+                     selected (or the raw XML panel is open — see the Add dropdown above), so
+                     surrounding buttons don't shift as selection changes.
                      Desktop only — folded into the ⋯ menu on mobile. -->
                 <button
                     type="button"
                     class="btn btn-sm preset-outlined-error-500 hidden md:inline-flex"
                     onclick={() => selectedNode && deleteElement(selectedNode.key)}
-                    disabled={!canDelete}
+                    disabled={$codeViewPanelOpen || !canDelete}
                     title={canDelete ? "Delete " + (selectedNode?.text ?? "") : "Delete"}
                 ><Trash2 size={14} /> Delete</button>
                 <div class="toolbar-divider hidden md:block"></div>
                 <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={() => assetManagerOpen.set(true)} title="Manage assets"><ImageIcon size={16} /></button>
-                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={undo} disabled={!$canUndo} title="Undo"><Undo2 size={16} /></button>
-                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={redo} disabled={!$canRedo} title="Redo"><Redo2 size={16} /></button>
+                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleUndo} disabled={$hasActiveCmView ? false : !$canUndo} title={$hasActiveCmView ? "Undo (in code editor)" : "Undo"}><Undo2 size={16} /></button>
+                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleRedo} disabled={$hasActiveCmView ? false : !$canRedo} title={$hasActiveCmView ? "Redo (in code editor)" : "Redo"}><Redo2 size={16} /></button>
+                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleToggleCodeView} title="Raw XML code view"><FileCode size={16} /></button>
                 <div class="toolbar-divider hidden md:block"></div>
                 {#if fileMenuItems.length > 0}
                     <div class="hidden md:block">

--- a/src/AppShell/src/lib/code-editor-registry.ts
+++ b/src/AppShell/src/lib/code-editor-registry.ts
@@ -1,0 +1,26 @@
+import { writable } from "svelte/store";
+import type { EditorView } from "@codemirror/view";
+import { undo as cmUndoCommand, redo as cmRedoCommand } from "@codemirror/commands";
+
+// Only one CodeEditor (per-script "Code view" or the whole-file raw XML panel) is ever mounted at
+// a time in this app, so a single module-level slot is enough to let the toolbar's Undo/Redo
+// buttons reach whichever CodeMirror instance is currently active. Without this, those buttons
+// would keep operating on Quest's own undo/redo stack while the author is mid-edit in a
+// not-yet-applied text buffer — silently mutating the underlying model in the background instead
+// of undoing the text they're actually looking at.
+let activeView: EditorView | null = null;
+
+export const hasActiveCmView = writable(false);
+
+export function registerActiveCmView(view: EditorView | null): void {
+    activeView = view;
+    hasActiveCmView.set(view !== null);
+}
+
+export function cmUndo(): boolean {
+    return activeView ? cmUndoCommand(activeView) : false;
+}
+
+export function cmRedo(): boolean {
+    return activeView ? cmRedoCommand(activeView) : false;
+}

--- a/src/AppShell/src/lib/codemirror-theme.ts
+++ b/src/AppShell/src/lib/codemirror-theme.ts
@@ -1,0 +1,61 @@
+import { EditorView } from "@codemirror/view";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags as t } from "@lezer/highlight";
+
+// Built entirely from Skeleton's paired light/dark CSS custom properties (e.g.
+// --color-surface-200-800, which resolves via light-dark() in
+// @skeletonlabs/skeleton/src/base/theme.css) rather than a separate CodeMirror
+// theme package, so the editor tracks the app's light/dark mode automatically
+// and stays consistent with every other panel. See the "invisible text in
+// modals in dark mode" fix (commit 3b1f2964) for why bare single-shade colors
+// (e.g. --color-primary-500 alone) are unsafe for backgrounds here — only use
+// them for accents/text against the paired surface background below.
+export const questEditorTheme = EditorView.theme({
+    "&": {
+        backgroundColor: "var(--color-surface-50-950)",
+        color: "var(--color-surface-900-100)",
+        fontSize: "var(--text-xs)",
+    },
+    ".cm-content, .cm-gutters": {
+        // matches the old textarea's "text-xs font-mono" — CodeMirror defaults to a much larger
+        // browser default font-size otherwise, out of step with the rest of this app's controls.
+        lineHeight: "var(--text-xs--line-height)",
+    },
+    ".cm-content": {
+        caretColor: "var(--color-primary-500)",
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+    },
+    ".cm-cursor, .cm-dropCursor": {
+        borderLeftColor: "var(--color-primary-500)",
+    },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+        backgroundColor: "color-mix(in srgb, var(--color-primary-500) 25%, transparent)",
+    },
+    ".cm-activeLine": {
+        backgroundColor: "color-mix(in srgb, var(--color-surface-500-400) 10%, transparent)",
+    },
+    ".cm-gutters": {
+        backgroundColor: "var(--color-surface-50-950)",
+        color: "var(--color-surface-500-400)",
+        border: "none",
+        borderRight: "1px solid var(--color-surface-200-800)",
+    },
+    ".cm-activeLineGutter": {
+        backgroundColor: "color-mix(in srgb, var(--color-surface-500-400) 10%, transparent)",
+    },
+    ".cm-matchingBracket, .cm-nonmatchingBracket": {
+        backgroundColor: "color-mix(in srgb, var(--color-primary-500) 20%, transparent)",
+        outline: "none",
+    },
+}, { dark: false });
+
+export const questHighlightStyle = HighlightStyle.define([
+    { tag: t.keyword, color: "var(--color-primary-500)", fontWeight: "bold" },
+    { tag: [t.string, t.attributeValue], color: "var(--color-success-600-400)" },
+    { tag: t.comment, color: "var(--color-surface-500-400)", fontStyle: "italic" },
+    { tag: t.number, color: "var(--color-tertiary-500)" },
+    { tag: [t.tagName, t.attributeName], color: "var(--color-primary-500)" },
+    { tag: [t.bracket, t.paren, t.squareBracket, t.brace], color: "var(--color-surface-500-400)" },
+]);
+
+export const questEditorExtensions = [questEditorTheme, syntaxHighlighting(questHighlightStyle)];

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -70,6 +70,11 @@ export const scriptClipboardHasContent = writable(false);
 export const assets = writable<AssetInfo[]>([]);
 export const assetManagerOpen = writable(false);
 export const publishModalOpen = writable(false);
+export const codeViewPanelOpen = writable(false);
+// Bumped by Toolbar's toggle button when the panel is already open, asking CodeViewPanel to
+// attempt closing — rather than the toolbar forcing codeViewPanelOpen to false directly, which
+// would silently discard any not-yet-applied raw XML edits.
+export const codeViewCloseRequested = writable(0);
 
 function refreshUndoRedo() {
     canUndo.set(_bridge?.CanUndo() ?? false);
@@ -116,6 +121,46 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
         if (gameNode) await selectNode(gameNode.key);
     }
     return ok;
+}
+
+// Read-only peek at the current game's XML for the raw Code View panel — unlike Save(), this
+// does not clear the bridge's dirty flag (it's not a save action).
+export function getGameXml(): string {
+    return _bridge?.GetGameXml() ?? "";
+}
+
+// Applies raw-XML edits from the Code View panel. SetGameXml validates the new XML against a
+// throwaway controller before touching the live one (see WasmEditorBridge.cs), so a malformed
+// edit returns "error:..." without disturbing the currently-open game. On success this reloads
+// the whole in-memory model, which mirrors openGame()'s post-load sequence — and necessarily
+// wipes Quest's own undo/redo stack, which is why the caller (CodeViewPanel) confirms with the
+// user before invoking this.
+export async function setGameXml(xml: string): Promise<string> {
+    if (!_bridge) return "error";
+    cancelPendingAutosave();
+    // Double rAF ensures the browser actually paints the caller's "Applying…" state before
+    // SetGameXml's Initialise() call blocks the JS thread (C# WASM calls are synchronous) — same
+    // pattern openGame() uses below for the equivalent reason.
+    await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+    const result = await _bridge.SetGameXml(xml);
+    if (result === "ok") {
+        clearAssetUrlCache();
+        isGamebook.set(_bridge.IsGamebook());
+        const nodes: TreeNode[] = JSON.parse(_bridge.GetTreeNodes());
+        treeNodes.set(nodes);
+        scriptClipboardHasContent.set(false);
+        cutElementKeys.set(new Set());
+        await refreshAssets();
+        const gameNode = nodes.find(n => n.nodeType === "game");
+        if (gameNode) await selectNode(gameNode.key);
+        refreshUndoRedo();
+        // SetGameXml() resets the bridge's dirty flag after the reload (matching Initialise()'s
+        // own behavior), but the in-memory content now differs from the last persisted save, so
+        // that must be corrected here rather than trusted from refreshUndoRedo() above.
+        isDirty.set(true);
+        scheduleAutosave();
+    }
+    return result;
 }
 
 export async function selectNode(key: string) {

--- a/src/AppShell/src/lib/quest-script-lang.ts
+++ b/src/AppShell/src/lib/quest-script-lang.ts
@@ -1,0 +1,63 @@
+import { StreamLanguage, LanguageSupport } from "@codemirror/language";
+import type { StreamParser, StringStream } from "@codemirror/language";
+
+// Approximate, non-validating highlighter for Quest's own line-oriented script
+// DSL (e.g. `msg ("Hello")`, `if (x = 1) { ... }`) — distinct from the ASLX XML
+// file format. Keyword list curated from the `Keyword =>` properties across
+// src/Engine/Scripts/*.cs plus ScriptFactory.cs's special-cased else/else
+// if/otherwise handling. Multi-word keywords are matched before single-word
+// ones so e.g. "create exit" isn't tokenized as the bare "create" keyword.
+const MULTI_WORD_KEYWORDS = [
+    "create exit", "create timer", "create turnscript",
+    "dictionary add", "dictionary remove",
+    "list add", "list remove",
+    "get input", "on ready",
+    "play sound", "stop sound",
+    "else if",
+];
+
+const SINGLE_WORD_KEYWORDS = new Set([
+    "if", "else", "otherwise", "for", "foreach", "do", "msg", "create", "destroy",
+    "ask", "insert", "invoke", "finish", "error", "picture", "requestsave", "firsttime",
+]);
+
+const multiWordPattern = new RegExp(`^(${MULTI_WORD_KEYWORDS.join("|")})\\b`);
+
+const questScriptParser: StreamParser<null> = {
+    token(stream: StringStream): string | null {
+        if (stream.sol() && stream.match(/^\s*\/\//)) {
+            stream.skipToEnd();
+            return "comment";
+        }
+        if (stream.match(multiWordPattern)) {
+            return "keyword";
+        }
+        if (stream.match(/^JS\./) || stream.match(/^@failed\b/)) {
+            return "keyword";
+        }
+        if (stream.match(/^"(?:[^"\\]|\\.)*"?/)) {
+            return "string";
+        }
+        if (stream.match(/^\d+(\.\d+)?/)) {
+            return "number";
+        }
+        if (stream.match(/^[{}()[\]]/)) {
+            return "bracket";
+        }
+        const word = stream.match(/^[a-zA-Z_][a-zA-Z0-9_.]*/);
+        if (word) {
+            const text = (word as RegExpMatchArray)[0];
+            return SINGLE_WORD_KEYWORDS.has(text) ? "keyword" : "variableName";
+        }
+        stream.next();
+        return null;
+    },
+};
+
+// Exported (not just wrapped in questScript()'s LanguageSupport) so xml-with-script.ts can embed
+// this language's .parser directly as a Lezer nested parser inside <element type="script"> content.
+export const questScriptLanguage = StreamLanguage.define(questScriptParser);
+
+export function questScript(): LanguageSupport {
+    return new LanguageSupport(questScriptLanguage);
+}

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -8,6 +8,8 @@ export interface WasmBridge {
   SetDropdownType(elementKey: string, controlId: string, selectedType: string): string
   Save(): string
   IsDirty(): boolean
+  GetGameXml(): string
+  SetGameXml(xml: string): Promise<string>
   GetGameId(): string
   IsGamebook(): boolean
   AddPublishAsset(filename: string, data: Uint8Array): void

--- a/src/AppShell/src/lib/xml-with-script-lang.ts
+++ b/src/AppShell/src/lib/xml-with-script-lang.ts
@@ -1,0 +1,37 @@
+import { parseMixed } from "@lezer/common";
+import type { SyntaxNodeRef, Input } from "@lezer/common";
+import { xmlLanguage, autoCloseTags } from "@codemirror/lang-xml";
+import { LanguageSupport } from "@codemirror/language";
+import { questScriptLanguage } from "./quest-script-lang";
+
+// ASLX marks every script-bearing attribute the same way regardless of the wrapping element's own
+// name — e.g. <start type="script">, <script type="script">, <take type="script">, <lock
+// type="script"> all through src/Engine/Core/*.aslx — so "does this element's opening tag have
+// type="script"?" is a reliable, element-name-agnostic signal for where to switch languages.
+function isScriptElement(node: SyntaxNodeRef, input: Input): boolean {
+    const openTag = node.node.parent?.firstChild;
+    if (!openTag || openTag.type.name !== "OpenTag") return false;
+    for (let attr = openTag.firstChild; attr; attr = attr.nextSibling) {
+        if (attr.type.name !== "Attribute") continue;
+        const nameNode = attr.getChild("AttributeName");
+        const valueNode = attr.getChild("AttributeValue");
+        if (!nameNode || !valueNode) continue;
+        if (input.read(nameNode.from, nameNode.to) !== "type") continue;
+        if (input.read(valueNode.from, valueNode.to).replace(/"/g, "") === "script") return true;
+    }
+    return false;
+}
+
+// xmlLanguage.configure() reuses the same language-data facet and layers this wrap onto the
+// existing (already tag/attribute-highlighting-configured) parser, rather than rebuilding one from
+// scratch — see LRLanguage.configure in @codemirror/language.
+const xmlWithScriptLanguage = xmlLanguage.configure({
+    wrap: parseMixed((node, input) => {
+        if (node.type.name !== "Text" && node.type.name !== "CData") return null;
+        return isScriptElement(node, input) ? { parser: questScriptLanguage.parser } : null;
+    }),
+});
+
+export function xmlWithScript(): LanguageSupport {
+    return new LanguageSupport(xmlWithScriptLanguage, [autoCloseTags]);
+}

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -4,12 +4,13 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { get } from "svelte/store";
-    import { isLoaded, isDirty, isEditingField, markFieldEditing, clearFieldEditing, saveGame, loadingStatus, addElementModal, assetManagerOpen, publishModalOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType, moveElementModal, moveElement } from "$lib/editor-store";
+    import { isLoaded, isDirty, isEditingField, markFieldEditing, clearFieldEditing, saveGame, loadingStatus, addElementModal, assetManagerOpen, publishModalOpen, codeViewPanelOpen, openGame, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType, moveElementModal, moveElement } from "$lib/editor-store";
     import { loadFromServer } from "$lib/filesystem/server-adapter";
     import Toolbar from "$components/Toolbar.svelte";
     import BackupBanner from "$components/BackupBanner.svelte";
     import TreePanel from "$components/TreePanel.svelte";
     import PropertyEditor from "$components/PropertyEditor.svelte";
+    import CodeViewPanel from "$components/CodeViewPanel.svelte";
     import { isNarrow } from "$lib/layout.svelte";
     import AddElementModal from "$components/AddElementModal.svelte";
     import MoveElementModal from "$components/MoveElementModal.svelte";
@@ -144,26 +145,30 @@
         <Toolbar />
         <BackupBanner />
         <div class="flex flex-1 overflow-hidden" oninput={handleFieldInput} onfocusout={clearFieldEditing}>
-            <!-- Both panes stay mounted (display toggled, not {#if}'d away) so tree
-                 expansion state and property tab state survive switching panes on
-                 mobile. -->
-            <div class={isNarrow.current && mobilePane !== "tree" ? "hidden" : "contents"}>
-                <TreePanel
-                    width={isNarrow.current ? undefined : treeWidth}
-                    onactivate={() => { mobilePane = "props"; }}
-                />
-            </div>
-            {#if !isNarrow.current}
-                <div
-                    role="separator"
-                    aria-orientation="vertical"
-                    class="w-1 shrink-0 cursor-col-resize hover:bg-primary-500/50 active:bg-primary-500/70 transition-colors"
-                    onpointerdown={handleSplitterPointerDown}
-                ></div>
+            {#if $codeViewPanelOpen}
+                <CodeViewPanel onclose={() => codeViewPanelOpen.set(false)} />
+            {:else}
+                <!-- Both panes stay mounted (display toggled, not {#if}'d away) so tree
+                     expansion state and property tab state survive switching panes on
+                     mobile. -->
+                <div class={isNarrow.current && mobilePane !== "tree" ? "hidden" : "contents"}>
+                    <TreePanel
+                        width={isNarrow.current ? undefined : treeWidth}
+                        onactivate={() => { mobilePane = "props"; }}
+                    />
+                </div>
+                {#if !isNarrow.current}
+                    <div
+                        role="separator"
+                        aria-orientation="vertical"
+                        class="w-1 shrink-0 cursor-col-resize hover:bg-primary-500/50 active:bg-primary-500/70 transition-colors"
+                        onpointerdown={handleSplitterPointerDown}
+                    ></div>
+                {/if}
+                <div class={isNarrow.current && mobilePane !== "props" ? "hidden" : "contents"}>
+                    <PropertyEditor onback={isNarrow.current ? () => { mobilePane = "tree"; } : undefined} />
+                </div>
             {/if}
-            <div class={isNarrow.current && mobilePane !== "props" ? "hidden" : "contents"}>
-                <PropertyEditor onback={isNarrow.current ? () => { mobilePane = "tree"; } : undefined} />
-            </div>
         </div>
     </div>
 

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -154,29 +154,29 @@ public partial class WasmEditorBridge
     private static string? _pendingRenameNewKey;
     private static bool _isDirty;
 
-    [JSExport]
-    public static async Task<bool> Initialise(byte[] gameFileBytes, string filename)
+    // Wires the tree/dirty events a live controller needs to keep the JS-side TreeNodes cache and
+    // _isDirty flag in sync. Shared by Initialise (wired before the initial parse, since nothing
+    // valid exists yet to protect) and SetGameXml (wired only after a candidate controller has
+    // already parsed successfully, so a failed raw-XML edit can never mutate the shared TreeNodes
+    // list for the game that's still actually loaded).
+    private static void AttachControllerEvents(EditorController controller)
     {
-        _controller?.Dispose();
-        TreeNodes.Clear();
-
-        _controller = new EditorController();
-        _controller.ClearTree += (_, _) =>
+        controller.ClearTree += (_, _) =>
         {
             TreeNodes.Clear();
             _isRebuilding = true;
         };
-        _controller.BeginTreeUpdate += (_, _) => { };
-        _controller.EndTreeUpdate += (_, _) => { _isRebuilding = false; };
-        _controller.AddedNode += OnAddedNode;
-        _controller.RemovedNode += (_, e) =>
+        controller.BeginTreeUpdate += (_, _) => { };
+        controller.EndTreeUpdate += (_, _) => { _isRebuilding = false; };
+        controller.AddedNode += OnAddedNode;
+        controller.RemovedNode += (_, e) =>
         {
             if (!_suppressTreeEvents)
             {
                 TreeNodes.RemoveAll(n => n.Key == e.Key);
             }
         };
-        _controller.RenamedNode += (_, e) =>
+        controller.RenamedNode += (_, e) =>
         {
             _pendingRenameNewKey = e.NewName;
             for (var i = 0; i < TreeNodes.Count; i++)
@@ -194,7 +194,7 @@ public partial class WasmEditorBridge
                 }
             }
         };
-        _controller.RetitledNode += (_, e) =>
+        controller.RetitledNode += (_, e) =>
         {
             var idx = TreeNodes.FindIndex(n => n.Key == e.Key);
             if (idx >= 0)
@@ -203,7 +203,17 @@ public partial class WasmEditorBridge
             }
         };
 
-        _controller.Dirty += (_, _) => { _isDirty = true; };
+        controller.Dirty += (_, _) => { _isDirty = true; };
+    }
+
+    [JSExport]
+    public static async Task<bool> Initialise(byte[] gameFileBytes, string filename)
+    {
+        _controller?.Dispose();
+        TreeNodes.Clear();
+
+        _controller = new EditorController();
+        AttachControllerEvents(_controller);
 
         var provider = new ByteArrayGameDataProvider(gameFileBytes, filename);
         var ok = await _controller.Initialise(provider);
@@ -214,6 +224,60 @@ public partial class WasmEditorBridge
         }
 
         return ok;
+    }
+
+    [JSExport]
+    public static string GetGameXml()
+    {
+        // Unlike Save(), this must not clear _isDirty — it's a read-only peek at the current
+        // in-memory state for display purposes, not a save action.
+        return _controller?.Save() ?? string.Empty;
+    }
+
+    [JSExport]
+    public static async Task<string> SetGameXml(string xml)
+    {
+        if (_controller == null)
+        {
+            return "error:No game loaded.";
+        }
+
+        var filename = _controller.Filename;
+        var bytes = System.Text.Encoding.UTF8.GetBytes(xml);
+        var provider = new ByteArrayGameDataProvider(bytes, filename);
+
+        // Parse into a throwaway controller first — the shared TreeNodes cache and _isDirty flag
+        // must not be touched (see AttachControllerEvents) and the live _controller must not be
+        // disposed until we know the new XML is actually valid, otherwise a malformed edit would
+        // destroy the game that's currently open instead of just failing to apply.
+        var candidate = new EditorController();
+        string? errorMessage = null;
+        candidate.ShowMessage += (_, e) => errorMessage = e.Message;
+
+        bool ok;
+        try
+        {
+            ok = await candidate.Initialise(provider);
+        }
+        catch (Exception ex)
+        {
+            candidate.Dispose();
+            return $"error:{ex.Message}";
+        }
+
+        if (!ok)
+        {
+            candidate.Dispose();
+            return $"error:{errorMessage ?? "Failed to parse ASLX."}";
+        }
+
+        AttachControllerEvents(candidate);
+        _controller.Dispose();
+        TreeNodes.Clear();
+        _controller = candidate;
+        _controller.UpdateTree();
+        _isDirty = false;
+        return "ok";
     }
 
     [JSExport]

--- a/tests/e2e/verify-appshell-code-view.mjs
+++ b/tests/e2e/verify-appshell-code-view.mjs
@@ -1,0 +1,204 @@
+// Verifies the new Code View feature: (a) the per-script "Code view" toggle now renders a
+// syntax-highlighted CodeMirror editor instead of a plain textarea and still round-trips edits,
+// and (b) the new top-level "Raw XML code view" toggle shows the whole game's ASLX, applies edits
+// (reloading the model and clearing undo history, after a confirm step), rejects malformed XML
+// with an inline error while leaving the currently-open game untouched, and Cancel discards
+// in-panel edits without applying them.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+// CodeMirror's contenteditable content doesn't reliably pick up Playwright's locator.fill()
+// (confirmed interactively — fill() left the doc unchanged). Typing long content character-by-
+// character via page.keyboard.type() is also unreliable here — CodeMirror's closeBrackets/
+// indentOnInput extensions can desync from Playwright's rapid synthetic keystrokes on strings of
+// a few hundred+ characters, corrupting the result (confirmed interactively: a duplicated/garbled
+// tail appeared after typing a full ASLX document). Paste (a single transaction) avoids both
+// problems and is also how a real author would replace a large block of text.
+const selectAllKey = process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
+const pasteKey = process.platform === 'darwin' ? 'Meta+V' : 'Control+V';
+
+async function setCmContent(page, text) {
+    const cm = page.locator('.cm-editor .cm-content').first();
+    await cm.click();
+    await page.keyboard.press(selectAllKey);
+    await page.evaluate(t => navigator.clipboard.writeText(t), text);
+    await page.keyboard.press(pasteKey);
+    return cm;
+}
+
+// The Print script's message renders as an <input>'s value, not visible text content, so this
+// checks inputValue() rather than a text= selector (which only matches rendered text nodes).
+async function waitForInputValue(page, value) {
+    await page.waitForFunction(
+        v => [...document.querySelectorAll('input[type="text"]')].some(i => i.value === v),
+        value,
+        { timeout: 5000 }
+    );
+}
+
+try {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    await ctx.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Code View Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    // --- Per-script Code view: syntax highlighting + round trip ---
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+    await page.getByRole('button', { name: /^Scripts$/ }).click();
+    await page.waitForSelector('text=Start script', { timeout: 5000 });
+
+    await page.click('button:has-text("Add script")');
+    await page.waitForSelector('[role="dialog"]', { timeout: 5000 });
+    await page.getByRole('button', { name: 'Print', exact: true }).click();
+    await page.waitForSelector('input[type="checkbox"]', { timeout: 5000 });
+
+    await page.click('button:has-text("Code view")');
+    await page.waitForSelector('.cm-editor', { timeout: 5000 });
+    // HighlightStyle.define() generates obfuscated per-rule class names (not fixed ".tok-*" names),
+    // so check for classed token spans generically rather than a specific class — a plain textarea
+    // (the old implementation) never produces these.
+    const classedTokenCount = await page.locator('.cm-line span[class]').count();
+    if (classedTokenCount === 0) throw new Error('Expected classed (syntax-highlighted) token spans in the per-script code view, found none');
+    console.log('PASS: per-script Code view renders CodeMirror with syntax-highlighted tokens (not a plain textarea)');
+
+    await setCmContent(page, 'msg ("Hello from code view")');
+    await page.locator('button:has-text("Visual editor")').click();
+    await waitForInputValue(page, 'Hello from code view');
+    console.log('PASS: per-script code-view edit committed on blur and is reflected back in Visual mode');
+
+    // --- Locked/inherited script: code view stays read-only, "Make editable copy" still works ---
+    // (The freshly-created game's Start script is not inherited, so this checks the general
+    // codeViewMode/readonly wiring instead: re-enter code view and confirm it's still editable.)
+    await page.click('button:has-text("Code view")');
+    await page.waitForSelector('.cm-editor', { timeout: 5000 });
+    const isEditable = await page.locator('.cm-content').first().getAttribute('contenteditable');
+    if (isEditable !== 'true') throw new Error('Expected the per-script code view to be editable (not locked) for a non-inherited script');
+    console.log('PASS: per-script code view is editable for a non-inherited script (readonly wiring intact)');
+    await page.click('button:has-text("Visual editor")');
+
+    // --- Whole-file raw ASLX editor ---
+    await page.click('button[title="Raw XML code view"]');
+    await page.waitForSelector('.cm-editor', { timeout: 5000 });
+    let xmlText = await page.locator('.cm-content').first().innerText();
+    if (!xmlText.includes('<asl')) throw new Error('Expected the raw XML view to contain the <asl> root element');
+    if (!xmlText.includes('Hello from code view')) throw new Error('Expected the raw XML to reflect the earlier per-script edit');
+    console.log('PASS: raw XML code view opens and shows the current game XML, including the earlier per-script edit');
+
+    // The quest-script inside <start type="script"> should itself be highlighted (nested-language
+    // nesting via parseMixed, keyed on the type="script" attribute regardless of tag name) — not
+    // just rendered as plain XML text content. A bare "msg" span with no class means it fell back
+    // to plain text.
+    const msgTokenClass = await page.locator('.cm-line span', { hasText: 'msg' }).first().getAttribute('class');
+    if (!msgTokenClass) throw new Error('Expected the embedded quest-script keyword "msg" inside the raw XML view to be highlighted (nested-language parsing), but it has no highlight class');
+    console.log('PASS: quest-script embedded inside <... type="script"> elements is itself syntax-highlighted within the raw XML view');
+
+    // --- Add/Delete are disabled while the raw XML panel is open (no tree selection context) ---
+    const addDisabled = await page.locator('button[title="Add element"]').isDisabled();
+    const deleteDisabled = await page.locator('button:has-text("Delete")').first().isDisabled();
+    if (!addDisabled) throw new Error('Expected the toolbar "Add" button to be disabled while the raw XML panel is open');
+    if (!deleteDisabled) throw new Error('Expected the toolbar "Delete" button to be disabled while the raw XML panel is open');
+    console.log('PASS: toolbar Add/Delete are disabled while the raw XML panel is open');
+
+    // --- Cancel discards in-panel edits (prompting first, since there are unsaved changes) ---
+    await setCmContent(page, xmlText.replace('Hello from code view', 'THIS SHOULD BE DISCARDED'));
+    await page.click('button:has-text("Cancel")');
+    await page.waitForSelector('text=You have unsaved raw XML changes', { timeout: 5000 });
+    await page.click('button:has-text("Discard changes")');
+    await page.waitForSelector('button[title="Raw XML code view"]', { timeout: 5000 });
+    await page.click('button[title="Raw XML code view"]');
+    await page.waitForSelector('.cm-editor', { timeout: 5000 });
+    const reopenedXml = await page.locator('.cm-content').first().innerText();
+    if (reopenedXml.includes('THIS SHOULD BE DISCARDED')) throw new Error('Expected Cancel to discard in-panel edits, but the discarded text reappeared on reopen');
+    if (!reopenedXml.includes('Hello from code view')) throw new Error('Expected reopening the panel to show the original (unedited) XML');
+    console.log('PASS: Cancel discards in-panel XML edits without applying them');
+
+    // --- Undo/Redo route to CodeMirror while the raw XML panel is open, not Quest's model ---
+    // (the per-script edit above already created real Quest undo history to try to corrupt)
+    const undoTitle = await page.locator('button[title*="Undo"]').getAttribute('title');
+    if (undoTitle !== 'Undo (in code editor)') throw new Error(`Expected the Undo button title to indicate code-editor context while the raw XML panel is open, got "${undoTitle}"`);
+    const xmlBeforeUndoClicks = await page.locator('.cm-content').first().innerText();
+    await page.click('button[title*="Undo"]');
+    await page.click('button[title*="Undo"]');
+    const xmlAfterUndoClicks = await page.locator('.cm-content').first().innerText();
+    if (xmlAfterUndoClicks !== xmlBeforeUndoClicks) throw new Error('Expected clicking Undo while the raw XML panel is open to leave the XML unchanged (nothing to undo in a fresh CodeMirror buffer) — it changed, meaning the click likely undid something in the background model instead');
+    if (!xmlAfterUndoClicks.includes('Hello from code view')) throw new Error('Expected the underlying model to still be intact (still contain the earlier per-script edit) after clicking Undo inside the raw XML panel');
+    console.log("PASS: Undo/Redo route to CodeMirror's own history while the raw XML panel is open, not to Quest's model undo stack");
+
+    // --- Toggling the toolbar button closed while there are unsaved edits prompts, not silently discards ---
+    await setCmContent(page, xmlBeforeUndoClicks.replace('<asl', '<!--EDIT MARKER--><asl'));
+    await page.click('button[title="Raw XML code view"]');
+    await page.waitForSelector('text=You have unsaved raw XML changes', { timeout: 5000 });
+    console.log('PASS: toggling the toolbar button while the panel has unsaved edits prompts to Apply/Discard rather than closing immediately');
+    await page.click('button:has-text("Discard changes")');
+    await page.waitForSelector('[data-value="game"][data-part="branch-control"]', { timeout: 5000 });
+    console.log('PASS: "Discard changes" closes the panel without applying the discarded edit');
+
+    // --- Malformed XML: inline error, no crash, previous game state preserved ---
+    await page.click('button[title="Raw XML code view"]');
+    await page.waitForSelector('.cm-editor', { timeout: 5000 });
+    await setCmContent(page, 'not valid xml <unclosed');
+    await page.click('button:has-text("Apply")');
+    await page.waitForSelector('[role="dialog"] button:has-text("Apply")', { timeout: 5000 });
+    await page.click('[role="dialog"] button:has-text("Apply")');
+    await page.waitForSelector('text=Failed to load game', { timeout: 10000 });
+    console.log('PASS: applying malformed XML shows an inline error');
+    // The panel should still be open (not silently closed) and the app not crashed.
+    if (!(await page.locator('.cm-editor').first().isVisible())) throw new Error('Expected the code view panel to remain open after a failed Apply');
+    console.log('PASS: app did not crash after a failed Apply; panel remains open with the invalid text');
+
+    // Cancel out of the broken edit (still counts as an unsaved change, so this also prompts) and
+    // confirm the previously-open game is still intact.
+    await page.click('button:has-text("Cancel")');
+    await page.waitForSelector('text=You have unsaved raw XML changes', { timeout: 5000 });
+    await page.click('button:has-text("Discard changes")');
+    await page.waitForSelector('[data-value="game"][data-part="branch-control"]', { timeout: 10000 });
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+    await page.getByRole('button', { name: /^Scripts$/ }).click();
+    await waitForInputValue(page, 'Hello from code view');
+    console.log('PASS: previously-open game is still intact after the failed raw-XML apply attempt');
+
+    // --- Successful Apply: reloads tree, clears undo history, marks dirty ---
+    await page.click('button[title="Raw XML code view"]');
+    await page.waitForSelector('.cm-editor', { timeout: 5000 });
+    xmlText = await page.locator('.cm-content').first().innerText();
+    await setCmContent(page, xmlText.replace('Hello from code view', 'Hello from raw XML apply'));
+    await page.click('button:has-text("Apply")');
+    await page.waitForSelector('[role="dialog"] button:has-text("Apply")', { timeout: 5000 });
+    await page.click('[role="dialog"] button:has-text("Apply")');
+    await page.waitForSelector('[data-value="game"][data-part="branch-control"]', { timeout: 10000 });
+    console.log('PASS: applying valid edited XML closes the panel and returns to the normal editor view');
+
+    // refreshUndoRedo() runs asynchronously after the reload, so poll rather than check once.
+    await page.waitForFunction(
+        () => document.querySelector('button[title="Undo"]')?.disabled === true,
+        { timeout: 5000 }
+    );
+    console.log('PASS: Undo is disabled after applying raw XML edits (undo history cleared, as warned)');
+
+    await page.waitForSelector('.save-chip-unsaved, .save-chip-saving, .save-chip-saved', { timeout: 5000 });
+    console.log('PASS: save-chip reflects the post-apply state (dirty flag was force-set, then autosave ran)');
+
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+    await page.getByRole('button', { name: /^Scripts$/ }).click();
+    await waitForInputValue(page, 'Hello from raw XML apply');
+    console.log('PASS: tree/model reflects the applied raw XML edit');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}

--- a/tests/e2e/verify-appshell-preview-flush.mjs
+++ b/tests/e2e/verify-appshell-preview-flush.mjs
@@ -1,0 +1,56 @@
+// Regression test: clicking Toolbar's "Preview game" button used to open the WasmPlayer preview
+// without first blurring the currently-focused field or flushing pending edits to storage —
+// unlike handleHome(), which explicitly calls saveGame() before navigating away. A field the
+// author was still mid-typing in (not yet blurred) never committed into the bridge at all (text
+// inputs commit on blur/change, not on every keystroke), so Preview could open showing stale
+// content. Fixed by calling saveGame() at the top of handlePreview(), matching handleHome()'s
+// pattern. This only checks the editor-side flush (blur + persist) — it doesn't drive the actual
+// WasmPlayer preview tab, since that requires its own dev server running separately.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+try {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Preview Flush Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Preview game"]', { timeout: 30000 });
+    await page.waitForSelector('.save-chip-saved', { timeout: 10000 });
+    console.log('PASS: local draft created and starts in Saved state');
+
+    // Edit the Author field (Setup tab, third text input) and deliberately do NOT blur it —
+    // clicking straight into Preview from here is the exact scenario that used to lose the edit.
+    const authorInput = page.locator('input').nth(2);
+    await authorInput.click();
+    await authorInput.type('UNBLURRED AUTHOR EDIT', { delay: 20 });
+    const activeBefore = await page.evaluate(() => document.activeElement?.tagName);
+    if (activeBefore !== 'INPUT') throw new Error(`Expected the Author input to be focused before clicking Preview, got activeElement=${activeBefore}`);
+
+    // window.open() targets a real new tab; ignore rejection if the headless context blocks it —
+    // we only care about what handlePreview() did to the *editor* page before that point.
+    await page.click('button[title="Preview game"]').catch(() => {});
+    await page.waitForTimeout(1500);
+
+    const activeAfter = await page.evaluate(() => document.activeElement?.tagName);
+    if (activeAfter === 'INPUT') throw new Error('Expected clicking Preview to blur the focused field (so its edit commits into the bridge), but it is still focused');
+    console.log('PASS: clicking Preview blurs the focused field, committing its pending edit');
+
+    await page.waitForSelector('.save-chip-saved', { timeout: 5000 });
+    console.log('PASS: clicking Preview flushes the committed edit to storage (chip settles to Saved, not left Unsaved)');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary

- Upgrades the per-script "Code view" (previously a plain `<textarea>`) to a CodeMirror 6 editor with syntax highlighting for Quest's own script DSL (keywords, strings, comments, brackets).
- Adds a new top-level "Raw XML code view" toolbar toggle for editing the whole game's ASLX directly, with XML highlighting plus highlighting for embedded quest-script inside any `type="script"` element (via a Lezer mixed-parser keyed on that attribute, not the wrapping tag name — so it works regardless of which element carries the script).
- Theme is built from Skeleton's existing CSS custom properties so it tracks the app's light/dark mode automatically, matching the rest of the editor.

## Safety / correctness details

- `SetGameXml` validates the edited XML against a throwaway `EditorController` before touching the live one — a malformed edit surfaces an inline error and leaves the currently-open game untouched, rather than destroying it.
- Undo/Redo route to CodeMirror's own history while any code view (per-script or the raw XML panel) is open and editable, instead of silently acting on Quest's model in the background.
- The toolbar's toggle button prompts to Apply/Discard/Keep editing when closing the raw XML panel with unsaved edits (shared with the panel's own Cancel button).
- Add/Delete are disabled while the raw XML panel is open, since there's no tree selection context to act on (the tree isn't even mounted then).
- Applying shows a full-screen loading state (matching the app's initial game-load treatment) rather than a small in-button spinner, and the model reload is preceded by a double-`requestAnimationFrame` yield so that state actually paints before the blocking WASM call.

## Also fixed along the way

- `Toolbar`'s Preview button never blurred the focused field or flushed to storage before opening the preview (unlike `handleHome()`, which does this before navigating away) — an in-progress edit could be silently lost. Now calls `saveGame()` first.
- `ConfirmDialog`'s fixed-width card overflowed once a 3-choice dialog (Keep editing / Discard / Apply) needed more room than the 2-choice case it was originally sized for. Now sizes to content with a max-width and wraps as a fallback.

## Test plan

- [x] `dotnet build`/`dotnet test` (Release) — all pass
- [x] AppShell `svelte-check`, `eslint`, and production build — clean
- [x] New Playwright scripts (manually run, not part of CI): `tests/e2e/verify-appshell-code-view.mjs` (18 checks) and `tests/e2e/verify-appshell-preview-flush.mjs` (3 checks) — all pass
- [x] Manually verified in-browser: light + dark mode, mobile layout, malformed-XML rejection without data loss, Undo/Redo routing while a code view is open, and the Apply loading overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)