### PR TITLE
fix(AppShell): correct Inventory take/drop editor and Attributes editor gaps

### DIFF
--- a/src/AppShell/src/components/AttributesEditor.svelte
+++ b/src/AppShell/src/components/AttributesEditor.svelte
@@ -229,9 +229,50 @@
     }
 
     const UNDELETABLE_ATTRIBUTES = new Set(["name", "type", "elementtype"]);
+    // elementtype/type identify what kind of element this is and must never be
+    // hand-edited; name may only be renamed (via its value), never retyped.
+    const LOCKED_ATTRIBUTES = new Set(["elementtype", "type"]);
 
     function canDeleteAttribute(attr: AttributeDataItem): boolean {
         return !attr.isInherited && !UNDELETABLE_ATTRIBUTES.has(attr.name);
+    }
+
+    function isTypeLocked(attr: AttributeDataItem): boolean {
+        return attr.isDefaultType || attr.name === "name" || LOCKED_ATTRIBUTES.has(attr.name);
+    }
+
+    function isValueLocked(attr: AttributeDataItem): boolean {
+        return attr.isDefaultType || LOCKED_ATTRIBUTES.has(attr.name);
+    }
+
+    function hasChangeScript(name: string): boolean {
+        return ($fullAttributeData?.attributes ?? []).some(a => a.name === "changed" + name);
+    }
+
+    // v5's AddChangeScriptAllowed doesn't exclude inherited attributes (only
+    // read-only elements and a blank attribute name), so a change script can
+    // still be attached to a value this element currently gets from a type —
+    // e.g. adding a custom "changedopen" on top of an inherited "open".
+    function canAddChangeScript(attr: AttributeDataItem): boolean {
+        return !UNDELETABLE_ATTRIBUTES.has(attr.name) && !attr.name.startsWith("changed")
+            && !hasChangeScript(attr.name);
+    }
+
+    function canGoToChangeScript(attr: AttributeDataItem): boolean {
+        return !UNDELETABLE_ATTRIBUTES.has(attr.name) && !attr.name.startsWith("changed")
+            && hasChangeScript(attr.name);
+    }
+
+    function selectChangeScript(name: string) {
+        const changeAttrName = "changed" + name;
+        selectedAttrName = changeAttrName;
+        Promise.resolve().then(() => requestAnimationFrame(() => focusAttrRow(changeAttrName)));
+    }
+
+    function onAddChangeScript(attr: AttributeDataItem) {
+        if (!$selectedKey) return;
+        changeAttributeType($selectedKey, "changed" + attr.name, "script");
+        selectChangeScript(attr.name);
     }
 
     function isTextEditable(attr: AttributeDataItem): boolean {
@@ -445,13 +486,27 @@
                             class="select text-xs py-0 px-1.5 h-7"
                             value={attr.type}
                             onchange={(e) => onChangeType((e.target as HTMLSelectElement).value)}
-                            disabled={attr.isDefaultType}
+                            disabled={isTypeLocked(attr)}
                         >
                             {#each TYPE_OPTIONS as opt (opt.value)}
                                 <option value={opt.value}>{opt.label}</option>
                             {/each}
                         </select>
                     </div>
+
+                    {#if canAddChangeScript(attr)}
+                        <button
+                            type="button"
+                            onclick={() => onAddChangeScript(attr)}
+                            class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0 h-6 self-start flex-shrink-0"
+                        >Add Change Script</button>
+                    {:else if canGoToChangeScript(attr)}
+                        <button
+                            type="button"
+                            onclick={() => selectChangeScript(attr.name)}
+                            class="btn btn-sm preset-outlined-surface-500 text-xs px-2 py-0 h-6 self-start flex-shrink-0"
+                        >Go to Change Script</button>
+                    {/if}
 
                     <!-- Value editor -->
                     <div class="flex flex-col gap-1">
@@ -461,7 +516,7 @@
                         {:else if attr.type === "boolean"}
                             <Switch
                                 checked={editingBool}
-                                disabled={attr.isDefaultType}
+                                disabled={isValueLocked(attr)}
                                 onCheckedChange={(e) => { editingBool = e.checked; onBoolChange(editingBool); }}
                             >
                                 <Switch.Control><Switch.Thumb /></Switch.Control>
@@ -471,12 +526,12 @@
                         {:else if attr.type === "script"}
                             <div class="min-h-48">
                                 {#if $selectedKey}
-                                    <ScriptEditor elementKey={$selectedKey} attribute={attr.name} isLocked={attr.isInherited || attr.isDefaultType} />
+                                    <ScriptEditor elementKey={$selectedKey} attribute={attr.name} isLocked={attr.isInherited || isValueLocked(attr)} />
                                 {/if}
                             </div>
                         {:else if attr.type === "scriptdictionary"}
                             {#if $selectedKey}
-                                <ScriptDictionaryEditor elementKey={$selectedKey} attribute={attr.name} value={attr.value} isLocked={attr.isInherited || attr.isDefaultType} />
+                                <ScriptDictionaryEditor elementKey={$selectedKey} attribute={attr.name} value={attr.value} isLocked={attr.isInherited || isValueLocked(attr)} />
                             {/if}
                         {:else if attr.type === "stringlist"}
                             {#if $selectedKey}
@@ -490,7 +545,7 @@
                             <select
                                 class="select text-xs py-0 px-1.5 h-7"
                                 bind:value={editingObject}
-                                disabled={attr.isDefaultType}
+                                disabled={isValueLocked(attr)}
                                 onchange={(e) => onObjectChange((e.target as HTMLSelectElement).value)}
                             >
                                 {#each objectNames as name (name)}
@@ -503,7 +558,7 @@
                                 class="input text-xs py-1 px-1.5 w-full"
                                 step={attr.type === "double" ? "any" : "1"}
                                 value={editingValue}
-                                disabled={attr.isDefaultType}
+                                disabled={isValueLocked(attr)}
                                 oninput={(e) => { editingValue = (e.target as HTMLInputElement).value; }}
                                 onblur={commitTextEdit}
                                 onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); commitTextEdit(); } }}
@@ -515,7 +570,7 @@
                                 class="input text-xs py-1 px-1.5 w-full resize-none"
                                 rows="4"
                                 value={editingValue}
-                                disabled={attr.isDefaultType}
+                                disabled={isValueLocked(attr)}
                                 oninput={(e) => { editingValue = (e.target as HTMLTextAreaElement).value; }}
                                 onblur={commitTextEdit}
                                 onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commitTextEdit(); } }}

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -505,6 +505,16 @@
                 />
             {:else if subEditorType === "script" && ctrl.subAttribute !== null && $selectedKey !== null}
                 <ScriptEditor elementKey={$selectedKey} attribute={ctrl.subAttribute} />
+            {:else if subEditorType === "boolean" && ctrl.subAttribute !== null}
+                <label class="flex items-center gap-2">
+                    <input
+                        type="checkbox"
+                        class="checkbox flex-shrink-0"
+                        checked={boolValue(ctrl.subAttribute)}
+                        onchange={(e) => onCheckboxChange(ctrl.subAttribute!, (e.target as HTMLInputElement).checked)}
+                    />
+                    <span class="text-xs text-surface-600-400">{ctrl.checkboxCaption ?? ctrl.subAttribute}</span>
+                </label>
             {/if}
         </div>
     {:else if ctrl.controlType === "script" && ctrl.attribute !== null && $selectedKey !== null}
@@ -623,6 +633,16 @@
                     />
                 {:else if subEditorType === "script" && ctrl.subAttribute !== null && $selectedKey !== null}
                     <ScriptEditor elementKey={$selectedKey} attribute={ctrl.subAttribute} />
+                {:else if subEditorType === "boolean" && ctrl.subAttribute !== null}
+                    <label class="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            class="checkbox flex-shrink-0"
+                            checked={boolValue(ctrl.subAttribute)}
+                            onchange={(e) => onCheckboxChange(ctrl.subAttribute!, (e.target as HTMLInputElement).checked)}
+                        />
+                        <span class="text-xs text-surface-600-400">{ctrl.checkboxCaption ?? ctrl.subAttribute}</span>
+                    </label>
                 {/if}
             </div>
         {:else}

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -35,6 +35,7 @@ export interface ControlInfo {
   keyPrompt?: string | null
   valuePrompt?: string | null
   sourceExclude?: string | null
+  checkboxCaption?: string | null
 }
 
 export interface TabInfo {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -38,7 +38,8 @@ internal record ControlInfo(
     bool Advanced = false,
     string? KeyPrompt = null,
     string? ValuePrompt = null,
-    string? SourceExclude = null);
+    string? SourceExclude = null,
+    string? CheckboxCaption = null);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -426,6 +427,9 @@ public partial class WasmEditorBridge
                 case "string":
                     data.SetAttribute(attribute, "");
                     break;
+                case "boolean":
+                    data.SetAttribute(attribute, false);
+                    break;
                 case "script":
                     _controller.CreateNewEditableScripts(elementKey, attribute, null!, false);
                     break;
@@ -798,6 +802,9 @@ public partial class WasmEditorBridge
             {
                 null => "null",
                 string => "string",
+                bool => "boolean",
+                int => "int",
+                double => "double",
                 IEditableScripts => "script",
                 IEditableObjectReference => "object",
                 _ => "null"
@@ -3239,7 +3246,7 @@ public partial class WasmEditorBridge
 
             var caption = ctrl.Caption ?? ctrl.GetString("selfcaption");
             return new ControlInfo(ctrl.Id, ctrl.ControlType, caption, options, subEditors, ctrl.Attribute,
-                multiTpCommands, Advanced: !ctrl.IsControlVisibleInSimpleMode);
+                multiTpCommands, Advanced: !ctrl.IsControlVisibleInSimpleMode, CheckboxCaption: ctrl.GetString("checkbox"));
         }
         else if (ctrl.ControlType == "elementslist")
         {


### PR DESCRIPTION
## Summary

Fixes several gaps in the AppShell editor found while comparing it against the v5 desktop/web editors:

**Inventory tab (Take/Drop):**
- `AddDropdownTypeValues` (WASM bridge) never resolved `bool` values to `"boolean"`, so the Take/Drop dropdown showed blank instead of defaulting to "Default behaviour", and the "Object can be taken"/"Take message" controls never rendered (no boolean branch existed in `PropertyEditor.svelte`'s "multi" control renderer).
- `SetMultiType` had no `"boolean"` case, so switching the dropdown back from "Run script" to "Default behaviour" silently failed (hit the unknown-type fallback).
- Forwarded the ASLX `<checkbox>` caption through a new `checkboxCaption` field on `ControlInfo` so the checkbox label ("Object can be taken") renders correctly.

**Attributes editor:**
- `elementtype`/`type` are now fully locked (type dropdown + value), since they identify the element and must never be hand-edited.
- `name`'s type dropdown is locked to string, but its value stays editable (renaming still works).
- Added an "Add Change Script" button (creates a `changed<attr>` script attribute), matching v5's `WFAttributesControl.AddChangeScriptAllowed` — including for inherited attributes, which v5 also allows (unlike delete, which v5 blocks for inherited attributes).
- When a `changed<attr>` already exists, shows a "Go to Change Script" button instead, which selects and scrolls to that attribute.

## Test plan

- [x] `dotnet build src/WasmEditor/WasmEditor.csproj` — 0 errors/warnings
- [x] `npm run check` (svelte-check) in `src/AppShell` — 0 errors/warnings
- [x] Verified live in the editor (local draft game, `player` object):
  - Take dropdown defaults to "Default behaviour"; "Object can be taken"/"Take message" render and toggle correctly
  - Switching Take from "Run script" back to "Default behaviour" correctly clears the script and resets to a boolean checkbox
  - `elementtype`/`type` rows: type dropdown and value both disabled
  - `name` row: type dropdown disabled, value still editable
  - "Add Change Script" on `take` creates `changedtake` and selects it; hidden for `elementtype`/`type`/`name`
  - "Go to Change Script" shown for inherited `isopen` (has `changedisopen`) and correctly navigates to it
- [x] No console errors during manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)