### PR TITLE
fix(AppShell): replace invalid text-surface-400-500/500-400 utilities

### DIFF
--- a/src/AppShell/src/components/AddElementModal.svelte
+++ b/src/AppShell/src/components/AddElementModal.svelte
@@ -67,7 +67,7 @@
         </h2>
 
         <div class="flex flex-col gap-1">
-            <label for="element-name" class="text-xs text-surface-500-400">Name</label>
+            <label for="element-name" class="text-xs text-surface-600-400">Name</label>
             <input
                 id="element-name"
                 type="text"

--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -214,7 +214,7 @@
             <button
                 type="button"
                 onclick={onClose}
-                class="text-surface-400-500 hover:text-surface-900-50 text-xl leading-none px-1 transition-colors"
+                class="text-surface-600-400 hover:text-surface-900-50 text-xl leading-none px-1 transition-colors"
                 aria-label="Close"
             >×</button>
         </div>
@@ -224,7 +224,7 @@
              narrow modal, and each row only fit one or two pills. -->
         {#if shortcuts.length > 0}
             <div class="px-5 py-2 border-b border-surface-200-800 flex-shrink-0 flex items-center gap-2">
-                <span class="text-xs font-medium text-surface-500-400 flex-shrink-0">Quick add:</span>
+                <span class="text-xs font-medium text-surface-600-400 flex-shrink-0">Quick add:</span>
                 <div class="flex gap-1.5 overflow-x-auto">
                     {#each shortcuts as shortcut (shortcut.createString)}
                         <button
@@ -303,7 +303,7 @@
                     {#each categories as cat, ci (ci)}
                         {@const isSelected = selectedCategoryIndex === ci}
                         {#if ci === firstAdvancedIndex && ci > 0}
-                            <div class="px-4 py-1 text-[10px] font-semibold uppercase tracking-wide text-surface-400-500 border-t border-surface-200-800 mt-1 pt-2">Advanced</div>
+                            <div class="px-4 py-1 text-[10px] font-semibold uppercase tracking-wide text-surface-600-400 border-t border-surface-200-800 mt-1 pt-2">Advanced</div>
                         {/if}
                         <button
                             bind:this={categoryButtonEls[ci]}
@@ -334,7 +334,7 @@
                         {#each selectedCategory.commands as cmd, idx (cmd.createString)}
                             {@const isSelected = selectedCommand?.createString === cmd.createString}
                             {#if idx === firstAdvancedCommandIndex && idx > 0}
-                                <div class="px-5 py-1 text-[10px] font-semibold uppercase tracking-wide text-surface-400-500 border-t border-surface-200-800 mt-1 pt-2">Advanced</div>
+                                <div class="px-5 py-1 text-[10px] font-semibold uppercase tracking-wide text-surface-600-400 border-t border-surface-200-800 mt-1 pt-2">Advanced</div>
                             {/if}
                             <button
                                 bind:this={rowEls[idx]}

--- a/src/AppShell/src/components/AssetManagerModal.svelte
+++ b/src/AppShell/src/components/AssetManagerModal.svelte
@@ -89,7 +89,7 @@
 
         <div class="flex-1 overflow-y-auto flex flex-col gap-1">
             {#if $assets.length === 0}
-                <p class="text-xs text-surface-400-500">No assets yet.</p>
+                <p class="text-xs text-surface-600-400">No assets yet.</p>
             {/if}
             {#each $assets as asset (asset.key)}
                 <div class="flex items-center gap-2 px-1.5 py-1 rounded hover:bg-surface-100-900">

--- a/src/AppShell/src/components/AttributesEditor.svelte
+++ b/src/AppShell/src/components/AttributesEditor.svelte
@@ -332,11 +332,11 @@
                 <!-- Inherited types -->
                 <div class="border-b border-surface-200-800">
                     <div class="px-3 py-1.5 border-b border-surface-100-900">
-                        <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Inherited types</span>
+                        <span class="font-semibold text-surface-600-400 uppercase tracking-wide">Inherited types</span>
                     </div>
                     <table class="w-full">
                         <thead>
-                            <tr class="text-surface-400-500 border-b border-surface-100-900">
+                            <tr class="text-surface-600-400 border-b border-surface-100-900">
                                 <th class="text-left py-1 px-3 font-medium">Name</th>
                                 <th class="text-left py-1 px-3 font-medium">Source</th>
                                 <th class="w-6"></th>
@@ -346,7 +346,7 @@
                             {#each $fullAttributeData?.inheritedTypes ?? [] as t (t.name)}
                                 <tr class="border-b border-surface-100-900">
                                     <td class="py-0.5 px-3">{t.name}</td>
-                                    <td class="py-0.5 px-3 text-surface-400-500">{t.source}</td>
+                                    <td class="py-0.5 px-3 text-surface-600-400">{t.source}</td>
                                     <td class="py-0.5 pr-2 text-right">
                                         {#if !t.isDefaultType}
                                             <button
@@ -359,7 +359,7 @@
                                     </td>
                                 </tr>
                             {:else}
-                                <tr><td colspan="3" class="py-1 px-3 text-surface-400-500 italic">No inherited types</td></tr>
+                                <tr><td colspan="3" class="py-1 px-3 text-surface-600-400 italic">No inherited types</td></tr>
                             {/each}
                         </tbody>
                     </table>
@@ -386,11 +386,11 @@
 
                 <!-- Attributes -->
                 <div class="px-3 py-1.5 border-b border-surface-100-900">
-                    <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Attributes</span>
+                    <span class="font-semibold text-surface-600-400 uppercase tracking-wide">Attributes</span>
                 </div>
                 <table class="w-full">
                     <thead class="sticky top-0 bg-surface-50-950 z-10">
-                        <tr class="text-surface-400-500 border-b border-surface-200-800">
+                        <tr class="text-surface-600-400 border-b border-surface-200-800">
                             <th class="text-left py-1 px-3 font-medium">Name</th>
                             <th class="text-left py-1 px-3 font-medium">Value</th>
                             <th class="hidden @lg:table-cell text-left py-1 px-3 font-medium">Source</th>
@@ -405,7 +405,7 @@
                                 class="border-b border-surface-100-900 cursor-pointer outline-none
                                     focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500
                                     {isSelected ? "bg-primary-100-900" : "hover:bg-surface-100-900"}
-                                    {dimmed ? "text-surface-400-500" : ""}"
+                                    {dimmed ? "text-surface-600-400" : ""}"
                                 tabindex={isSelected ? 0 : -1}
                                 data-attr={attr.name}
                                 onclick={() => onSelectAttribute(attr)}
@@ -413,7 +413,7 @@
                             >
                                 <td class="py-0.5 px-3 truncate max-w-36 {!dimmed ? "font-medium" : ""}" title={attr.name}>{attr.name}</td>
                                 <td class="py-0.5 px-3 max-w-40 truncate" title={attr.value ?? ""}>{displayValue(attr)}</td>
-                                <td class="hidden @lg:table-cell py-0.5 px-3 text-surface-400-500 truncate" title={attr.source}>{attr.source}</td>
+                                <td class="hidden @lg:table-cell py-0.5 px-3 text-surface-600-400 truncate" title={attr.source}>{attr.source}</td>
                                 <td class="py-0.5 pr-2 text-right">
                                     {#if canDeleteAttribute(attr)}
                                         <button
@@ -427,7 +427,7 @@
                                 </td>
                             </tr>
                         {:else}
-                            <tr><td colspan="4" class="py-2 px-3 text-surface-400-500 italic">No attributes</td></tr>
+                            <tr><td colspan="4" class="py-2 px-3 text-surface-600-400 italic">No attributes</td></tr>
                         {/each}
                     </tbody>
                 </table>
@@ -458,12 +458,12 @@
             class:flex-shrink-0={!selectedAttr}
             style="--panel-width: {panelWidth}px"
         >
-            <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-500-400 uppercase tracking-wide flex-shrink-0 flex items-center justify-between">
+            <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-600-400 uppercase tracking-wide flex-shrink-0 flex items-center justify-between">
                 <span>Assignment</span>
                 {#if selectedAttr}
                     <button
                         type="button"
-                        class="normal-case text-surface-400-500 hover:text-surface-900-50"
+                        class="normal-case text-surface-600-400 hover:text-surface-900-50"
                         onclick={() => { selectedAttrName = null; }}
                         title="Close"
                         aria-label="Close"
@@ -476,12 +476,12 @@
                     <div class="font-medium text-surface-700-300 truncate flex-shrink-0" title={attr.name}>{attr.name}</div>
 
                     {#if attr.isInherited || attr.isDefaultType}
-                        <p class="text-surface-400-500 italic text-xs flex-shrink-0">Inherited from <span class="font-medium">{attr.source}</span></p>
+                        <p class="text-surface-600-400 italic text-xs flex-shrink-0">Inherited from <span class="font-medium">{attr.source}</span></p>
                     {/if}
 
                     <!-- Type selector -->
                     <div class="flex flex-col gap-1 flex-shrink-0">
-                        <span class="text-surface-400-500 uppercase tracking-wide text-xs">Type</span>
+                        <span class="text-surface-600-400 uppercase tracking-wide text-xs">Type</span>
                         <select
                             class="select text-xs py-0 px-1.5 h-7"
                             value={attr.type}
@@ -510,9 +510,9 @@
 
                     <!-- Value editor -->
                     <div class="flex flex-col gap-1">
-                        <span class="text-surface-400-500 uppercase tracking-wide text-xs flex-shrink-0">Value</span>
+                        <span class="text-surface-600-400 uppercase tracking-wide text-xs flex-shrink-0">Value</span>
                         {#if attr.type === "null"}
-                            <p class="text-surface-400-500 italic">(no value)</p>
+                            <p class="text-surface-600-400 italic">(no value)</p>
                         {:else if attr.type === "boolean"}
                             <Switch
                                 checked={editingBool}
@@ -579,7 +579,7 @@
                     </div>
                 </div>
             {:else}
-                <p class="p-3 text-surface-400-500 italic">Select an attribute to edit it.</p>
+                <p class="p-3 text-surface-600-400 italic">Select an attribute to edit it.</p>
             {/if}
         </div>
     </div>

--- a/src/AppShell/src/components/CodeViewPanel.svelte
+++ b/src/AppShell/src/components/CodeViewPanel.svelte
@@ -93,7 +93,7 @@
          operation, and deserves to be at least as obvious as the initial load. -->
     <main class="flex flex-col items-center justify-center flex-1 gap-6 p-8">
         <div class="size-10 rounded-full border-4 border-surface-300-700 border-t-primary-500 animate-spin"></div>
-        <p class="text-surface-500-400 text-sm">Applying changes…</p>
+        <p class="text-surface-600-400 text-sm">Applying changes…</p>
     </main>
 {:else}
     <div class="flex flex-col flex-1 min-w-0 overflow-hidden">

--- a/src/AppShell/src/components/DictionaryEditor.svelte
+++ b/src/AppShell/src/components/DictionaryEditor.svelte
@@ -44,7 +44,7 @@
 <div class="flex flex-col gap-1 w-full">
     {#each items as item (item.key)}
         <div class="flex items-center gap-1">
-            <span class="text-xs text-surface-500-400 px-1 flex-shrink-0">{item.key}:</span>
+            <span class="text-xs text-surface-600-400 px-1 flex-shrink-0">{item.key}:</span>
             {#if editingKey === item.key}
                 <input
                     type="text"

--- a/src/AppShell/src/components/ElementsList.svelte
+++ b/src/AppShell/src/components/ElementsList.svelte
@@ -145,7 +145,7 @@
 
     <!-- Item rows -->
     {#if items.length === 0}
-        <p class="text-xs text-surface-400-500 italic">No items.</p>
+        <p class="text-xs text-surface-600-400 italic">No items.</p>
     {:else}
         {#each items as item, i (item.key)}
             <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-center">
@@ -215,7 +215,7 @@
                     onclick={onMoveDownSelected}
                 >↓ Move down</button>
             {/if}
-            <span class="ml-auto text-surface-400-500">{sel.length} selected</span>
+            <span class="ml-auto text-surface-600-400">{sel.length} selected</span>
         </div>
     {/if}
 </div>

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -130,17 +130,17 @@
     {:else if dir.exitKey !== null}
         <div class="border border-surface-200-800 rounded p-1.5 bg-surface-50-950 min-h-14 min-w-0 flex flex-col gap-0.5">
             <div class="flex items-center justify-between gap-1 min-w-0">
-                <span class="text-[10px] uppercase text-surface-400-500 truncate">{dir.direction}</span>
+                <span class="text-[10px] uppercase text-surface-600-400 truncate">{dir.direction}</span>
                 <button
                     type="button"
-                    class="text-surface-400-500 hover:text-primary-600-400 flex-shrink-0"
+                    class="text-surface-600-400 hover:text-primary-600-400 flex-shrink-0"
                     title="Edit exit"
                     onclick={() => selectNode(dir.exitKey!)}
                 ><Pencil size={11} /></button>
             </div>
             <div class="flex items-center gap-1 min-w-0">
                 {#if dir.lookOnly}
-                    <span class="flex-1 min-w-0 text-xs text-surface-500-400 truncate">(look)</span>
+                    <span class="flex-1 min-w-0 text-xs text-surface-600-400 truncate">(look)</span>
                 {:else}
                     <button
                         type="button"
@@ -164,7 +164,7 @@
             class="border rounded p-1.5 min-h-14 min-w-0 flex items-center text-left text-xs transition-colors
                 {isOpen
                     ? "border-primary-500 bg-primary-50-950 text-primary-600-400"
-                    : "border-dashed border-surface-300-700 text-surface-400-500 hover:border-primary-400 hover:text-primary-600-400"}"
+                    : "border-dashed border-surface-300-700 text-surface-600-400 hover:border-primary-400 hover:text-primary-600-400"}"
             onclick={() => toggleDirection(dir.direction)}
         ><span class="truncate">{dir.direction}</span></button>
     {/if}
@@ -193,7 +193,7 @@
                     <span class="text-xs font-medium text-surface-600-400">Create exit: {openDirection}</span>
                     <button
                         type="button"
-                        class="text-xs text-surface-400-500 hover:text-surface-600-400"
+                        class="text-xs text-surface-600-400 hover:text-surface-600-400"
                         onclick={() => { openDirection = null; }}
                     >✕</button>
                 </div>
@@ -216,7 +216,7 @@
                     >Create exit</button>
                     <button
                         type="button"
-                        class="text-xs text-surface-400-500 hover:text-primary-600-400 underline text-left"
+                        class="text-xs text-surface-600-400 hover:text-primary-600-400 underline text-left"
                         onclick={() => doCreateLook(openDirection!)}
                     >Create a look exit instead</button>
                 </div>
@@ -236,7 +236,7 @@
             </div>
 
             {#if data.allExits.length === 0}
-                <p class="text-xs text-surface-400-500 italic">No exits.</p>
+                <p class="text-xs text-surface-600-400 italic">No exits.</p>
             {:else}
                 {#each data.allExits as exit, i (exit.key)}
                     <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-center">
@@ -247,7 +247,7 @@
                                 onclick={() => selectNode(exit.to!)}
                             >{exit.alias ?? "(none)"} → {exit.to}</button>
                         {:else}
-                            <span class="flex-1 text-xs px-1.5 py-1 pr-28 text-surface-500-400 truncate">{exit.alias ?? "(none)"} → {exit.lookOnly ? "(look)" : "(nowhere)"}</span>
+                            <span class="flex-1 text-xs px-1.5 py-1 pr-28 text-surface-600-400 truncate">{exit.alias ?? "(none)"} → {exit.lookOnly ? "(look)" : "(nowhere)"}</span>
                         {/if}
                         <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
                             <button

--- a/src/AppShell/src/components/HomeTabs.svelte
+++ b/src/AppShell/src/components/HomeTabs.svelte
@@ -9,12 +9,12 @@
 
     // Tailwind's dark: variant here follows the OS colour-scheme media query
     // (not a class toggle — see globals.css), so the auto-switching "paired"
-    // utilities (e.g. text-surface-500-400) can't be forced dark by wrapping
+    // utilities (e.g. text-surface-600-400) can't be forced dark by wrapping
     // them in a dark background; they'd still resolve to their light-mode
     // value if the OS is in light mode. forceDark instead picks the dark-side
     // member of each pair explicitly.
     const activeText = $derived(forceDark ? "text-surface-100" : "text-surface-900-100");
-    const inactiveText = $derived(forceDark ? "text-surface-400 hover:text-surface-100" : "text-surface-500-400 hover:text-surface-900-100");
+    const inactiveText = $derived(forceDark ? "text-surface-400 hover:text-surface-100" : "text-surface-600-400 hover:text-surface-900-100");
 </script>
 
 <nav class="flex gap-1 px-4 border-b {forceDark ? "border-surface-800" : "border-surface-300-700"}">

--- a/src/AppShell/src/components/MoveElementModal.svelte
+++ b/src/AppShell/src/components/MoveElementModal.svelte
@@ -48,7 +48,7 @@
         <h2 class="text-base font-semibold">Move "{elementKey}"</h2>
 
         <div class="flex flex-col gap-1">
-            <span class="text-xs text-surface-500-400">New parent</span>
+            <span class="text-xs text-surface-600-400">New parent</span>
             <Combobox
                 {options}
                 value={target}

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -148,7 +148,7 @@
     function tabClass(caption: string | null): string {
         return activeTab === caption
             ? "px-3 py-1.5 text-xs whitespace-nowrap transition-colors text-primary-600-400 border-b-2 border-primary-500 font-medium"
-            : "px-3 py-1.5 text-xs whitespace-nowrap transition-colors text-surface-500-400 hover:text-surface-900-100";
+            : "px-3 py-1.5 text-xs whitespace-nowrap transition-colors text-surface-600-400 hover:text-surface-900-100";
     }
 </script>
 
@@ -161,12 +161,12 @@
                 onclick={onback}
             ><ChevronLeft size={16} /> {selectedNode?.text ?? "Properties"}</button>
         {:else}
-            <span class="text-xs font-semibold uppercase text-surface-500-400">Properties</span>
+            <span class="text-xs font-semibold uppercase text-surface-600-400">Properties</span>
         {/if}
     </div>
 
     {#if $selectedKey === null}
-        <p class="px-3 py-4 text-sm text-surface-400-500">Select an object to view its properties.</p>
+        <p class="px-3 py-4 text-sm text-surface-600-400">Select an object to view its properties.</p>
     {:else if $selectedKey === "_advanced"}
         <div class="flex flex-col items-start gap-1.5 px-3 py-3">
             {#each ADVANCED_ADDERS as adder (adder.label)}
@@ -178,7 +178,7 @@
             {/each}
         </div>
     {:else if $selectedData === null}
-        <p class="px-3 py-4 text-sm text-surface-400-500">No properties available.</p>
+        <p class="px-3 py-4 text-sm text-surface-600-400">No properties available.</p>
     {:else}
         {#if $selectedData.tabs.length > 0}
             <div class="flex border-b border-surface-200-800 overflow-x-auto flex-shrink-0">
@@ -229,7 +229,7 @@
                     class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 w-28 justify-start"
                     onclick={(e) => insertTextProcessorText(attribute, controlType, cmd.insertBefore, cmd.insertAfter, e)}
                 >{cmd.command}</button>
-                <span class="text-xs text-surface-400-500 whitespace-nowrap">{cmd.info}</span>
+                <span class="text-xs text-surface-600-400 whitespace-nowrap">{cmd.info}</span>
             </div>
         {/each}
         <a href="https://docs.textadventures.co.uk/quest/text_processor.html" target="_blank" class="text-xs text-primary-500 underline mt-1">Text Processor help</a>
@@ -330,7 +330,7 @@
             {#each items as item (item.key)}
                 {@const isEditing = editingItem?.attribute === dk && editingItem?.key === item.key}
                 <div class="flex items-center gap-1">
-                    <span class="text-xs text-surface-500-400 w-24 flex-shrink-0 truncate" title={item.key}>{item.key}</span>
+                    <span class="text-xs text-surface-600-400 w-24 flex-shrink-0 truncate" title={item.key}>{item.key}</span>
                     {#if isEditing}
                         <input
                             type="text"
@@ -534,7 +534,7 @@
                 {attrValue(ctrl.attribute!)}
             </span>
         {:else}
-            <em class="text-xs text-surface-400-500">null</em>
+            <em class="text-xs text-surface-600-400">null</em>
         {/if}
     {/if}
 {/snippet}
@@ -542,7 +542,7 @@
 {#snippet advancedExpander(controls: ControlInfo[])}
     {#if controls.length > 0}
         <details class="mt-2 border-t border-surface-200-800">
-            <summary class="px-3 pt-2.5 pb-1.5 text-xs font-semibold uppercase text-surface-500-400 cursor-pointer select-none">
+            <summary class="px-3 pt-2.5 pb-1.5 text-xs font-semibold uppercase text-surface-600-400 cursor-pointer select-none">
                 Advanced
             </summary>
             {#each controls as ctrl, i (i)}
@@ -556,11 +556,11 @@
     {#if ctrl.controlType === "attributes"}
         <AttributesEditor />
     {:else if ctrl.controlType === "title"}
-        <div class="px-3 pt-3 pb-1 text-xs font-semibold text-surface-500-400 uppercase tracking-wide">
+        <div class="px-3 pt-3 pb-1 text-xs font-semibold text-surface-600-400 uppercase tracking-wide">
             {ctrl.caption ?? ""}
         </div>
     {:else if ctrl.controlType === "label"}
-        <div class="px-3 py-1 text-xs text-surface-500-400 italic">
+        <div class="px-3 py-1 text-xs text-surface-600-400 italic">
             {ctrl.caption ?? ""}
         </div>
     {:else if ctrl.controlType === "elementslist" && $selectedKey}

--- a/src/AppShell/src/components/PublishModal.svelte
+++ b/src/AppShell/src/components/PublishModal.svelte
@@ -46,7 +46,7 @@
             <button class="btn btn-sm preset-tonal" onclick={oncancel}>Close</button>
         </div>
 
-        <p class="text-sm text-surface-500-400">
+        <p class="text-sm text-surface-600-400">
             {#if $canPublishToServer}
                 Builds a <code>.quest</code> package (game file plus assets) and submits it to
                 textadventures.co.uk, where you'll fill in title, description, category and visibility.

--- a/src/AppShell/src/components/ScriptDictionaryEditor.svelte
+++ b/src/AppShell/src/components/ScriptDictionaryEditor.svelte
@@ -55,7 +55,7 @@
 
 <div class="flex flex-col gap-1 w-full">
     {#if isLocked}
-        <div class="flex items-center gap-2 py-1 px-2 mb-1 text-xs text-surface-400-500 italic border border-surface-200-800 rounded">
+        <div class="flex items-center gap-2 py-1 px-2 mb-1 text-xs text-surface-600-400 italic border border-surface-200-800 rounded">
             <span class="flex-1">This script dictionary is inherited — read-only.</span>
             <button
                 type="button"
@@ -66,7 +66,7 @@
     {/if}
     {#if isLocked}
         {#each items as item (item.key)}
-            <div class="border border-surface-200-800 rounded px-2 py-1 text-xs text-surface-400-500 opacity-60"><span class="font-medium">{item.key}</span> = <span class="italic">{item.value || "(empty)"}</span></div>
+            <div class="border border-surface-200-800 rounded px-2 py-1 text-xs text-surface-600-400 opacity-60"><span class="font-medium">{item.key}</span> = <span class="italic">{item.value || "(empty)"}</span></div>
         {/each}
     {:else}
         {#each keys as key (key)}
@@ -77,7 +77,7 @@
                         class="flex-1 text-left text-xs font-medium hover:text-primary-600-400"
                         onclick={() => toggleExpanded(key)}
                     >
-                        <span class="mr-1 text-surface-400-500">{expandedKeys.has(key) ? "▼" : "▶"}</span>{key}
+                        <span class="mr-1 text-surface-600-400">{expandedKeys.has(key) ? "▼" : "▶"}</span>{key}
                     </button>
                     <button
                         type="button"

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -354,7 +354,7 @@
 
 <div class={indentClass}>
     {#if isRoot && isLocked}
-        <div class="flex items-center gap-2 py-1 px-2 mb-1 text-xs text-surface-400-500 italic border border-surface-200-800 rounded">
+        <div class="flex items-center gap-2 py-1 px-2 mb-1 text-xs text-surface-600-400 italic border border-surface-200-800 rounded">
             <span class="flex-1">This script is inherited — read-only.</span>
             <button
                 type="button"
@@ -464,7 +464,7 @@
                             onclick={onMoveDownSelected}
                         >↓ Move down</button>
                     {/if}
-                    <span class="ml-auto pl-2 flex-shrink-0 text-surface-400-500">{sel.length} selected</span>
+                    <span class="ml-auto pl-2 flex-shrink-0 text-surface-600-400">{sel.length} selected</span>
                 </div>
             {/if}
         </div>
@@ -480,7 +480,7 @@
                     onclick={() => (showAddModal = true)}
                 >+ Add script</button>
             {:else if !codeViewMode && isRoot}
-                <span class="text-xs text-surface-400-500 italic">Loading commands…</span>
+                <span class="text-xs text-surface-600-400 italic">Loading commands…</span>
             {/if}
             {#if isRoot && $scriptClipboardHasContent && !codeViewMode}
                 <button
@@ -523,7 +523,7 @@
         <!-- Nested script block for commands like for/while/foreach/firsttime -->
         <div class="w-full mt-0.5">
             {#if ctrl.caption}
-                <span class="text-surface-500-400 text-xs italic">{ctrl.caption}:</span>
+                <span class="text-surface-600-400 text-xs italic">{ctrl.caption}:</span>
             {/if}
             <ScriptEditor
                 {elementKey}
@@ -670,7 +670,7 @@
             {/each}
         </select>
     {:else}
-        <span class="text-surface-400-500 italic text-xs">[{ctrl.controlType}]</span>
+        <span class="text-surface-600-400 italic text-xs">[{ctrl.controlType}]</span>
     {/if}
 {/snippet}
 

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -289,7 +289,7 @@
         width: 2rem;
         height: 2rem;
         border-radius: var(--radius-container);
-        color: var(--color-surface-500-400);
+        color: var(--color-surface-600-400);
     }
     .toolbar-icon-btn:hover:not(:disabled) {
         background-color: var(--color-surface-200-800);
@@ -336,7 +336,7 @@
         background-color: color-mix(in srgb, var(--color-success-500) 12%, transparent);
     }
     .save-chip-saving {
-        color: var(--color-surface-500-400);
+        color: var(--color-surface-600-400);
     }
     .save-chip-unsaved {
         color: var(--color-warning-600-400);

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -332,7 +332,7 @@
     class="flex flex-col shrink-0 border-r border-surface-200-800 bg-surface-50-950 {width === undefined ? "w-full" : ""}"
     style={width !== undefined ? `width: ${width}px` : undefined}
 >
-    <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-500-400 border-b border-surface-200-800">
+    <div class="px-3 py-2 text-xs font-semibold uppercase text-surface-600-400 border-b border-surface-200-800">
         {$isGamebook ? "Game Pages" : "Game Objects"}
     </div>
     <div class="p-1.5 border-b border-surface-200-800 relative">

--- a/src/AppShell/src/components/VerbsEditor.svelte
+++ b/src/AppShell/src/components/VerbsEditor.svelte
@@ -167,12 +167,12 @@
          content instead, scrolling with the rest of the tab if the list ever gets long. -->
     <div class="flex flex-col flex-1 min-w-0">
         <div class="px-3 py-1.5 border-b border-surface-100-900">
-            <span class="font-semibold text-surface-500-400 uppercase tracking-wide">Verbs</span>
+            <span class="font-semibold text-surface-600-400 uppercase tracking-wide">Verbs</span>
         </div>
         <div>
             <table class="w-full">
                 <thead class="sticky top-0 bg-surface-50-950 z-10">
-                    <tr class="text-surface-400-500 border-b border-surface-200-800">
+                    <tr class="text-surface-600-400 border-b border-surface-200-800">
                         <th class="text-left py-1 px-3 font-medium">Verb</th>
                         <th class="text-left py-1 px-3 font-medium">Behaviour</th>
                         <th class="w-6"></th>
@@ -188,7 +188,7 @@
                             onclick={() => onSelectVerb(attr)}
                         >
                             <td class="py-0.5 px-3 font-medium truncate max-w-36" title={display}>{display}</td>
-                            <td class="py-0.5 px-3 text-surface-400-500">
+                            <td class="py-0.5 px-3 text-surface-600-400">
                                 {TYPE_OPTIONS.find(t => t.value === attr.type)?.label ?? attr.type}
                             </td>
                             <td class="py-0.5 pr-2 text-right">
@@ -201,7 +201,7 @@
                             </td>
                         </tr>
                     {:else}
-                        <tr><td colspan="3" class="py-2 px-3 text-surface-400-500 italic">No verbs added yet</td></tr>
+                        <tr><td colspan="3" class="py-2 px-3 text-surface-600-400 italic">No verbs added yet</td></tr>
                     {/each}
                 </tbody>
             </table>
@@ -243,12 +243,12 @@
         class="w-full @2xl:w-[var(--panel-width)] @2xl:flex-shrink-0 flex flex-col overflow-hidden border-l border-surface-200-800"
         style="--panel-width: {panelWidth}px"
     >
-        <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-500-400 uppercase tracking-wide flex-shrink-0 flex items-center justify-between">
+        <div class="px-3 py-1.5 border-b border-surface-100-900 font-semibold text-surface-600-400 uppercase tracking-wide flex-shrink-0 flex items-center justify-between">
             <span>Behaviour</span>
             {#if selectedAttr}
                 <button
                     type="button"
-                    class="normal-case text-surface-400-500 hover:text-surface-900-50"
+                    class="normal-case text-surface-600-400 hover:text-surface-900-50"
                     onclick={() => { selectedAttrName = null; }}
                     title="Close"
                     aria-label="Close"
@@ -263,7 +263,7 @@
                 </div>
 
                 <div class="flex flex-col gap-1 flex-shrink-0">
-                    <span class="text-surface-400-500 uppercase tracking-wide text-xs">Type</span>
+                    <span class="text-surface-600-400 uppercase tracking-wide text-xs">Type</span>
                     <select
                         class="select text-xs py-0 px-1.5 h-7"
                         value={attr.type}
@@ -276,7 +276,7 @@
                 </div>
 
                 <div class="flex flex-col gap-1">
-                    <span class="text-surface-400-500 uppercase tracking-wide text-xs flex-shrink-0">Value</span>
+                    <span class="text-surface-600-400 uppercase tracking-wide text-xs flex-shrink-0">Value</span>
                     {#if attr.type === "script"}
                         <div class="min-h-48">
                             <ScriptEditor elementKey={elementKey} attribute={attr.name} />
@@ -297,7 +297,7 @@
                 </div>
             </div>
         {:else}
-            <p class="p-3 text-surface-400-500 italic">Select a verb to edit its behaviour.</p>
+            <p class="p-3 text-surface-600-400 italic">Select a verb to edit its behaviour.</p>
         {/if}
     </div>
 </div>

--- a/src/AppShell/src/lib/codemirror-theme.ts
+++ b/src/AppShell/src/lib/codemirror-theme.ts
@@ -32,16 +32,16 @@ export const questEditorTheme = EditorView.theme({
         backgroundColor: "color-mix(in srgb, var(--color-primary-500) 25%, transparent)",
     },
     ".cm-activeLine": {
-        backgroundColor: "color-mix(in srgb, var(--color-surface-500-400) 10%, transparent)",
+        backgroundColor: "color-mix(in srgb, var(--color-surface-600-400) 10%, transparent)",
     },
     ".cm-gutters": {
         backgroundColor: "var(--color-surface-50-950)",
-        color: "var(--color-surface-500-400)",
+        color: "var(--color-surface-600-400)",
         border: "none",
         borderRight: "1px solid var(--color-surface-200-800)",
     },
     ".cm-activeLineGutter": {
-        backgroundColor: "color-mix(in srgb, var(--color-surface-500-400) 10%, transparent)",
+        backgroundColor: "color-mix(in srgb, var(--color-surface-600-400) 10%, transparent)",
     },
     ".cm-matchingBracket, .cm-nonmatchingBracket": {
         backgroundColor: "color-mix(in srgb, var(--color-primary-500) 20%, transparent)",
@@ -52,10 +52,10 @@ export const questEditorTheme = EditorView.theme({
 export const questHighlightStyle = HighlightStyle.define([
     { tag: t.keyword, color: "var(--color-primary-500)", fontWeight: "bold" },
     { tag: [t.string, t.attributeValue], color: "var(--color-success-600-400)" },
-    { tag: t.comment, color: "var(--color-surface-500-400)", fontStyle: "italic" },
+    { tag: t.comment, color: "var(--color-surface-600-400)", fontStyle: "italic" },
     { tag: t.number, color: "var(--color-tertiary-500)" },
     { tag: [t.tagName, t.attributeName], color: "var(--color-primary-500)" },
-    { tag: [t.bracket, t.paren, t.squareBracket, t.brace], color: "var(--color-surface-500-400)" },
+    { tag: [t.bracket, t.paren, t.squareBracket, t.brace], color: "var(--color-surface-600-400)" },
 ]);
 
 export const questEditorExtensions = [questEditorTheme, syntaxHighlighting(questHighlightStyle)];

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -138,7 +138,7 @@
 {:else if $loadingStatus}
     <main class="flex flex-col items-center justify-center min-h-svh gap-6 p-8">
         <div class="size-10 rounded-full border-4 border-surface-300-700 border-t-primary-500 animate-spin"></div>
-        <p class="text-surface-500-400 text-sm">{$loadingStatus}</p>
+        <p class="text-surface-600-400 text-sm">{$loadingStatus}</p>
     </main>
 {:else if $isLoaded}
     <div class="flex flex-col h-dvh overflow-hidden safe-area-inset">

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -435,10 +435,10 @@
     {#if loading}
         <div class="flex flex-col items-center gap-3">
             <div class="size-10 rounded-full border-4 border-surface-300-700 border-t-primary-500 animate-spin"></div>
-            <p class="text-surface-500-400 text-sm">{$loadingStatus}</p>
+            <p class="text-surface-600-400 text-sm">{$loadingStatus}</p>
         </div>
     {:else if pendingFiles.length > 0}
-        <p class="text-surface-500-400">Multiple game files found — choose one to open:</p>
+        <p class="text-surface-600-400">Multiple game files found — choose one to open:</p>
         <div class="flex flex-col gap-2 w-full max-w-sm">
             {#each pendingFiles as file (file)}
                 <button
@@ -458,7 +458,7 @@
 
             {#if !hasServer}
                 <!-- Open existing game -->
-                <p class="text-surface-500-400 text-sm font-medium self-start">Open existing game</p>
+                <p class="text-surface-600-400 text-sm font-medium self-start">Open existing game</p>
 
                 {#if isElectronApp}
                     <button type="button" class="btn preset-filled-primary-500 w-full" onclick={handleOpenFolder}>
@@ -504,7 +504,7 @@
 
                 {#if isElectronApp && recentGames.length > 0}
                     <hr class="w-full border-surface-300-700 my-2" />
-                    <p class="text-surface-500-400 text-sm font-medium self-start">Recent</p>
+                    <p class="text-surface-600-400 text-sm font-medium self-start">Recent</p>
                     <div class="flex flex-col gap-2 w-full">
                         {#each recentGames as game (game.dirPath + "/" + game.filename)}
                             <div class="flex items-center gap-2 w-full">
@@ -514,7 +514,7 @@
                                     onclick={() => loadFromElectron(game.dirPath, game.filename)}
                                 >
                                     <span class="w-full truncate text-left">{game.filename}</span>
-                                    <span class="w-full truncate text-left text-surface-500-400 text-xs">{folderName(game.dirPath)} · {relativeTime(game.lastOpened)}</span>
+                                    <span class="w-full truncate text-left text-surface-600-400 text-xs">{folderName(game.dirPath)} · {relativeTime(game.lastOpened)}</span>
                                 </button>
                                 <button
                                     type="button"
@@ -529,7 +529,7 @@
 
                 {#if !isElectronApp && drafts.length > 0}
                     <hr class="w-full border-surface-300-700 my-2" />
-                    <p class="text-surface-500-400 text-sm font-medium self-start">Your local drafts</p>
+                    <p class="text-surface-600-400 text-sm font-medium self-start">Your local drafts</p>
                     <div class="flex flex-col gap-2 w-full">
                         {#each drafts as draft (draft.gameId)}
                             <div class="flex items-center gap-2 w-full">
@@ -539,7 +539,7 @@
                                     onclick={() => handleOpenDraft(draft.gameId)}
                                 >
                                     <span>{draft.filename}</span>
-                                    <span class="text-surface-500-400">{relativeTime(draft.lastModified)}</span>
+                                    <span class="text-surface-600-400">{relativeTime(draft.lastModified)}</span>
                                 </button>
                                 <button
                                     type="button"
@@ -551,7 +551,7 @@
                         {/each}
                     </div>
                     {#if isSafari}
-                        <p class="text-xs text-surface-500-400 max-w-[40ch] text-center">
+                        <p class="text-xs text-surface-600-400 max-w-[40ch] text-center">
                             Safari may clear local drafts if you don't open this site for a week or more —
                             export a backup of anything important.
                         </p>
@@ -562,7 +562,7 @@
             {/if}
 
             <!-- Create new game -->
-            <p class="text-surface-500-400 text-sm font-medium self-start">Create new game</p>
+            <p class="text-surface-600-400 text-sm font-medium self-start">Create new game</p>
 
             {#if templatesError}
                 <p class="text-error-500 text-sm">{templatesError}</p>
@@ -580,13 +580,13 @@
                     />
 
                     {#if templatesLoading}
-                        <div class="flex items-center gap-2 text-surface-500-400 text-sm">
+                        <div class="flex items-center gap-2 text-surface-600-400 text-sm">
                             <div class="size-4 rounded-full border-2 border-surface-300-700 border-t-primary-500 animate-spin"></div>
                             Loading templates...
                         </div>
                     {:else if templates.length > 0}
                         <div class="flex flex-col gap-1">
-                            <p class="text-sm text-surface-500-400">Game type</p>
+                            <p class="text-sm text-surface-600-400">Game type</p>
                             <div class="flex gap-4">
                                 {#each [{ value: "textadventure", label: "Text adventure" }, { value: "gamebook", label: "Gamebook" }] as type (type.value)}
                                     <label class="flex items-center gap-2 cursor-pointer">
@@ -624,7 +624,7 @@
                     {#if creating}
                         <div class="flex items-center gap-3">
                             <div class="size-5 rounded-full border-2 border-surface-300-700 border-t-primary-500 animate-spin"></div>
-                            <span class="text-surface-500-400 text-sm">{$loadingStatus || "Creating..."}</span>
+                            <span class="text-surface-600-400 text-sm">{$loadingStatus || "Creating..."}</span>
                         </div>
                     {:else}
                         <div class="flex gap-2">
@@ -639,7 +639,7 @@
                                     >
                                         Save to server
                                     </button>
-                                    <p class="text-xs text-surface-500-400 text-center">Saved to your textadventures.co.uk account</p>
+                                    <p class="text-xs text-surface-600-400 text-center">Saved to your textadventures.co.uk account</p>
                                 </div>
                             {:else}
                                 <div class="flex flex-col gap-1 flex-1">
@@ -653,7 +653,7 @@
                                         {isElectronApp ? "Create" : "Create local draft"}
                                     </button>
                                     {#if !isElectronApp}
-                                        <p class="text-xs text-surface-500-400 text-center">Stored in this browser only</p>
+                                        <p class="text-xs text-surface-600-400 text-center">Stored in this browser only</p>
                                     {/if}
                                 </div>
                                 {#if canUseFSA}
@@ -667,14 +667,14 @@
                                         >
                                             Save to folder…
                                         </button>
-                                        <p class="text-xs text-surface-500-400 text-center">You'll choose a folder on this device</p>
+                                        <p class="text-xs text-surface-600-400 text-center">You'll choose a folder on this device</p>
                                     </div>
                                 {/if}
                             {/if}
                         </div>
 
                         {#if isElectron()}
-                            <p class="text-xs text-surface-500-400 text-center self-center">
+                            <p class="text-xs text-surface-600-400 text-center self-center">
                                 Will be created as a new folder in:<br />
                                 <span class="font-mono">{electronGamesDir || "…"}</span>
                                 <button type="button" class="anchor" onclick={handleChangeLocation}>Change location…</button>
@@ -682,7 +682,7 @@
                         {/if}
 
                         {#if hasServer}
-                            <p class="text-xs text-surface-500-400 max-w-[40ch] text-center self-center">
+                            <p class="text-xs text-surface-600-400 max-w-[40ch] text-center self-center">
                                 Want to keep this game only on your own device? Use the
                                 <a class="anchor" href="https://play.questviva.com/open">play.questviva.com editor</a> instead.
                             </p>

--- a/tests/e2e/verify-appshell-surface-shade-fix.mjs
+++ b/tests/e2e/verify-appshell-surface-shade-fix.mjs
@@ -1,0 +1,79 @@
+// Verifies that the previously-broken `text-surface-400-500` /
+// `text-surface-500-400` utilities (not in Skeleton's generated dual-tone
+// shade-pair set: 50-950, 100-900, 200-800, 300-700, 400-600, 600-400,
+// 700-300, 900-100, 950-50) were replaced with the valid `text-surface-600-400`
+// pair everywhere in src/AppShell/src, and that the compiled Tailwind output
+// now contains a real color rule for it (no dead classes).
+//
+// NOTE: this only exercises routes/open/+page.svelte, since the rest of the
+// affected components (TreePanel, AttributesEditor, AddElementModal, etc.)
+// only render once a game is loaded through the WasmEditor .NET/WASM bridge,
+// which requires `dotnet build src/WasmEditor` — unavailable in some sandboxed
+// environments. All affected files use the identical Tailwind utility class,
+// so this route is a reliable proxy for the fix everywhere else.
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+const browser = await chromium.launch({ executablePath: process.env.CHROME_PATH || '/opt/pw-browsers/chromium' });
+
+async function toRgb(page, colorStr) {
+    // Modern browsers may report computed color as oklch(...); normalize via
+    // a canvas round-trip rather than hand-parsing every CSS color syntax.
+    return page.evaluate((str) => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 1;
+        canvas.height = 1;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = str;
+        ctx.fillRect(0, 0, 1, 1);
+        return Array.from(ctx.getImageData(0, 0, 1, 1).data.slice(0, 3));
+    }, colorStr);
+}
+
+try {
+    // 1. Compiled CSS: the valid pair exists, the invalid ones don't.
+    const page0 = await browser.newPage();
+    await page0.goto(`${baseUrl}/open`);
+    await page0.waitForTimeout(1000);
+    const css = await page0.evaluate(() => {
+        let all = '';
+        for (const s of document.styleSheets) {
+            try { for (const r of s.cssRules) all += r.cssText + '\n'; } catch { /* cross-origin sheet */ }
+        }
+        return all;
+    });
+    if (!css.includes('.text-surface-600-400')) throw new Error('Compiled CSS is missing .text-surface-600-400 rule');
+    if (css.includes('.text-surface-400-500') || css.includes('.text-surface-500-400')) {
+        throw new Error('Compiled CSS still contains a dead .text-surface-400-500/500-400 rule');
+    }
+    console.log('PASS: compiled CSS has .text-surface-600-400 and no dead 400-500/500-400 rules');
+    await page0.close();
+
+    // 2. Rendered color in both color schemes: muted grey, not default black/white.
+    for (const scheme of ['light', 'dark']) {
+        const ctx = await browser.newContext({ colorScheme: scheme });
+        const page = await ctx.newPage();
+        await page.goto(`${baseUrl}/open`);
+        const label = page.locator('text=Create new game');
+        await label.waitFor({ timeout: 10000 });
+        const color = await label.evaluate(el => getComputedStyle(el).color);
+        const [r, g, b] = await toRgb(page, color);
+        const isBlack = r === 0 && g === 0 && b === 0;
+        const isWhite = r === 255 && g === 255 && b === 255;
+        // Skeleton's "surface" scale has a faint blue-grey tint by design, so
+        // allow some channel spread rather than requiring pure neutral grey.
+        const isMidToned = Math.max(r, g, b) - Math.min(r, g, b) <= 50 && r > 40 && r < 220;
+        console.log(`  ${scheme}: "Create new game" label color=${color} -> rgb(${r},${g},${b})`);
+        if (isBlack || isWhite) throw new Error(`${scheme} mode: label rendered default ${isBlack ? 'black' : 'white'} — utility still broken`);
+        if (!isMidToned) throw new Error(`${scheme} mode: label rendered unexpected color rgb(${r},${g},${b}) — expected a muted mid-tone grey`);
+        console.log(`PASS: ${scheme} mode renders a muted grey label`);
+        await ctx.close();
+    }
+
+    console.log('\nPASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Skeleton's theme only generates CSS custom properties (and thus utility classes) for a fixed set of dual-tone shade pairs: `50-950`, `100-900`, `200-800`, `300-700`, `400-600`, `600-400`, `700-300`, `900-100`, `950-50`. `400-500` and `500-400` aren't in that set, so every `text-surface-400-500`/`text-surface-500-400` class compiled to nothing and silently fell back to inherited text color instead of a muted grey.
- Replaced all 91 occurrences across 20 files (Svelte class attributes, `codemirror-theme.ts`'s CSS variable references, and `Toolbar.svelte`'s `<style>` block) with the valid `text-surface-600-400` pair, already used successfully elsewhere in the codebase.
- Checked for the same mistake with other color names (`primary`/`secondary`/`tertiary`/`success`/`warning`/`error`) — none found.

## Test plan
- [x] Confirmed via compiled CSS inspection in a running dev server that `.text-surface-600-400` now produces a real `color: light-dark(...)` rule, and that no dead `.text-surface-400-500`/`.text-surface-500-400` rules remain.
- [x] Verified in-browser (light and dark mode) that labels on the `/open` route render a muted grey instead of default black/white text.
- [x] Added `tests/e2e/verify-appshell-surface-shade-fix.mjs` as a checked-in regression script following the existing ad-hoc Playwright convention in `tests/e2e`.
- [ ] Full in-editor components (TreePanel, AttributesEditor, AddElementModal, AssetManagerModal, AddScriptModal) weren't visually re-verified in this environment (no `dotnet` SDK available to build the WasmEditor bridge locally), but use the identical utility class fixed and confirmed above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1pqPA7D7XDMR4m8EHmc2F)_