### PR TITLE
feat(AppShell): add Back/Forward tree navigation history

### DIFF
--- a/src/AppShell/src/app.css
+++ b/src/AppShell/src/app.css
@@ -43,7 +43,7 @@
 [data-scope='tree-view'][data-part='item'],
 [data-scope='tree-view'][data-part='branch-control'] {
     padding-inline-end: 0;
-    padding-block: calc(var(--spacing) * 1);
+    padding-block: calc(var(--spacing) * 0.5);
     cursor: pointer;
 }
 

--- a/src/AppShell/src/components/PreviewBanner.svelte
+++ b/src/AppShell/src/components/PreviewBanner.svelte
@@ -1,6 +1,0 @@
-<div class="flex items-center gap-3 px-4 py-2 bg-warning-100-900 border-b border-warning-300-700 text-sm w-full">
-    <span class="flex-1">
-        Quest Viva's editor is in preview. Some functionality is incomplete. You can use
-        <a class="anchor" href="https://textadventures.co.uk/quest" target="_blank" rel="noopener">Quest 5</a> in the meantime.
-    </span>
-</div>

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -9,6 +9,7 @@
         publishModalOpen,
         previewInWasmPlayer,
         undo, redo, canUndo, canRedo,
+        navigateBack, navigateForward, canGoBack, canGoForward,
         treeNodes, selectedKey, isGamebook, openAddModal,
         createExit, createTurnScript, createCommand, createVerb,
         deleteElement,
@@ -19,6 +20,8 @@
     import { hasActiveCmView, cmUndo, cmRedo } from "$lib/code-editor-registry";
     import type { TreeNode } from "$lib/types";
     import Home from "@lucide/svelte/icons/home";
+    import ArrowLeft from "@lucide/svelte/icons/arrow-left";
+    import ArrowRight from "@lucide/svelte/icons/arrow-right";
     import ImageIcon from "@lucide/svelte/icons/image";
     import Undo2 from "@lucide/svelte/icons/undo-2";
     import Redo2 from "@lucide/svelte/icons/redo-2";
@@ -192,6 +195,22 @@
     <AppBar.Toolbar class="grid-cols-[auto_1fr_auto]">
         <AppBar.Lead class="flex-1 min-w-0">
             <div class="flex items-center min-w-0">
+                {#if $isLoaded}
+                    <button
+                        type="button"
+                        class="toolbar-icon-btn shrink-0"
+                        onclick={() => navigateBack()}
+                        disabled={!$canGoBack}
+                        title="Back"
+                    ><ArrowLeft size={16} /></button>
+                    <button
+                        type="button"
+                        class="toolbar-icon-btn mr-2 shrink-0"
+                        onclick={() => navigateForward()}
+                        disabled={!$canGoForward}
+                        title="Forward"
+                    ><ArrowRight size={16} /></button>
+                {/if}
                 {#if showHome}
                     <button
                         type="button"

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -42,6 +42,39 @@ export const selectedData = writable<EditorDataResponse | null>(null);
 export const fullAttributeData = writable<FullAttributeData | null>(null);
 export const canUndo = writable(false);
 export const canRedo = writable(false);
+// Selection history stack (Back/Forward), independent of Quest's own model undo/redo above —
+// this just remembers which elements you've clicked through in the tree, like browser history.
+let _navHistory: string[] = [];
+let _navIndex = -1;
+let _suppressHistoryPush = false;
+export const canGoBack = writable(false);
+export const canGoForward = writable(false);
+function updateNavFlags() {
+    canGoBack.set(_navIndex > 0);
+    canGoForward.set(_navIndex >= 0 && _navIndex < _navHistory.length - 1);
+}
+// Called once a game (or a freshly reloaded model, see setGameXml) has already selected its
+// root node via selectNode() — collapses whatever that call pushed down to a single starting
+// entry, so Back/Forward don't reach across into the previous game/reload.
+function resetNavHistory(currentKey: string | null) {
+    _navHistory = currentKey ? [currentKey] : [];
+    _navIndex = _navHistory.length - 1;
+    updateNavFlags();
+}
+export async function navigateBack() {
+    if (_navIndex <= 0) return;
+    _navIndex--;
+    _suppressHistoryPush = true;
+    try { await selectNode(_navHistory[_navIndex]); } finally { _suppressHistoryPush = false; }
+    updateNavFlags();
+}
+export async function navigateForward() {
+    if (_navIndex >= _navHistory.length - 1) return;
+    _navIndex++;
+    _suppressHistoryPush = true;
+    try { await selectNode(_navHistory[_navIndex]); } finally { _suppressHistoryPush = false; }
+    updateNavFlags();
+}
 export const isDirty = writable(false);
 // True while a field somewhere in the editor has an in-progress, not-yet-committed
 // edit (set on input, cleared on focusout via a delegated listener in
@@ -121,6 +154,7 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
         await refreshAssets();
         const gameNode = nodes.find(n => n.nodeType === "game");
         if (gameNode) await selectNode(gameNode.key);
+        resetNavHistory(gameNode?.key ?? null);
     }
     return ok;
 }
@@ -156,6 +190,7 @@ export async function setGameXml(xml: string): Promise<string> {
         await refreshAssets();
         const gameNode = nodes.find(n => n.nodeType === "game");
         if (gameNode) await selectNode(gameNode.key);
+        resetNavHistory(gameNode?.key ?? null);
         refreshUndoRedo();
         // SetGameXml() resets the bridge's dirty flag after the reload (matching Initialise()'s
         // own behavior), but the in-memory content now differs from the last persisted save, so
@@ -173,6 +208,13 @@ export async function selectNode(key: string) {
     selectedData.set(json ? JSON.parse(json) : null);
     const attrJson = _bridge.GetFullAttributeData(key);
     fullAttributeData.set(attrJson ? JSON.parse(attrJson) : null);
+
+    if (!_suppressHistoryPush && _navHistory[_navIndex] !== key) {
+        _navHistory = _navHistory.slice(0, _navIndex + 1);
+        _navHistory.push(key);
+        _navIndex = _navHistory.length - 1;
+        updateNavFlags();
+    }
 }
 
 export function toggleShowLibraryElements(): void {
@@ -199,6 +241,9 @@ export function setAttribute(elementKey: string, attribute: string, controlType:
     if (result.startsWith("renamed:")) {
         const newKey = result.slice("renamed:".length);
         selectedKey.set(newKey);
+        // Renaming changes the element's key, not the element — keep Back/Forward pointing at
+        // it rather than leaving stale entries for a key that no longer resolves to anything.
+        _navHistory = _navHistory.map(k => k === elementKey ? newKey : k);
         refreshTree();
         refreshSelectedData();
         refreshUndoRedo();
@@ -1007,6 +1052,12 @@ export function deleteElement(key: string) {
     _bridge.DeleteElement(key);
     selectedKey.set(null);
     selectedData.set(null);
+    // Drop the deleted element from Back/Forward history too — it no longer resolves to
+    // anything, so leaving it in would let navigateBack/Forward select a dead key.
+    const keptBefore = _navHistory.slice(0, _navIndex + 1).filter(k => k !== key).length;
+    _navHistory = _navHistory.filter(k => k !== key);
+    _navIndex = keptBefore - 1;
+    updateNavFlags();
     refreshTree();
     refreshUndoRedo();
 }

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -22,7 +22,6 @@
     } from "$lib/filesystem/local-adapter";
     import type { LocalDraftSummary, ZipEntries } from "$lib/filesystem/local-adapter";
     import { loadWasm } from "$lib/wasm";
-    import PreviewBanner from "$components/PreviewBanner.svelte";
 
     const hasServer = PUBLIC_HAS_SERVER === "true";
 
@@ -426,8 +425,6 @@
 
     const creating = $derived(creatingLocal || creatingServer);
 </script>
-
-<PreviewBanner />
 
 <main class="flex flex-col items-center justify-center min-h-[calc(100svh-var(--home-bar-height,0px))] gap-6 p-8">
     <h1 class="text-3xl font-semibold">Quest Viva Editor</h1>


### PR DESCRIPTION
## Summary
- Add Back/Forward toolbar buttons that retrace previously-selected tree elements, similar to browser history — a nice-to-have carried over from the v5 desktop editor. Implemented as a client-side selection-history stack in `editor-store.ts` (no URL/routing changes), kept in sync across element renames and deletions.
- Remove the "Quest Viva's editor is in preview" yellow banner from the Open/Create screen — the editor is considered stable enough now that this warning is no longer accurate.
- Trim the tree panel's per-row vertical padding (4px → 2px per side) for a slightly more compact view.

## Test plan
- [x] `npx svelte-check` passes with 0 errors
- [x] Manually verified in browser: created a local draft game, selected game → room → player in the tree, confirmed Back/Forward buttons enable/disable correctly and retrace selection in both directions
- [x] Confirmed the yellow preview banner no longer renders on the Open screen
- [x] Confirmed tree rows render with tighter spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)