### PR TITLE
feat(WasmPlayer): responsive, non-modal Debugger dialog that stays in sync while playing

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,12 @@
       "runtimeArgs": ["run", "dev"],
       "cwd": "src/AppShell",
       "port": 5174
+    },
+    {
+      "name": "WasmPlayer",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["src/WasmPlayer/dev-server.mjs"],
+      "port": 5175
     }
   ]
 }

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -154,9 +154,17 @@
 
 /* The resize handle needs to sit above the scrollable panes/table without
    being clipped by their overflow:auto — absolute positioning within the
-   card (position:relative) keeps it reachable regardless of scroll state. */
+   card (position:relative) keeps it reachable regardless of scroll state.
+   container-type/-name turn this into the query container for the
+   list/detail stacking breakpoint further down — the card always fills
+   whatever width the dialog itself currently has (applyDebuggerRect's
+   default, or wherever the user has since dragged the resize handle to —
+   see wireDebuggerMoveResize), so sizing off *this* container tracks the
+   dialog's own resizable width instead of the browser window's. */
 #qv-debugger-card {
     position: relative;
+    container-type: inline-size;
+    container-name: qv-debugger-card;
 }
 
 #qv-debugger-resize-handle {
@@ -222,12 +230,29 @@
 #qv-debugger-detail {
     display: flex;
     flex-direction: column;
+    /* A touch of breathing room from the splitter — #qv-debugger-splitter's
+       negative inline margin (below) pulls its neighbours in to enlarge its
+       grab target, which otherwise left this pane's content (search input,
+       table) hugging the splitter's line with almost no visual gap. */
+    padding-left: 0.5rem;
 }
 
 .qv-debugger-scroll {
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
+    /* The attribute table's colgroup gives Attribute/Value fixed pixel
+       widths (renderDebuggerAttributesDetail in wasm-player.js). Without
+       overflow-x here, a container narrower than those widths combined
+       (routine once the object list eats into a narrow dialog on mobile —
+       see the max-width:767px block below) squeezes the unsized Source
+       column down toward 0 width instead; overflow-wrap:break-word then
+       wraps its text one character per line, which can inflate that cell —
+       and with it the whole row, since row height tracks the tallest cell —
+       to hundreds of pixels for nothing longer than a normal script/value
+       string. Letting the table keep its intended widths and scroll
+       horizontally instead avoids that entirely. */
+    overflow-x: auto;
 }
 
 .qv-debugger-footer {
@@ -235,6 +260,45 @@
     border-top: 1px solid var(--color-surface-300-700);
     padding-top: 0.75rem;
     margin-top: 0.75rem;
+}
+
+/* Below this width, the dialog is too narrow to fit #qv-debugger-list's
+   default 192px alongside a usable detail pane and still leave the
+   attribute table room to breathe (192px list + the table's own
+   100px/140px/100px-min Attribute/Value/Source columns needs ~450px for the
+   panes alone, plus the card's own padding) — stack list-above-detail
+   instead of the side-by-side splitter layout so each gets the dialog's
+   full width. A *container* query against #qv-debugger-card (see its
+   container-type/-name above), not a @media viewport query — the dialog is
+   independently movable/resizable (wireDebuggerMoveResize), so its own
+   current width is what actually determines whether the side-by-side
+   layout still fits, regardless of how wide the browser window is. 640px
+   is comfortably above DEBUGGER_MIN_WIDTH (480px, wasm-player.js) so the
+   dialog's user-resizable floor always gets the stacked layout too. */
+@container qv-debugger-card (max-width: 640px) {
+    #qv-debugger-panes {
+        flex-direction: column;
+    }
+
+    /* Overrides wireDebuggerSplitter's inline width (set once in
+       ensureDebuggerWired, and again on every drag) — !important is the
+       only way to win against an inline style from a plain stylesheet
+       rule. The splitter's horizontal drag no longer applies once the two
+       panes are stacked rather than side-by-side, so it's hidden below. */
+    #qv-debugger-list {
+        width: 100% !important;
+        max-height: 40%;
+        flex-shrink: 0;
+    }
+
+    #qv-debugger-splitter {
+        display: none;
+    }
+
+    #qv-debugger-detail {
+        padding-left: 0;
+        padding-top: 0.75rem;
+    }
 }
 
 /* Left-hand object/walkthrough list — a plain selectable list (block rows
@@ -302,6 +366,17 @@
        against it — top-aligning keeps the attribute name anchored to the
        first line of its value regardless of how many lines it wraps to. */
     vertical-align: top;
+}
+
+/* .qv-debugger-scroll (the table's wrapper) flex-grows to fill whatever
+   vertical space #qv-debugger-detail has, so an object with only one or two
+   attributes leaves a lot of empty space below the last row. Without a
+   per-row boundary that empty space reads as part of the row itself (a
+   single row looking implausibly "tall") rather than as blank area past the
+   end of the table — this border makes clear where each row actually ends. */
+.qv-debugger-table tbody td {
+    padding-block: 0.375rem;
+    border-bottom: 1px solid var(--color-surface-200-800);
 }
 
 /* Column headers weren't visually differentiated from the body rows —

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -117,22 +117,37 @@
 }
 
 /* Debugger — movable and resizable (wireDebuggerMoveResize in wasm-player.js
-   sets explicit left/top/width/height right after every showModal(), before
-   the first paint — see that function's doc comment). margin:0 is required
+   sets explicit left/top/width/height right after every open, before the
+   first paint — see applyDebuggerRect's doc comment). margin:0 is required
    for those inline top/left values to actually take effect: the UA
    stylesheet's default centering for <dialog> relies on auto margins, which
    would otherwise still apply and fight the explicit position. No
    max-width/fixed width here at all — every dimension is JS-driven, with
-   sensible defaults computed on first open. */
+   sensible defaults computed on first open.
+
+   Non-modal (see wireDebuggerButton's doc comment) — a *modal* dialog is
+   promoted to the top layer and given `position:fixed` by the UA stylesheet
+   for free, so neither of those was needed while this used showModal().
+   Without that promotion, position defaults back to the UA stylesheet's
+   plain `absolute` (our JS-set left/top would drift with the page instead
+   of staying viewport-relative) and stacking falls back to normal DOM/z-index
+   order, which would put it *underneath* the shared game chrome's #sidebar
+   (playercore.css, z-index:1000) and #qv-status (z-index:100) rather than
+   above them. Both set explicitly here instead.
+
+   border + box-shadow: non-modal means no ::backdrop dimming the page
+   behind it (see wireDebuggerButton's doc comment — it's never left open
+   long enough to actually render one anyway), so without its own edge the
+   dialog had nothing visually separating it from the live game content
+   it now floats over while the player keeps playing. */
 :scope#questVivaDebugger {
-    border: none;
+    border: 1px solid var(--color-surface-300-700);
     border-radius: 0.75rem;
     padding: 0;
     margin: 0;
-}
-
-:scope#questVivaDebugger::backdrop {
-    background: rgb(0 0 0 / 0.5);
+    position: fixed;
+    z-index: 1500;
+    box-shadow: var(--shadow-xl, 0 20px 25px -5px rgb(0 0 0 / 0.15), 0 8px 10px -6px rgb(0 0 0 / 0.15));
 }
 
 #qv-debugger-titlebar {

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -836,11 +836,32 @@ const DEBUGGER_MIN_HEIGHT = 360;
 const DEBUGGER_MIN_LIST_WIDTH = 100;
 const DEBUGGER_MIN_DETAIL_WIDTH = 200;
 const DEBUGGER_MIN_COLUMN_WIDTH = 60;
+// Source (the unsized, "whatever's left" column — see renderDebuggerAttributesDetail)
+// has no floor of its own otherwise: table-layout:fixed hands it literally
+// whatever pixels remain after Attribute/Value, which on a narrow dialog can
+// be smaller than common Source values like "defaultobject" need to render
+// on one line. overflow-wrap:break-word then wraps that single word
+// character-by-character, inflating the *whole row* (row height tracks its
+// tallest cell) — worse the narrower the leftover gets, all the way down to
+// a one-row table filling hundreds of pixels at the extreme. Below, this
+// becomes a min-width on the table itself so the table can never be
+// squeezed narrower than Attribute+Value+this — .qv-debugger-scroll's
+// overflow-x:auto (chrome.css) then takes over with a horizontal scrollbar
+// instead, which is a far smaller UX cost than every row ballooning.
+const DEBUGGER_MIN_SOURCE_WIDTH = 100;
 
 // null until the first time the dialog is ever opened — see applyDebuggerRect.
 let debuggerRect = null;
 let debuggerListWidth = 192; // matches the old w-48 (12rem) Tailwind default
-let debuggerColWidths = { attribute: 160, value: 260 }; // 'source' just takes whatever's left
+// Narrower starting point on a phone-width viewport (chrome.css's
+// max-width:767px breakpoint stacks the list above the table instead of
+// beside it, but even the full dialog width rarely clears 160+260=420px) —
+// still just a default the user can widen via the column-resize handles
+// (wireDebuggerColumnResize), and still small enough to require scrolling
+// for a long Value, but sized so a typical short one doesn't need it.
+let debuggerColWidths = window.innerWidth < 767
+    ? { attribute: 100, value: 140 }
+    : { attribute: 160, value: 260 }; // 'source' just takes whatever's left
 
 // Generic pointer-drag helper — used by the title bar, resize handle,
 // splitter, and column-resize handles below. onMove receives the raw
@@ -882,14 +903,44 @@ function applyDebuggerRect() {
     const dlg = document.getElementById('questVivaDebugger');
     if (!dlg) return;
 
+    // Available space after the same 40px (20px/side) margin the default
+    // sizing below already budgets for. On a narrow phone viewport this can
+    // be smaller than DEBUGGER_MIN_WIDTH/HEIGHT — clamp()'s min always wins
+    // over a smaller max, so without this the dialog would still be forced
+    // to the 480x360 floor, end up wider/taller than the viewport, and (via
+    // the centering below) get a negative left/top that pushes it off to one
+    // side instead of actually centering it.
+    const maxAvailableWidth = window.innerWidth - 40;
+    const maxAvailableHeight = window.innerHeight - 40;
+
     if (!debuggerRect) {
-        const width = clamp(Math.round(window.innerWidth * DEBUGGER_DEFAULT_SIZE_FRACTION), DEBUGGER_MIN_WIDTH, Math.min(DEBUGGER_MAX_DEFAULT_WIDTH, window.innerWidth - 40));
-        const height = clamp(Math.round(window.innerHeight * DEBUGGER_DEFAULT_SIZE_FRACTION), DEBUGGER_MIN_HEIGHT, Math.min(DEBUGGER_MAX_DEFAULT_HEIGHT, window.innerHeight - 40));
+        const width = maxAvailableWidth < DEBUGGER_MIN_WIDTH
+            ? maxAvailableWidth
+            : clamp(Math.round(window.innerWidth * DEBUGGER_DEFAULT_SIZE_FRACTION), DEBUGGER_MIN_WIDTH, Math.min(DEBUGGER_MAX_DEFAULT_WIDTH, maxAvailableWidth));
+        const height = maxAvailableHeight < DEBUGGER_MIN_HEIGHT
+            ? maxAvailableHeight
+            : clamp(Math.round(window.innerHeight * DEBUGGER_DEFAULT_SIZE_FRACTION), DEBUGGER_MIN_HEIGHT, Math.min(DEBUGGER_MAX_DEFAULT_HEIGHT, maxAvailableHeight));
         debuggerRect = {
             left: Math.round((window.innerWidth - width) / 2),
             top: Math.round((window.innerHeight - height) / 2),
             width,
             height,
+        };
+    } else {
+        // Re-clamp whatever geometry the user last left it at (dragged,
+        // resized, or just the computed default above) to the *current*
+        // viewport. debuggerRect is session-only state that otherwise only
+        // changes from explicit drags (wireDebuggerMoveResize/wireDebuggerSplitter),
+        // so reopening after a resize/orientation change would otherwise
+        // keep reapplying a stale rect sized for the old viewport and could
+        // end up partly or fully off-screen.
+        const width = Math.min(debuggerRect.width, maxAvailableWidth);
+        const height = Math.min(debuggerRect.height, maxAvailableHeight);
+        debuggerRect = {
+            width,
+            height,
+            left: clamp(debuggerRect.left, 0, Math.max(0, window.innerWidth - width)),
+            top: clamp(debuggerRect.top, 0, Math.max(0, window.innerHeight - height)),
         };
     }
 
@@ -977,6 +1028,12 @@ function wireDebuggerColumnResize(startEvent) {
         const width = Math.max(DEBUGGER_MIN_COLUMN_WIDTH, startWidth + (moveEvent.clientX - startX));
         debuggerColWidths = { ...debuggerColWidths, [key]: width };
         col.style.width = `${width}px`;
+        // Keep the table's own min-width (set in renderDebuggerAttributesDetail)
+        // in sync — otherwise widening Attribute/Value here just shrinks
+        // Source's leftover share instead of actually growing the table,
+        // reintroducing the cramped-Source wrapping this min-width exists
+        // to prevent (see DEBUGGER_MIN_SOURCE_WIDTH's doc comment).
+        table.style.minWidth = `${debuggerColWidths.attribute + debuggerColWidths.value + DEBUGGER_MIN_SOURCE_WIDTH}px`;
     }, () => handle.classList.remove('qv-debugger-dragging'));
 
     return true;
@@ -1130,7 +1187,7 @@ function renderDebuggerAttributesDetail(tab, obj) {
     // wireDebuggerSplitter uses for the two-pane list/detail split.
     detail.innerHTML = `<input type="text" class="qv-debugger-input mb-2" id="qv-debugger-attr-search" placeholder="Search attributes…" autocomplete="off" value="${_esc(debuggerAttrSearch)}">`
         + '<div class="qv-debugger-scroll">'
-        + '<table class="table qv-debugger-table">'
+        + `<table class="table qv-debugger-table" style="min-width:${debuggerColWidths.attribute + debuggerColWidths.value + DEBUGGER_MIN_SOURCE_WIDTH}px">`
         + `<colgroup><col data-col="attribute" style="width:${debuggerColWidths.attribute}px">`
         + `<col data-col="value" style="width:${debuggerColWidths.value}px"><col data-col="source"></colgroup>`
         + '<thead><tr>'
@@ -1288,6 +1345,15 @@ function ensureDebuggerWired() {
     wireDebuggerMoveResize();
     wireDebuggerSplitter();
     document.getElementById('qv-debugger-detail').addEventListener('pointerdown', wireDebuggerColumnResize);
+
+    // Keep the dialog on-screen through a live resize/orientation change
+    // (e.g. rotating a phone) too, not just the next reopen — applyDebuggerRect
+    // re-clamps debuggerRect to whatever the viewport is now. Only while the
+    // dialog is actually open; otherwise this would silently reset a resized
+    // dialog's geometry every time the window resizes for an unrelated reason.
+    window.addEventListener('resize', () => {
+        if (dlg.open) applyDebuggerRect();
+    });
 
     document.getElementById('qv-debugger-tabs').addEventListener('click', (e) => {
         const btn = e.target.closest('[data-tab]');

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -211,6 +211,7 @@ window.WebPlayer = {
         const metadataJson = metadata ? JSON.stringify(metadata) : null;
         await Bridge.SendCommand(command, tickCount, metadataJson);
         canSendCommand = true;
+        refreshDebuggerAfterTurn();
     },
 
     async uiChoice(choice) { await Bridge.SetMenuResponse(choice); },
@@ -223,6 +224,7 @@ window.WebPlayer = {
     async uiSendEvent(eventName, param) {
         await Bridge.SendEvent(eventName, param);
         canSendCommand = true;
+        refreshDebuggerAfterTurn();
     },
 
     async uiSaveGame(html) {
@@ -1059,6 +1061,9 @@ function renderDebuggerTabs(types) {
     ).join('');
 }
 
+// Returns the rendered items — refreshDebuggerAfterTurn uses this to notice
+// when a turn has made the currently-selected item (an object that got
+// destroyed, a timer that finished, ...) disappear from its own list.
 function renderDebuggerList() {
     const list = document.getElementById('qv-debugger-list');
     const items = debuggerActiveTab === 'Walkthrough'
@@ -1067,7 +1072,7 @@ function renderDebuggerList() {
 
     if (!items.length) {
         list.innerHTML = '<li class="text-sm text-surface-500 px-2 py-1">Nothing here.</li>';
-        return;
+        return items;
     }
 
     // A plain selectable list, not hyperlinks — .qv-debugger-list-item is a
@@ -1077,6 +1082,7 @@ function renderDebuggerList() {
         const selected = item === debuggerSelectedItem;
         return `<li><button type="button" class="qv-debugger-list-item${selected ? ' qv-debugger-row-selected' : ''}" data-item="${_esc(item)}" aria-selected="${selected}">${_esc(item)}</button></li>`;
     }).join('');
+    return items;
 }
 
 function renderDebuggerWalkthroughDetail(name) {
@@ -1263,6 +1269,30 @@ function renderDebuggerDetail() {
     }
 }
 
+// Called after every turn (WebPlayer.sendCommand/uiSendEvent below) now that
+// the dialog is non-modal and can be left open while playing (see
+// wireDebuggerButton's doc comment) — without this, it only ever reflected
+// whatever the game's state was at the moment an object/tab was last
+// clicked, which used to be the *only* moment it could possibly go stale
+// (nothing else could run a turn while a modal dialog had the page inert).
+function refreshDebuggerAfterTurn() {
+    const dlg = document.getElementById('questVivaDebugger');
+    if (!dlg || !dlg.open) return;
+
+    // Re-list first, not just the selected item's own attributes — a turn
+    // can create/destroy objects, open new exits, add/remove timers, etc.
+    renderDebuggerTabs(JSON.parse(Bridge.GetDebuggerObjectTypesJson()));
+    const items = renderDebuggerList();
+    // The very thing being inspected can itself be the casualty of a turn
+    // (the object got destroyed, moved out of scope, or a timer fired and
+    // removed itself) — fall back to the placeholder instead of asking
+    // Bridge for debug data on something that may no longer exist.
+    if (debuggerSelectedItem && !items.includes(debuggerSelectedItem)) {
+        debuggerSelectedItem = null;
+    }
+    withPreservedDebuggerScroll(renderDebuggerDetail);
+}
+
 function selectDebuggerTab(tab) {
     debuggerActiveTab = tab;
     // Same reasoning as wireDebuggerButton's reopen handling: switching back
@@ -1334,6 +1364,18 @@ function ensureDebuggerWired() {
     if (!dlg) return;
 
     document.getElementById('qv-debugger-close').addEventListener('click', () => dlg.close());
+
+    // A *modal* dialog gets Escape-to-close for free (the browser fires a
+    // native 'cancel' event); a non-modal one — which this now always is,
+    // see wireDebuggerButton's doc comment — doesn't. Scoped to the dialog
+    // itself (not a document-level listener) so it only fires while focus is
+    // actually inside it, matching the native behavior it's standing in for
+    // and leaving Escape free to do whatever it already does elsewhere
+    // (e.g. _waitMode's body-level handler in playercore.js) the rest of the
+    // time.
+    dlg.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') dlg.close();
+    });
 
     // Only needs setting once — #qv-debugger-list itself is never rebuilt
     // (only its innerHTML, by renderDebuggerList), so this inline width
@@ -1426,6 +1468,23 @@ function wireDebuggerButton() {
     const cmdDebug = document.getElementById('cmdDebug');
     if (!cmdDebug) return;
     cmdDebug.addEventListener('click', () => {
+        // playercore.js's own click listener (registered first — see this
+        // function's doc comment — and shared with WebPlayer, whose separate
+        // Blazor Debugger.razor still wants the native modal behavior it
+        // gives) has already opened this as a *modal* dialog by the time
+        // this listener runs. Reopen it non-modally instead of touching that
+        // shared file: unlike WebPlayer's dialog, this one is resizable and
+        // movable (wireDebuggerMoveResize) rather than a fixed centered
+        // overlay, so keeping it modal only got in the way of the thing a
+        // dev tool window is actually for — leaving it open while still
+        // playing (refreshDebuggerAfterTurn keeps it in sync as turns
+        // happen). close()+show() in the same synchronous click handler,
+        // before the browser gets a chance to paint the modal state — same
+        // reasoning as applyDebuggerRect's doc comment — so there's no
+        // visible flash of the modal backdrop.
+        const dlg = document.getElementById('questVivaDebugger');
+        dlg.close();
+        dlg.show();
         ensureDebuggerWired();
         applyDebuggerRect();
         debuggerActiveTab = 'Walkthrough';


### PR DESCRIPTION
## Summary
- Fixes the Debugger dialog overflowing/landing off-center on narrow (mobile) viewports, and re-clamps it on resize/orientation change.
- Fixes attribute table rows rendering implausibly tall by giving the unsized Source column a minimum width (`overflow-x` scroll instead of squeezing to near-zero and wrapping character-by-character), and stacks the object list above the table (instead of side-by-side) once the dialog itself gets narrow — via a CSS container query on the dialog's own resizable width, not just the browser viewport.
- Makes the dialog non-modal so the player can keep issuing commands with it open, and refreshes the currently-viewed object/tab after every turn so it stays in sync instead of only updating on next selection. Adds a border/shadow and Escape-to-close now that native modal styling/behavior no longer applies.
- Adds a `WasmPlayer` entry to `.claude/launch.json` for local dev.

## Test plan
- [x] Verified in-browser at mobile (375×700) and desktop (1280×800) widths: dialog stays fully on-screen, no overflow.
- [x] Verified manually shrinking the dialog on a wide desktop window triggers the stacked mobile layout (container query, not viewport-driven).
- [x] Verified the dialog is non-modal (`dlg.matches(':modal') === false`) and the game's command input/Debug button remain clickable while it's open.
- [x] Verified end-to-end: selected an object in the debugger, submitted a command through the real game input, and watched its attribute table update live (e.g. `timesexamined` 0→1) without touching the debugger.
- [x] Manual smoke test in a real browser/device appreciated, given this session's dev environment became resource-constrained toward the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)