### PR TITLE
feat: add walkthrough recording and playback to the editor

### DIFF
--- a/src/AppShell/src/components/ListEditor.svelte
+++ b/src/AppShell/src/components/ListEditor.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-    import { addListItem, removeListItem, updateListItem } from "$lib/editor-store";
+    import { addListItem, removeListItem, updateListItem, recordWalkthrough, playWalkthrough } from "$lib/editor-store";
 
     interface Props {
         elementKey: string;
         attribute: string;
         value: string | null;
         addPrompt?: string;
+        isWalkthrough?: boolean;
     }
 
-    let { elementKey, attribute, value, addPrompt = "Add item…" }: Props = $props();
+    let { elementKey, attribute, value, addPrompt = "Add item…", isWalkthrough = false }: Props = $props();
 
     let items = $derived.by<{key: string, value: string}[]>(() => {
         try { return JSON.parse(value ?? "[]"); } catch { return []; }
@@ -33,6 +34,23 @@
 </script>
 
 <div class="flex flex-col gap-1 w-full">
+    {#if isWalkthrough}
+        <div class="flex justify-end gap-1 mb-1">
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
+                onclick={() => playWalkthrough(elementKey)}
+                disabled={items.length === 0}
+                title="Play the game and run these steps"
+            >▶ Play</button>
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-error-500 text-xs px-2 py-0.5"
+                onclick={() => recordWalkthrough(elementKey)}
+                title="Play the game — replaying these steps first, if any — and record every further command as a new walkthrough step"
+            >● Record</button>
+        </div>
+    {/if}
     {#each items as item (item.key)}
         <div class="flex items-center gap-1">
             {#if editingItem?.key === item.key}

--- a/src/AppShell/src/components/MoveElementModal.svelte
+++ b/src/AppShell/src/components/MoveElementModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getMovePossibleParents } from "$lib/editor-store";
+    import { getMovePossibleParents, treeNodes } from "$lib/editor-store";
     import Combobox from "$components/Combobox.svelte";
     import type { ControlOption } from "$lib/types";
 
@@ -11,11 +11,15 @@
 
     const { elementKey, onconfirm, oncancel }: Props = $props();
 
-    // "_objects" un-parents the element back to the top level (mirrors MoveElement's
-    // own special-case for that key) — always offered first regardless of what
-    // GetMovePossibleParents itself returns.
+    // "_objects"/"_walkthrough" un-parent the element back to the top level (mirrors
+    // MoveElement's own special-casing of those keys) — always offered first
+    // regardless of what GetMovePossibleParents itself returns. Which sentinel
+    // applies depends on the moved element's own type.
+    let topLevelKey = $derived(
+        $treeNodes.find(n => n.key === elementKey)?.nodeType === "walkthrough" ? "_walkthrough" : "_objects"
+    );
     let options: ControlOption[] = $derived([
-        { value: "_objects", label: "(top level)" },
+        { value: topLevelKey, label: "(top level)" },
         ...getMovePossibleParents(elementKey).map(name => ({ value: name, label: name })),
     ]);
 

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -322,7 +322,7 @@
             containerClass="w-full"
         />
     {:else if ctrl.controlType === "list" && ctrl.attribute && $selectedKey}
-        <ListEditor elementKey={$selectedKey} attribute={ctrl.attribute} value={attrValue(ctrl.attribute)} addPrompt={ctrl.addPrompt ?? undefined} />
+        <ListEditor elementKey={$selectedKey} attribute={ctrl.attribute} value={attrValue(ctrl.attribute)} addPrompt={ctrl.addPrompt ?? undefined} isWalkthrough={ctrl.isWalkthrough ?? false} />
     {:else if (ctrl.controlType === "stringdictionary" || ctrl.controlType === "gamebookoptions") && ctrl.attribute}
         {@const items = (() => { try { return JSON.parse(attrValue(ctrl.attribute) ?? "[]") as {key: string, value: string}[]; } catch { return []; } })()}
         {@const dk = ctrl.attribute}

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -312,6 +312,11 @@
                 { label: "Add Verb", action: () => createVerb(id) },
                 { label: "Add Turn Script", action: () => createTurnScript(id) },
             );
+        } else if (nt === "walkthrough") {
+            opts.push({ label: "Add Walkthrough here", action: () => openAddModal("walkthrough", id) });
+            if (canMoveElement(id)) {
+                opts.push({ label: "Move to…", action: () => openMoveModal(id) });
+            }
         }
 
         // Gamebook pages ("page") are plain ElementType.Object elements underneath —

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -1,5 +1,6 @@
 import { writable, get } from "svelte/store";
 import { zipSync } from "fflate";
+import { PUBLIC_WASM_PLAYER_URL } from "$env/static/public";
 import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
 import type { AssetInfo, FileAdapter } from "./filesystem/types";
@@ -288,7 +289,7 @@ function blobToDataUrl(blob: Blob): Promise<string> {
 
 let _previewChannel: BroadcastChannel | null = null;
 
-export async function previewInWasmPlayer(wasmPlayerUrl: string): Promise<void> {
+export async function previewInWasmPlayer(wasmPlayerUrl: string, opts?: { recordWalkthrough?: string; runWalkthrough?: string }): Promise<void> {
     if (!_bridge || !_adapter) return;
 
     // Close stale channel so old bytes aren't sent to a new preview window.
@@ -306,15 +307,37 @@ export async function previewInWasmPlayer(wasmPlayerUrl: string): Promise<void> 
             // Serialize fresh on every 'ready' so WasmPlayer refreshes also pick up latest edits.
             if (!_bridge) return;
             const bytes = new TextEncoder().encode(_bridge.Save());
-            bc.postMessage({ type: "game", bytes, filename });
+            bc.postMessage({
+                type: "game",
+                bytes,
+                filename,
+                recordWalkthrough: opts?.recordWalkthrough ?? null,
+                runWalkthrough: opts?.runWalkthrough ?? null,
+            });
         } else if (data.type === "resource-request") {
             const blob = await adapter.getAsset(data.name);
             if (blob) {
                 const dataUrl = await blobToDataUrl(blob);
                 bc.postMessage({ type: "resource-response", id: data.id, dataUrl });
             }
+        } else if (data.type === "walkthrough-recorded") {
+            if (!_bridge) return;
+            _bridge.RecordWalkthroughSteps(data.name, JSON.stringify(data.steps));
+            refreshSelectedData();
+            refreshUndoRedo();
         }
     };
+}
+
+// Same default WasmPlayer URL Toolbar.svelte's Preview button uses, applied
+// here too so the walkthrough Record button (ListEditor.svelte) doesn't need
+// its own env plumbing.
+export function recordWalkthrough(elementKey: string): Promise<void> {
+    return previewInWasmPlayer(PUBLIC_WASM_PLAYER_URL || "/player/", { recordWalkthrough: elementKey });
+}
+
+export function playWalkthrough(elementKey: string): Promise<void> {
+    return previewInWasmPlayer(PUBLIC_WASM_PLAYER_URL || "/player/", { runWalkthrough: elementKey });
 }
 
 // ── Autosave ─────────────────────────────────────────────────────────────────
@@ -1017,9 +1040,9 @@ export function createVerb(parent: string | null): string {
     return afterCreate(_bridge.CreateVerb(parent ?? ""));
 }
 
-export function createWalkthrough(name: string): string {
+export function createWalkthrough(name: string, parent: string | null = null): string {
     if (!_bridge) return "error:not loaded";
-    return afterCreate(_bridge.CreateWalkthrough(name, ""));
+    return afterCreate(_bridge.CreateWalkthrough(name, parent ?? ""));
 }
 
 export function createTemplate(name: string): string {

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -37,6 +37,7 @@ export interface ControlInfo {
   valuePrompt?: string | null
   sourceExclude?: string | null
   checkboxCaption?: string | null
+  isWalkthrough?: boolean
 }
 
 export interface TabInfo {

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -81,6 +81,7 @@ export interface WasmBridge {
   CreateCommand(parent: string): string
   CreateVerb(parent: string): string
   CreateWalkthrough(name: string, parent: string): string
+  RecordWalkthroughSteps(name: string, stepsJson: string): string
   CreateTemplate(name: string): string
   CreateDynamicTemplate(name: string): string
   CreateObjectType(name: string): string

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -124,7 +124,7 @@
         else if (mode.type === "object" || mode.type === "page") createObject(name, mode.parent);
         else if (mode.type === "function") createFunction(name);
         else if (mode.type === "timer") createTimer(name);
-        else if (mode.type === "walkthrough") createWalkthrough(name);
+        else if (mode.type === "walkthrough") createWalkthrough(name, mode.parent);
         else if (mode.type === "template") createTemplate(name);
         else if (mode.type === "dynamictemplate") createDynamicTemplate(name);
         else if (mode.type === "type") createObjectType(name);

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -1690,7 +1690,8 @@ public sealed class EditorController : IDisposable
         }
 
         var element = WorldModel.Elements.Get(elementKey);
-        return element.ElemType == ElementType.Object && element.Type != ObjectType.Game;
+        return (element.ElemType == ElementType.Object && element.Type != ObjectType.Game)
+               || element.ElemType == ElementType.Walkthrough;
     }
 
     public bool CanMoveElement(string elementKey, string newParentKey)
@@ -1705,7 +1706,7 @@ public sealed class EditorController : IDisposable
             return false;
         }
 
-        if (newParentKey != "_objects" && !WorldModel.Elements.ContainsKey(newParentKey))
+        if (newParentKey != "_objects" && newParentKey != "_walkthrough" && !WorldModel.Elements.ContainsKey(newParentKey))
         {
             return false;
         }
@@ -1719,11 +1720,37 @@ public sealed class EditorController : IDisposable
                 return true;
             }
 
+            if (newParentKey == "_walkthrough")
+            {
+                return false;
+            }
+
             var newParent = WorldModel.Elements.Get(newParentKey);
 
             if (newParent.ElemType == ElementType.Object)
             {
                 // Can't drag a parent object onto one of its own children
+                return !WorldModel.ObjectContains(element, newParent);
+            }
+        }
+        else if (element.ElemType == ElementType.Walkthrough)
+        {
+            if (newParentKey == "_walkthrough")
+            {
+                // Can always drag a walkthrough to the "Walkthrough" header to unset its parent
+                return true;
+            }
+
+            if (newParentKey == "_objects")
+            {
+                return false;
+            }
+
+            var newParent = WorldModel.Elements.Get(newParentKey);
+
+            if (newParent.ElemType == ElementType.Walkthrough)
+            {
+                // Can't drag a parent walkthrough onto one of its own children
                 return !WorldModel.ObjectContains(element, newParent);
             }
         }
@@ -1735,7 +1762,7 @@ public sealed class EditorController : IDisposable
     {
         WorldModel.UndoLogger.StartTransaction(string.Format("Move object '{0}' to '{1}'", elementKey, newParentKey));
         var element = WorldModel.Elements.Get(elementKey);
-        var newParent = newParentKey == "_objects" ? null : WorldModel.Elements.Get(newParentKey);
+        var newParent = newParentKey is "_objects" or "_walkthrough" ? null : WorldModel.Elements.Get(newParentKey);
         element.Parent = newParent;
         WorldModel.UndoLogger.EndTransaction();
     }
@@ -1795,6 +1822,16 @@ public sealed class EditorController : IDisposable
         }
 
         var element = WorldModel.Elements.Get(elementKey);
+
+        if (element.ElemType == ElementType.Walkthrough)
+        {
+            return from possibleParent in WorldModel.Elements.GetElements(ElementType.Walkthrough)
+                where possibleParent != element
+                      && possibleParent != element.Parent
+                      && !WorldModel.ObjectContains(element, possibleParent)
+                orderby possibleParent.Name
+                select possibleParent.Name;
+        }
 
         return from possibleParent in WorldModel.Elements.GetElements(ElementType.Object)
             where possibleParent != element

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -39,7 +39,8 @@ internal record ControlInfo(
     string? KeyPrompt = null,
     string? ValuePrompt = null,
     string? SourceExclude = null,
-    string? CheckboxCaption = null);
+    string? CheckboxCaption = null,
+    bool IsWalkthrough = false);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -1978,6 +1979,30 @@ public partial class WasmEditorBridge
         }
     }
 
+    // Appends steps captured by WasmPlayer's walkthrough recorder (see wasm-player.js's
+    // recordWalkthroughName/recordedSteps) onto an existing walkthrough element — the same
+    // append-not-replace behaviour as EditorController.RecordWalkthrough, which this just exposes
+    // across the JS boundary.
+    [JSExport]
+    public static string RecordWalkthroughSteps(string name, string stepsJson)
+    {
+        if (_controller == null)
+        {
+            return "error:Not initialised";
+        }
+
+        try
+        {
+            var steps = JsonSerializer.Deserialize(stepsJson, WasmEditorJsonContext.Default.ListString);
+            _controller.RecordWalkthrough(name, steps ?? []);
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return $"error:{ex.Message}";
+        }
+    }
+
     [JSExport]
     public static string CreateTemplate(string name)
     {
@@ -3149,6 +3174,7 @@ public partial class WasmEditorBridge
                 "s_function" => "function",
                 "s_timer" => "timer",
                 "s_game" => "game",
+                "s_walk" => "walkthrough",
                 _ => "other"
             };
     }
@@ -3286,6 +3312,7 @@ public partial class WasmEditorBridge
         }
 
         var addPrompt = ctrl.ControlType == "list" ? ctrl.GetString("editprompt") : null;
+        var isWalkthrough = ctrl.ControlType == "list" && ctrl.GetBool("iswalkthrough");
         var isDictionary = ctrl.ControlType is "stringdictionary" or "gamebookoptions";
         var source = ctrl.ControlType == "file" || isDictionary ? ctrl.GetString("source") : null;
         var keyPrompt = isDictionary ? ctrl.GetString("keyprompt") : null;
@@ -3295,7 +3322,8 @@ public partial class WasmEditorBridge
         return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
             null, null, textProcessorCommands, addPrompt, Source: source,
             Advanced: !ctrl.IsControlVisibleInSimpleMode,
-            KeyPrompt: keyPrompt, ValuePrompt: valuePrompt, SourceExclude: sourceExclude);
+            KeyPrompt: keyPrompt, ValuePrompt: valuePrompt, SourceExclude: sourceExclude,
+            IsWalkthrough: isWalkthrough);
     }
 
     [JSExport]

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -107,6 +107,24 @@
     </div>
 </div>
 
+<!-- Shown by beginRecording (wasm-player.js) for the lifetime of an editor-launched
+     "Record Walkthrough" preview session (see AppShell's ListEditor.svelte Record
+     button and editor-store.ts's recordWalkthrough/previewInWasmPlayer). Non-modal
+     and non-blocking, unlike #qv-restarting above — the game stays fully playable
+     while this is up, it just floats over the chrome reporting progress. Preserved
+     across swapInPlayerUi() (a mid-session restart) the same way #qv-restarting is,
+     so a restart mid-recording doesn't lose the banner (recordedSteps itself is
+     plain JS module state and survives a restart regardless). -->
+<div id="qv-recording" class="qv-chrome hidden" role="status" aria-live="polite">
+    <div class="flex items-center gap-2 preset-filled-error-500 rounded-full px-3 py-1.5 text-sm shadow-lg">
+        <span class="inline-block h-2 w-2 rounded-full bg-current animate-pulse" aria-hidden="true"></span>
+        <span id="qv-recording-status">Recording&hellip;</span>
+        <button id="qv-recording-stop" type="button" class="btn-icon preset-tonal-surface ml-1" aria-label="Stop recording">
+            <svg class="qv-icon" aria-hidden="true"><use href="#square"></use></svg>
+        </button>
+    </div>
+</div>
+
 <dialog id="qv-saves" class="qv-chrome" data-mode="boot">
     <!-- ICONS_SPRITE: spliced in at build time by scripts/build-icons.mjs (into
          generated/index.html) — a hidden <symbol> defs block, kept inside

--- a/src/WasmPlayer/scripts/build-icons.mjs
+++ b/src/WasmPlayer/scripts/build-icons.mjs
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 
-const ICONS = ['x', 'trash-2', 'folder-open'];
+const ICONS = ['x', 'trash-2', 'folder-open', 'square'];
 
 const sprite = fs.readFileSync(path.join(root, 'node_modules/lucide-static/sprite.svg'), 'utf8');
 

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -39,7 +39,8 @@
 :scope#qv-start,
 :scope#qv-saves,
 :scope#questVivaDebugger,
-:scope#qv-restarting {
+:scope#qv-restarting,
+:scope#qv-recording {
     font-family: var(--font-sans);
 }
 
@@ -86,6 +87,22 @@
 }
 
 :scope#qv-restarting.hidden {
+    display: none;
+}
+
+/* Non-blocking, unlike #qv-start/#qv-restarting above — floats over the top-right
+   corner of the game chrome for the duration of a recording session, but the game
+   itself stays fully interactive underneath (no inset:0, no background). Below the
+   debugger's z-index:1500 (chosen deliberately, see #questVivaDebugger below) so an
+   opened debugger dialog still renders above it if both are up at once. */
+:scope#qv-recording {
+    position: fixed;
+    top: 0.75rem;
+    right: 0.75rem;
+    z-index: 1400;
+}
+
+:scope#qv-recording.hidden {
     display: none;
 }
 

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -19,6 +19,127 @@ const pendingResources = new Map();
 let editorChannel = null;
 let resourceRoot = null;
 
+// ── Walkthrough recording/playback status banner ────────────────────────────
+// Drives the #qv-recording banner (element ids kept as-is from the original
+// record-only implementation — they're internal, not user-facing) through
+// three mutually exclusive modes, all only ever entered via the 'game'
+// message's recordWalkthrough/runWalkthrough fields (AppShell's
+// ListEditor.svelte Play/Record buttons → editor-store.ts's
+// playWalkthrough/recordWalkthrough/previewInWasmPlayer) — never set for a
+// normal Play/source=local session, which never sends either field:
+//   'replay' — replaying a walkthrough's existing steps before recording
+//              continues (see beginRecordWithReplay). Banner button cancels.
+//   'record' — capturing new commands into recordedSteps (see recordStep).
+//              Banner button stops and relays them to the editor tab.
+//   'play'   — a standalone Play (see runWalkthroughStandalone), no
+//              recording follows. Banner button cancels.
+// recordedSteps is plain module state, not tied to the DOM, so it survives a
+// mid-recording restart (see swapInPlayerUi's doc comment).
+let walkthroughStatusMode = null; // null | 'replay' | 'record' | 'play'
+let recordWalkthroughName = null;
+let recordedSteps = [];
+
+function recordStep(step) {
+    if (walkthroughStatusMode !== 'record') return;
+    recordedSteps.push(step);
+    updateWalkthroughStatusUi();
+}
+
+function updateWalkthroughStatusUi() {
+    const el = document.getElementById('qv-recording');
+    if (!el) return;
+    el.classList.toggle('hidden', !walkthroughStatusMode);
+    const status = document.getElementById('qv-recording-status');
+    const stopBtn = document.getElementById('qv-recording-stop');
+    if (walkthroughStatusMode === 'replay') {
+        if (status) status.textContent = 'Replaying existing steps…';
+        stopBtn?.setAttribute('aria-label', 'Cancel replay');
+    } else if (walkthroughStatusMode === 'play') {
+        if (status) status.textContent = 'Playing…';
+        stopBtn?.setAttribute('aria-label', 'Cancel');
+    } else if (walkthroughStatusMode === 'record') {
+        if (status) {
+            const n = recordedSteps.length;
+            status.textContent = `Recording — ${n} step${n === 1 ? '' : 's'}`;
+        }
+        stopBtn?.setAttribute('aria-label', 'Stop recording');
+    }
+}
+
+function beginRecording(name) {
+    walkthroughStatusMode = 'record';
+    recordWalkthroughName = name;
+    recordedSteps = [];
+    updateWalkthroughStatusUi();
+}
+
+// Relays the captured steps back to the editor tab over the same channel used
+// to hand off the game itself — see editor-store.ts's 'walkthrough-recorded'
+// handler, which appends them onto the walkthrough element via
+// WasmEditorBridge.RecordWalkthroughSteps. Stopping only ends the *recording*
+// — the preview session itself carries on exactly as an ordinary Preview
+// would (no Save button, Debugger still available, etc.).
+function stopRecording() {
+    if (walkthroughStatusMode !== 'record' || !editorChannel) return;
+    editorChannel.postMessage({ type: 'walkthrough-recorded', name: recordWalkthroughName, steps: recordedSteps });
+    walkthroughStatusMode = null;
+    recordWalkthroughName = null;
+    recordedSteps = [];
+    updateWalkthroughStatusUi();
+}
+
+// Runs a walkthrough's existing steps (if any) before switching into live
+// recording, so re-recording into a walkthrough that already has steps
+// starts from the right game state instead of a blank slate. Must run after
+// Bridge.Begin() — WalkthroughRunner drives the game via SendCommand, which
+// needs an already-started game (current room, game.pov, etc. all set).
+// Proceeds to recording regardless of how the replay ends (finished, failed,
+// or cancelled via the banner's button — Bridge.RunWalkthrough never throws,
+// see its own try/catch) since aborting instead would leave the author with
+// no way to add new steps after a bad replay.
+async function beginRecordWithReplay(name) {
+    let stepCount = 0;
+    try {
+        stepCount = JSON.parse(Bridge.GetWalkthroughStepsJson(name)).length;
+    } catch { /* treat as no existing steps */ }
+
+    if (stepCount > 0) {
+        walkthroughStatusMode = 'replay';
+        updateWalkthroughStatusUi();
+        const error = await Bridge.RunWalkthrough(name);
+        if (error) console.error('[Quest] Walkthrough replay before recording failed:', error);
+    }
+
+    beginRecording(name);
+}
+
+// Standalone playback (the ListEditor.svelte "Play" button) — no recording
+// follows. Must run after Bridge.Begin(), same reasoning as beginRecordWithReplay.
+async function runWalkthroughStandalone(name) {
+    walkthroughStatusMode = 'play';
+    updateWalkthroughStatusUi();
+    const error = await Bridge.RunWalkthrough(name);
+    if (error) console.error('[Quest] Walkthrough playback failed:', error);
+    walkthroughStatusMode = null;
+    updateWalkthroughStatusUi();
+}
+
+function wireRecordingStopButton() {
+    document.getElementById('qv-recording-stop')?.addEventListener('click', () => {
+        if (walkthroughStatusMode === 'record') stopRecording();
+        else if (walkthroughStatusMode === 'replay' || walkthroughStatusMode === 'play') Bridge.CancelWalkthrough();
+    });
+}
+
+// Best-effort — BroadcastChannel.postMessage during pagehide isn't guaranteed
+// to be delivered, but costs nothing to attempt, so closing the tab mid-
+// recording (instead of clicking Stop) doesn't silently lose the steps.
+window.addEventListener('pagehide', () => {
+    if (walkthroughStatusMode === 'record' && editorChannel && recordedSteps.length > 0) {
+        editorChannel.postMessage({ type: 'walkthrough-recorded', name: recordWalkthroughName, steps: recordedSteps });
+    }
+});
+
 // The *original* game bytes/filename for the current session — always the
 // primary game file, never a save. Saves are loaded as an overlay on top of
 // these via Bridge.InitialiseWithSave, so resource lookups (images/sounds
@@ -211,19 +332,21 @@ window.WebPlayer = {
         const metadataJson = metadata ? JSON.stringify(metadata) : null;
         await Bridge.SendCommand(command, tickCount, metadataJson);
         canSendCommand = true;
+        recordStep(command);
         refreshDebuggerAfterTurn();
     },
 
-    async uiChoice(choice) { await Bridge.SetMenuResponse(choice); },
+    async uiChoice(choice) { await Bridge.SetMenuResponse(choice); recordStep(`menu:${choice}`); },
     async uiChoiceCancel() { await Bridge.SetMenuResponse(null); },
     async uiTick(tickCount) { await Bridge.Tick(tickCount); },
     async uiEndWait() { await Bridge.FinishWait(); },
     async uiEndPause() { await Bridge.FinishPause(); },
-    async uiSetQuestionResponse(response) { await Bridge.SetQuestionResponse(response); },
+    async uiSetQuestionResponse(response) { await Bridge.SetQuestionResponse(response); recordStep(`answer:${response ? 'yes' : 'no'}`); },
 
     async uiSendEvent(eventName, param) {
         await Bridge.SendEvent(eventName, param);
         canSendCommand = true;
+        recordStep(`event:${eventName};${param ?? ''}`);
         refreshDebuggerAfterTurn();
     },
 
@@ -263,7 +386,7 @@ async function setupPaperJs() {
 }
 
 // Replaces document.body with a fresh copy of the player chrome, preserving
-// #qv-start/#qv-saves/#questVivaDebugger (the static markup's overlays, which
+// #qv-start/#qv-saves/#questVivaDebugger/#qv-recording (the static markup's overlays, which
 // live outside the swapped-in playerHtml and would otherwise be destroyed by
 // the innerHTML assignment). Used both for the initial boot and for a
 // mid-session restart ("Start from the beginning" / Load) — a restart must
@@ -278,10 +401,12 @@ function swapInPlayerUi() {
     const savesDialogEl = document.getElementById('qv-saves');
     const debuggerDialogEl = document.getElementById('questVivaDebugger');
     const restartingEl = document.getElementById('qv-restarting');
+    const recordingEl = document.getElementById('qv-recording');
     startScreenEl?.remove();
     savesDialogEl?.remove();
     debuggerDialogEl?.remove();
     restartingEl?.remove();
+    recordingEl?.remove();
 
     document.body.innerHTML = originalPlayerHtml;
 
@@ -289,6 +414,7 @@ function swapInPlayerUi() {
     if (savesDialogEl) document.body.appendChild(savesDialogEl);
     if (debuggerDialogEl) document.body.appendChild(debuggerDialogEl);
     if (restartingEl) document.body.appendChild(restartingEl);
+    if (recordingEl) document.body.appendChild(recordingEl);
     // This is a genuinely fresh chrome (see above) — addExternalScript's
     // dedupe-by-URL (player.js) must not carry over, or the game's external
     // scripts silently no-op against it on the very next Initialise() call
@@ -303,7 +429,7 @@ function swapInPlayerUi() {
 // beginning"/Load in an editor-preview session.
 let currentIsPreview = false;
 
-async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false) {
+async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null) {
     currentIsPreview = isPreview;
     const [htmResponse, { dotnet }] = await Promise.all([
         fetch('playercore.htm'),
@@ -406,6 +532,7 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
     WebPlayer.initUI();
     wireDebuggerButton();
     wireDebuggerRestartButton(isPreview);
+    wireRecordingStopButton();
     // Editor-preview sessions (isPreview) don't offer saving at all — by
     // design: a save captures the whole game state, so reloading one while
     // iterating would show stale state that doesn't reflect the developer's
@@ -420,6 +547,22 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
     WebPlayer.setCanDebug(isPreview && Bridge.IsDebugEnabled());
 
     await Bridge.Begin();
+
+    // Both require the game to have already started (Begin() run) — see their
+    // own doc comments — so they run after Bridge.Begin(), unlike the rest of
+    // this function's setup above. The extra tick (matching the jsYield
+    // JSImport's own setTimeout(...,0) idiom used elsewhere for the same
+    // reason) lets the JS/WASM event loop settle after Begin()'s own async
+    // engine work before issuing another engine call back-to-back — chaining
+    // straight through without it was observed to hang indefinitely.
+    if (recordWalkthrough || runWalkthrough) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    if (recordWalkthrough) {
+        await beginRecordWithReplay(recordWalkthrough);
+    } else if (runWalkthrough) {
+        await runWalkthroughStandalone(runWalkthrough);
+    }
 }
 
 // Guards restartGame against overlapping calls — e.g. impatiently clicking
@@ -506,7 +649,7 @@ async function restartGameCore(saveBytes) {
 // Wraps initWasmPlayer with the boot-time "Continue / New Game" prompt: if
 // saves already exist for this game, ask before committing to either the
 // fresh game or a chosen save. Used by all boot entry points below.
-async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPreview = false) {
+async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null) {
     originalGameBytes = bytes;
     originalGameFilename = filename;
     // gameIdOverride lets callers with a stronger identity than the filename
@@ -531,7 +674,7 @@ async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPr
         }
     }
 
-    await initWasmPlayer(bytes, filename, bc, saveBytes, isPreview);
+    await initWasmPlayer(bytes, filename, bc, saveBytes, isPreview, recordWalkthrough, runWalkthrough);
 }
 
 // ── Start screen helpers ──────────────────────────────────────────────────────
@@ -1748,7 +1891,7 @@ async function fetchGameBytes(url) {
         bc.onmessage = async ({ data }) => {
             if (data.type === 'game') {
                 bc.onmessage = null;
-                await startGame(data.bytes, data.filename, bc, null, true);
+                await startGame(data.bytes, data.filename, bc, null, true, data.recordWalkthrough ?? null, data.runWalkthrough ?? null);
             }
         };
         return;


### PR DESCRIPTION
## Summary

- **Record** — a "● Record" button on a walkthrough element's steps list launches the game in a preview session and captures every command, menu choice, question answer, and event as a new step, in the same syntax `WalkthroughRunner` already plays back. If the walkthrough already has steps, they're replayed first (so re-recording continues from the right game state) before live capture begins.
- **Play** — a "▶ Play" button next to it runs the walkthrough's existing steps via the existing `Bridge.RunWalkthrough`, without recording.
- Both reuse the `quest-preview` `BroadcastChannel` already used for the editor↔player preview handoff, extended with `recordWalkthrough`/`runWalkthrough` fields on the boot handshake and a new `walkthrough-recorded` message relaying captured steps back to the editor.
- **Walkthrough nesting exposed**: the model already let one walkthrough inherit another's steps as its parent, but there was no way to create one "inside" another or move one after creation. Added a tree "Add Walkthrough here" / "Move to…" affordance, and extended `EditorController`'s move methods (previously `ElementType.Object`-only) to support walkthroughs.
- **Fixed Delete being disabled** for walkthrough elements — `WasmEditorBridge.GetNodeType` had no case for the walkthrough node icon, so it fell into a generic "other" bucket the toolbar/tree treat as non-deletable.

## Test plan

- [x] `dotnet build --configuration Release` (full solution) and `npx tsc --noEmit` in `src/AppShell` both clean
- [x] Manual browser verification (AppShell + WasmPlayer dev servers): Delete now enabled for a walkthrough; "Add Walkthrough here" creates a correctly nested child; "Move to…" lists valid targets (excluding current parent) and reparents/unparents correctly
- [x] Manual verification of Record: steps captured correctly and relayed back to the editor across two separate recording sessions, appending (not overwriting) each time
- [x] Live re-verification of the newest replay-before-record boot sequence and Play was inconclusive this session due to host machine resource exhaustion (confirmed via `top`, and by a completely unmodified Preview hanging identically) — recommend a manual smoke test before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)