### PR TITLE
feat(AppShell): redesign rich text toolbar as icons + grouped Insert menu

### DIFF
--- a/src/AppShell/src/components/DropdownMenu.svelte
+++ b/src/AppShell/src/components/DropdownMenu.svelte
@@ -7,6 +7,7 @@
         icon?: Component<{ size?: number }>;
         disabled?: boolean;
         divider?: boolean;
+        heading?: string;
     }
 
     interface Props {
@@ -57,6 +58,9 @@
             {#each items as item (item.label)}
                 {#if item.divider}
                     <div class="my-1 border-t border-surface-200-800"></div>
+                {/if}
+                {#if item.heading}
+                    <div class="px-3 pt-1.5 pb-1 text-[11px] font-semibold text-surface-600-400 uppercase tracking-wide">{item.heading}</div>
                 {/if}
                 <button
                     type="button"

--- a/src/AppShell/src/components/LinkPickerModal.svelte
+++ b/src/AppShell/src/components/LinkPickerModal.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+    import Combobox from "./Combobox.svelte";
+    import AssetPicker from "./AssetPicker.svelte";
+    import type { ControlOption } from "$lib/types";
+
+    interface Props {
+        title: string;
+        targetLabel: string;
+        targetOptions: ControlOption[];
+        // When set, the target is picked via AssetPicker (existing assets + upload) instead of a Combobox.
+        assetSource?: string | null;
+        textMode: "none" | "optional" | "required";
+        textLabel?: string;
+        initialText?: string;
+        onconfirm: (target: string, text: string) => void;
+        oncancel: () => void;
+    }
+
+    const {
+        title, targetLabel, targetOptions, assetSource = null,
+        textMode, textLabel = "Link text", initialText = "",
+        onconfirm, oncancel,
+    }: Props = $props();
+
+    let target = $state("");
+    let text = $state(initialText);
+    let textInputEl: HTMLInputElement | undefined = $state();
+
+    $effect(() => { textInputEl?.focus(); });
+
+    function onBackdropClick(e: MouseEvent) {
+        if (e.target === e.currentTarget) oncancel();
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") oncancel();
+    }
+
+    function handleTextKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter") confirm();
+    }
+
+    let canConfirm = $derived(!!target && (textMode !== "required" || !!text.trim()));
+
+    function confirm() {
+        if (!canConfirm) return;
+        onconfirm(target, text.trim());
+    }
+</script>
+
+<div
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
+    onclick={onBackdropClick}
+    onkeydown={handleKeydown}
+>
+    <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-96 p-6 flex flex-col gap-4">
+        <h2 class="text-base font-semibold">{title}</h2>
+
+        <div class="flex flex-col gap-1">
+            <label for="link-picker-target" class="text-xs text-surface-600-400">{targetLabel}</label>
+            {#if assetSource !== null}
+                <AssetPicker
+                    value={target}
+                    source={assetSource}
+                    onchange={(v) => { target = v; }}
+                    class="input bg-surface-50-950 px-2 py-1 text-sm w-full min-w-0"
+                    containerClass="w-full"
+                />
+            {:else}
+                <Combobox
+                    value={target}
+                    options={targetOptions}
+                    onchange={(v) => { target = v; }}
+                    class="input bg-surface-50-950 px-2 py-1 text-sm w-full"
+                    wrapperClass="w-full"
+                />
+                {#if targetOptions.length === 0}
+                    <p class="text-xs text-surface-600-400">No {targetLabel.toLowerCase()}s found.</p>
+                {/if}
+            {/if}
+        </div>
+
+        {#if textMode !== "none"}
+            <div class="flex flex-col gap-1">
+                <label for="link-picker-text" class="text-xs text-surface-600-400">
+                    {textLabel}{textMode === "optional" ? " (optional)" : ""}
+                </label>
+                <input
+                    id="link-picker-text"
+                    type="text"
+                    autocapitalize="off"
+                    class="input bg-surface-50-950 px-2 py-1 text-sm"
+                    bind:this={textInputEl}
+                    bind:value={text}
+                    onkeydown={handleTextKeydown}
+                />
+            </div>
+        {/if}
+
+        <div class="flex justify-end gap-2">
+            <button class="btn btn-sm preset-tonal" onclick={oncancel}>Cancel</button>
+            <button
+                class="btn btn-sm preset-filled-primary-500"
+                onclick={confirm}
+                disabled={!canConfirm}
+            >Insert</button>
+        </div>
+    </div>
+</div>

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-    import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, addDictItem, removeDictItem, updateDictItem, getObjectNames, selectNode, createObjectSilent, openAddModal, createIncludedLibrary, createJavascript } from "$lib/editor-store";
+    import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, addDictItem, removeDictItem, updateDictItem, getObjectNames, getExitNames, selectNode, createObjectSilent, openAddModal, createIncludedLibrary, createJavascript } from "$lib/editor-store";
     import { showToast } from "$lib/toast";
-    import type { ControlInfo, TextProcessorCommand } from "$lib/types";
+    import type { ControlInfo, ControlOption, TextProcessorCommand } from "$lib/types";
     import type { TreeNode } from "$lib/types";
     import ChevronLeft from "@lucide/svelte/icons/chevron-left";
     import ArrowRight from "@lucide/svelte/icons/arrow-right";
@@ -25,6 +25,7 @@
     import ScriptEditor from "./ScriptEditor.svelte";
     import DropdownMenu from "./DropdownMenu.svelte";
     import type { DropdownMenuItem } from "./DropdownMenu.svelte";
+    import LinkPickerModal from "./LinkPickerModal.svelte";
     import ScriptDictionaryEditor from "./ScriptDictionaryEditor.svelte";
     import Combobox from "./Combobox.svelte";
     import AttributesEditor from "./AttributesEditor.svelte";
@@ -188,6 +189,99 @@
         onTextChange(attribute, controlType, textarea.value);
     }
 
+    function insertComposedText(attribute: string, controlType: string, range: { start: number; end: number }, text: string) {
+        const textarea = document.getElementById(textProcessorTextareaId(attribute)) as HTMLTextAreaElement | null;
+        if (!textarea) return;
+        textarea.value = textarea.value.substring(0, range.start) + text + textarea.value.substring(range.end);
+        const cursor = range.start + text.length;
+        textarea.selectionStart = cursor;
+        textarea.selectionEnd = cursor;
+        textarea.focus();
+        onTextChange(attribute, controlType, textarea.value);
+    }
+
+    // Commands whose insertBefore appears here need a target picked from a list (or an asset
+    // upload) rather than just wrapping the selection in fixed markup — matches the `source`
+    // hint the old Quest 5 editor used to decide when to pop up a picker dialog. Keyed by
+    // insertBefore for the same locale-independence reason as PINNED_ICONS/INSERT_MENU_GROUPS.
+    interface LinkCommandConfig {
+        kind: "objects" | "exits" | "pages" | "images";
+        textMode: "none" | "optional" | "required";
+        targetLabel: string;
+        textLabel?: string;
+        format: (target: string, text: string) => string;
+    }
+    const LINK_COMMANDS: Record<string, LinkCommandConfig> = {
+        "{object:": {
+            kind: "objects", textMode: "optional", targetLabel: "Object",
+            format: (target, text) => (text ? `{object:${target}:${text}}` : `{object:${target}}`),
+        },
+        "{exit:": {
+            kind: "exits", textMode: "none", targetLabel: "Exit",
+            format: (target) => `{exit:${target}}`,
+        },
+        "{here ": {
+            kind: "objects", textMode: "required", targetLabel: "Object", textLabel: "Text to show",
+            format: (target, text) => `{here ${target}:${text}}`,
+        },
+        "{nothere ": {
+            kind: "objects", textMode: "required", targetLabel: "Object", textLabel: "Text to show",
+            format: (target, text) => `{nothere ${target}:${text}}`,
+        },
+        "{img:": {
+            kind: "images", textMode: "none", targetLabel: "Image",
+            format: (target) => `{img:${target}}`,
+        },
+        "{page:": {
+            kind: "pages", textMode: "optional", targetLabel: "Page",
+            format: (target, text) => (text ? `{page:${target}:${text}}` : `{page:${target}}`),
+        },
+    };
+
+    interface ActiveLinkCommand {
+        title: string;
+        config: LinkCommandConfig;
+        options: ControlOption[];
+        initialText: string;
+        range: { start: number; end: number };
+        attribute: string;
+        controlType: string;
+    }
+    let activeLinkCommand = $state<ActiveLinkCommand | null>(null);
+
+    // Entry point for every toolbar/menu command: link commands (see LINK_COMMANDS) open the
+    // picker modal, everything else keeps the old immediate wrap-the-selection insert.
+    function activateTextProcessorCommand(cmd: TextProcessorCommand, attribute: string, controlType: string) {
+        const config = LINK_COMMANDS[cmd.insertBefore];
+        if (!config) {
+            insertTextProcessorText(attribute, controlType, cmd.insertBefore, cmd.insertAfter);
+            return;
+        }
+        const textarea = document.getElementById(textProcessorTextareaId(attribute)) as HTMLTextAreaElement | null;
+        const start = textarea?.selectionStart ?? 0;
+        const end = textarea?.selectionEnd ?? 0;
+        const options: ControlOption[] =
+            config.kind === "exits" ? (getExitNames() ?? []).map(name => ({ value: name, label: name })) :
+                config.kind === "images" ? [] :
+                    (getObjectNames() ?? []).map(name => ({ value: name, label: name }));
+        activeLinkCommand = {
+            title: cmd.command,
+            config,
+            options,
+            initialText: textarea?.value.substring(start, end) ?? "",
+            range: { start, end },
+            attribute,
+            controlType,
+        };
+    }
+
+    function confirmLinkCommand(target: string, text: string) {
+        if (!activeLinkCommand) return;
+        const { config, range, attribute, controlType } = activeLinkCommand;
+        insertComposedText(attribute, controlType, range, config.format(target, text));
+        activeLinkCommand = null;
+    }
+
     // Commands not covered by PINNED_ICONS go into the "Insert" dropdown, grouped by
     // INSERT_MENU_GROUPS; anything not in that map (e.g. a future CoreEditor.aslx addition)
     // still shows up, ungrouped, under "More" rather than silently disappearing.
@@ -209,7 +303,7 @@
                     icon: INSERT_MENU_GROUPS[cmd.insertBefore]?.icon,
                     heading: i === 0 ? group : undefined,
                     divider: i === 0 && seenGroup,
-                    action: () => insertTextProcessorText(attribute, controlType, cmd.insertBefore, cmd.insertAfter),
+                    action: () => activateTextProcessorCommand(cmd, attribute, controlType),
                 });
             });
             seenGroup = true;
@@ -299,6 +393,20 @@
     {/if}
 </div>
 
+{#if activeLinkCommand}
+    <LinkPickerModal
+        title={activeLinkCommand.title}
+        targetLabel={activeLinkCommand.config.targetLabel}
+        targetOptions={activeLinkCommand.options}
+        assetSource={activeLinkCommand.config.kind === "images" ? "*.jpg;*.jpeg;*.png;*.gif" : null}
+        textMode={activeLinkCommand.config.textMode}
+        textLabel={activeLinkCommand.config.textLabel}
+        initialText={activeLinkCommand.initialText}
+        onconfirm={confirmLinkCommand}
+        oncancel={() => { activeLinkCommand = null; }}
+    />
+{/if}
+
 {#snippet textProcessorPanel(commands: TextProcessorCommand[], attribute: string, controlType: string)}
     <div class="flex items-center gap-1 shrink-0">
         {#each commands as cmd (cmd.command)}
@@ -309,7 +417,7 @@
                     class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
                     title="{cmd.command} {cmd.info}"
                     aria-label={cmd.command}
-                    onclick={() => insertTextProcessorText(attribute, controlType, cmd.insertBefore, cmd.insertAfter)}
+                    onclick={() => activateTextProcessorCommand(cmd, attribute, controlType)}
                 ><Icon size={14} aria-hidden="true" /></button>
             {/if}
         {/each}

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -5,7 +5,25 @@
     import type { TreeNode } from "$lib/types";
     import ChevronLeft from "@lucide/svelte/icons/chevron-left";
     import ArrowRight from "@lucide/svelte/icons/arrow-right";
+    import Bold from "@lucide/svelte/icons/bold";
+    import Italic from "@lucide/svelte/icons/italic";
+    import Underline from "@lucide/svelte/icons/underline";
+    import Repeat1 from "@lucide/svelte/icons/repeat-1";
+    import LinkIcon from "@lucide/svelte/icons/link";
+    import Terminal from "@lucide/svelte/icons/terminal";
+    import LogOut from "@lucide/svelte/icons/log-out";
+    import GitBranch from "@lucide/svelte/icons/git-branch";
+    import GitFork from "@lucide/svelte/icons/git-fork";
+    import MapPin from "@lucide/svelte/icons/map-pin";
+    import MapPinOff from "@lucide/svelte/icons/map-pin-off";
+    import Dices from "@lucide/svelte/icons/dices";
+    import ImageIcon from "@lucide/svelte/icons/image";
+    import LifeBuoy from "@lucide/svelte/icons/life-buoy";
+    import ChevronDown from "@lucide/svelte/icons/chevron-down";
+    import ListPlus from "@lucide/svelte/icons/list-plus";
     import ScriptEditor from "./ScriptEditor.svelte";
+    import DropdownMenu from "./DropdownMenu.svelte";
+    import type { DropdownMenuItem } from "./DropdownMenu.svelte";
     import ScriptDictionaryEditor from "./ScriptDictionaryEditor.svelte";
     import Combobox from "./Combobox.svelte";
     import AttributesEditor from "./AttributesEditor.svelte";
@@ -127,9 +145,33 @@
         return v === "True" || v === "true";
     }
 
-    function insertTextProcessorText(attribute: string, controlType: string, insertBefore: string, insertAfter: string, event: MouseEvent) {
-        const wrapper = (event.target as HTMLElement).closest(".richtext-wrap");
-        const textarea = wrapper?.querySelector("textarea") as HTMLTextAreaElement | null;
+    // Keyed by insertBefore (Quest syntax, stable across locales) rather than cmd.command
+    // (a localized caption) so the toolbar icons/grouping don't depend on the editor language.
+    const FORMATTING_ICONS: Record<string, typeof Bold | undefined> = {
+        "<b>": Bold,
+        "<i>": Italic,
+        "<u>": Underline,
+    };
+    const INSERT_MENU_GROUPS: Record<string, { group: string; icon: typeof Bold }> = {
+        "{object:": { group: "Links", icon: LinkIcon },
+        "{command:": { group: "Links", icon: Terminal },
+        "{exit:": { group: "Links", icon: LogOut },
+        "{if ": { group: "Conditions", icon: GitBranch },
+        "{if not ": { group: "Conditions", icon: GitFork },
+        "{here ": { group: "Conditions", icon: MapPin },
+        "{nothere ": { group: "Conditions", icon: MapPinOff },
+        "{once:": { group: "Other", icon: Repeat1 },
+        "{random:": { group: "Other", icon: Dices },
+        "{img:": { group: "Other", icon: ImageIcon },
+    };
+    const INSERT_MENU_GROUP_ORDER = ["Links", "Conditions", "Other", "More"];
+
+    function textProcessorTextareaId(attribute: string): string {
+        return `richtext-${attribute}`;
+    }
+
+    function insertTextProcessorText(attribute: string, controlType: string, insertBefore: string, insertAfter: string) {
+        const textarea = document.getElementById(textProcessorTextareaId(attribute)) as HTMLTextAreaElement | null;
         if (!textarea) return;
         const start = textarea.selectionStart ?? 0;
         const end = textarea.selectionEnd ?? 0;
@@ -139,6 +181,36 @@
         textarea.selectionEnd = start + insertBefore.length + selectedText.length;
         textarea.focus();
         onTextChange(attribute, controlType, textarea.value);
+    }
+
+    // Commands not covered by FORMATTING_ICONS go into the "Insert" dropdown, grouped by
+    // INSERT_MENU_GROUPS; anything not in that map (e.g. a future CoreEditor.aslx addition)
+    // still shows up, ungrouped, under "More" rather than silently disappearing.
+    function buildInsertMenuItems(commands: TextProcessorCommand[], attribute: string, controlType: string): DropdownMenuItem[] {
+        const byGroup = new Map<string, TextProcessorCommand[]>();
+        for (const cmd of commands) {
+            if (FORMATTING_ICONS[cmd.insertBefore]) continue;
+            const group = INSERT_MENU_GROUPS[cmd.insertBefore]?.group ?? "More";
+            if (!byGroup.has(group)) byGroup.set(group, []);
+            byGroup.get(group)!.push(cmd);
+        }
+        const items: DropdownMenuItem[] = [];
+        let seenGroup = false;
+        for (const group of INSERT_MENU_GROUP_ORDER) {
+            const cmds = byGroup.get(group);
+            if (!cmds) continue;
+            cmds.forEach((cmd, i) => {
+                items.push({
+                    label: cmd.command,
+                    icon: INSERT_MENU_GROUPS[cmd.insertBefore]?.icon,
+                    heading: i === 0 ? group : undefined,
+                    divider: i === 0 && seenGroup,
+                    action: () => insertTextProcessorText(attribute, controlType, cmd.insertBefore, cmd.insertAfter),
+                });
+            });
+            seenGroup = true;
+        }
+        return items;
     }
 
     function focusOnMount(node: HTMLElement) {
@@ -224,18 +296,36 @@
 </div>
 
 {#snippet textProcessorPanel(commands: TextProcessorCommand[], attribute: string, controlType: string)}
-    <div class="flex flex-col gap-0.5 shrink-0 max-h-32 overflow-y-auto @2xl:max-h-none @2xl:overflow-visible">
+    <div class="flex items-center gap-1 shrink-0">
         {#each commands as cmd (cmd.command)}
-            <div class="flex items-center gap-1">
+            {@const Icon = FORMATTING_ICONS[cmd.insertBefore]}
+            {#if Icon}
                 <button
                     type="button"
-                    class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 w-28 justify-start"
-                    onclick={(e) => insertTextProcessorText(attribute, controlType, cmd.insertBefore, cmd.insertAfter, e)}
-                >{cmd.command}</button>
-                <span class="text-xs text-surface-600-400 whitespace-nowrap">{cmd.info}</span>
-            </div>
+                    class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5"
+                    title="{cmd.command} {cmd.info}"
+                    aria-label={cmd.command}
+                    onclick={() => insertTextProcessorText(attribute, controlType, cmd.insertBefore, cmd.insertAfter)}
+                ><Icon size={14} aria-hidden="true" /></button>
+            {/if}
         {/each}
-        <a href="https://docs.textadventures.co.uk/quest/text_processor.html" target="_blank" class="text-xs text-primary-500 underline mt-1">Text Processor help</a>
+        <span class="w-px h-5 bg-surface-200-800 mx-0.5"></span>
+        <DropdownMenu items={buildInsertMenuItems(commands, attribute, controlType)} align="left">
+            {#snippet trigger(toggle)}
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 gap-1"
+                    onclick={toggle}
+                ><ListPlus size={14} aria-hidden="true" />Insert<ChevronDown size={12} aria-hidden="true" /></button>
+            {/snippet}
+        </DropdownMenu>
+        <a
+            href="https://docs.textadventures.co.uk/quest/text_processor.html"
+            target="_blank"
+            class="btn btn-sm text-xs px-2 py-0.5 text-surface-600-400 ml-auto"
+            title="Text Processor help"
+            aria-label="Text Processor help"
+        ><LifeBuoy size={14} aria-hidden="true" /></a>
     </div>
 {/snippet}
 
@@ -274,14 +364,15 @@
         </select>
     {:else if ctrl.controlType === "richtext"}
         {#if ctrl.textProcessorCommands?.length}
-            <div class="richtext-wrap flex flex-col @2xl:flex-row gap-2 w-full">
+            <div class="flex flex-col gap-1 w-full">
+                {@render textProcessorPanel(ctrl.textProcessorCommands, ctrl.attribute!, ctrl.controlType)}
                 <textarea
+                    id={textProcessorTextareaId(ctrl.attribute!)}
                     autocapitalize="off"
                     class="input text-xs py-0.5 px-1.5 flex-1 min-h-32 resize-y"
                     value={attrValue(ctrl.attribute!) ?? ""}
                     onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLTextAreaElement).value)}
                 ></textarea>
-                {@render textProcessorPanel(ctrl.textProcessorCommands, ctrl.attribute!, ctrl.controlType)}
             </div>
         {:else}
             <textarea
@@ -481,14 +572,15 @@
             </select>
             {#if subEditorType === "richtext" && ctrl.subAttribute !== null}
                 {#if ctrl.textProcessorCommands?.length}
-                    <div class="richtext-wrap flex flex-col @2xl:flex-row gap-2 w-full">
+                    <div class="flex flex-col gap-1 w-full">
+                        {@render textProcessorPanel(ctrl.textProcessorCommands, ctrl.subAttribute, "richtext")}
                         <textarea
+                            id={textProcessorTextareaId(ctrl.subAttribute)}
                             autocapitalize="off"
                             class="input text-xs py-0.5 px-1.5 flex-1 min-h-32 resize-y"
                             value={attrValue(ctrl.subAttribute) ?? ""}
                             onchange={(e) => onTextChange(ctrl.subAttribute!, "richtext", (e.target as HTMLTextAreaElement).value)}
                         ></textarea>
-                        {@render textProcessorPanel(ctrl.textProcessorCommands, ctrl.subAttribute, "richtext")}
                     </div>
                 {:else}
                     <textarea
@@ -609,14 +701,15 @@
                 </div>
                 {#if subEditorType === "richtext" && ctrl.subAttribute !== null}
                     {#if ctrl.textProcessorCommands?.length}
-                        <div class="richtext-wrap flex flex-col @2xl:flex-row gap-2 w-full">
+                        <div class="flex flex-col gap-1 w-full">
+                            {@render textProcessorPanel(ctrl.textProcessorCommands, ctrl.subAttribute, "richtext")}
                             <textarea
+                                id={textProcessorTextareaId(ctrl.subAttribute)}
                                 autocapitalize="off"
                                 class="input text-xs py-0.5 px-1.5 flex-1 min-h-32 resize-y"
                                 value={attrValue(ctrl.subAttribute) ?? ""}
                                 onchange={(e) => onTextChange(ctrl.subAttribute!, "richtext", (e.target as HTMLTextAreaElement).value)}
                             ></textarea>
-                            {@render textProcessorPanel(ctrl.textProcessorCommands, ctrl.subAttribute, "richtext")}
                         </div>
                     {:else}
                         <textarea

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -192,17 +192,16 @@
     // INSERT_MENU_GROUPS; anything not in that map (e.g. a future CoreEditor.aslx addition)
     // still shows up, ungrouped, under "More" rather than silently disappearing.
     function buildInsertMenuItems(commands: TextProcessorCommand[], attribute: string, controlType: string): DropdownMenuItem[] {
-        const byGroup = new Map<string, TextProcessorCommand[]>();
+        const byGroup: Record<string, TextProcessorCommand[]> = {};
         for (const cmd of commands) {
             if (PINNED_ICONS[cmd.insertBefore]) continue;
             const group = INSERT_MENU_GROUPS[cmd.insertBefore]?.group ?? "More";
-            if (!byGroup.has(group)) byGroup.set(group, []);
-            byGroup.get(group)!.push(cmd);
+            (byGroup[group] ??= []).push(cmd);
         }
         const items: DropdownMenuItem[] = [];
         let seenGroup = false;
         for (const group of INSERT_MENU_GROUP_ORDER) {
-            const cmds = byGroup.get(group);
+            const cmds = byGroup[group];
             if (!cmds) continue;
             cmds.forEach((cmd, i) => {
                 items.push({

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -18,6 +18,7 @@
     import MapPinOff from "@lucide/svelte/icons/map-pin-off";
     import Dices from "@lucide/svelte/icons/dices";
     import ImageIcon from "@lucide/svelte/icons/image";
+    import BookOpen from "@lucide/svelte/icons/book-open";
     import LifeBuoy from "@lucide/svelte/icons/life-buoy";
     import ChevronDown from "@lucide/svelte/icons/chevron-down";
     import ListPlus from "@lucide/svelte/icons/list-plus";
@@ -147,10 +148,14 @@
 
     // Keyed by insertBefore (Quest syntax, stable across locales) rather than cmd.command
     // (a localized caption) so the toolbar icons/grouping don't depend on the editor language.
-    const FORMATTING_ICONS: Record<string, typeof Bold | undefined> = {
+    // These commands stay as always-visible buttons instead of going in the "Insert" dropdown:
+    // Bold/Italic/Underline as the most-reached-for formatting, and (gamebook mode only) Page
+    // Link since linking between pages is the core authoring action in a gamebook.
+    const PINNED_ICONS: Record<string, typeof Bold | undefined> = {
         "<b>": Bold,
         "<i>": Italic,
         "<u>": Underline,
+        "{page:": BookOpen,
     };
     const INSERT_MENU_GROUPS: Record<string, { group: string; icon: typeof Bold }> = {
         "{object:": { group: "Links", icon: LinkIcon },
@@ -183,13 +188,13 @@
         onTextChange(attribute, controlType, textarea.value);
     }
 
-    // Commands not covered by FORMATTING_ICONS go into the "Insert" dropdown, grouped by
+    // Commands not covered by PINNED_ICONS go into the "Insert" dropdown, grouped by
     // INSERT_MENU_GROUPS; anything not in that map (e.g. a future CoreEditor.aslx addition)
     // still shows up, ungrouped, under "More" rather than silently disappearing.
     function buildInsertMenuItems(commands: TextProcessorCommand[], attribute: string, controlType: string): DropdownMenuItem[] {
         const byGroup = new Map<string, TextProcessorCommand[]>();
         for (const cmd of commands) {
-            if (FORMATTING_ICONS[cmd.insertBefore]) continue;
+            if (PINNED_ICONS[cmd.insertBefore]) continue;
             const group = INSERT_MENU_GROUPS[cmd.insertBefore]?.group ?? "More";
             if (!byGroup.has(group)) byGroup.set(group, []);
             byGroup.get(group)!.push(cmd);
@@ -298,7 +303,7 @@
 {#snippet textProcessorPanel(commands: TextProcessorCommand[], attribute: string, controlType: string)}
     <div class="flex items-center gap-1 shrink-0">
         {#each commands as cmd (cmd.command)}
-            {@const Icon = FORMATTING_ICONS[cmd.insertBefore]}
+            {@const Icon = PINNED_ICONS[cmd.insertBefore]}
             {#if Icon}
                 <button
                     type="button"


### PR DESCRIPTION
## Summary
- Bold/Italic/Underline become icon-only buttons; most other text-processor commands move into a single "Insert" dropdown grouped as Links / Conditions / Other, instead of a wall of 13 labeled buttons that either sat in a side rail or stacked awkwardly on narrow screens. In gamebook mode, Page Link is pinned next to Bold/Italic/Underline instead — it's the core authoring action for a gamebook, so it doesn't belong buried in a dropdown.
- Reuses the existing `DropdownMenu` component (same one behind the File/Add/"…" menus) rather than a bespoke popover. Added an optional `heading` field to `DropdownMenuItem` for the group labels — additive, other call sites unaffected.
- "Text Processor help" moves into the toolbar row as an icon button instead of a separate link below the buttons.
- Icon/grouping/pinning is keyed off `insertBefore` (the underlying Quest syntax, e.g. `<b>`, `{once:`) rather than the localized caption, so it doesn't depend on editor language.
- **Picker dialogs for the six commands that reference something specific** (Object Link, Exit Link, Here, Not Here, Image, and gamebook Page Link) instead of just inserting raw braces for the author to fill in by hand — this is how the old Quest 5 editor behaved. Clicking one opens a small modal to pick the target (and link text, where the syntax supports it — see [the text processor docs](https://docs.textadventures.co.uk/quest/text_processor.html) for the exact `{object:name:text}` etc. formats) before composing and inserting the final markup.
  - Object Link / Page Link: target combobox + optional link text
  - Exit Link: target combobox only (exits don't support custom link text), with an empty-state message when none exist yet
  - Here / Not Here: target combobox + required text (the syntax needs both)
  - Image: reuses the existing `AssetPicker` component (pick an existing upload or upload a new one)
  - Object/Here/Not Here/Page all reuse the existing object-name list (gamebook pages are plain Objects under the hood, so no new backend call was needed); Exit Link reuses the existing exit-name list. Kept entirely on the frontend rather than threading a new `source` field through the WASM bridge, consistent with how icons/grouping are already keyed off `insertBefore`.
- Insert logic now looks up the textarea by a stable id instead of the click event, since dropdown/modal actions don't carry a `MouseEvent`.

## Test plan
- [x] `svelte-check` and `eslint` — 0 errors, 0 warnings
- [x] Manually verified in the AppShell dev server across both a text-adventure and a gamebook draft:
  - Bold/Italic/Underline icon buttons insert `<b></b>` etc. at the cursor
  - Insert dropdown opens with Links/Conditions/Other groups and inserts correctly
  - Gamebook Page Link is pinned and opens its picker
  - Object Link, Here, Exit Link (empty state), and Image pickers all open with the right fields, correct disabled states, and compose the correct final markup (e.g. `{object:player:yourself}`, `{here player:You can see the player here.}`, `{page:Page2}`)
- [x] Verified responsive behavior at desktop and 375px mobile width — toolbar stays on one row at both

🤖 Generated with [Claude Code](https://claude.com/claude-code)