### PR TITLE
fix: fix editor keyboard shortcuts and unsaved-close dialog freeze

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -767,9 +767,18 @@
             {ctrl.caption ?? ""}
         </div>
     {:else if ctrl.controlType === "label"}
-        <div class="px-3 py-1 text-xs text-surface-600-400 italic">
-            {ctrl.caption ?? ""}
-        </div>
+        {#if ctrl.href}
+            <a
+                href={ctrl.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="block px-3 py-1 text-xs text-primary-600-400 italic hover:underline"
+            >{ctrl.caption ?? ""}</a>
+        {:else}
+            <div class="px-3 py-1 text-xs text-surface-600-400 italic">
+                {ctrl.caption ?? ""}
+            </div>
+        {/if}
     {:else if ctrl.controlType === "elementslist" && $selectedKey}
         <ElementsList
             elementKey={$selectedKey}

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface ControlInfo {
   sourceExclude?: string | null
   checkboxCaption?: string | null
   isWalkthrough?: boolean
+  href?: string | null
 }
 
 export interface TabInfo {

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -117,9 +117,23 @@ function broadcastRecentChanged(kind: RecentKind): void {
     editorWindow?.webContents.send("recent-games-changed", kind);
 }
 
+// New Game/Open Game must work even with the editor window fully closed
+// (macOS: app stays running, menu bar stays up, no window at all) — same
+// requirement the comment on focusEditorWindow above already describes, but
+// that function (and the plain IPC send below) both silently no-op once
+// editorWindow is null, so this was never actually reachable. Save/Save
+// As/Undo/Redo have nothing to act on with no game loaded, so those stay
+// plain no-ops in that state, same as before.
 function sendMenuAction(action: MenuAction): void {
+    if (!editorWindow) {
+        if (staticServer && (action === "new-game" || action === "open-file")) {
+            const query = action === "open-file" ? `?action=open&t=${Date.now()}` : "";
+            createEditorWindow(staticServer.port, null, `/open${query}`);
+        }
+        return;
+    }
     focusEditorWindow();
-    editorWindow?.webContents.send("menu-action", action);
+    editorWindow.webContents.send("menu-action", action);
 }
 
 // Undo/Redo can't just forward blindly like sendMenuAction does for File
@@ -390,7 +404,7 @@ async function refreshMenu(): Promise<void> {
     Menu.setApplicationMenu(buildAppMenu(await listRecentGames("edit")));
 }
 
-function createEditorWindow(port: number, initialPath?: string | null): void {
+function createEditorWindow(port: number, initialPath?: string | null, initialRoute?: string): void {
     editorWindow = new BrowserWindow({
         title: "Quest Viva",
         width: 1280,
@@ -520,7 +534,11 @@ function createEditorWindow(port: number, initialPath?: string | null): void {
         return { action: "deny" };
     });
 
-    void editorWindow.loadURL(`http://127.0.0.1:${port}${initialUrlPath(initialPath ?? null)}`);
+    // initialRoute is a pre-built route (used by sendMenuAction below to land
+    // straight on /open, optionally with its own action query param) — it
+    // bypasses initialUrlPath, which only ever derives a route from a file
+    // path (file-association opens), not from an arbitrary in-app action.
+    void editorWindow.loadURL(`http://127.0.0.1:${port}${initialRoute ?? initialUrlPath(initialPath ?? null)}`);
 
     editorWindow.on("closed", () => {
         editorWindow = null;

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -133,10 +133,35 @@ function sendMenuAction(action: MenuAction): void {
 // already the focused window; otherwise fall back to the focused window's
 // own native text-field undo/redo (e.g. text typed into the player's command
 // box), exactly like Electron's default 'undo'/'redo' roles would.
+//
+// Within the editor window itself, the same ambiguity exists one level down:
+// the accelerator fires before the DOM ever sees the keystroke, so it can't
+// tell "focus is on the tree/canvas" (app-level undo should apply) apart from
+// "focus is in a <textarea>/<input>/contenteditable script or richtext field"
+// (the browser's own native undo should apply instead, or app-level undo
+// would clobber in-progress text edits the native undo stack still has).
+// Ask the renderer which kind of element is currently focused before
+// deciding which undo to invoke.
+async function isTextEditingFocused(window: BrowserWindow): Promise<boolean> {
+    try {
+        return await window.webContents.executeJavaScript(
+            "(() => { const el = document.activeElement; if (!el) return false; " +
+            "return el.tagName === 'TEXTAREA' || el.tagName === 'INPUT' || el.isContentEditable; })()",
+        );
+    } catch {
+        return false;
+    }
+}
+
 function editorUndoRedo(action: "undo" | "redo") {
-    return (_item: MenuItem, focusedWindow: Electron.BaseWindow | undefined): void => {
-        if (focusedWindow === editorWindow) {
-            editorWindow?.webContents.send("menu-action", action);
+    return async (_item: MenuItem, focusedWindow: Electron.BaseWindow | undefined): Promise<void> => {
+        if (focusedWindow === editorWindow && editorWindow) {
+            if (await isTextEditingFocused(editorWindow)) {
+                if (action === "undo") editorWindow.webContents.undo();
+                else editorWindow.webContents.redo();
+            } else {
+                editorWindow.webContents.send("menu-action", action);
+            }
         } else if (focusedWindow instanceof BrowserWindow) {
             if (action === "undo") focusedWindow.webContents.undo();
             else focusedWindow.webContents.redo();
@@ -272,16 +297,23 @@ function buildAppMenu(recentGames: RecentGame[]): Menu {
                 // Undo/Redo replace the role-based defaults (which only ever
                 // undo native text-field edits) with the editor's real
                 // command-stack undo — see editorUndoRedo's comment. Cut/
-                // Copy/Paste stay as plain roles: there's no app-level
-                // clipboard concept for tree/canvas content, only ordinary
-                // text fields, which the native roles already handle
-                // correctly for whichever window/field is focused.
+                // Copy/Paste/Select All stay as plain roles: there's no
+                // app-level clipboard or selection concept for tree/canvas
+                // content, only ordinary text fields, which the native roles
+                // already handle correctly for whichever window/field is
+                // focused. Select All's role must be listed explicitly like
+                // this — Electron only auto-adds Cmd+A (and Cut/Copy/Paste)
+                // to a *default* Edit menu; once this app builds its own
+                // Edit submenu, nothing claims that accelerator unless a
+                // role item for it is present, so without one Cmd+A silently
+                // does nothing in every text field.
                 { label: "Undo", accelerator: "CmdOrCtrl+Z", click: editorUndoRedo("undo") },
                 { label: "Redo", accelerator: isMac ? "Shift+Cmd+Z" : "Ctrl+Y", click: editorUndoRedo("redo") },
                 { type: "separator" },
                 { role: "cut" },
                 { role: "copy" },
                 { role: "paste" },
+                { role: "selectAll" },
             ],
         },
         {
@@ -411,17 +443,46 @@ function createEditorWindow(port: number, initialPath?: string | null): void {
     // is the hook it gives main for exactly this. Without a handler here the
     // window just silently refuses to close (no dialog, no feedback) and
     // Force Quit becomes the only way out.
+    //
+    // Calling event.preventDefault() here is what forces the close through
+    // (its semantics: "ignore the page's beforeunload and unload anyway"),
+    // and per Electron's contract that has to happen synchronously, before
+    // this listener returns — checked immediately once the event finishes
+    // firing, with no way to come back to it later. That rules out an async
+    // confirmation dialog directly in this handler: it would return before
+    // the user answers, preventDefault() would never be called in time, and
+    // the close would just stay silently blocked (same as no handler at
+    // all), no matter what the user later picks.
+    //
+    // So instead: leave the first attempt blocked (this handler returns
+    // without calling preventDefault(), same as "Cancel" today) while an
+    // async dialog is up, and only if the user confirms, close() the window
+    // again ourselves — that re-runs the page's beforeunload and re-fires
+    // this same event, and this time forceCloseConfirmed lets it through
+    // immediately without asking again. Using the async dialog (rather than
+    // *Sync) matters beyond just this handler: the sync version blocks the
+    // entire main process — no IPC, no other window's menu actions, nothing
+    // — for as long as it's on screen; this way only this window sits idle
+    // pending an answer while the rest of the app stays responsive.
+    let forceCloseConfirmed = false;
     editorWindow.webContents.on("will-prevent-unload", (event) => {
         if (!editorWindow) return;
-        const choice = dialog.showMessageBoxSync(editorWindow, {
+        if (forceCloseConfirmed) {
+            event.preventDefault();
+            return;
+        }
+        void dialog.showMessageBox(editorWindow, {
             type: "question",
             buttons: ["Cancel", "Leave"],
             defaultId: 0,
             cancelId: 0,
             message: "Leave without saving?",
             detail: "You have unsaved changes. If you leave now, they'll be lost.",
+        }).then(({ response }) => {
+            if (response !== 1 || !editorWindow) return;
+            forceCloseConfirmed = true;
+            editorWindow.close();
         });
-        if (choice === 1) event.preventDefault();
     });
 
     // The editor's Preview button calls window.open('/player/...') unchanged

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -40,7 +40,8 @@ internal record ControlInfo(
     string? ValuePrompt = null,
     string? SourceExclude = null,
     string? CheckboxCaption = null,
-    bool IsWalkthrough = false);
+    bool IsWalkthrough = false,
+    string? Href = null);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -3319,11 +3320,13 @@ public partial class WasmEditorBridge
         var valuePrompt = isDictionary ? ctrl.GetString("valueprompt") : null;
         var sourceExclude = isDictionary ? ctrl.GetString("sourceexclude") : null;
 
+        var href = ctrl.ControlType == "label" ? ctrl.GetString("href") : null;
+
         return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
             null, null, textProcessorCommands, addPrompt, Source: source,
             Advanced: !ctrl.IsControlVisibleInSimpleMode,
             KeyPrompt: keyPrompt, ValuePrompt: valuePrompt, SourceExclude: sourceExclude,
-            IsWalkthrough: isWalkthrough);
+            IsWalkthrough: isWalkthrough, Href: href);
     }
 
     [JSExport]

--- a/tests/e2e/verify-electron-open-game-no-window.mjs
+++ b/tests/e2e/verify-electron-open-game-no-window.mjs
@@ -1,0 +1,94 @@
+// Ad-hoc manual verification for File > New Game…/Open Game… doing nothing
+// when the editor window has been closed entirely (macOS: the app keeps
+// running with the menu bar up, but zero windows open) — sendMenuAction
+// required editorWindow to already exist, so with it null, both
+// focusEditorWindow() and the plain IPC send silently no-op. The comment on
+// focusEditorWindow already claimed "every File-menu editor action is
+// reachable even ... on mac, no window at all", but that was never actually
+// true until this fix: sendMenuAction now recreates the editor window
+// (landing straight on /open, with ?action=open for "Open Game…" so the
+// file picker opens immediately, matching the existing file-association
+// cold-start pattern in initialUrlPath) when there isn't one already.
+//
+// Uses Playwright's _electron launcher against the already-built
+// src/ElectronApp/dist — run electron.sh once first (or the build steps
+// inside it) so dist/ and resources/app-static exist.
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const electronAppDir = join(import.meta.dirname, '..', '..', 'src', 'ElectronApp');
+const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'))('electron');
+
+async function clickMenuItem(app, itemLabel) {
+    await app.evaluate(({ Menu, BrowserWindow }, label) => {
+        const menu = Menu.getApplicationMenu();
+        const fileMenu = menu.items.find((i) => i.label === 'File');
+        const item = fileMenu.submenu.items.find((i) => i.label === label);
+        const win = BrowserWindow.getAllWindows()[0]; // may be undefined — that's the whole point being tested
+        item.click(undefined, win, undefined);
+    }, itemLabel);
+}
+
+const userDataDir = mkdtempSync(join(tmpdir(), 'quest-electron-userdata-'));
+
+let app;
+try {
+    app = await electron.launch({ executablePath: electronExecutablePath, args: [electronAppDir, `--user-data-dir=${userDataDir}`] });
+    const win = await app.firstWindow();
+    win.on('pageerror', err => console.log('[editor] [pageerror]', err.message));
+    await win.waitForSelector('a:has-text("Create"), a:has-text("Play")', { timeout: 30000 });
+    console.log('[editor] app ready, closing the only window');
+
+    // Fresh Home page, nothing loaded/dirtied — closes immediately, no beforeunload dialog involved.
+    await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].close());
+    for (let i = 0; i < 20; i++) {
+        const count = await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
+        if (count === 0) break;
+        await new Promise((r) => setTimeout(r, 100));
+    }
+    const windowCount = await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
+    console.log('[editor] window count after close:', windowCount);
+    if (windowCount !== 0) throw new Error('FAIL: window did not actually close (test setup problem, not the fix)');
+
+    // --- "Open Game…" with no window open ---
+    const [newWinForOpen] = await Promise.all([
+        app.waitForEvent('window', { timeout: 10000 }),
+        clickMenuItem(app, 'Open Game…'),
+    ]);
+    await newWinForOpen.waitForLoadState();
+    console.log('[editor] "Open Game…" with no window recreated one at:', newWinForOpen.url());
+    if (!newWinForOpen.url().includes('/open') || !newWinForOpen.url().includes('action=open')) {
+        throw new Error(`FAIL: expected the new window to land on /open?action=open..., got ${newWinForOpen.url()}`);
+    }
+    console.log('PASS: "Open Game…" with no window open recreates a window and lands on the file-open action');
+
+    await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].close());
+    for (let i = 0; i < 20; i++) {
+        const count = await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length);
+        if (count === 0) break;
+        await new Promise((r) => setTimeout(r, 100));
+    }
+
+    // --- "New Game…" with no window open ---
+    const [newWinForNew] = await Promise.all([
+        app.waitForEvent('window', { timeout: 10000 }),
+        clickMenuItem(app, 'New Game…'),
+    ]);
+    await newWinForNew.waitForLoadState();
+    console.log('[editor] "New Game…" with no window recreated one at:', newWinForNew.url());
+    if (!newWinForNew.url().includes('/open') || newWinForNew.url().includes('action=open')) {
+        throw new Error(`FAIL: expected the new window to land on plain /open (no action=open), got ${newWinForNew.url()}`);
+    }
+    console.log('PASS: "New Game…" with no window open recreates a window and lands on /open');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    app?.process().kill('SIGKILL');
+    rmSync(userDataDir, { recursive: true, force: true });
+}

--- a/tests/e2e/verify-electron-selectall-textbox.mjs
+++ b/tests/e2e/verify-electron-selectall-textbox.mjs
@@ -1,0 +1,122 @@
+// Ad-hoc manual verification for Cmd+A doing nothing in a text field: the
+// editor's custom Edit menu (main.ts's buildAppMenu) replaces Electron's
+// default Edit menu wholesale, and the default menu is the only thing that
+// registers CmdOrCtrl+A -> role: "selectAll" — Cut/Copy/Paste were already
+// carried over as explicit roles, but Select All wasn't, so nothing claimed
+// that accelerator and it silently did nothing in every text field.
+//
+// A real physical Cmd+A goes through macOS's NSMenu key-equivalent matching
+// before the keystroke ever reaches the renderer, so (like the Undo fix's
+// test) this can't be verified by dispatching a synthetic keydown via CDP —
+// that bypasses the OS menu layer entirely and would "pass" whether or not
+// the role is actually wired up. Instead this drives the same menu item
+// Electron itself would invoke, directly, and checks the resulting native
+// text-field selection.
+//
+// Uses Playwright's _electron launcher against the already-built
+// src/ElectronApp/dist — run electron.sh once first (or the build steps
+// inside it) so dist/ and resources/app-static exist.
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const electronAppDir = join(import.meta.dirname, '..', '..', 'src', 'ElectronApp');
+const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'))('electron');
+
+const userDataDir = mkdtempSync(join(tmpdir(), 'quest-electron-userdata-'));
+const gameName = `SelectAllTest-${Date.now()}`;
+const gameDirPath = join(homedir(), 'Documents', 'Quest Games', gameName);
+
+let app;
+try {
+    app = await electron.launch({
+        executablePath: electronExecutablePath,
+        args: [electronAppDir, `--user-data-dir=${userDataDir}`],
+    });
+    const win = await app.firstWindow();
+    win.on('pageerror', err => console.log('[editor] [pageerror]', err.message));
+    win.on('console', msg => { if (msg.type() === 'error') console.log('[editor] [console.error]', msg.text()); });
+
+    await win.waitForSelector('a:has-text("Create")', { timeout: 30000 });
+    await win.click('a:has-text("Create")');
+    await win.waitForSelector('input[placeholder="Game name"]', { timeout: 15000 });
+    await win.fill('input[placeholder="Game name"]', gameName);
+    await win.locator('label:has-text("Text adventure")').click();
+    await win.waitForSelector('text=Please select a template.', { state: 'detached', timeout: 15000 }).catch(() => {});
+    const templateRadio = win.locator('input[type="radio"]').first();
+    await templateRadio.waitFor({ timeout: 15000 });
+    await templateRadio.click();
+    await win.click('button:has-text("Create"):near(:text("Will be created as a new folder"))');
+
+    await win.waitForSelector('text=GAME OBJECTS', { timeout: 30000 });
+    console.log('[editor] editor loaded');
+
+    // Structural check: the custom Edit menu must actually list a selectAll-role item now.
+    const editMenuLabels = await app.evaluate(({ Menu }) => {
+        const menu = Menu.getApplicationMenu();
+        const editMenu = menu.items.find((i) => i.label === 'Edit');
+        return editMenu.submenu.items.map((i) => ({ label: i.label, role: i.role }));
+    });
+    console.log('[editor] Edit menu items:', JSON.stringify(editMenuLabels));
+    if (!editMenuLabels.some((i) => i.role === 'selectall')) {
+        throw new Error('FAIL: Edit menu has no selectAll-role item');
+    }
+    console.log('PASS: Edit menu now includes a selectAll-role item');
+
+    // Behavioral check: select the room's Name field, type distinctive text, then
+    // invoke the same menu item Electron itself would invoke on a real Cmd+A.
+    const roomNode = win.locator('text=room').first();
+    await roomNode.click();
+    await win.waitForSelector('text=Alias:', { timeout: 10000 });
+
+    const nameInput = win.locator('input[type="text"]:not([placeholder="Filter..."])').first();
+    await nameInput.click();
+    await win.keyboard.press('End');
+    await win.keyboard.type('XYZ');
+    const value = await nameInput.inputValue();
+    console.log('[editor] Name field value:', value);
+    if (value !== 'roomXYZ') throw new Error(`Expected "roomXYZ", got "${value}"`);
+
+    // role-based MenuItems are implemented natively (not via a JS click
+    // callback we can invoke standalone) — calling .click() manually with a
+    // supplied window doesn't reliably replay that native behavior the way
+    // it does for our own custom Undo/Redo click functions. What role:
+    // "selectAll" actually *is*, under the hood, is Electron always calling
+    // webContents.selectAll() on the target webContents; that's the well-
+    // established mechanism Cut/Copy/Paste already rely on in production, so
+    // exercising it directly here checks the one part that was actually
+    // missing (the role wired up in the menu, asserted above) without
+    // re-testing Electron's own accelerator-dispatch internals.
+    await app.evaluate(({ BrowserWindow }) => {
+        const editorWin = BrowserWindow.getAllWindows()[0];
+        editorWin.webContents.selectAll();
+    });
+    await win.waitForTimeout(300);
+
+    const selection = await nameInput.evaluate((el) => ({
+        start: el.selectionStart,
+        end: el.selectionEnd,
+        length: el.value.length,
+    }));
+    console.log('[editor] selection after Select All:', JSON.stringify(selection));
+    if (selection.start !== 0 || selection.end !== selection.length) {
+        throw new Error(`FAIL: Select All did not select the full field (got ${JSON.stringify(selection)})`);
+    }
+    console.log('PASS: Select All selected the entire Name field');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    // Not app.close(): this test always leaves unsaved edits (typed text
+    // never saved), which trips main.ts's will-prevent-unload handler and
+    // pops a *synchronous* native "Leave without saving?" dialog that blocks
+    // the whole process — nothing left to click it away with here. Kill the
+    // process directly instead of asking it to close gracefully.
+    app?.process().kill('SIGKILL');
+    rmSync(userDataDir, { recursive: true, force: true });
+    rmSync(gameDirPath, { recursive: true, force: true });
+}

--- a/tests/e2e/verify-electron-undo-textarea.mjs
+++ b/tests/e2e/verify-electron-undo-textarea.mjs
@@ -1,0 +1,146 @@
+// Ad-hoc manual verification for the Cmd+Z-in-a-textarea fix (main.ts's
+// editorUndoRedo): pressing the app-wide Undo accelerator while a text field
+// inside the editor window is focused should invoke the native
+// webContents.undo() edit command (so in-progress typing can be undone
+// character-by-character, like any browser text field), not blindly route to
+// EditorCore's app-level undo stack — which previously happened whenever the
+// editor window had OS focus, textarea or not.
+//
+// Verifies both sides of the routing so a future regression that always
+// takes one path would be caught:
+//  - text field focused -> native undo fires (value reverts), no "undo"
+//    menu-action reaches the renderer's onAction listener.
+//  - no text field focused (tree/canvas) -> app-level "undo" menu-action
+//    still fires, preserving the original app-level undo behavior.
+//
+// Uses Playwright's _electron launcher against the already-built
+// src/ElectronApp/dist — run electron.sh once first (or the build steps
+// inside it) so dist/ and resources/app-static exist.
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const electronAppDir = join(import.meta.dirname, '..', '..', 'src', 'ElectronApp');
+const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'))('electron');
+
+const userDataDir = mkdtempSync(join(tmpdir(), 'quest-electron-userdata-'));
+// Electron creates games as a real folder on disk (unlike the browser build's
+// in-browser draft) — use a unique name so reruns never collide with a
+// leftover folder from a previous (e.g. failed) run.
+const gameName = `UndoTest-${Date.now()}`;
+const gameDirPath = join(homedir(), 'Documents', 'Quest Games', gameName);
+
+let app;
+try {
+    app = await electron.launch({
+        executablePath: electronExecutablePath,
+        args: [electronAppDir, `--user-data-dir=${userDataDir}`],
+    });
+    const win = await app.firstWindow();
+    win.on('pageerror', err => console.log('[editor] [pageerror]', err.message));
+    win.on('console', msg => { if (msg.type() === 'error') console.log('[editor] [console.error]', msg.text()); });
+
+    // Root is the Play/Create Home (PUBLIC_SHOW_HOME=true, see electron.sh) — switch to Create, make a local draft.
+    await win.waitForSelector('a:has-text("Create")', { timeout: 30000 });
+    await win.click('a:has-text("Create")');
+    await win.waitForSelector('input[placeholder="Game name"]', { timeout: 15000 });
+    await win.fill('input[placeholder="Game name"]', gameName);
+    // "Game type" radios + a template list only render once a name is entered;
+    // pick "Text adventure" and its first available template before creating.
+    await win.locator('label:has-text("Text adventure")').click();
+    await win.waitForSelector('text=Please select a template.', { state: 'detached', timeout: 15000 }).catch(() => {});
+    const templateRadio = win.locator('input[type="radio"]').first();
+    await templateRadio.waitFor({ timeout: 15000 });
+    await templateRadio.click();
+    // Electron (unlike the browser build) creates games as a real folder on disk
+    // rather than an in-browser draft — the button is a plain "Create" near the
+    // "Will be created as a new folder in: ..." text, not "Create local draft".
+    await win.click('button:has-text("Create"):near(:text("Will be created as a new folder"))');
+
+    // Editor loaded once the tree's default "room" object is selectable.
+    await win.waitForSelector('text=GAME OBJECTS', { timeout: 30000 });
+    console.log('[editor] editor loaded');
+
+    // Record every app-level menu-action the renderer receives, alongside the +layout.svelte subscriber already listening.
+    await win.evaluate(() => {
+        window.__actionsSeen = [];
+        window.electronApp.menu.onAction((a) => window.__actionsSeen.push(a));
+    });
+
+    // Select the "room" tree node (second top-level item under game), whose Setup tab has a plain <input> Name field.
+    const roomNode = win.locator('text=room').first();
+    await roomNode.click();
+    await win.waitForSelector('text=Alias:', { timeout: 10000 }); // Room Setup tab loaded
+
+    // Svelte binds .value as a JS property, not a static "value" attribute, so
+    // match by DOM position instead: "Name:" is the first text input on the
+    // properties panel (excluding the sidebar's "Filter game objects" box).
+    const nameInput = win.locator('input[type="text"]:not([placeholder="Filter..."])').first();
+    if ((await nameInput.inputValue()) !== 'room') {
+        throw new Error(`Expected the Name field to read "room", got "${await nameInput.inputValue()}"`);
+    }
+    await nameInput.click();
+    await win.keyboard.press('End');
+    await win.keyboard.type('XYZ'); // real keystrokes, so Chromium builds a native undo entry
+    const valueBeforeUndo = await nameInput.inputValue();
+    console.log('[editor] typed into Name field, value now:', valueBeforeUndo);
+    if (valueBeforeUndo !== 'roomXYZ') throw new Error(`Expected "roomXYZ", got "${valueBeforeUndo}"`);
+
+    // --- Case A: text field focused -> Undo accelerator should take the native path ---
+    await app.evaluate(({ Menu, BrowserWindow }) => {
+        const menu = Menu.getApplicationMenu();
+        const editMenu = menu.items.find((i) => i.label === 'Edit');
+        const undoItem = editMenu.submenu.items.find((i) => i.label === 'Undo');
+        const editorWin = BrowserWindow.getAllWindows()[0];
+        undoItem.click(undefined, editorWin, undefined);
+    });
+    await win.waitForTimeout(500); // let the async executeJavaScript focus-check + native undo settle
+
+    const valueAfterUndo = await nameInput.inputValue();
+    const actionsAfterTextFieldUndo = await win.evaluate(() => window.__actionsSeen.slice());
+    console.log('[editor] value after Undo (text field focused):', valueAfterUndo);
+    console.log('[editor] app-level actions seen so far:', actionsAfterTextFieldUndo);
+
+    if (valueAfterUndo === valueBeforeUndo) {
+        throw new Error('FAIL: native undo did not revert the Name field — Cmd+Z-in-textfield bug is back');
+    }
+    if (actionsAfterTextFieldUndo.includes('undo')) {
+        throw new Error('FAIL: app-level "undo" menu-action fired while a text field was focused');
+    }
+    console.log('PASS: text-field-focused Undo took the native webContents.undo() path, not app-level undo');
+
+    // --- Case B: no text field focused (blur to the tree) -> app-level Undo should still fire ---
+    await win.locator('text=GAME OBJECTS').click();
+    await win.waitForTimeout(100);
+    await app.evaluate(({ Menu, BrowserWindow }) => {
+        const menu = Menu.getApplicationMenu();
+        const editMenu = menu.items.find((i) => i.label === 'Edit');
+        const undoItem = editMenu.submenu.items.find((i) => i.label === 'Undo');
+        const editorWin = BrowserWindow.getAllWindows()[0];
+        undoItem.click(undefined, editorWin, undefined);
+    });
+    await win.waitForTimeout(500);
+
+    const actionsAfterTreeUndo = await win.evaluate(() => window.__actionsSeen.slice());
+    console.log('[editor] app-level actions seen after tree-focused Undo:', actionsAfterTreeUndo);
+    if (!actionsAfterTreeUndo.includes('undo')) {
+        throw new Error('FAIL: app-level "undo" menu-action did not fire when no text field was focused');
+    }
+    console.log('PASS: tree-focused Undo still routes to the app-level EditorCore undo stack');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    // Not app.close(): this test always leaves unsaved edits (typed text
+    // never saved), which trips main.ts's will-prevent-unload handler and
+    // pops a *synchronous* native "Leave without saving?" dialog that blocks
+    // the whole process — nothing left to click it away with here. Kill the
+    // process directly instead of asking it to close gracefully.
+    app?.process().kill('SIGKILL');
+    rmSync(userDataDir, { recursive: true, force: true });
+    rmSync(gameDirPath, { recursive: true, force: true });
+}

--- a/tests/e2e/verify-electron-unsaved-close-dialog.mjs
+++ b/tests/e2e/verify-electron-unsaved-close-dialog.mjs
@@ -1,0 +1,142 @@
+// Ad-hoc manual verification for main.ts's async "Leave without saving?"
+// dialog (the will-prevent-unload handler). The previous implementation used
+// dialog.showMessageBoxSync, which blocks the entire main process — no IPC,
+// no other window's menu actions — for as long as it's on screen. The fix
+// defers: the first close attempt just stays blocked (event.preventDefault()
+// is NOT called synchronously) while an async dialog.showMessageBox() is
+// pending, and only a confirmed "Leave" answer calls editorWindow.close()
+// again, which re-fires this same event — this time forced through
+// immediately via a forceCloseConfirmed flag, without asking again.
+//
+// Driving this through a *real* window close (clicking the OS close button,
+// or BrowserWindow.close()) turns out to also trigger Chromium's own native
+// beforeunload confirmation as a CDP-visible "javascript dialog", which
+// races with Playwright's own default auto-dismiss handling for such dialogs
+// and throws unrelated to anything this change touches — that plumbing
+// (beforeunload -> will-prevent-unload) is unchanged, pre-existing Electron
+// behavior. So instead this emits 'will-prevent-unload' on the editor
+// window's webContents directly (it's a plain EventEmitter event) to
+// exercise exactly the handler logic that changed, in isolation.
+//
+// forceCloseConfirmed is real per-window state that's meant to persist once
+// set (so a confirmed close's retry doesn't ask again) — so "Leave" and
+// "Cancel" each get their own fresh app launch/window rather than sharing
+// one, otherwise the second scenario would inherit the first's already-
+// confirmed flag and skip its own dialog (which is correct production
+// behavior, just not what a fresh scenario means to exercise).
+//
+// Uses Playwright's _electron launcher against the already-built
+// src/ElectronApp/dist — run electron.sh once first (or the build steps
+// inside it) so dist/ and resources/app-static exist.
+import { _electron as electron } from 'playwright';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const electronAppDir = join(import.meta.dirname, '..', '..', 'src', 'ElectronApp');
+const electronExecutablePath = createRequire(join(electronAppDir, 'package.json'))('electron');
+
+async function withFreshApp(fn) {
+    const userDataDir = mkdtempSync(join(tmpdir(), 'quest-electron-userdata-'));
+    let app;
+    try {
+        app = await electron.launch({ executablePath: electronExecutablePath, args: [electronAppDir, `--user-data-dir=${userDataDir}`] });
+        const win = await app.firstWindow();
+        win.on('pageerror', err => console.log('[editor] [pageerror]', err.message));
+        await win.waitForSelector('a:has-text("Create"), a:has-text("Play")', { timeout: 30000 });
+        return await fn(app, win);
+    } finally {
+        app?.process().kill('SIGKILL');
+        rmSync(userDataDir, { recursive: true, force: true });
+    }
+}
+
+try {
+    // --- Scenario: "Leave" ---
+    const leaveResult = await withFreshApp((app) => app.evaluate(({ BrowserWindow, dialog }) => new Promise((resolve, reject) => {
+        try {
+            const editorWin = BrowserWindow.getAllWindows()[0];
+            let closeCalled = false;
+            editorWin.close = () => { closeCalled = true; }; // spy, avoid the real native close/CDP-dialog path
+
+            let resolveDialog;
+            let showMessageBoxCalls = 0;
+            dialog.showMessageBox = () => {
+                showMessageBoxCalls++;
+                return new Promise((res) => { resolveDialog = () => res({ response: 1 }); }); // 1 = "Leave"
+            };
+
+            const event1 = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+            editorWin.webContents.emit('will-prevent-unload', event1);
+            const blockedSynchronously = event1.defaultPrevented === false; // must stay false: no sync preventDefault
+
+            setTimeout(() => {
+                try {
+                    if (typeof resolveDialog !== 'function') throw new Error('dialog.showMessageBox was never called on the first attempt');
+                    resolveDialog();
+                    setTimeout(() => {
+                        const event2 = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+                        editorWin.webContents.emit('will-prevent-unload', event2); // stands in for close()'s real retry
+                        resolve({ blockedSynchronously, closeCalledAfterLeave: closeCalled, forcedThroughOnRetry: event2.defaultPrevented, showMessageBoxCalls });
+                    }, 50);
+                } catch (err) { reject(err); }
+            }, 50);
+        } catch (err) { reject(err); }
+    })));
+    console.log('[editor] Leave scenario:', JSON.stringify(leaveResult));
+    if (!leaveResult.blockedSynchronously) throw new Error('FAIL: first will-prevent-unload call synchronously prevented default — no room for an async dialog');
+    if (!leaveResult.closeCalledAfterLeave) throw new Error('FAIL: confirming "Leave" did not call editorWindow.close()');
+    if (!leaveResult.forcedThroughOnRetry) throw new Error('FAIL: retried will-prevent-unload after "Leave" was not forced through synchronously');
+    if (leaveResult.showMessageBoxCalls !== 1) throw new Error(`FAIL: expected exactly one dialog for the retry (forceCloseConfirmed should skip it), got ${leaveResult.showMessageBoxCalls}`);
+    console.log('PASS: "Leave" flow — first attempt stays open async, close() called, retry forced through without a second dialog');
+
+    // --- Scenario: "Cancel" (fresh app/window — forceCloseConfirmed must start false) ---
+    const cancelResult = await withFreshApp((app) => app.evaluate(({ BrowserWindow, dialog }) => new Promise((resolve, reject) => {
+        try {
+            const editorWin = BrowserWindow.getAllWindows()[0];
+            let closeCalled = false;
+            editorWin.close = () => { closeCalled = true; };
+
+            let resolveDialog;
+            dialog.showMessageBox = () => new Promise((res) => { resolveDialog = () => res({ response: 0 }); }); // 0 = "Cancel"
+
+            const event1 = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+            editorWin.webContents.emit('will-prevent-unload', event1);
+
+            setTimeout(() => {
+                try {
+                    if (typeof resolveDialog !== 'function') throw new Error('dialog.showMessageBox was never called on the first attempt');
+                    resolveDialog();
+                    setTimeout(() => {
+                        const event2 = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+                        editorWin.webContents.emit('will-prevent-unload', event2); // a later close attempt should ask again, not force through
+                        resolve({ closeCalledAfterCancel: closeCalled, forcedOnSecondAttempt: event2.defaultPrevented });
+                    }, 50);
+                } catch (err) { reject(err); }
+            }, 50);
+        } catch (err) { reject(err); }
+    })));
+    console.log('[editor] Cancel scenario:', JSON.stringify(cancelResult));
+    if (cancelResult.closeCalledAfterCancel) throw new Error('FAIL: "Cancel" incorrectly called editorWindow.close()');
+    if (cancelResult.forcedOnSecondAttempt) throw new Error('FAIL: a later attempt after "Cancel" was forced through instead of asking again');
+    console.log('PASS: "Cancel" flow — window never closed, a later attempt still asks again rather than forcing through');
+
+    // --- Responsiveness proof: main process answers unrelated work while a dialog is deliberately left pending ---
+    const responsive = await withFreshApp((app) => app.evaluate(({ BrowserWindow, dialog }) => new Promise((resolve) => {
+        const editorWin = BrowserWindow.getAllWindows()[0];
+        editorWin.close = () => {};
+        dialog.showMessageBox = () => new Promise(() => {}); // never resolves
+        editorWin.webContents.emit('will-prevent-unload', { defaultPrevented: false, preventDefault() {} });
+        // If the handler were still synchronous (the old showMessageBoxSync), this
+        // very evaluate() call would never have gotten a chance to run at all.
+        setTimeout(() => resolve(true), 100);
+    })));
+    if (!responsive) throw new Error('FAIL: main process did not respond promptly with a dialog left pending');
+    console.log('PASS: main process stayed responsive with an unresolved dialog pending (would have hung under the old *Sync call)');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- Fix Cmd+Z (Undo) always routing to the app-level EditorCore undo stack in Electron, even when a text field (`<textarea>`/`<input>`/contenteditable) has focus — now defers to the native text-field undo/redo in that case, matching how a browser tab behaves.
- Fix Cmd+A (Select All) doing nothing at all in Electron text fields — the custom Edit menu never carried over `role: "selectAll"` the way it already does for Cut/Copy/Paste.
- Replace the native "Leave without saving?" close-confirmation's `dialog.showMessageBoxSync` with an async `dialog.showMessageBox` — the sync call froze the *entire* main process (no IPC, no other window's menu actions) for as long as it was on screen, which could leave the whole app stuck if the dialog was still up when the machine went to sleep.
- Wire up the room "Light/Dark" tab's "Instructions for use" label as an actual link (`https://docs.textadventures.co.uk/quest/handling_light_and_dark.html`) — the aslx editor definition already carried an `<href>` for it, but it was never threaded through `ControlInfo` into the Svelte UI, so it rendered as inert italic text.
- Fix File > New Game…/Open Game… doing nothing when the editor window has been closed entirely (macOS: app stays running with the menu bar up, zero windows open) — `sendMenuAction` required `editorWindow` to already exist; now it recreates the window (landing on `/open`, with `?action=open` for Open Game… so the file picker opens immediately) when there isn't one already.

## Test plan
- [x] `dotnet build` (WasmEditor) — clean
- [x] `tsc --noEmit` (ElectronApp) — clean
- [x] `svelte-check` (AppShell) — clean (pre-existing unrelated warning in `LinkPickerModal.svelte`, spun off separately)
- [x] Manually verified the Light/Dark link renders and points to the right URL in the browser dev server
- [x] `node tests/e2e/verify-electron-undo-textarea.mjs` — native undo fires with a text field focused, app-level undo still fires from the tree
- [x] `node tests/e2e/verify-electron-selectall-textbox.mjs` — Select All now selects the full field
- [x] `node tests/e2e/verify-electron-unsaved-close-dialog.mjs` — Leave/Cancel routing correct, main process stays responsive with the dialog pending
- [x] `node tests/e2e/verify-electron-open-game-no-window.mjs` — New Game…/Open Game… recreate the editor window and land on the right route when none is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)