### PR TITLE
fix(AppShell): suppress stale svelte-check warning, fail CI on future ones

### DIFF
--- a/src/AppShell/package.json
+++ b/src/AppShell/package.json
@@ -7,7 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --fail-on-warnings",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix"
   },

--- a/src/AppShell/src/components/LinkPickerModal.svelte
+++ b/src/AppShell/src/components/LinkPickerModal.svelte
@@ -23,9 +23,10 @@
     }: Props = $props();
 
     let target = $state("");
-    // svelte-ignore state_referenced_locally -- intentional one-time snapshot: this component is
-    // always freshly mounted per link-edit invocation (see PropertyEditor's `{#if activeLinkCommand}`),
-    // so initialText never changes on an existing instance.
+    // This component is always freshly mounted per link-edit invocation (see
+    // PropertyEditor's `{#if activeLinkCommand}`), so initialText never changes
+    // on an existing instance: intentional one-time snapshot.
+    // svelte-ignore state_referenced_locally
     let text = $state(initialText);
     let textInputEl: HTMLInputElement | undefined = $state();
 

--- a/src/AppShell/src/components/LinkPickerModal.svelte
+++ b/src/AppShell/src/components/LinkPickerModal.svelte
@@ -23,6 +23,9 @@
     }: Props = $props();
 
     let target = $state("");
+    // svelte-ignore state_referenced_locally -- intentional one-time snapshot: this component is
+    // always freshly mounted per link-edit invocation (see PropertyEditor's `{#if activeLinkCommand}`),
+    // so initialText never changes on an existing instance.
     let text = $state(initialText);
     let textInputEl: HTMLInputElement | undefined = $state();
 


### PR DESCRIPTION
## Summary
- `LinkPickerModal`'s `let text = $state(initialText)` was tripping Svelte 5's `state_referenced_locally` warning. Investigated whether the component is ever reused across two link-edit invocations with different `initialText` (which would make the warning a real bug) — it isn't: `PropertyEditor`'s `{#if activeLinkCommand}` only ever transitions `null → object → null`, and the modal's full-screen overlay prevents a second invocation while one is open, so the component is always freshly mounted and the snapshot is never stale. Suppressed with a `svelte-ignore` comment explaining why.
- With the AppShell project now warning-free, added `--fail-on-warnings` to the `check` script so `build-and-test.yml`'s "Type check" step catches future svelte-check warnings instead of letting them pile up silently.

## Test plan
- [x] `npm run check` in `src/AppShell` passes with 0 errors, 0 warnings (exit 0)
- [x] Verified `--fail-on-warnings` actually enforces the gate: temporarily removed the ignore comment, confirmed `npm run check` reports the warning and exits 1, then restored the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)