### PR TITLE
fix(AppShell): fix web fonts, verb pattern default, and turn scripts list

### DIFF
--- a/src/AppShell/src/components/ElementsList.svelte
+++ b/src/AppShell/src/components/ElementsList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { SvelteSet } from "svelte/reactivity";
-    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createIncludedLibrary, createJavascript, swapElements } from "$lib/editor-store";
+    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createTurnScript, createIncludedLibrary, createJavascript, swapElements } from "$lib/editor-store";
 
     interface Props {
         elementKey: string;
@@ -17,6 +17,7 @@
                 if (lf === "verb") return ["verb"];
                 return ["command"];
             }
+            if (ot === "turnscript") return ["turnscript"];
             return ["room", "object"];
         }
         return [et];
@@ -56,6 +57,7 @@
             nodeTypes.includes("timer") ? "Add Timer" :
                 nodeTypes.includes("verb") ? "Add Verb" :
                 nodeTypes.includes("command") ? "Add Command" :
+                nodeTypes.includes("turnscript") ? "Add Turn Script" :
                 nodeTypes.includes("walkthrough") ? "Add Walkthrough" :
                 nodeTypes.includes("template") ? "Add Template" :
                 nodeTypes.includes("dynamictemplate") ? "Add Dynamic Template" :
@@ -72,6 +74,7 @@
         else if (nodeTypes.includes("timer")) openAddModal("timer", null);
         else if (nodeTypes.includes("verb")) createVerb(parent);
         else if (nodeTypes.includes("command")) createCommand(parent);
+        else if (nodeTypes.includes("turnscript")) createTurnScript(parent ?? "");
         else if (nodeTypes.includes("walkthrough")) openAddModal("walkthrough", null);
         else if (nodeTypes.includes("template")) openAddModal("template", null);
         else if (nodeTypes.includes("dynamictemplate")) openAddModal("dynamictemplate", null);

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, addDictItem, removeDictItem, updateDictItem, getObjectNames, getExitNames, selectNode, createObjectSilent, openAddModal, createIncludedLibrary, createJavascript } from "$lib/editor-store";
+    import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, setSelectedFilter, addDictItem, removeDictItem, updateDictItem, getObjectNames, getExitNames, selectNode, createObjectSilent, openAddModal, createIncludedLibrary, createJavascript } from "$lib/editor-store";
     import { showToast } from "$lib/toast";
     import type { ControlInfo, ControlOption, TextProcessorCommand } from "$lib/types";
     import type { TreeNode } from "$lib/types";
@@ -494,7 +494,7 @@
                 onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLTextAreaElement).value)}
             ></textarea>
         {/if}
-    {:else if ctrl.controlType === "textbox"}
+    {:else if ctrl.controlType === "textbox" || ctrl.controlType === "expression"}
         <input
             type="text"
             autocapitalize="off"
@@ -502,6 +502,16 @@
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value)}
         />
+    {:else if ctrl.controlType === "filter" && ctrl.options}
+        <select
+            class="select text-xs py-0.5 px-1.5 w-auto"
+            value={attrValue(ctrl.attribute!) ?? ""}
+            onchange={(e) => $selectedKey && setSelectedFilter($selectedKey, ctrl.subAttribute!, (e.target as HTMLSelectElement).value)}
+        >
+            {#each ctrl.options as opt (opt.value)}
+                <option value={opt.value}>{opt.label}</option>
+            {/each}
+        </select>
     {:else if ctrl.controlType === "gameid"}
         <div class="flex items-center gap-2 w-full">
             <input
@@ -780,12 +790,17 @@
             </div>
         {/if}
     {:else if ctrl.controlType === "elementslist" && $selectedKey}
-        <ElementsList
-            elementKey={$selectedKey}
-            elementType={ctrl.elementType ?? "object"}
-            objectType={ctrl.objectType}
-            listFilter={ctrl.listFilter}
-        />
+        <div class="flex flex-col gap-1">
+            {#if ctrl.caption}
+                <span class="text-xs text-surface-600-400 px-3 pt-1.5">{ctrl.caption}</span>
+            {/if}
+            <ElementsList
+                elementKey={$selectedKey}
+                elementType={ctrl.elementType ?? "object"}
+                objectType={ctrl.objectType}
+                listFilter={ctrl.listFilter}
+            />
+        </div>
     {:else if ctrl.controlType === "exits" && $selectedKey}
         <ExitsEditor elementKey={$selectedKey} />
     {:else if ctrl.controlType === "verbs" && $selectedKey}

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -271,6 +271,14 @@ export function setObjectReference(elementKey: string, attribute: string, object
     return result;
 }
 
+export function setSelectedFilter(elementKey: string, filterGroupName: string, filterValue: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetSelectedFilter(elementKey, filterGroupName, filterValue);
+    refreshSelectedData();
+    refreshUndoRedo();
+    return result;
+}
+
 export function setDropdownType(elementKey: string, controlId: string, selectedType: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SetDropdownType(elementKey, controlId, selectedType);

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -8,6 +8,7 @@ export interface WasmBridge {
   SetMultiType(elementKey: string, attribute: string, newType: string): string
   SetObjectReference(elementKey: string, attribute: string, objectName: string): string
   SetDropdownType(elementKey: string, controlId: string, selectedType: string): string
+  SetSelectedFilter(elementKey: string, filterGroupName: string, filterValue: string): string
   Save(): string
   IsDirty(): boolean
   GetGameXml(): string

--- a/src/Engine/Core/CoreEditorObjectRoom.aslx
+++ b/src/Engine/Core/CoreEditorObjectRoom.aslx
@@ -34,6 +34,7 @@
       <controltype>objects</controltype>
       <caption>[EditorObjectRoomDropDestination]</caption>
       <attribute>dropdestination</attribute>
+      <advanced/>
     </control>
 
     <control>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -647,6 +647,64 @@ public partial class WasmEditorBridge
     }
 
     [JSExport]
+    public static string SetSelectedFilter(string elementKey, string filterGroupName, string filterValue)
+    {
+        if (_controller == null)
+        {
+            return "error";
+        }
+
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null)
+        {
+            return "error";
+        }
+
+        // GetEditorData() returns a fresh IEditorData on every call, so the in-memory selection
+        // SetSelectedFilter() would normally record doesn't survive past this one call — the very
+        // next GetEditorData() (e.g. the refetch after this returns) starts over and falls back to
+        // GetDefaultFilterName()'s inference from which of the group's attributes is populated. So
+        // to make the choice stick, drive that same inference: populate the chosen filter's
+        // attribute (if not already) and clear the others in the group.
+        var editorName = _controller.GetElementEditorName(elementKey);
+        if (editorName == null)
+        {
+            return "error";
+        }
+
+        var def = _controller.GetEditorDefinition(editorName);
+        var groupControls = def.Tabs.Values.SelectMany(t => t.Controls)
+            .Concat(def.Controls)
+            .Where(c => c.Attribute != null && c.GetString("filtergroup") == filterGroupName)
+            .ToList();
+
+        _controller.StartTransaction($"Set {filterGroupName}");
+        try
+        {
+            foreach (var ctrl in groupControls)
+            {
+                var isSelected = ctrl.GetString("filter") == filterValue;
+                var hasValue = data.GetAttribute(ctrl.Attribute!) != null;
+                if (isSelected && !hasValue)
+                {
+                    data.SetAttribute(ctrl.Attribute!, "");
+                }
+                else if (!isSelected && hasValue)
+                {
+                    data.SetAttribute(ctrl.Attribute!, null!);
+                }
+            }
+
+            data.SetSelectedFilter(filterGroupName, filterValue);
+            return "ok";
+        }
+        finally
+        {
+            _controller.EndTransaction();
+        }
+    }
+
+    [JSExport]
     public static string AddListItem(string elementKey, string attribute, string value)
     {
         if (_controller == null)
@@ -831,8 +889,21 @@ public partial class WasmEditorBridge
                 double => "double",
                 IEditableScripts => "script",
                 IEditableObjectReference => "object",
+                IEditableCommandPattern => "simplepattern",
                 _ => "null"
             };
+        }
+
+        foreach (var ctrl in controls.Where(c => c.ControlType == "filter"))
+        {
+            var filterGroupName = ctrl.GetString("filtergroupname");
+            if (filterGroupName == null)
+            {
+                continue;
+            }
+
+            attrs[ctrl.Id] = data.GetSelectedFilter(filterGroupName)
+                ?? ctrl.Parent.GetDefaultFilterName(filterGroupName, data);
         }
     }
 
@@ -3260,6 +3331,19 @@ public partial class WasmEditorBridge
                 {
                     options = dict.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
                 }
+                else
+                {
+                    var fonts = ctrl.GetString("source") switch
+                    {
+                        "basefonts" => _controller!.AvailableBaseFonts(),
+                        "webfonts" => _controller!.AvailableWebFonts(),
+                        _ => null
+                    };
+                    if (fonts != null)
+                    {
+                        options = fonts.Select(f => new ControlOption(f, f)).ToList();
+                    }
+                }
             }
         }
         else if (ctrl.ControlType == "dropdowntypes")
@@ -3271,6 +3355,14 @@ public partial class WasmEditorBridge
             }
 
             attribute = ctrl.Id;
+        }
+        else if (ctrl.ControlType == "filter")
+        {
+            var dict = ctrl.GetDictionary("filters");
+            options = dict?.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
+
+            return new ControlInfo(ctrl.Id, "filter", ctrl.Caption, options, null,
+                ctrl.GetString("filtergroupname"), Advanced: !ctrl.IsControlVisibleInSimpleMode);
         }
         else if (ctrl.ControlType == "objects")
         {
@@ -3299,7 +3391,7 @@ public partial class WasmEditorBridge
         }
         else if (ctrl.ControlType == "elementslist")
         {
-            return new ControlInfo(null, "elementslist", null, null, null, null, null, null,
+            return new ControlInfo(null, "elementslist", ctrl.Caption, null, null, null, null, null,
                 ctrl.GetString("elementtype"),
                 ctrl.GetString("objecttype"),
                 ctrl.GetString("listfilter"),


### PR DESCRIPTION
## Summary
Fixes several editor bugs found in manual testing of the AppShell-based editor:

- **Web fonts not listed**: the font dropdowns (Base font / Web font on the game's Display tab) were empty — `ToControlInfo` only read `<validvalues>` for `dropdown` controls, never the `<source>basefonts|webfonts</source>` tag. Now falls back to `AvailableBaseFonts()`/`AvailableWebFonts()`.
- **Verb pattern dropdown not set**: new verbs showed a blank Pattern selector instead of defaulting to "Command pattern" — `AddDropdownTypeValues` had no case for `IEditableCommandPattern`, so it fell through to `"null"`.
- **"Objects dropped here go to"** moved under the Room tab's Advanced section, matching its sibling fields (was just missing the `<advanced/>` tag).
- **Room Scripts tab**: the Turn Scripts list was actually listing room objects instead of turn scripts (`ElementsList` had no case for `objectType="turnscript"`), and both the Turn Scripts and Commands lists had no visible caption/label.
- **Elements list padding**: Turn Scripts/Commands/the room's Objects tab all had doubled padding from a wrapper `<div>` stacking on top of `ElementsList`'s own padding.
- Added a **"+ Add Turn Script"** button to the Turn Scripts list (previously only reachable via the tree's Add menu).
- **Verb "Default" dropdown** (Text/Template/Expression) now renders and works, and the **Expression field is editable** — previously `expression`/`filter` control types weren't handled in `PropertyEditor.svelte` at all, so Expression silently fell through to a read-only span. Filter selection is made durable by writing/clearing the underlying `defaulttext`/`defaulttemplate`/`defaultexpression` attributes (since `GetEditorData` builds a fresh `IEditorData` per call, so session-only filter state doesn't survive a refetch).

## Test plan
- [x] `dotnet build src/WasmEditor/WasmEditor.csproj` — clean
- [x] `npm run check` (svelte-check) in `src/AppShell` — clean
- [x] Manually verified in the running AppShell editor (Browser pane):
  - Base font / Web font dropdowns populate with options
  - New verb defaults to "Command pattern"
  - Room's "Objects dropped here go to" is under Advanced
  - Turn Scripts list shows only turn scripts (confirmed a room object does *not* appear, a real turn script does), both lists show captions, padding is tight
  - "+ Add Turn Script" creates a turn script
  - Verb Default dropdown switches to Expression, field is editable, and the value/selection survives navigating away and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)