### PR TITLE
feat(AppShell): add object/function insert helper for expression fields

### DIFF
--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+    import Wand2 from "@lucide/svelte/icons/wand-2";
+    import { getExpressionFunctions } from "$lib/editor-store";
+    import type { ExpressionFunctionInfo } from "$lib/types";
+
+    interface Props {
+        value: string;
+        onchange: (value: string) => void;
+        // Object names to offer in the "Objects" section — callers that already have this list
+        // loaded (e.g. ScriptEditor's script-block state) should pass it through rather than
+        // have every field independently re-fetch it.
+        objectNames: string[];
+        class?: string;
+    }
+
+    let { value, onchange, objectNames, class: className = "" }: Props = $props();
+
+    let inputEl = $state<HTMLInputElement | undefined>();
+    let rootEl = $state<HTMLDivElement | undefined>();
+    let open = $state(false);
+    let filter = $state("");
+    let functions = $state<ExpressionFunctionInfo[]>([]);
+
+    function toggle() {
+        if (!open) {
+            functions = getExpressionFunctions();
+            filter = "";
+        }
+        open = !open;
+    }
+
+    function close() {
+        open = false;
+    }
+
+    // Splices text into the field at the current cursor position (falling back to the end if
+    // the field never had focus), then restores focus/cursor there once Svelte has re-rendered
+    // the now-longer value.
+    function insertAtCursor(text: string) {
+        const start = inputEl?.selectionStart ?? value.length;
+        const end = inputEl?.selectionEnd ?? value.length;
+        const newValue = value.slice(0, start) + text + value.slice(end);
+        const cursorPos = start + text.length;
+        close();
+        onchange(newValue);
+        requestAnimationFrame(() => {
+            inputEl?.focus();
+            inputEl?.setSelectionRange(cursorPos, cursorPos);
+        });
+    }
+
+    function insertFunction(fn: ExpressionFunctionInfo) {
+        insertAtCursor(`${fn.name}(${fn.parameters.join(", ")})`);
+    }
+
+    let filteredObjects = $derived(
+        filter === "" ? objectNames : objectNames.filter(n => n.toLowerCase().includes(filter.toLowerCase()))
+    );
+    let filteredFunctions = $derived(
+        filter === "" ? functions : functions.filter(f => f.name.toLowerCase().includes(filter.toLowerCase()))
+    );
+
+    $effect(() => {
+        if (!open) return;
+        function onOutside(e: MouseEvent) {
+            if (!rootEl?.contains(e.target as Node)) close();
+        }
+        function onKeydown(e: KeyboardEvent) {
+            if (e.key === "Escape") close();
+        }
+        document.addEventListener("mousedown", onOutside);
+        document.addEventListener("keydown", onKeydown);
+        return () => {
+            document.removeEventListener("mousedown", onOutside);
+            document.removeEventListener("keydown", onKeydown);
+        };
+    });
+</script>
+
+<div class="relative flex items-center gap-1 min-w-0 flex-1" bind:this={rootEl}>
+    <input
+        bind:this={inputEl}
+        type="text"
+        autocapitalize="off"
+        class={className || "input text-xs py-0.5 px-1.5 w-full"}
+        {value}
+        onchange={(e) => onchange((e.target as HTMLInputElement).value)}
+    />
+    <button
+        type="button"
+        class="btn btn-sm preset-outlined-primary-500 px-1 py-0.5 flex-shrink-0"
+        title="Insert object or function"
+        onclick={toggle}
+    ><Wand2 size={13} aria-hidden="true" /></button>
+    {#if open}
+        <div class="absolute z-50 right-0 top-full mt-1 w-64 max-h-72 flex flex-col rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-lg">
+            <input
+                type="text"
+                autocapitalize="off"
+                placeholder="Filter…"
+                class="input text-xs py-1 px-2 rounded-none border-0 border-b border-surface-200-800"
+                bind:value={filter}
+            />
+            <div class="overflow-y-auto flex-1">
+                {#if filteredObjects.length > 0}
+                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Objects</div>
+                    {#each filteredObjects as name (name)}
+                        <button
+                            type="button"
+                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                            onclick={() => insertAtCursor(name)}
+                        >{name}</button>
+                    {/each}
+                {/if}
+                {#if filteredFunctions.length > 0}
+                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Functions</div>
+                    {#each filteredFunctions as fn (fn.name)}
+                        <button
+                            type="button"
+                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                            onclick={() => insertFunction(fn)}
+                        >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
+                    {/each}
+                {/if}
+                {#if filteredObjects.length === 0 && filteredFunctions.length === 0}
+                    <p class="px-2 py-2 text-xs text-surface-600-400 italic">No matches.</p>
+                {/if}
+            </div>
+        </div>
+    {/if}
+</div>

--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -21,24 +21,39 @@
     let open = $state(false);
     let filter = $state("");
     let functions = $state<ExpressionFunctionInfo[]>([]);
-    // Defaults to opening downward, but flips upward when there isn't room below — same
-    // heuristic as Combobox.svelte, needed since these fields often sit near the bottom of a
-    // scrolled panel (e.g. a script's last parameter, or the last property in a tab).
-    let openUpward = $state(false);
+    // These fields commonly sit inside a scrolled panel (a script row, a property tab). An
+    // absolutely-positioned popover is still clipped by that panel's overflow regardless of
+    // z-index, so the popover is portaled to <body> (see `portal` below) and positioned with
+    // `fixed` viewport coordinates computed from the button's rect instead.
+    let popoverStyle = $state("");
 
-    function updateOpenDirection() {
+    function portal(node: HTMLElement) {
+        document.body.appendChild(node);
+        return {
+            destroy() {
+                node.remove();
+            },
+        };
+    }
+
+    // Opens downward by default, flipping upward when there isn't room below — mirrors
+    // Combobox.svelte's heuristic. Re-run on scroll/resize while open so the popover tracks the
+    // button if the underlying panel scrolls.
+    function updatePosition() {
         if (!buttonEl) return;
         const rect = buttonEl.getBoundingClientRect();
+        const approxPopoverHeight = 300;
         const spaceBelow = window.innerHeight - rect.bottom;
         const spaceAbove = rect.top;
-        openUpward = spaceBelow < 300 && spaceAbove > spaceBelow;
+        const openUpward = spaceBelow < approxPopoverHeight && spaceAbove > spaceBelow;
+        const top = openUpward ? rect.top - 4 : rect.bottom + 4;
+        popoverStyle = `position: fixed; left: ${rect.right}px; top: ${top}px; transform: translate(-100%, ${openUpward ? "-100%" : "0"});`;
     }
 
     function toggle() {
         if (!open) {
             functions = getExpressionFunctions();
             filter = "";
-            updateOpenDirection();
         }
         open = !open;
     }
@@ -76,6 +91,7 @@
 
     $effect(() => {
         if (!open) return;
+        updatePosition();
         function onOutside(e: MouseEvent) {
             const target = e.target as Node;
             if (buttonEl?.contains(target) || popoverRootEl?.contains(target)) return;
@@ -84,11 +100,20 @@
         function onKeydown(e: KeyboardEvent) {
             if (e.key === "Escape") close();
         }
+        function onReposition() {
+            updatePosition();
+        }
         document.addEventListener("mousedown", onOutside);
         document.addEventListener("keydown", onKeydown);
+        // capture:true so this also fires for scrolls inside nested scroll containers, not just
+        // the window itself.
+        window.addEventListener("scroll", onReposition, true);
+        window.addEventListener("resize", onReposition);
         return () => {
             document.removeEventListener("mousedown", onOutside);
             document.removeEventListener("keydown", onKeydown);
+            window.removeEventListener("scroll", onReposition, true);
+            window.removeEventListener("resize", onReposition);
         };
     });
 </script>
@@ -102,52 +127,52 @@
         {value}
         onchange={(e) => onchange((e.target as HTMLInputElement).value)}
     />
-    <div class="relative flex-shrink-0">
-        <button
-            bind:this={buttonEl}
-            type="button"
-            class="btn btn-sm preset-outlined-primary-500 px-1 py-0.5"
-            title="Insert object or function"
-            onclick={toggle}
-        ><Wand2 size={13} aria-hidden="true" /></button>
-        {#if open}
-            <div
-                bind:this={popoverRootEl}
-                class="absolute z-50 right-0 w-64 max-h-72 flex flex-col rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-lg {openUpward ? "bottom-full mb-1" : "top-full mt-1"}"
-            >
-                <input
-                    type="text"
-                    autocapitalize="off"
-                    placeholder="Filter…"
-                    class="input text-xs py-1 px-2 rounded-none border-0 border-b border-surface-200-800"
-                    bind:value={filter}
-                />
-                <div class="overflow-y-auto flex-1">
-                    {#if filteredObjects.length > 0}
-                        <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Objects</div>
-                        {#each filteredObjects as name (name)}
-                            <button
-                                type="button"
-                                class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
-                                onclick={() => insertAtCursor(name)}
-                            >{name}</button>
-                        {/each}
-                    {/if}
-                    {#if filteredFunctions.length > 0}
-                        <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Functions</div>
-                        {#each filteredFunctions as fn (fn.name)}
-                            <button
-                                type="button"
-                                class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
-                                onclick={() => insertFunction(fn)}
-                            >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
-                        {/each}
-                    {/if}
-                    {#if filteredObjects.length === 0 && filteredFunctions.length === 0}
-                        <p class="px-2 py-2 text-xs text-surface-600-400 italic">No matches.</p>
-                    {/if}
-                </div>
+    <button
+        bind:this={buttonEl}
+        type="button"
+        class="btn btn-sm preset-outlined-primary-500 px-1 py-0.5 flex-shrink-0"
+        title="Insert object or function"
+        onclick={toggle}
+    ><Wand2 size={13} aria-hidden="true" /></button>
+    {#if open}
+        <div
+            bind:this={popoverRootEl}
+            use:portal
+            style={popoverStyle}
+            class="z-50 w-64 max-h-72 flex flex-col rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-lg"
+        >
+            <input
+                type="text"
+                autocapitalize="off"
+                placeholder="Filter…"
+                class="input text-xs py-1 px-2 rounded-none border-0 border-b border-surface-200-800"
+                bind:value={filter}
+            />
+            <div class="overflow-y-auto flex-1">
+                {#if filteredObjects.length > 0}
+                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Objects</div>
+                    {#each filteredObjects as name (name)}
+                        <button
+                            type="button"
+                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                            onclick={() => insertAtCursor(name)}
+                        >{name}</button>
+                    {/each}
+                {/if}
+                {#if filteredFunctions.length > 0}
+                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Functions</div>
+                    {#each filteredFunctions as fn (fn.name)}
+                        <button
+                            type="button"
+                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                            onclick={() => insertFunction(fn)}
+                        >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
+                    {/each}
+                {/if}
+                {#if filteredObjects.length === 0 && filteredFunctions.length === 0}
+                    <p class="px-2 py-2 text-xs text-surface-600-400 italic">No matches.</p>
+                {/if}
             </div>
-        {/if}
-    </div>
+        </div>
+    {/if}
 </div>

--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -16,15 +16,29 @@
     let { value, onchange, objectNames, class: className = "" }: Props = $props();
 
     let inputEl = $state<HTMLInputElement | undefined>();
-    let rootEl = $state<HTMLDivElement | undefined>();
+    let buttonEl = $state<HTMLButtonElement | undefined>();
+    let popoverRootEl = $state<HTMLDivElement | undefined>();
     let open = $state(false);
     let filter = $state("");
     let functions = $state<ExpressionFunctionInfo[]>([]);
+    // Defaults to opening downward, but flips upward when there isn't room below — same
+    // heuristic as Combobox.svelte, needed since these fields often sit near the bottom of a
+    // scrolled panel (e.g. a script's last parameter, or the last property in a tab).
+    let openUpward = $state(false);
+
+    function updateOpenDirection() {
+        if (!buttonEl) return;
+        const rect = buttonEl.getBoundingClientRect();
+        const spaceBelow = window.innerHeight - rect.bottom;
+        const spaceAbove = rect.top;
+        openUpward = spaceBelow < 300 && spaceAbove > spaceBelow;
+    }
 
     function toggle() {
         if (!open) {
             functions = getExpressionFunctions();
             filter = "";
+            updateOpenDirection();
         }
         open = !open;
     }
@@ -63,7 +77,9 @@
     $effect(() => {
         if (!open) return;
         function onOutside(e: MouseEvent) {
-            if (!rootEl?.contains(e.target as Node)) close();
+            const target = e.target as Node;
+            if (buttonEl?.contains(target) || popoverRootEl?.contains(target)) return;
+            close();
         }
         function onKeydown(e: KeyboardEvent) {
             if (e.key === "Escape") close();
@@ -77,7 +93,7 @@
     });
 </script>
 
-<div class="relative flex items-center gap-1 min-w-0 flex-1" bind:this={rootEl}>
+<div class="flex items-center gap-1 min-w-0 flex-1">
     <input
         bind:this={inputEl}
         type="text"
@@ -86,46 +102,52 @@
         {value}
         onchange={(e) => onchange((e.target as HTMLInputElement).value)}
     />
-    <button
-        type="button"
-        class="btn btn-sm preset-outlined-primary-500 px-1 py-0.5 flex-shrink-0"
-        title="Insert object or function"
-        onclick={toggle}
-    ><Wand2 size={13} aria-hidden="true" /></button>
-    {#if open}
-        <div class="absolute z-50 right-0 top-full mt-1 w-64 max-h-72 flex flex-col rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-lg">
-            <input
-                type="text"
-                autocapitalize="off"
-                placeholder="Filter…"
-                class="input text-xs py-1 px-2 rounded-none border-0 border-b border-surface-200-800"
-                bind:value={filter}
-            />
-            <div class="overflow-y-auto flex-1">
-                {#if filteredObjects.length > 0}
-                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Objects</div>
-                    {#each filteredObjects as name (name)}
-                        <button
-                            type="button"
-                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
-                            onclick={() => insertAtCursor(name)}
-                        >{name}</button>
-                    {/each}
-                {/if}
-                {#if filteredFunctions.length > 0}
-                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Functions</div>
-                    {#each filteredFunctions as fn (fn.name)}
-                        <button
-                            type="button"
-                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
-                            onclick={() => insertFunction(fn)}
-                        >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
-                    {/each}
-                {/if}
-                {#if filteredObjects.length === 0 && filteredFunctions.length === 0}
-                    <p class="px-2 py-2 text-xs text-surface-600-400 italic">No matches.</p>
-                {/if}
+    <div class="relative flex-shrink-0">
+        <button
+            bind:this={buttonEl}
+            type="button"
+            class="btn btn-sm preset-outlined-primary-500 px-1 py-0.5"
+            title="Insert object or function"
+            onclick={toggle}
+        ><Wand2 size={13} aria-hidden="true" /></button>
+        {#if open}
+            <div
+                bind:this={popoverRootEl}
+                class="absolute z-50 right-0 w-64 max-h-72 flex flex-col rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-lg {openUpward ? "bottom-full mb-1" : "top-full mt-1"}"
+            >
+                <input
+                    type="text"
+                    autocapitalize="off"
+                    placeholder="Filter…"
+                    class="input text-xs py-1 px-2 rounded-none border-0 border-b border-surface-200-800"
+                    bind:value={filter}
+                />
+                <div class="overflow-y-auto flex-1">
+                    {#if filteredObjects.length > 0}
+                        <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Objects</div>
+                        {#each filteredObjects as name (name)}
+                            <button
+                                type="button"
+                                class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                                onclick={() => insertAtCursor(name)}
+                            >{name}</button>
+                        {/each}
+                    {/if}
+                    {#if filteredFunctions.length > 0}
+                        <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Functions</div>
+                        {#each filteredFunctions as fn (fn.name)}
+                            <button
+                                type="button"
+                                class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                                onclick={() => insertFunction(fn)}
+                            >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
+                        {/each}
+                    {/if}
+                    {#if filteredObjects.length === 0 && filteredFunctions.length === 0}
+                        <p class="px-2 py-2 text-xs text-surface-600-400 italic">No matches.</p>
+                    {/if}
+                </div>
             </div>
-        </div>
-    {/if}
+        {/if}
+    </div>
 </div>

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -31,6 +31,7 @@
     import AttributesEditor from "./AttributesEditor.svelte";
     import ListEditor from "./ListEditor.svelte";
     import ElementsList from "./ElementsList.svelte";
+    import ExpressionInput from "./ExpressionInput.svelte";
     import AssetPicker from "./AssetPicker.svelte";
     import ExitsEditor from "./ExitsEditor.svelte";
     import VerbsEditor from "./VerbsEditor.svelte";
@@ -494,13 +495,20 @@
                 onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLTextAreaElement).value)}
             ></textarea>
         {/if}
-    {:else if ctrl.controlType === "textbox" || ctrl.controlType === "expression"}
+    {:else if ctrl.controlType === "textbox"}
         <input
             type="text"
             autocapitalize="off"
             class={"input text-xs py-0.5 px-1.5 w-full" + (ctrl.attribute && attributeErrors[ctrl.attribute] ? " !border-error-500" : "")}
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value)}
+        />
+    {:else if ctrl.controlType === "expression"}
+        <ExpressionInput
+            value={attrValue(ctrl.attribute!) ?? ""}
+            onchange={(v) => onTextChange(ctrl.attribute!, ctrl.controlType, v)}
+            objectNames={dictSourceObjectNames}
+            class={"input text-xs py-0.5 px-1.5 w-full" + (ctrl.attribute && attributeErrors[ctrl.attribute] ? " !border-error-500" : "")}
         />
     {:else if ctrl.controlType === "filter" && ctrl.options}
         <select

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -4,6 +4,7 @@
     import AddScriptModal from "./AddScriptModal.svelte";
     import AssetPicker from "./AssetPicker.svelte";
     import CodeEditor from "./CodeEditor.svelte";
+    import ExpressionInput from "./ExpressionInput.svelte";
     import {
         scriptVersion,
         scriptClipboardHasContent,
@@ -634,16 +635,22 @@
                 {/if}
             {:else}
                 <!-- Expression mode: raw expression text input -->
-                <input
-                    type="text"
-                    autocapitalize="off"
-                    class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+                <ExpressionInput
                     value={ctrl.value ?? ""}
-                    onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
+                    onchange={(v) => onSetParam(scriptIndex, ctrl.attribute!, v)}
+                    {objectNames}
+                    class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
                 />
             {/if}
         {/if}
-    {:else if ctrl.controlType === "expression" || ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
+    {:else if ctrl.controlType === "expression"}
+        <ExpressionInput
+            value={ctrl.value ?? ""}
+            onchange={(v) => onSetParam(scriptIndex, ctrl.attribute!, v)}
+            {objectNames}
+            class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+        />
+    {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
         <input
             type="text"
             autocapitalize="off"
@@ -736,12 +743,11 @@
                     {/if}
                 {/each}
             {:else}
-                <input
-                    type="text"
-                    autocapitalize="off"
-                    class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
+                <ExpressionInput
                     value={script.expression ?? ""}
-                    onchange={(e) => onSetIfExpr(i, (e.target as HTMLInputElement).value)}
+                    onchange={(v) => onSetIfExpr(i, v)}
+                    {objectNames}
+                    class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
                 />
             {/if}
             <span class="text-surface-600-400 select-none">then</span>
@@ -817,12 +823,11 @@
                         {/if}
                     {/each}
                 {:else}
-                    <input
-                        type="text"
-                        autocapitalize="off"
+                    <ExpressionInput
+                        value={elseIf.expression ?? ""}
+                        onchange={(v) => onSetElseIfExpr(i, ei, v)}
+                        {objectNames}
                         class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
-                        value={elseIf.expression}
-                        onchange={(e) => onSetElseIfExpr(i, ei, (e.target as HTMLInputElement).value)}
                     />
                 {/if}
                 <span class="text-surface-600-400 select-none">then</span>

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -7,7 +7,7 @@ import type { AssetInfo, FileAdapter } from "./filesystem/types";
 import { LocalDraftAdapter, shouldShowBackupBanner, markBackupBannerResolved } from "./filesystem/local-adapter";
 import { ServerFileAdapter } from "./filesystem/server-adapter";
 import { triggerDownload } from "./filesystem/download";
-import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData, ExitsData, VerbInfo } from "./types";
+import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData, ExitsData, VerbInfo, ExpressionFunctionInfo } from "./types";
 
 export type AddElementModalState = { type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
 
@@ -1220,6 +1220,14 @@ export function createLookExitInDirection(roomKey: string, direction: string): s
 export function getVerbAttributesInfo(): VerbInfo[] {
     if (!_bridge) return [];
     try { return JSON.parse(_bridge.GetVerbAttributesInfo()); }
+    catch { return []; }
+}
+
+// ── Expression helper ────────────────────────────────────────────────────────
+
+export function getExpressionFunctions(): ExpressionFunctionInfo[] {
+    if (!_bridge) return [];
+    try { return JSON.parse(_bridge.GetExpressionFunctions()); }
     catch { return []; }
 }
 

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -19,6 +19,12 @@ export interface TextProcessorCommand {
   insertAfter: string
 }
 
+export interface ExpressionFunctionInfo {
+  name: string
+  parameters: string[]
+  isUserDefined: boolean
+}
+
 export interface ControlInfo {
   attribute: string | null
   controlType: string

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -77,6 +77,7 @@ export interface WasmBridge {
   CreateLookExitInDirection(roomKey: string, direction: string): string
   // Verbs editor API
   GetVerbAttributesInfo(): string
+  GetExpressionFunctions(): string
   AddVerb(elementKey: string, verbPattern: string): string
   CreateTurnScript(parent: string): string
   CreateCommand(parent: string): string

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -2339,6 +2339,21 @@ public sealed class EditorController : IDisposable
         return WorldModel.GetBuiltInFunctionNames();
     }
 
+    // Feeds the editor's expression-insert helper: built-in engine functions plus the game's own
+    // (non-library) Function elements, both with real parameter names rather than a hand-curated
+    // guess at what's useful.
+    public IEnumerable<(string Name, string[] Parameters, bool IsUserDefined)> GetExpressionFunctions()
+    {
+        var builtIn = WorldModel.GetBuiltInFunctionSignatures()
+            .Select(f => (f.Name, f.Parameters, IsUserDefined: false));
+
+        var userFunctions = WorldModel.Elements.GetElements(ElementType.Function)
+            .Where(e => !e.MetaFields[MetaFieldDefinitions.Library])
+            .Select(e => (e.Name, e.Fields[FieldDefinitions.ParamNames].ToArray(), IsUserDefined: true));
+
+        return builtIn.Concat(userFunctions).OrderBy(f => f.Name, StringComparer.Ordinal);
+    }
+
     public static Dictionary<string, TemplateData> GetAvailableTemplates()
     {
         var resources = WorldModel.GetEmbeddedResources()

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -2349,7 +2349,10 @@ public sealed class EditorController : IDisposable
 
         var userFunctions = WorldModel.Elements.GetElements(ElementType.Function)
             .Where(e => !e.MetaFields[MetaFieldDefinitions.Library])
-            .Select(e => (e.Name, e.Fields[FieldDefinitions.ParamNames].ToArray(), IsUserDefined: true));
+            // A freshly-created function has no ParamNames field set yet (only populated by the
+            // aslx <function parameters="..."> loader), so Fields[...] is null until the user
+            // adds a parameter.
+            .Select(e => (e.Name, e.Fields[FieldDefinitions.ParamNames]?.ToArray() ?? [], IsUserDefined: true));
 
         return builtIn.Concat(userFunctions).OrderBy(f => f.Name, StringComparer.Ordinal);
     }

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -1636,6 +1636,31 @@ public partial class WorldModel : IGame, IGameDebug
         return FunctionNames.AsReadOnly();
     }
 
+    // Signatures (name + parameter names) for the built-in expression functions, reflected from
+    // the same classes GetBuiltInFunctionNames() draws from — used to power the editor's
+    // expression-insert helper. DeclaredOnly + !IsSpecialName excludes inherited object members
+    // (ToString/Equals/...) and property accessors, which GetBuiltInFunctionNames() above doesn't
+    // filter out (harmless there since only the name list is used, but would show up as bogus
+    // zero-arg "functions" here).
+    public IEnumerable<(string Name, string[] Parameters)> GetBuiltInFunctionSignatures()
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                                    BindingFlags.DeclaredOnly;
+
+        // Each GetMethods() call is made directly on a typeof(...) constant (rather than via a
+        // lambda over a Type variable) so the trimmer can see which type's members to preserve —
+        // matching GetBuiltInFunctionNames() above.
+        var methods = typeof(ExpressionOwner).GetMethods(flags)
+            .Concat(typeof(StringFunctions).GetMethods(flags))
+            .Concat(typeof(DateTimeFunctions).GetMethods(flags));
+
+        return methods
+            .Where(m => !m.IsSpecialName)
+            .Select(m => (m.Name, m.GetParameters().Select(p => p.Name ?? "").ToArray()))
+            .DistinctBy(f => f.Name)
+            .OrderBy(f => f.Name, StringComparer.Ordinal);
+    }
+
     internal void UpdateElementSortOrder(Element movedElement)
     {
         // There's no need to worry about element sort order when playing the game, unless this is an element that can be seen by the

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -134,6 +134,8 @@ internal record ExitsData(
 
 internal record VerbInfo(string Attribute, string DisplayPattern);
 
+internal record ExpressionFunctionData(string Name, List<string> Parameters, bool IsUserDefined);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
 [JsonSerializable(typeof(EditorDataResponse))]
@@ -148,6 +150,7 @@ internal record VerbInfo(string Attribute, string DisplayPattern);
 [JsonSerializable(typeof(List<GameTemplateInfo>))]
 [JsonSerializable(typeof(ExitsData))]
 [JsonSerializable(typeof(List<VerbInfo>))]
+[JsonSerializable(typeof(List<ExpressionFunctionData>))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext
 {
 }
@@ -2363,6 +2366,23 @@ public partial class WasmEditorBridge
             .ToList();
 
         return JsonSerializer.Serialize(verbs, WasmEditorJsonContext.Default.ListVerbInfo);
+    }
+
+    // Feeds the expression-insert helper's Functions list — built-in engine functions plus the
+    // game's own (non-library) Function elements, both with real parameter names.
+    [JSExport]
+    public static string GetExpressionFunctions()
+    {
+        if (_controller == null)
+        {
+            return "[]";
+        }
+
+        var functions = _controller.GetExpressionFunctions()
+            .Select(f => new ExpressionFunctionData(f.Name, f.Parameters.ToList(), f.IsUserDefined))
+            .ToList();
+
+        return JsonSerializer.Serialize(functions, WasmEditorJsonContext.Default.ListExpressionFunctionData);
     }
 
     [JSExport]


### PR DESCRIPTION
## Summary
Expression fields (Verb "Default" → Expression, Script Editor's expression-mode inputs, if/else-if conditions) were plain textboxes with no help building expression syntax — a gap noted against the v5 desktop editor, which has a "helpers" dropdown for inserting objects/variables/functions/syntax. Rather than replicate that dropdown as-is (it was itself reported as too hidden to discover in v5), this adds a small icon button next to every expression field that opens a filterable popover listing:

- **Objects**: existing object names in the game.
- **Functions**: built-in engine functions (reflected from `ExpressionOwner`/`StringFunctions`/`DateTimeFunctions`, so signatures — name + real parameter names — are always accurate, not hand-curated) plus the game's own non-library `Function` elements.

Clicking an entry inserts it at the current cursor position and keeps focus/selection in the field.

Scope intentionally excludes "Variables" (Quest doesn't have a first-class variable list — it's really object attributes) and hand-curated "Syntax" snippets, since there's no accurate data source for either in this codebase, and CoreFunctions.aslx-declared library convenience functions (`RandomChance`, `IsSwitchedOn`, etc.) are also out of scope for this pass — only true built-ins + the user's own functions.

### Implementation notes
- `WorldModel.GetBuiltInFunctionSignatures()` (Engine) reflects over the three built-in function classes for name + parameter names — written to call `GetMethods()` directly on each `typeof(...)` (not via a lambda over a `Type` variable) to stay trim/AOT-safe, matching the existing `GetBuiltInFunctionNames()` right above it.
- `EditorController.GetExpressionFunctions()` (EditorCore) merges that with the game's own non-library `Function` elements.
- `WasmEditorBridge.GetExpressionFunctions()` exposes it as JSON.
- New `ExpressionInput.svelte` wraps a plain `<input>` with the insert button + popover, dropped in everywhere expression text is edited in `PropertyEditor.svelte` and `ScriptEditor.svelte`.

## Test plan
- [x] `dotnet build`/`--configuration Release` for WasmEditor — clean
- [x] `npm run check` (svelte-check) — clean
- [x] `dotnet test tests/EngineTests` and `tests/EditorCoreTests` — all passing
- [x] Manually verified in the running AppShell editor (Browser pane):
  - Verb Default → Expression: insert button opens popover with Objects (player, room) and Functions (e.g. `HasAttribute(obj, property)`, `GetObject(name)`), filtering works, click inserts at cursor and field keeps focus
  - Script Editor "if" condition: same popover works inline in the compact expression row; inserting `GetBoolean(obj, property)` produces valid syntax the existing if-template matcher recognized and switched into its structured "object has flag" view
  - Confirmed out-of-scope library functions (e.g. `IsSwitchedOn`) correctly don't appear, matching the intended scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)