### PR TITLE
docs: refresh README and homepage now the editor is usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,26 @@
 Quest Viva
 ==========
 
-Quest Viva is an open-source system for creating and playing text adventure games. Designed for accessibility and flexibility, Quest Viva makes it easy for anyone to create a game without needing any previous experience of programming. For those who want more control, Quest Viva also offers powerful scripting capabilities.
+Quest Viva is a powerful platform for creating text adventure games and interactive fiction. It's easy to use, and you can create games quickly - no programming required, though a powerful scripting language is there if you need it.
 
-Formerly known as Quest 5, Quest Viva is a modern cross-platform update, currently in development.
+Previously known as Quest 5, Quest Viva is a modern cross-platform update. You can download it for Windows, macOS or Linux, or use the [web app](https://play.questviva.com) in your browser, which has identical functionality.
+
+When you're ready to publish your game, you can host it on any website.
 
 ## Features
 
 - **User-Friendly Interface** - Create text adventures with an intuitive editor, no coding required.
-- **Powerful Scripting** - Extend your games with custom logic using Quest's scripting language.
-- **Cross-Platform** - Games can be played in a web browser, or offline on Windows, Mac and Linux.
+- **Powerful Scripting** - Extend your games with custom logic using Quest Viva's scripting language.
+- **Cross-Platform** - Games can be played in a web browser, or in the app on Windows, Mac and Linux.
 - **Multimedia Support** - Add images and sounds to your games, run JavaScript, and embed videos.
-- **Extensible and Open-Source** - Modify and expand Quest to suit your needs.
+- **Extensible and Open-Source** - Modify and expand Quest Viva to suit your needs.
 - **Multiple languages** - Quest Viva supports creating games in English, French, German, Spanish, Dutch, Portuguese and more.
 
 ## Getting started
 
-**⚠️⚠️⚠️ If you just want to create a game, then [please use Quest 5 for now](https://textadventures.co.uk/quest) ⚠️⚠️⚠️**
-
-### For Developers testing and contributing to Quest Viva
-
-- [Install Docker](https://www.docker.com/)
-- Clone this GitHub repository
-- Run `docker compose up --build`
+- [Download the app](https://questviva.com/download), or use it in your browser at [play.questviva.com](https://play.questviva.com).
 
 ## Community and Support
 
-- [Documentation](https://docs.textadventures.co.uk/quest)
-- For help, [join us in Discord](https://textadventures.co.uk/community/discord) or post in [Quest discussions](https://github.com/textadventures/quest/discussions)
-
----
-
-## Sample compose.yml
-
-```
-services:
-  webplayer:
-    image: ghcr.io/textadventures/quest-viva-webplayer:latest
-    ports:
-      - "8080:8080"
-    environment:
-      Home__File: "/data/game.quest"
-    volumes:
-      - "/path/to/game.quest:/data/game.quest:ro"
-```
+- [Documentation](https://questviva.com)
+- For help, [join us in Discord](https://textadventures.co.uk/community/discord) or post in [GitHub discussions](https://github.com/textadventures/quest/discussions)

--- a/site/src/content/docs/guides/introduction.md
+++ b/site/src/content/docs/guides/introduction.md
@@ -4,14 +4,6 @@ sidebar:
   order: 1
 ---
 
-:::caution
-Quest Viva is currently in development.
-
-What you **can** do: You can use Quest Viva to host Quest games on any website.
-
-What you **can't** (yet) do: The Editor is still under construction. So if you are looking to create a game, [please use Quest 5](https://textadventures.co.uk/quest) for now.
-:::
-
 ## What is Quest Viva?
 
 Quest Viva is the "next version" of [Quest 5](https://textadventures.co.uk/quest).
@@ -26,6 +18,8 @@ Because there's [another system](https://github.com/ThePix/QuestJS) already call
 
 ## Sounds great, how do I get started?
 
-If you want to create a game, you will still need to use [Quest 5](https://textadventures.co.uk/quest) for now.
+[Download the app](/download), or use it in your browser at [play.questviva.com](https://play.questviva.com).
 
-If you've already created a game with Quest 5, then great - you can now host your game on any website. See [Hosting your game](/guides/hosting/).
+## Where's all the documentation?
+
+The proper Quest Viva documentation is a work in progress - for now, the [Quest 5 documentation](https://docs.textadventures.co.uk/quest/) is the place to look. Quest Viva 6 is pretty much "a modern version of Quest 5" so the way you build a game is pretty much the same. The docs will be migrated to this site soon.

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -10,12 +10,18 @@ hero:
     alt: Quest Viva logo
     file: ../../assets/quest-viva.svg
   actions:
-    - text: Get Started
-      link: /guides/introduction
+    - text: Open Quest Viva
+      link: https://play.questviva.com/
       icon: right-arrow
+      variant: primary
+    - text: Read the Docs
+      link: /guides/introduction
+      icon: open-book
+      variant: secondary
     - text: Download
       link: /download
       icon: download
+      variant: secondary
     - text: View on GitHub
       link: https://github.com/textadventures/quest
       icon: external


### PR DESCRIPTION
## Summary
- Drop the "editor still under construction, use Quest 5 for now" warnings from README.md and the docs intro guide — the editor is usable now, so point people at the app instead of away from it.
- Rework the docs homepage hero: **Open Quest Viva** (→ play.questviva.com) is now the primary CTA — the WASM app has no install/signup, so it's the fastest way to actually try the product — followed by **Read the Docs** and **Download** as secondary actions, with GitHub kept as a minimal link.

## Test plan
- [x] Ran the docs site locally (`npm run dev`) and confirmed the new hero renders with correct button hierarchy and links
- [ ] Click through Open Quest Viva / Read the Docs / Download / GitHub on the deployed site once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)