### PR TITLE
fix(WasmPlayer): batch JS.* script calls instead of painting per call

### DIFF
--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -713,11 +713,17 @@ public partial class WorldModel : IGame, IGameDebug
         _questionTcs?.TrySetCanceled();
         _commandInputTcs?.TrySetCanceled();
         _pauseTcs?.TrySetCanceled();
-        _turnSuspendedTcs.TrySetResult();
         _onReadyQueue.Clear();
 
         RequestNextTimerTick?.Invoke(0);
         Finished?.Invoke();
+
+        // Resolve last, matching SignalTurnSuspended's own ordering (side effects
+        // before the commit) - TrySetResult runs its awaiter's continuation
+        // synchronously/inline, so a caller awaiting SendCommand's turn-suspended
+        // signal would otherwise resume - and could observe player state - before
+        // Finished's own subscribers (e.g. WasmPlayer's IsFinished flag) have run.
+        _turnSuspendedTcs.TrySetResult();
     }
 
     internal string GetUniqueId(string? prefix = null)

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -159,6 +159,33 @@ function initPlayerUI() {
         }
     });
 
+    // ShowMenu (and anything built on it - Ask, disambiguation) renders each
+    // choice as a bare <a class="cmdlink" onclick="ASLEvent(...)"> baked into the
+    // game's own compiled script - unlike .commandlink, it gets no client-side
+    // disable until the engine round-trip finishes and calls back
+    // disableMenuOutputSection. That's invisible on a fast round-trip, but on a
+    // slow one (e.g. WasmPlayer on an underpowered device) it leaves a long
+    // window where an impatient second click fires another ASLEvent after the
+    // engine has already cleared game.menucallback for the first, surfacing as
+    // "Unexpected menu response". This runs after the clicked link's own inline
+    // onclick (which fires at the target phase, before bubbling reaches this
+    // document-level delegate), so it can't stop that first click, but it does
+    // disable every live menu link before any subsequent click can be
+    // processed. Exact-match selector so it only catches bare ShowMenu-style
+    // links, not the compound-class .elementmenu/.exitlink/.commandlink ones
+    // that are meant to stay clickable across multiple turns. Scoped to
+    // #divOutput (where createNewDiv/msg append everything ShowMenu prints)
+    // rather than the whole document - #endWaitLink is also a bare
+    // class="cmdlink" for its styling, but lives in the static #endWaitDiv
+    // chrome outside #divOutput and must stay clickable across repeated
+    // wait()s; disabling it after the first would silently break every wait
+    // after it. Living here (rather than in the aslx ShowMenu template) means
+    // it protects every already-published game, not just ones re-exported
+    // after a library fix.
+    $(document).on("click", "#divOutput a[class=\"cmdlink\"]", function () {
+        $("#divOutput a[class=\"cmdlink\"]").addClass("disabled").attr("onclick", null);
+    });
+
     const sidebar = document.getElementById("sidebar");
     const cmdShowPanes = document.getElementById("cmdShowPanes");
     const gamePanes = document.getElementById("gamePanes");

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -112,7 +112,7 @@ public partial class WasmPlayerBridge
         if (!ok)
         {
             _ui.OutputText(string.Join("<br/>", errors) + "<br/>");
-            _ui.FlushBuffer();
+            await _ui.FlushBufferAndYieldAsync();
             return false;
         }
 
@@ -150,7 +150,7 @@ public partial class WasmPlayerBridge
     {
         if (_game == null || _ui == null) return;
         await _game.Begin();
-        _ui.FlushBuffer();
+        await _ui.FlushBufferAndYieldAsync();
     }
 
     [JSExport]
@@ -162,7 +162,7 @@ public partial class WasmPlayerBridge
             : JsonSerializer.Deserialize(metadataJson, WasmJsonContext.Default.DictionaryStringString)
               ?? new Dictionary<string, string>();
         await _game.SendCommand(command, tickCount, metadata);
-        _ui.FlushBuffer();
+        await _ui.FlushBufferAndYieldAsync();
     }
 
     [JSExport]
@@ -170,7 +170,7 @@ public partial class WasmPlayerBridge
     {
         if (_game == null || _ui == null || _ui.IsFinished) return;
         await _game.SendEvent(eventName, param);
-        _ui.FlushBuffer();
+        await _ui.FlushBufferAndYieldAsync();
     }
 
     [JSExport]
@@ -178,7 +178,7 @@ public partial class WasmPlayerBridge
     {
         if (_game == null || _ui == null) return;
         await _game.FinishWait();
-        _ui.FlushBuffer();
+        await _ui.FlushBufferAndYieldAsync();
     }
 
     [JSExport]
@@ -186,7 +186,7 @@ public partial class WasmPlayerBridge
     {
         if (_game == null || _ui == null) return;
         await _game.FinishPause();
-        _ui.FlushBuffer();
+        await _ui.FlushBufferAndYieldAsync();
     }
 
     [JSExport]
@@ -194,7 +194,7 @@ public partial class WasmPlayerBridge
     {
         if (_game == null || _ui == null) return;
         await _game.SetMenuResponse(response);
-        _ui.FlushBuffer();
+        await _ui.FlushBufferAndYieldAsync();
     }
 
     [JSExport]
@@ -202,7 +202,7 @@ public partial class WasmPlayerBridge
     {
         if (_game == null || _ui == null) return;
         await _game.SetQuestionResponse(response);
-        _ui.FlushBuffer();
+        await _ui.FlushBufferAndYieldAsync();
     }
 
     [JSExport]
@@ -210,7 +210,7 @@ public partial class WasmPlayerBridge
     {
         if (_game == null || _ui == null || _ui.IsFinished) return;
         await _game.Tick(elapsedTime);
-        _ui.FlushBuffer();
+        await _ui.FlushBufferAndYieldAsync();
     }
 
     // Split in two because the JS interop source generator doesn't support
@@ -294,7 +294,7 @@ public partial class WasmPlayerBridge
         finally
         {
             _ui.Runner = null;
-            _ui.FlushBuffer();
+            await _ui.FlushBufferAndYieldAsync();
         }
     }
 
@@ -549,6 +549,24 @@ public partial class WasmPlayerBridge
             FlushBuffer();
         }
 
+        // Like FlushBuffer, but also gives the browser event loop a tick (throttled to
+        // roughly once per 16ms/frame) after flushing — used at genuine turn boundaries
+        // (SendCommand, Tick, etc.) rather than per JS.xxx(...) call, so CSS
+        // transitions/layout have a chance to settle once per turn (originally added to
+        // fix a game whose custom UI stayed hidden after a hide/show pair — see git
+        // history on RunScriptAsync) without forcing a browser paint mid-turn for every
+        // statement a script's custom refresh issues.
+        public async Task FlushBufferAndYieldAsync()
+        {
+            FlushBuffer();
+            var now = Environment.TickCount64;
+            if (now - _lastYieldMs >= 16)
+            {
+                _lastYieldMs = now;
+                await JsYield();
+            }
+        }
+
         public void SetPendingTimerTick(int seconds)
         {
             _pendingTimerTick = seconds;
@@ -698,16 +716,16 @@ public partial class WasmPlayerBridge
 
         private static long _lastYieldMs = 0;
 
+        // Buffered rather than run immediately (matching WebPlayer's AddJavaScriptToBuffer),
+        // so a turn issuing many JS.xxx(...) calls (e.g. a game's custom status/HUD refresh)
+        // paints as one batch at end-of-turn (FlushBufferAndYieldAsync) instead of a browser
+        // repaint per call. Still throttle-yields here (without flushing) so a turn/walkthrough
+        // with many calls in a row doesn't monopolise the single WASM thread for its whole
+        // duration — e.g. RunWalkthrough's loop never awaits anything else between steps, so
+        // without this the browser couldn't process input or DevTools protocol calls until the
+        // entire walkthrough finished.
         async Task IPlayer.RunScriptAsync(string function, object[]? parameters)
         {
-            FlushBuffer();
-            var now = Environment.TickCount64;
-            if (now - _lastYieldMs >= 16)
-            {
-                _lastYieldMs = now;
-                await JsYield();
-            }
-
             // Strip newlines from string parameters — some games depend on this (matching WebPlayer behaviour)
             var processedParams = parameters?.Select(p =>
                 p is string s ? (object)s.Replace("\r", "").Replace("\n", "") : p).ToArray();
@@ -716,13 +734,21 @@ public partial class WasmPlayerBridge
             // so it runs in global scope (matching WebPlayer behaviour; e.g. spondre defines global functions this way)
             if (function == "eval" && processedParams is [string evalCode])
             {
-                JsRunScript(evalCode);
-                return;
+                _uiBuffer.Add(() => JsRunScript(evalCode));
+            }
+            else
+            {
+                var serializedArgs = string.Join(',',
+                    processedParams?.Select(SerializeJsArg) ?? System.Array.Empty<string>());
+                _uiBuffer.Add(() => JsRunScript($"{function}({serializedArgs})"));
             }
 
-            var serializedArgs = string.Join(',',
-                processedParams?.Select(SerializeJsArg) ?? System.Array.Empty<string>());
-            JsRunScript($"{function}({serializedArgs})");
+            var now = Environment.TickCount64;
+            if (now - _lastYieldMs >= 16)
+            {
+                _lastYieldMs = now;
+                await JsYield();
+            }
         }
 
         private static string SerializeJsArg(object? arg) => arg switch


### PR DESCRIPTION
## Summary
- WasmPlayer rendered a game turn's `JS.xxx(...)` calls (custom status/HUD refreshes, `TextFX` effects, etc.) one at a time — each call flushed the DOM and, if 16ms had elapsed, yielded to the browser to paint. A turn with several such calls painted incrementally, visible as a typewriter-style reveal on slower devices (reported for "Mission To Arms" on Android/older Windows). WebPlayer batches an entire turn's JS calls into one round trip and never showed this.
- `RunScriptAsync` now buffers each `JS.*` call alongside the existing buffered UI actions and paints once per turn boundary (new `FlushBufferAndYieldAsync`), matching WebPlayer's granularity, while keeping a throttled bare yield (no flush) so a long turn or the debugger's walkthrough runner (which loops without ever otherwise yielding) still gives the browser a tick for input/DevTools responsiveness.
- Fixing this exposed a latent ordering bug in `WorldModel.FinishGame()`: it resolved `_turnSuspendedTcs` (which a caller is `await`ing) *before* firing `Finished`, so the caller could resume and observe player state before `Finished`'s subscribers (e.g. WasmPlayer's `IsFinished` flag, which gates the Save button) had run. WasmPlayer's old per-call `FlushBuffer()` accidentally masked this by giving the buffered game-finished action another chance to flush on the very next JS call. Reordered to resolve the TCS last, matching `SignalTurnSuspended`'s existing side-effects-before-commit pattern elsewhere in the same file.
- Follow-up: on the same slow-device testing, "Mission To Arms" also surfaced a double-click race in `ShowMenu` (the "Accept mission? 1: Yes / 2: No" style prompt): the rendered `<a class="cmdlink" onclick="ASLEvent(...)">` choices get no client-side disable until the engine round-trip finishes, so an impatient second click on a slow WasmPlayer turn fires a second `ShowMenuResponse` after the engine has already cleared `game.menucallback`, surfacing as "Unexpected menu response". Fixed in the shared player JS (`playercore.js`) rather than the aslx `ShowMenu` template, since a template fix would only help games re-exported after the change — existing games (including this one) already have their own compiled copy of the old `ShowMenu` baked in. Scoped to `#divOutput` so it doesn't also disable the (structurally similar but reusable) `#endWaitLink` control.

## Test plan
- [x] `dotnet test` — EngineTests, WebPlayerTests, PlayerCoreTests, LegacyTests, EditorCoreTests all pass
- [x] Manually verified "Mission To Arms" in WasmPlayer — turns render as a single batch, no console errors
- [x] `tests/e2e/verify-wasmplayer-debugger.mjs`, `verify-wasmplayer-restart-sidebar-dup.mjs`, `verify-wasmplayer-save-disabled-during-wait-input.mjs`, `verify-wasmplayer-save-turn-pending.mjs`, `verify-wasmplayer-showmenu-select-default.mjs` all pass
- [x] Isolated DOM-level test confirms the menu-click fix: clicking one option instantly disables all choices (onclick stripped) and a subsequent click is silently ignored, with no "Unexpected menu response"

🤖 Generated with [Claude Code](https://claude.com/claude-code)