### PR TITLE
fix(Engine): request the next timer tick only after Tick() fully completes

### DIFF
--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -527,7 +527,7 @@ public partial class WorldModel : IGame, IGameDebug
         return Task.FromResult(Encoding.UTF8.GetBytes(saveData));
     }
 
-    public Task Tick(int elapsedTime)
+    public async Task Tick(int elapsedTime)
     {
         if (_timerRunner == null)
         {
@@ -536,7 +536,7 @@ public partial class WorldModel : IGame, IGameDebug
 
         if (State == GameState.Finished)
         {
-            return Task.CompletedTask;
+            return;
         }
 
         if (_beginInProgress)
@@ -545,12 +545,24 @@ public partial class WorldModel : IGame, IGameDebug
             // _beginInProgress). Drop it — BeginInternalAsync calls
             // SendNextTimerRequest() itself once it completes, so the next tick
             // gets scheduled correctly from actual post-startup state.
-            return Task.CompletedTask;
+            return;
         }
 
-        var task = TickAsyncInternal(elapsedTime);
+        // SendNextTimerRequest() must run after TickAsyncInternal fully completes, not
+        // right after starting it: a timer's own script can genuinely suspend mid-execution
+        // (any msg()/JS.* call goes through IPlayer.RunScriptAsync, which real players are
+        // free to implement as a genuine async yield back to the browser) after disabling
+        // itself but before enabling the next timer in the chain - a common EnableTimer/
+        // SetTimeout pattern. Computing "next due" before that point sees no enabled timers
+        // and requests 0 - and since nothing else re-requests a tick afterwards, the JS-side
+        // interval never gets re-armed and every timer after this one in the chain silently
+        // stops firing. This is the "game just stops" bug reported for Timer/SetTimeout
+        // chains: every other entry point here (FinishWait, FinishPause,
+        // SetQuestionResponse, SetMenuResponse, HandleCommandAsyncInternal, SendEventCore,
+        // BeginInternalAsync) already requests the next tick only after its work completes;
+        // Tick() was the one exception.
+        await TickAsyncInternal(elapsedTime);
         SendNextTimerRequest();
-        return task;
     }
 
     private async Task TickAsyncInternal(int elapsedTime)

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -20,12 +20,15 @@ internal sealed class GameDriver
     private Exception _scriptError;
     public List<int> RequestedTimerTicks { get; } = [];
     public GameState State => _worldModel.State;
+    public WorldModel Model => _worldModel;
+    public Mock<IPlayer> PlayerMock { get; private set; }
 
     private static readonly Regex StripTags = new(@"<[^>]+>", RegexOptions.Compiled);
 
     private GameDriver(WorldModel worldModel, Mock<IPlayer> playerMock)
     {
         _worldModel = worldModel;
+        PlayerMock = playerMock;
         playerMock
             .Setup(p => p.RunScriptAsync(It.IsAny<string>(), It.IsAny<object[]>()))
             .Callback<string, object[]>((fn, args) =>
@@ -94,6 +97,15 @@ internal sealed class GameDriver
         _scriptError = null;
         RequestedTimerTicks.Clear();
         await _worldModel.FinishWait();
+        return TakeBatch();
+    }
+
+    public async Task<IReadOnlyList<string>> TickAsync(int elapsedTime)
+    {
+        _batch = [];
+        _scriptError = null;
+        RequestedTimerTicks.Clear();
+        await _worldModel.Tick(elapsedTime);
         return TakeBatch();
     }
 }
@@ -206,5 +218,53 @@ public class CallbackTests
         // finishes ("outer after"), not nested inside it.
         var list = output.ToList();
         list.IndexOf("outer after").ShouldBeLessThan(list.IndexOf("inner"));
+    }
+
+    // Tick() used to call SendNextTimerRequest() right after *starting* (not awaiting)
+    // TickAsyncInternal, unlike every other entry point (FinishWait, FinishPause,
+    // SetQuestionResponse, SetMenuResponse, HandleCommandAsyncInternal, SendEventCore,
+    // BeginInternalAsync), which all correctly request the next tick only after their
+    // work fully completes. On a real player, a timer's own script can genuinely suspend
+    // mid-execution (msg()/JS.* calls go through interop that can yield) - so if
+    // chaintimer1 disables itself, then yields, then enables chaintimer2, the premature
+    // request captures a stale snapshot with chaintimer1 already disabled and
+    // chaintimer2 not yet enabled: GetTimeUntilNextTimerRuns() sees no enabled timers and
+    // requests 0, and nothing ever re-requests afterwards - chaintimer2 silently never
+    // fires again. This is exactly the WasmPlayer-only "game just stops" bug reported for
+    // Timer/SetTimeout chains: WasmPlayer's RunScriptAsync genuinely yields via a
+    // throttled JS interop call; WebPlayer's happens not to hit the same race in practice.
+    [TestMethod]
+    public async Task Tick_TimerScriptYieldsBeforeEnablingNextTimer_RequestsCorrectNextTick()
+    {
+        var driver = await GameDriver.LoadAsync("callbacktest.aslx");
+
+        // chaintimer1 starts disabled and is enabled here (rather than from game start)
+        // so it can't collide with other tests' timers (e.g. racetimer's interval=5).
+        await driver.SendCommandAsync("enablechaintimer");
+        driver.RequestedTimerTicks.Clear();
+
+        // Simulate a real player's interop call (msg() -> JS.addText) genuinely suspending
+        // mid-script - a plain TaskCompletionSource rather than Task.Yield(), since
+        // Task.Yield()'s continuation runs on the CLR thread pool and can race the calling
+        // thread; this instead matches WasmPlayer's single-threaded JS event loop exactly,
+        // where nothing else can possibly run until this is explicitly completed below.
+        var addTextTcs = new TaskCompletionSource();
+        driver.PlayerMock
+            .Setup(p => p.RunScriptAsync("addText", It.IsAny<object[]>()))
+            .Returns(addTextTcs.Task);
+
+        var tickTask = driver.Model.Tick(2);
+
+        // chaintimer1 has run DisableTimer and is now suspended mid-msg(), before reaching
+        // EnableTimer(chaintimer2). The buggy Tick() calls SendNextTimerRequest() right here
+        // - before the timer's script has actually finished - so nothing should have been
+        // requested yet.
+        driver.RequestedTimerTicks.ShouldBeEmpty();
+
+        addTextTcs.TrySetResult();
+        await tickTask;
+
+        driver.RequestedTimerTicks.ShouldNotContain(0);
+        driver.RequestedTimerTicks.ShouldContain(3);
     }
 }

--- a/tests/EngineTests/callbacktest.aslx
+++ b/tests/EngineTests/callbacktest.aslx
@@ -96,4 +96,33 @@
       msg ("command ran")
     </script>
   </command>
+
+  <!-- Chained timers: chaintimer1 disables itself, prints (a genuine interop yield point
+       on a real player), then enables chaintimer2. If the host requests its next tick
+       before chaintimer1's whole script has finished running, it captures a stale snapshot
+       (chaintimer1 already disabled, chaintimer2 not yet enabled) and never re-arms for
+       chaintimer2 at all. -->
+  <timer name="chaintimer1">
+    <enabled type="boolean">false</enabled>
+    <interval type="int">2</interval>
+    <script>
+      DisableTimer (chaintimer1)
+      msg ("chain1 ran")
+      EnableTimer (chaintimer2)
+    </script>
+  </timer>
+  <timer name="chaintimer2">
+    <enabled type="boolean">false</enabled>
+    <interval type="int">3</interval>
+    <script>
+      msg ("chain2 ran")
+    </script>
+  </timer>
+  <command name="cmd_enable_chaintimer">
+    <pattern>enablechaintimer</pattern>
+    <script>
+      DisableTimer (racetimer)
+      EnableTimer (chaintimer1)
+    </script>
+  </command>
 </asl>


### PR DESCRIPTION
## Summary
- `Tick()` was the one entry point that called `SendNextTimerRequest()` immediately after *starting* `TickAsyncInternal` rather than after it fully completed, unlike every other entry point (`FinishWait`, `FinishPause`, `SetQuestionResponse`, `SetMenuResponse`, `HandleCommandAsyncInternal`, `SendEventCore`, `BeginInternalAsync`).
- Since `msg()`/`JS.*` calls go through `IPlayer.RunScriptAsync`, which a real player is free to implement as a genuine async yield back to the browser, a timer script that disables itself, yields, then enables the next timer in a chain (a common `EnableTimer`/`SetTimeout` pattern) could have its "next timer due" snapshot computed mid-script — with no timers enabled yet. That permanently kills the JS-side reschedule (requests `0`, nothing re-requests afterwards) and silently stops every subsequent timer in the chain.
- This reproduced as: a game's chained `Timer`/`SetTimeout` sequence would run its first step (e.g. printing "Status: Initializing") and then just stop, with no further timer output ever appearing — reported against a real game in WasmPlayer, confirmed fixed by the reporter.
- Fix: `Tick()` now `await`s `TickAsyncInternal` before calling `SendNextTimerRequest()`, matching the pattern already used everywhere else.

## Test plan
- [x] Added `Tick_TimerScriptYieldsBeforeEnablingNextTimer_RequestsCorrectNextTick` (`tests/EngineTests/CallbackTests.cs`), using a manually-controlled `TaskCompletionSource` (not `Task.Yield()`, which races against the real CLR thread pool) to deterministically simulate a timer script genuinely suspending mid-execution, matching a real single-threaded JS event loop.
- [x] Verified the new test fails without the fix (captures the stale `0` snapshot) and passes with it.
- [x] Full solution test suite passes (328/328: EngineTests, PlayerCoreTests, WebPlayerTests, EditorCoreTests, LegacyTests).
- [x] Manually verified against the originally reported game in WasmPlayer (built Release/AOT, ran via `AppShell` dev proxy) — confirmed by the reporter as fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)