### PR TITLE
fix: fix CI-only flakes found running the newly-wired e2e suite

### DIFF
--- a/tests/e2e/verify-electron-open-game-no-window.mjs
+++ b/tests/e2e/verify-electron-open-game-no-window.mjs
@@ -90,5 +90,7 @@ try {
     process.exitCode = 1;
 } finally {
     app?.process().kill('SIGKILL');
-    rmSync(userDataDir, { recursive: true, force: true });
+    // SIGKILL doesn't wait for Chromium to finish its disk-cache writeback, so an immediate
+    // rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
+    rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
 }

--- a/tests/e2e/verify-electron-selectall-textbox.mjs
+++ b/tests/e2e/verify-electron-selectall-textbox.mjs
@@ -117,6 +117,8 @@ try {
     // the whole process — nothing left to click it away with here. Kill the
     // process directly instead of asking it to close gracefully.
     app?.process().kill('SIGKILL');
-    rmSync(userDataDir, { recursive: true, force: true });
+    // SIGKILL doesn't wait for Chromium to finish its disk-cache writeback, so an immediate
+    // rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
+    rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
     rmSync(gameDirPath, { recursive: true, force: true });
 }

--- a/tests/e2e/verify-electron-undo-textarea.mjs
+++ b/tests/e2e/verify-electron-undo-textarea.mjs
@@ -141,6 +141,8 @@ try {
     // the whole process — nothing left to click it away with here. Kill the
     // process directly instead of asking it to close gracefully.
     app?.process().kill('SIGKILL');
-    rmSync(userDataDir, { recursive: true, force: true });
+    // SIGKILL doesn't wait for Chromium to finish its disk-cache writeback, so an immediate
+    // rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
+    rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
     rmSync(gameDirPath, { recursive: true, force: true });
 }

--- a/tests/e2e/verify-electron-unsaved-close-dialog.mjs
+++ b/tests/e2e/verify-electron-unsaved-close-dialog.mjs
@@ -48,7 +48,9 @@ async function withFreshApp(fn) {
         return await fn(app, win);
     } finally {
         app?.process().kill('SIGKILL');
-        rmSync(userDataDir, { recursive: true, force: true });
+        // SIGKILL doesn't wait for Chromium to finish its disk-cache writeback, so an immediate
+        // rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
+        rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
     }
 }
 

--- a/tests/e2e/verify-site-download-page.mjs
+++ b/tests/e2e/verify-site-download-page.mjs
@@ -146,7 +146,11 @@ let failed = false;
 // ── Run 4: release has no .deb — Linux label must say AppImage, not .deb ───
 {
     const browser = await chromium.launch();
-    const page = await browser.newPage();
+    // Explicit non-Linux UA: this run's assertion expects the Linux entry to render as a plain
+    // secondary link (no "Download for" prefix) — leaving userAgent unset relies on the host
+    // browser's own OS to not be detected as Linux, which broke in CI (Linux runner's default
+    // Chromium UA reports Linux, making it the *primary* button instead).
+    const page = await browser.newPage({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15' });
     page.on('pageerror', err => console.log('[pageerror]', err.message));
     const noDebRelease = {
         tag_name: 'v6.0.0-beta.42',

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -217,7 +217,12 @@ check('Override applied: player.parent is now livingroom', /livingroom/i.test(pa
 await previewPage.click('#qv-debugger-close');
 await previewPage.fill('#txtCommand', 'look');
 await previewPage.press('#txtCommand', 'Enter');
-await previewPage.waitForTimeout(300);
+// A fixed sleep here was flaky under CI's slower/more loaded runner (the WASM engine hadn't
+// finished processing "look" yet) — poll for the output to actually mention livingroom instead.
+await previewPage.waitForFunction(
+    () => /livingroom/i.test(document.querySelector('#divOutput')?.textContent ?? ''),
+    { timeout: 5000 }
+).catch(() => {});
 const outputText = await previewPage.$eval('#divOutput', el => el.textContent);
 console.log('  output after look:', JSON.stringify(outputText).slice(0, 300));
 check('The live game reflects the move (output mentions livingroom)', /livingroom/i.test(outputText));


### PR DESCRIPTION
## Summary

Follow-up to #1977. After merging that PR, running the `e2e` workflow for real (run [30692454759](https://github.com/textadventures/quest/actions/runs/30692454759)) surfaced three CI-only failures — genuine drift/races that a local run couldn't catch, not miswiring in the workflow itself.

## `site_chromium` — `verify-site-download-page.mjs`

"Run 4" opened a page with no explicit `userAgent`, silently depending on the host browser's own OS. Playwright's default Chromium UA reports Mac on my local machine but Linux on the `ubuntu-latest` runner — which flips the Linux download link from a plain secondary entry to the primary "Download for Linux" button (per `DownloadButton.astro`'s `detected`/`primary` logic) and breaks the label assertion. Pinned an explicit Mac UA, matching what the run actually intends to check (Linux rendered as a secondary/other-platform entry).

## `wasmplayer_chromium` — `verify-wasmplayer-debugger.mjs`

Read the game output after a fixed `300ms` sleep following an Enter keypress — not always enough time for the WASM engine to finish processing the command on a slower/more loaded CI runner. Replaced with polling for the expected output text.

## `electron` — 4 scripts

`verify-electron-open-game-no-window.mjs`, `verify-electron-selectall-textbox.mjs`, `verify-electron-undo-textarea.mjs`, `verify-electron-unsaved-close-dialog.mjs` all kill the Electron process with `SIGKILL` (needed to bypass a blocking native dialog these tests intentionally trigger) and then immediately `rmSync` the temp user-data dir. That races Chromium's async disk-cache writeback, which can still be touching `Cache_Data` when `rmSync` runs, throwing `ENOTEMPTY`. Only `verify-electron-unsaved-close-dialog.mjs` hit it in that run, but all four share the identical pattern — added `maxRetries`/`retryDelay` (`fs.rmSync`'s built-in retry, made for exactly this class of transient error) to all four rather than just the one that happened to fail this time.

## Test plan

- [x] `verify-site-download-page.mjs` and `verify-wasmplayer-debugger.mjs` re-run locally against local dev servers — clean.
- [x] All four `electron` scripts re-run locally against a locally-built Electron app (macOS, so `_electron` launches natively here) — clean.
- [ ] Another `workflow_dispatch` run of `e2e.yml` post-merge to confirm green in the real CI environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)