### PR TITLE
fix: on-ready queue draining + WasmPlayer JS-call flush timing for recursive get-input loops

### DIFF
--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -21,6 +21,15 @@ public interface IGame
     event UpdateListHandler? UpdateList;
     event FinishedHandler? Finished;
     event ErrorHandler? LogError;
+
+    // Raised on every genuine suspension boundary (wait/get input/ask/show menu opening or
+    // resolving), not just once per SendCommand/Begin/etc. call - a player implementation that
+    // buffers JS calls (e.g. WasmPlayer's WasmPlayerBridge) should flush on every occurrence,
+    // not only when the outermost await returns. A script can open its *next* suspension (e.g.
+    // a puzzle loop's next get input) before the one currently resolving has finished draining
+    // deferred on-ready work, so the first signal after a command starts isn't necessarily the
+    // last one relevant to that command's own output.
+    event Action? TurnSuspended;
     void Finish();
     Task<byte[]> SaveAsync(string html);
     Task FinishWait();

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -225,6 +225,7 @@ public partial class WorldModel : IGame, IGameDebug
     public event UpdateListHandler? UpdateList;
     public event FinishedHandler? Finished;
     public event ErrorHandler? LogError;
+    public event Action? TurnSuspended;
 
     public async Task SetMenuResponse(string? response)
     {
@@ -1156,6 +1157,11 @@ public partial class WorldModel : IGame, IGameDebug
         // at every point that matters, including games that never hit any of these
         // constructs at all (count stays 0 throughout, correctly reported as idle).
         PlayerUi.SetTurnPending(_pendingCallbackCount > 0);
+        // Unlike _turnSuspendedTcs.TrySetResult() below (a one-shot signal - only the first
+        // call per command actually resolves anything), this fires every time, so a buffering
+        // IPlayer can flush on every suspension boundary rather than only the first one a given
+        // command reaches.
+        TurnSuspended?.Invoke();
         _turnSuspendedTcs.TrySetResult();
     }
 

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -91,9 +91,18 @@ public partial class WorldModel : IGame, IGameDebug
     }
 
     // Tracks show menu / ask / get input callbacks that fire-and-forget their response handling.
-    // on ready defers until this reaches zero.
+    // on ready defers while this is above zero, so it doesn't run mid-callback while state may
+    // still be inconsistent.
     private int _pendingCallbackCount;
     private readonly List<(IScript Script, Context Context)> _onReadyQueue = [];
+
+    // Guards the on-ready drain loop in EndPendingCallbackAsync against re-entry: a queued
+    // script can itself synchronously await another prompt (e.g. a synchronous "play sound",
+    // or the GetInput()/Ask()/ShowMenu() expression forms), which calls EndPendingCallbackAsync
+    // again from within the drain loop's own call stack. When that happens, the inner call must
+    // not start a second drain loop - it just decrements the count and returns, leaving the
+    // outer loop (still on the stack) to keep going.
+    private bool _isFlushingOnReadyQueue;
 
     private bool _reportingScriptError;
 
@@ -1725,13 +1734,30 @@ public partial class WorldModel : IGame, IGameDebug
     internal async Task EndPendingCallbackAsync()
     {
         _pendingCallbackCount--;
-        while (_pendingCallbackCount == 0 && _onReadyQueue.Count > 0 && State != GameState.Finished)
+
+        // Drain whenever *this* Begin/End pair resolves - not only once every other
+        // outstanding callback has also resolved. A script (e.g. get_partition_sequence-style
+        // puzzle loops) can open its next get input/wait/ask/show menu before this one's finally
+        // block runs, which keeps _pendingCallbackCount above zero indefinitely; gating the drain
+        // on it reaching zero left anything queued while such a loop is active stuck forever.
+        if (_isFlushingOnReadyQueue)
         {
-            var (script, context) = _onReadyQueue[0];
-            _onReadyQueue.RemoveAt(0);
-            await RunScriptAsync(script, context);
-            // RunScriptAsync may have called BeginPendingCallback (e.g. via show menu inside on ready);
-            // if so, stop flushing — the new callback's EndPendingCallbackAsync will continue.
+            return;
+        }
+
+        _isFlushingOnReadyQueue = true;
+        try
+        {
+            while (_onReadyQueue.Count > 0 && State != GameState.Finished)
+            {
+                var (script, context) = _onReadyQueue[0];
+                _onReadyQueue.RemoveAt(0);
+                await RunScriptAsync(script, context);
+            }
+        }
+        finally
+        {
+            _isFlushingOnReadyQueue = false;
         }
     }
 

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -54,6 +54,12 @@ public partial class V4Game
 
     public event PrintTextHandler PrintText;
 
+    // Legacy V4 games have no wait/get-input/ask/show-menu suspension concept for a buffering
+    // IPlayer to flush on mid-command - never raised, but IGame requires the member.
+#pragma warning disable CS0067
+    public event Action TurnSuspended;
+#pragma warning restore CS0067
+
     public Task SendCommand(string command)
     {
         return SendCommand(command, 0, null);

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -107,6 +107,14 @@ public partial class WasmPlayerBridge
         _game.UpdateList += (listType, items) => _ui.HandleUpdateList(listType, items);
         _game.Finished += () => _ui.HandleFinished();
         _game.RequestNextTimerTick += seconds => _ui.SetPendingTimerTick(seconds);
+        // A script can open its *next* suspension (e.g. a puzzle loop's next get input) before
+        // the one currently resolving has finished draining deferred on-ready work (map redraws,
+        // JS.updateLocation, etc.) - _turnSuspendedTcs only resolves once per command, on the
+        // *first* such signal, so the FlushBufferAndYieldAsync call after `await _game.SendCommand`
+        // can fire before that later output is buffered, and it then only shows up a turn late.
+        // TurnSuspended fires on every occurrence (not just the first), so flush on each one -
+        // FlushBuffer is a cheap no-op when nothing new is buffered.
+        _game.TurnSuspended += () => _ui.FlushBuffer();
 
         var (ok, errors) = await _helper.Initialise(_ui);
         if (!ok)

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -220,6 +220,33 @@ public class CallbackTests
         list.IndexOf("outer after").ShouldBeLessThan(list.IndexOf("inner"));
     }
 
+    // Regression test for a bug (reported against Giantkiller Too's Indoor Market partition
+    // puzzle) where an on-ready queued mid-loop never ran: the loop's "get input" reopens the
+    // next prompt from inside the current callback, before that callback's own finally block
+    // decrements _pendingCallbackCount, so the count never returns to 0 while the loop is
+    // running. The old drain condition (_pendingCallbackCount == 0) meant anything queued during
+    // any round was stuck forever. Each round's on-ready must run in that same round.
+    [TestMethod]
+    public async Task OnReady_QueuedInsideRecursiveGetInputLoop_RunsEachRound()
+    {
+        var driver = await GameDriver.LoadAsync("callbacktest.aslx");
+
+        var phase1 = await driver.SendCommandAsync("puzzleloop");
+        phase1.ShouldContain("prompt");
+
+        var phase2 = await driver.SendCommandAsync("first");
+        phase2.ShouldContain("deferred: first");
+        phase2.ShouldContain("prompt");
+
+        var phase3 = await driver.SendCommandAsync("second");
+        phase3.ShouldContain("deferred: second");
+        phase3.ShouldContain("prompt");
+
+        var phase4 = await driver.SendCommandAsync("stop");
+        phase4.ShouldContain("deferred: stop");
+        phase4.ShouldContain("stopped");
+    }
+
     // Tick() used to call SendNextTimerRequest() right after *starting* (not awaiting)
     // TickAsyncInternal, unlike every other entry point (FinishWait, FinishPause,
     // SetQuestionResponse, SetMenuResponse, HandleCommandAsyncInternal, SendEventCore,

--- a/tests/EngineTests/callbacktest.aslx
+++ b/tests/EngineTests/callbacktest.aslx
@@ -80,6 +80,32 @@
     </script>
   </command>
 
+  <!-- Recursive get-input loop (the "get_partition_sequence" pattern used by mini-puzzles):
+       each response opens the next get input from inside the previous one's callback, before
+       that callback returns. This keeps _pendingCallbackCount above zero indefinitely (it never
+       falls all the way back to 0 while the loop is running), so an on-ready queued during a
+       round must still run on that same round, not be gated on the count reaching zero. -->
+  <function name="puzzle_loop">
+    msg ("prompt")
+    get input {
+      on ready {
+        msg ("deferred: " + result)
+      }
+      if (result = "stop") {
+        msg ("stopped")
+      }
+      else {
+        puzzle_loop
+      }
+    }
+  </function>
+  <command name="cmd_puzzle_loop">
+    <pattern>puzzleloop</pattern>
+    <script>
+      puzzle_loop
+    </script>
+  </command>
+
   <!-- Fires as soon as elapsed time reaches its 5-second interval. Used to verify that
        SendCommand runs elapsed-time-triggered timer scripts to completion before the
        command itself runs, rather than racing the two. -->

--- a/tests/e2e/fixtures/onready-recursive-getinput-test.aslx
+++ b/tests/e2e/fixtures/onready-recursive-getinput-test.aslx
@@ -1,0 +1,67 @@
+<asl version="580">
+
+  <include ref="English.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <game name="OnReadyRecursiveGetInputTest">
+    <gridmap />
+  </game>
+
+  <object name="RoomA">
+    <inherit name="editor_room" />
+    <attr name="grid_width" type="int">2</attr>
+    <attr name="grid_length" type="int">2</attr>
+    <object name="player">
+      <inherit name="defaultplayer" />
+    </object>
+    <exit alias="east" to="RoomB">
+      <inherit name="eastdirection" />
+    </exit>
+  </object>
+
+  <object name="RoomB">
+    <inherit name="editor_room" />
+    <attr name="grid_width" type="int">2</attr>
+    <attr name="grid_length" type="int">2</attr>
+    <exit alias="west" to="RoomA">
+      <inherit name="westdirection" />
+    </exit>
+  </object>
+
+  <!-- Mirrors Giantkiller Too's Indoor Market "get_partition_sequence" puzzle
+       pattern: a loop that opens its next get input from inside the current
+       one's callback, before that callback's own finally block runs, so
+       _pendingCallbackCount never returns to zero while the loop is active.
+       Moving the player triggers changedparent -> OnEnterRoom -> on ready ->
+       JS.updateLocation, same mechanism the automatic map redraw uses. -->
+  <command name="cmd_start">
+    <pattern>startloop</pattern>
+    <script>
+      puzzle_loop
+    </script>
+  </command>
+  <function name="puzzle_loop">
+    msg ("prompt")
+    get input {
+      if (result = "a") {
+        MoveObject (player, RoomA)
+        on ready {
+          msg ("moved-onready: " + result)
+        }
+      }
+      else if (result = "b") {
+        MoveObject (player, RoomB)
+        on ready {
+          msg ("moved-onready: " + result)
+        }
+      }
+      if (result = "stop") {
+        msg ("stopped")
+      }
+      else {
+        puzzle_loop
+      }
+    }
+  </function>
+
+</asl>

--- a/tests/e2e/verify-wasmplayer-onready-recursive-getinput.mjs
+++ b/tests/e2e/verify-wasmplayer-onready-recursive-getinput.mjs
@@ -1,0 +1,96 @@
+// Regression check for a bug reported against Giantkiller Too's Indoor Market
+// partition puzzle: the map (and other on-ready-driven UI, like the location
+// header) stopped updating partway through a "get_partition_sequence"-style
+// puzzle loop, where each response opens the next get input from inside the
+// current callback, before that callback's own finally block runs. This kept
+// WorldModel._pendingCallbackCount above zero indefinitely while the loop ran,
+// so anything queued via AddOnReady (changedparent -> OnEnterRoom -> on ready,
+// which drives JS.updateLocation and the automatic map redraw) never got
+// flushed - EndPendingCallbackAsync only drained the queue once the count
+// returned to exactly 0, which the loop's structure never allowed.
+//
+// That part is fixed in WorldModel.EndPendingCallbackAsync (drains whenever
+// its own Begin/End pair resolves, not only at global count zero) - confirmed
+// by tracing that the drain now runs and completes without error every turn.
+//
+// BUT: this script demonstrates the fix is still not enough for WasmPlayer
+// specifically. WasmPlayerBridge buffers JS.*() calls (_uiBuffer) and only
+// flushes them once WorldModel's _turnSuspendedTcs resolves (see
+// FlushBufferAndYieldAsync, called right after `await _game.SendCommand()`).
+// GetInputScript.ExecuteAsync calls SignalTurnSuspended() unconditionally
+// every time a *new* get input is opened - including the one the puzzle loop
+// opens for its *next* prompt, from inside the current response's own
+// callback, before EndPendingCallbackAsync's drain has run. Since
+// _turnSuspendedTcs only resolves once (TrySetResult, first call wins), that
+// nested get-input's signal fires and resolves it *before* the drain's output
+// has been added to _uiBuffer - so WasmPlayerBridge flushes too early and
+// misses it. The drained output isn't lost, just buffered - it only becomes
+// visible once the *next* command's own flush runs, so the map (and location
+// header) is permanently one input behind wherever the player actually is.
+// WebPlayer doesn't have this bug because its IPlayer.RunScriptAsync isn't
+// buffered this way - each JS call goes out as it happens.
+//
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+async function waitUntilCanSendCommand() {
+    await page.waitForFunction(() => window.canSendCommand === true, { timeout: 10000 });
+}
+
+async function sendCommand(command) {
+    await waitUntilCanSendCommand();
+    await page.fill('#txtCommand', command);
+    await page.press('#txtCommand', 'Enter');
+}
+
+async function locationText() {
+    return await page.$eval('#location', el => el.textContent.trim());
+}
+
+async function assertLocation(expected, label) {
+    const actual = await locationText();
+    if (actual !== expected) {
+        throw new Error(`${label}: expected location "${expected}", got "${actual}"`);
+    }
+    console.log(`PASS: ${label} (location="${actual}")`);
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/onready-recursive-getinput-test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000, state: 'attached' });
+
+    await sendCommand('startloop');
+    await page.waitForTimeout(300);
+    await assertLocation('A RoomA', 'location updates on the first move (top-level command, count starts at 0)');
+
+    // This is the buggy transition: resolving the puzzle loop's get input opens
+    // the *next* get input before this callback's own finally decrements the
+    // count, so it never returns to 0 while the loop keeps running.
+    await sendCommand('b');
+    await page.waitForTimeout(300);
+    await assertLocation('A RoomB', 'location updates on a move made from inside the recursive get-input loop');
+
+    await sendCommand('a');
+    await page.waitForTimeout(300);
+    await assertLocation('A RoomA', 'location updates on a second nested-loop move');
+
+    await sendCommand('stop');
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/wasmplayer-onready-recursive-getinput-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary

Bug report: on play.questviva.com and locally, the automatic map (`MAP` command) and location header stop updating partway through Giantkiller Too's Indoor Market "partition" puzzle — repro: `MAP, S, E, E, NE, N, W` to enter the puzzle, then erect a partition to the east and move west. Confirmed against a v5 side-by-side that this is a regression, not a game-authoring issue.

This turned out to be **two separate bugs**, one in the shared Engine and one WasmPlayer-specific.

### 1. Engine: `on ready` never drained during a recursive `get input` loop

The puzzle uses the common "`get_partition_sequence`" pattern — a function that ends by opening the *next* `get input { ... }` from inside the callback of the *previous* one, before that callback's own `finally` block runs. Each `get input`/`wait`/`ask`/`show menu` increments a shared `_pendingCallbackCount` while suspended; `on ready` scripts (which drive `changedparent` → `OnEnterRoom` → `Grid_CalculateMapCoordinates`/`Grid_DrawPlayerInRoom`, i.e. the map redraw) get queued instead of run immediately whenever that count is `> 0`, and were only ever drained once it returned to exactly **0**.

Because the puzzle's next `get input` opens *before* the previous one's `finally` decrements, the count cycles `1 → 2 → 1` instead of `1 → 0` between moves — it never reaches zero while the player stays in the puzzle, so anything queued mid-puzzle (map redraw, room-enter description text, `JS.updateLocation`, etc.) is stuck in `_onReadyQueue` forever.

**Fix:** `EndPendingCallbackAsync` now drains the queue whenever *its own* Begin/End pair resolves, guarded against re-entrancy with a `_isFlushingOnReadyQueue` flag, instead of gating the drain on the global counter reaching zero.

### 2. WasmPlayer: buffered JS calls flushed one turn too early

Fixing (1) made WebPlayer work correctly, but WasmPlayer still showed the bug. Root cause: `WasmPlayerBridge` buffers all `JS.*()` calls (`_uiBuffer`, added in #1975) and only flushes them once `WorldModel`'s `_turnSuspendedTcs` resolves — a one-shot signal, first call per command wins. But `GetInputScript`/`WaitScript`/`AskScript`/`ShowMenuScript`'s `ExecuteAsync` all call `SignalTurnSuspended()` unconditionally whenever a *new* suspension opens — including the one the puzzle loop opens for its *next* prompt, which happens *before* the current callback's own drain (fix 1) has produced its output. That premature signal resolves `_turnSuspendedTcs` before the drain's JS calls are buffered, so `WasmPlayerBridge` flushes too early and misses them — they only become visible a full turn late, once the *next* command's own flush runs. The map (and any other `on ready`-driven UI) is permanently one input behind. WebPlayer never hit this because its `IPlayer.RunScriptAsync` isn't buffered — each JS call goes out as it happens.

**Fix:** added `IGame.TurnSuspended`, an event that fires on *every* `SignalTurnSuspended()` call (not just the first per command, unlike the TCS). `WasmPlayerBridge` now flushes on every occurrence — `FlushBuffer()` is a cheap no-op when nothing new is buffered. `WorldModel` raises it; `V4Game` (legacy, no suspension concept) declares but never raises it.

## Test plan
- [x] New `EngineTests` regression test (`OnReady_QueuedInsideRecursiveGetInputLoop_RunsEachRound`) pins fix (1) at the engine level — fails on the pre-fix code, passes with it.
- [x] New e2e regression test (`verify-wasmplayer-onready-recursive-getinput.mjs` + fixture) reproduces the exact `get_partition_sequence` pattern through WasmPlayer's real JS interop pipeline — fails without fix (2), passes with it.
- [x] Full existing WasmPlayer e2e suite still green: `verify-wasmplayer-save-turn-pending`, `verify-wasmplayer-save-disabled-during-wait-input`, `verify-wasmplayer-showmenu-select-default`, `verify-wasmplayer-restart-sidebar-dup`, `verify-wasmplayer-debugger` — confirms the turn-pending/Save-button work from #1950/#1951 is undisturbed.
- [x] `dotnet test` — all 329 tests across the solution pass.
- [x] `dotnet build --configuration Release` — full solution builds clean.
- [x] Live repro against the actual published game (`y98gfs8dueudlctxnhx1ug`) via local WebPlayer: map and room-enter text now update correctly on the previously-stuck move, no exceptions in the server log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)