### PR TITLE
feat(AppShell): add Call function to the Script Adder

### DIFF
--- a/src/AppShell/src/components/Combobox.svelte
+++ b/src/AppShell/src/components/Combobox.svelte
@@ -24,19 +24,34 @@
     let activeIndex = $state(-1);
     let listboxEl = $state<HTMLDivElement | null>(null);
     let inputEl = $state<HTMLInputElement | null>(null);
-    // Defaults to opening downward, but flips upward when there isn't room below — otherwise a
-    // combobox pinned near the bottom of a panel (e.g. VerbsEditor's "Add Verb" row) renders its
-    // suggestion list past the bottom of the screen/scroll container, invisible.
-    let openUpward = $state(false);
+    // This field commonly sits inside a scrolled panel (a script row, a property tab). An
+    // absolutely-positioned popover is still clipped by that panel's overflow regardless of
+    // z-index, so the popover is portaled to <body> (see `portal` below) and positioned with
+    // `fixed` viewport coordinates computed from the input's rect instead — mirrors
+    // ExpressionInput.svelte's popover.
+    let popoverStyle = $state("");
+
+    function portal(node: HTMLElement) {
+        document.body.appendChild(node);
+        return {
+            destroy() {
+                node.remove();
+            },
+        };
+    }
 
     let hasEmptyOption = $derived(options.some(o => o.value === ""));
 
-    function updateOpenDirection() {
+    // Opens downward by default, flips upward when there isn't room below.
+    function updatePosition() {
         if (!inputEl) return;
         const rect = inputEl.getBoundingClientRect();
+        const approxPopoverHeight = 200;
         const spaceBelow = window.innerHeight - rect.bottom;
         const spaceAbove = rect.top;
-        openUpward = spaceBelow < 200 && spaceAbove > spaceBelow;
+        const openUpward = spaceBelow < approxPopoverHeight && spaceAbove > spaceBelow;
+        const top = openUpward ? rect.top - 4 : rect.bottom + 4;
+        popoverStyle = `position: fixed; left: ${rect.left}px; top: ${top}px; width: ${rect.width}px; transform: translateY(${openUpward ? "-100%" : "0"});`;
     }
 
     $effect(() => {
@@ -55,6 +70,22 @@
             const el = listboxEl.querySelector<HTMLElement>(`[data-idx="${activeIndex}"]`);
             el?.scrollIntoView({ block: "nearest" });
         }
+    });
+
+    // Re-run positioning on scroll/resize while open so the popover tracks the input if the
+    // underlying panel scrolls (capture:true so this also fires for nested scroll containers).
+    $effect(() => {
+        if (!open) return;
+        updatePosition();
+        function onReposition() {
+            updatePosition();
+        }
+        window.addEventListener("scroll", onReposition, true);
+        window.addEventListener("resize", onReposition);
+        return () => {
+            window.removeEventListener("scroll", onReposition, true);
+            window.removeEventListener("resize", onReposition);
+        };
     });
 
     let filtered = $derived(
@@ -79,14 +110,14 @@
 
     function handleFocus() {
         inputValue = "";
-        updateOpenDirection();
+        updatePosition();
         open = true;
     }
 
     function handleClick() {
         if (!open) {
             inputValue = "";
-            updateOpenDirection();
+            updatePosition();
             open = true;
         }
     }
@@ -110,7 +141,7 @@
     function handleKeydown(e: KeyboardEvent) {
         if (e.key === "ArrowDown") {
             e.preventDefault();
-            if (!open) { updateOpenDirection(); open = true; activeIndex = 0; return; }
+            if (!open) { updatePosition(); open = true; activeIndex = 0; return; }
             activeIndex = Math.min(activeIndex + 1, filtered.length - 1);
         } else if (e.key === "ArrowUp") {
             e.preventDefault();
@@ -157,9 +188,11 @@
     {#if open && filtered.length > 0}
         <div
             bind:this={listboxEl}
+            use:portal
+            style={popoverStyle}
             id="{uid}-listbox"
             role="listbox"
-            class="absolute z-50 left-0 min-w-full max-h-48 overflow-y-auto rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-md {openUpward ? "bottom-full mb-0.5" : "top-full mt-0.5"}"
+            class="z-50 max-h-48 overflow-y-auto rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-md"
         >
             {#each filtered as opt, i (opt.value)}
                 <div

--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -58,14 +58,16 @@
     // function here, and listing both would (a) violate the {#each} block's per-name key and
     // (b) offer an entry that, if inserted, wouldn't run what it appears to call.
     function dedupeByName(fns: ExpressionFunctionInfo[]): ExpressionFunctionInfo[] {
-        const byName = new Map<string, ExpressionFunctionInfo>();
+        // Plain object, not Map — this is a throwaway local lookup discarded when the function
+        // returns, not component state, so there's no Svelte-reactivity concern here.
+        const byName: Record<string, ExpressionFunctionInfo> = {};
         for (const fn of fns) {
-            const existing = byName.get(fn.name);
+            const existing = byName[fn.name];
             if (!existing || (existing.isUserDefined && !fn.isUserDefined)) {
-                byName.set(fn.name, fn);
+                byName[fn.name] = fn;
             }
         }
-        return [...byName.values()];
+        return Object.values(byName);
     }
 
     function toggle() {

--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -50,9 +50,27 @@
         popoverStyle = `position: fixed; left: ${rect.right}px; top: ${top}px; transform: translate(-100%, ${openUpward ? "-100%" : "0"});`;
     }
 
+    // A built-in function and a library-defined one can share a name (e.g. "Ask" — a native
+    // ExpressionOwner.Ask(caption) plus a CoreFunctions.aslx Ask(question, callback)). Within an
+    // expression that's not actually ambiguous: NcalcExpressionEvaluator tries the native
+    // ExpressionOwner method by name first and only falls through to WorldModel.Procedure() if no
+    // method of that name exists at all — so the built-in always shadows a same-named library
+    // function here, and listing both would (a) violate the {#each} block's per-name key and
+    // (b) offer an entry that, if inserted, wouldn't run what it appears to call.
+    function dedupeByName(fns: ExpressionFunctionInfo[]): ExpressionFunctionInfo[] {
+        const byName = new Map<string, ExpressionFunctionInfo>();
+        for (const fn of fns) {
+            const existing = byName.get(fn.name);
+            if (!existing || (existing.isUserDefined && !fn.isUserDefined)) {
+                byName.set(fn.name, fn);
+            }
+        }
+        return [...byName.values()];
+    }
+
     function toggle() {
         if (!open) {
-            functions = getExpressionFunctions();
+            functions = dedupeByName(getExpressionFunctions());
             filter = "";
         }
         open = !open;

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -78,7 +78,7 @@
     const expressionOverrides = new SvelteSet<string>();
     let objectNames = $state<string[]>([]);
     let exitNames = $state<string[]>([]);
-    let procedureNames = $state<string[]>([]);
+    let functionNames = $state<string[]>([]);
     let ifTemplates = $state<IfExpressionTemplate[]>([]);
 
     // Load on mount and whenever scriptVersion bumps (undo/redo)
@@ -103,9 +103,9 @@
             const names = getExitNames();
             if (names && names.length > 0) exitNames = names;
         }
-        if (procedureNames.length === 0) {
+        if (functionNames.length === 0) {
             const names = getExpressionFunctions().filter(f => f.isUserDefined).map(f => f.name);
-            if (names.length > 0) procedureNames = names;
+            if (names.length > 0) functionNames = names;
         }
         if (ifTemplates.length === 0) {
             const templates = getIfExpressionTemplates();
@@ -675,17 +675,17 @@
             {objectNames}
             class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
         />
-    {:else if ctrl.controlType === "textbox" && ctrl.objectType === "procedure"}
+    {:else if ctrl.controlType === "textbox" && ctrl.isFunctionPicker}
         <select
             class="select text-xs py-0 px-1 max-w-40"
             value={ctrl.value ?? ""}
             onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLSelectElement).value)}
         >
             <option value=""></option>
-            {#if ctrl.value && !procedureNames.includes(ctrl.value)}
+            {#if ctrl.value && !functionNames.includes(ctrl.value)}
                 <option value={ctrl.value}>{ctrl.value} (not found)</option>
             {/if}
-            {#each procedureNames as name (name)}
+            {#each functionNames as name (name)}
                 <option value={name}>{name}</option>
             {/each}
         </select>

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -4,6 +4,7 @@
     import AddScriptModal from "./AddScriptModal.svelte";
     import AssetPicker from "./AssetPicker.svelte";
     import CodeEditor from "./CodeEditor.svelte";
+    import Combobox from "./Combobox.svelte";
     import ExpressionInput from "./ExpressionInput.svelte";
     import {
         scriptVersion,
@@ -676,19 +677,13 @@
             class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
         />
     {:else if ctrl.controlType === "textbox" && ctrl.isFunctionPicker}
-        <select
-            class="select text-xs py-0 px-1 max-w-40"
+        {@const functionOptions = functionNames.map(name => ({ value: name, label: name }))}
+        <Combobox
             value={ctrl.value ?? ""}
-            onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLSelectElement).value)}
-        >
-            <option value=""></option>
-            {#if ctrl.value && !functionNames.includes(ctrl.value)}
-                <option value={ctrl.value}>{ctrl.value} (not found)</option>
-            {/if}
-            {#each functionNames as name (name)}
-                <option value={name}>{name}</option>
-            {/each}
-        </select>
+            options={functionOptions}
+            onchange={(v) => onSetParam(scriptIndex, ctrl.attribute!, v)}
+            class="input text-xs py-0 px-1 min-w-16 max-w-48"
+        />
     {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
         <input
             type="text"

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -31,6 +31,10 @@
         getIfExpressionTemplates,
         getIfExpressionTemplateData,
         makeScriptEditable,
+        getExpressionFunctions,
+        addScriptListItem,
+        removeScriptListItem,
+        updateScriptListItem,
     } from "$lib/editor-store";
     import type {
         ScriptBlockData,
@@ -74,6 +78,7 @@
     const expressionOverrides = new SvelteSet<string>();
     let objectNames = $state<string[]>([]);
     let exitNames = $state<string[]>([]);
+    let procedureNames = $state<string[]>([]);
     let ifTemplates = $state<IfExpressionTemplate[]>([]);
 
     // Load on mount and whenever scriptVersion bumps (undo/redo)
@@ -97,6 +102,10 @@
         if (exitNames.length === 0) {
             const names = getExitNames();
             if (names && names.length > 0) exitNames = names;
+        }
+        if (procedureNames.length === 0) {
+            const names = getExpressionFunctions().filter(f => f.isUserDefined).map(f => f.name);
+            if (names.length > 0) procedureNames = names;
         }
         if (ifTemplates.length === 0) {
             const templates = getIfExpressionTemplates();
@@ -308,6 +317,22 @@
 
     function onSetParam(scriptIndex: number, paramName: string, value: string) {
         mutate(() => setScriptParameter(elementKey, attribute, containerPath, scriptIndex, paramName, value));
+    }
+
+    function onAddParam(scriptIndex: number, paramAttribute: string, value: string) {
+        mutate(() => addScriptListItem(elementKey, attribute, containerPath, scriptIndex, paramAttribute, value));
+    }
+
+    function onRemoveParam(scriptIndex: number, paramAttribute: string, key: string) {
+        mutate(() => removeScriptListItem(elementKey, attribute, containerPath, scriptIndex, paramAttribute, key));
+    }
+
+    function onUpdateParam(scriptIndex: number, paramAttribute: string, key: string, value: string) {
+        mutate(() => updateScriptListItem(elementKey, attribute, containerPath, scriptIndex, paramAttribute, key, value));
+    }
+
+    function parseListItems(value: string | null): {key: string, value: string}[] {
+        try { return JSON.parse(value ?? "[]"); } catch { return []; }
     }
 
     function onSetIfExpr(scriptIndex: number, expression: string) {
@@ -650,6 +675,20 @@
             {objectNames}
             class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
         />
+    {:else if ctrl.controlType === "textbox" && ctrl.objectType === "procedure"}
+        <select
+            class="select text-xs py-0 px-1 max-w-40"
+            value={ctrl.value ?? ""}
+            onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLSelectElement).value)}
+        >
+            <option value=""></option>
+            {#if ctrl.value && !procedureNames.includes(ctrl.value)}
+                <option value={ctrl.value}>{ctrl.value} (not found)</option>
+            {/if}
+            {#each procedureNames as name (name)}
+                <option value={name}>{name}</option>
+            {/each}
+        </select>
     {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
         <input
             type="text"
@@ -658,6 +697,8 @@
             value={ctrl.value ?? ""}
             onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
         />
+    {:else if ctrl.controlType === "list"}
+        {@render paramListEditor(ctrl, scriptIndex)}
     {:else if ctrl.controlType === "checkbox"}
         <input
             type="checkbox"
@@ -679,6 +720,34 @@
     {:else}
         <span class="text-surface-600-400 italic text-xs">[{ctrl.controlType}]</span>
     {/if}
+{/snippet}
+
+{#snippet paramListEditor(ctrl: ScriptControlData, scriptIndex: number)}
+    {@const items = parseListItems(ctrl.value)}
+    <span class="flex flex-wrap items-center gap-1">
+        {#each items as item (item.key)}
+            <span class="flex items-center gap-0.5">
+                <input
+                    type="text"
+                    autocapitalize="off"
+                    class="input text-xs py-0 px-1 w-20"
+                    value={item.value}
+                    onchange={(e) => onUpdateParam(scriptIndex, ctrl.attribute!, item.key, (e.target as HTMLInputElement).value)}
+                />
+                <button
+                    type="button"
+                    class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
+                    title="Remove parameter"
+                    onclick={() => onRemoveParam(scriptIndex, ctrl.attribute!, item.key)}
+                >×</button>
+            </span>
+        {/each}
+        <button
+            type="button"
+            class="btn btn-sm preset-outlined-primary-500 text-xs py-0 px-1.5 leading-none"
+            onclick={() => onAddParam(scriptIndex, ctrl.attribute!, "")}
+        >+ param</button>
+    </span>
 {/snippet}
 
 {#snippet ifBlock(script: ScriptNodeData, i: number)}

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -856,6 +856,30 @@ export function setScriptParameter(elementKey: string, attribute: string, contai
     return result;
 }
 
+export function addScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, value: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.AddScriptListItem(elementKey, attribute, containerPath, scriptIndex, paramAttribute, value);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function removeScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, key: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.RemoveScriptListItem(elementKey, attribute, containerPath, scriptIndex, paramAttribute, key);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
+export function updateScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, key: string, value: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.UpdateScriptListItem(elementKey, attribute, containerPath, scriptIndex, paramAttribute, key, value);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
 export function setIfExpression(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, expression: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SetIfExpression(elementKey, attribute, containerPath, scriptIndex, expression);

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -99,6 +99,7 @@ export interface ScriptControlData {
   options: ControlOption[] | null
   scripts: ScriptNodeData[] | null
   objectType?: string | null
+  isFunctionPicker?: boolean
 }
 
 export interface ElseIfClauseData {

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -49,6 +49,10 @@ export interface WasmBridge {
   AddListItem(elementKey: string, attribute: string, value: string): string
   RemoveListItem(elementKey: string, attribute: string, key: string): string
   UpdateListItem(elementKey: string, attribute: string, key: string, value: string): string
+  // Script parameter-list API (e.g. Call function's parameters)
+  AddScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, value: string): string
+  RemoveScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, key: string): string
+  UpdateScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, key: string, value: string): string
   // Attributes editor API
   GetFullAttributeData(elementKey: string): string | null
   RemoveAttribute(elementKey: string, attribute: string): string

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -2339,16 +2339,20 @@ public sealed class EditorController : IDisposable
         return WorldModel.GetBuiltInFunctionNames();
     }
 
-    // Feeds the editor's expression-insert helper: built-in engine functions plus the game's own
-    // (non-library) Function elements, both with real parameter names rather than a hand-curated
-    // guess at what's useful.
+    // Feeds the editor's expression-insert helper: built-in engine functions plus every aslx
+    // Function element — the game's own, plus any from included libraries (both the always-
+    // embedded Core/English libraries and ones the author added, e.g. DiceRoll from
+    // CoreCombat.aslx). Unlike GetObjectNames() and friends, library elements are deliberately
+    // NOT filtered out here: a library function is exactly as callable as a game-authored one
+    // (WorldModel.Procedure() doesn't distinguish them), and both consumers of this list
+    // (ExpressionInput's popover, ScriptEditor's Call-function picker) are typeahead-filtered,
+    // so a larger pool isn't the UX problem a flat unfiltered dropdown would make it.
     public IEnumerable<(string Name, string[] Parameters, bool IsUserDefined)> GetExpressionFunctions()
     {
         var builtIn = WorldModel.GetBuiltInFunctionSignatures()
             .Select(f => (f.Name, f.Parameters, IsUserDefined: false));
 
         var userFunctions = WorldModel.Elements.GetElements(ElementType.Function)
-            .Where(e => !e.MetaFields[MetaFieldDefinitions.Library])
             // A freshly-created function has no ParamNames field set yet (only populated by the
             // aslx <function parameters="..."> loader), so Fields[...] is null until the user
             // adds a parameter.

--- a/src/Engine/Core/CoreEditorScriptsScripts.aslx
+++ b/src/Engine/Core/CoreEditorScriptsScripts.aslx
@@ -260,6 +260,7 @@
     <control>
       <controltype>textbox</controltype>
       <attribute>0</attribute>
+      <objecttype>procedure</objecttype>
     </control>
 
     <control>

--- a/src/Engine/Core/CoreEditorScriptsScripts.aslx
+++ b/src/Engine/Core/CoreEditorScriptsScripts.aslx
@@ -260,7 +260,7 @@
     <control>
       <controltype>textbox</controltype>
       <attribute>0</attribute>
-      <objecttype>procedure</objecttype>
+      <functionpicker/>
     </control>
 
     <control>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -62,7 +62,8 @@ internal record ScriptControlData(
     string? Source,
     List<ControlOption>? Options,
     List<ScriptNodeData>? Scripts,
-    string? ObjectType = null
+    string? ObjectType = null,
+    bool IsFunctionPicker = false
 );
 
 internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
@@ -3308,10 +3309,15 @@ public partial class WasmEditorBridge
 
         string? simpleLabel = null;
         string? source = null;
+        string? objectType = null;
         // Read for every control type, not just "expression" — e.g. Call function's plain
-        // "textbox" attribute-0 control uses <objecttype>procedure</objecttype> to ask the
-        // frontend for a function-name picker instead of a free-text box.
-        string? objectType = ctrl.GetString("objecttype");
+        // "textbox" attribute-0 control uses <functionpicker/> to ask the frontend for a
+        // dropdown of the game's user-defined functions instead of a free-text box. A
+        // dedicated tag rather than reusing <objecttype>, which elsewhere always means one
+        // of Quest's real object types (dispatched through WorldModel.GetObjectTypeForTypeString)
+        // — functions are ElementType.Function, not ElementType.Object, so that machinery
+        // doesn't apply to them and overloading the tag would be misleading.
+        var isFunctionPicker = ctrl.GetBool("functionpicker");
 
         if (ctrl.ControlType == "expression")
         {
@@ -3320,6 +3326,7 @@ public partial class WasmEditorBridge
             // If <simpleeditor> is absent but <simple> is set, default simple editor is a textbox
             simpleEditor = simpleEditorTag ?? (simpleLabel != null ? "textbox" : null);
             source = ctrl.GetString("source");
+            objectType = ctrl.GetString("objecttype");
 
             if (simpleEditor == "dropdown")
             {
@@ -3365,7 +3372,8 @@ public partial class WasmEditorBridge
             source,
             options,
             nestedScripts,
-            objectType
+            objectType,
+            isFunctionPicker
         );
     }
 

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -812,6 +812,114 @@ public partial class WasmEditorBridge
         }
     }
 
+    // Script-parameter-list variants of Add/Remove/UpdateListItem above. A script "list" control
+    // (e.g. Call function's parameters, FunctionCallScript attribute "1") lives inside a script
+    // tree at an arbitrary containerPath/scriptIndex rather than directly on an element, so it
+    // can't be reached via GetEditorData(elementKey) — and unlike element attributes there's no
+    // inherited/default-type variant to localize, so EnsureLocalList doesn't apply. Mutating the
+    // IEditableList<string> directly (Add/Remove/Update) is required here rather than going
+    // through script.SetParameter(paramAttribute, ...): FunctionCallScript.SetParameterInternal
+    // deliberately throws for its parameter-list index, since parameter changes must go through
+    // the list itself.
+    private static IEditableList<string>? GetScriptParamList(string elementKey, string attribute,
+        string containerPath, int scriptIndex, string paramAttribute)
+    {
+        var scripts = GetScripts(elementKey, attribute);
+        if (scripts == null)
+        {
+            return null;
+        }
+
+        var container = ResolveContainer(scripts, containerPath);
+        if (container == null || scriptIndex < 0 || scriptIndex >= container.Count)
+        {
+            return null;
+        }
+
+        var editorData = _controller!.GetScriptEditorData(container[scriptIndex]);
+        return editorData.GetAttribute(paramAttribute) as IEditableList<string>;
+    }
+
+    [JSExport]
+    public static string AddScriptListItem(string elementKey, string attribute, string containerPath,
+        int scriptIndex, string paramAttribute, string value)
+    {
+        if (_controller == null)
+        {
+            return "error";
+        }
+
+        var list = GetScriptParamList(elementKey, attribute, containerPath, scriptIndex, paramAttribute);
+        if (list == null)
+        {
+            return "error";
+        }
+
+        // No StartTransaction/EndTransaction here — EditableList<T>.Add already opens its own
+        // UndoLogger transaction, and nesting one throws ("previous transaction not finished").
+        try
+        {
+            list.Add(value);
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    [JSExport]
+    public static string RemoveScriptListItem(string elementKey, string attribute, string containerPath,
+        int scriptIndex, string paramAttribute, string key)
+    {
+        if (_controller == null)
+        {
+            return "error";
+        }
+
+        var list = GetScriptParamList(elementKey, attribute, containerPath, scriptIndex, paramAttribute);
+        if (list == null)
+        {
+            return "error";
+        }
+
+        try
+        {
+            list.Remove(key);
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    [JSExport]
+    public static string UpdateScriptListItem(string elementKey, string attribute, string containerPath,
+        int scriptIndex, string paramAttribute, string key, string value)
+    {
+        if (_controller == null)
+        {
+            return "error";
+        }
+
+        var list = GetScriptParamList(elementKey, attribute, containerPath, scriptIndex, paramAttribute);
+        if (list == null)
+        {
+            return "error";
+        }
+
+        try
+        {
+            list.Update(key, value);
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
     private static async Task<List<IEditorControl>> FilterVisibleAsync(IEnumerable<IEditorControl> controls, IEditorData data)
     {
         var result = new List<IEditorControl>();
@@ -3190,13 +3298,20 @@ public partial class WasmEditorBridge
             }
             else
             {
-                value = editorData.GetAttribute(ctrl.Attribute)?.ToString();
+                // SerializeAttributeValue (not a plain .ToString()) so a "list" control's
+                // IEditableList<string> — e.g. Call function's parameter list — comes through
+                // as the same [{key,value}] JSON shape ListEditor.svelte-style controls expect,
+                // instead of the useless default object.ToString().
+                value = SerializeAttributeValue(editorData.GetAttribute(ctrl.Attribute));
             }
         }
 
         string? simpleLabel = null;
         string? source = null;
-        string? objectType = null;
+        // Read for every control type, not just "expression" — e.g. Call function's plain
+        // "textbox" attribute-0 control uses <objecttype>procedure</objecttype> to ask the
+        // frontend for a function-name picker instead of a free-text box.
+        string? objectType = ctrl.GetString("objecttype");
 
         if (ctrl.ControlType == "expression")
         {
@@ -3205,7 +3320,6 @@ public partial class WasmEditorBridge
             // If <simpleeditor> is absent but <simple> is set, default simple editor is a textbox
             simpleEditor = simpleEditorTag ?? (simpleLabel != null ? "textbox" : null);
             source = ctrl.GetString("source");
-            objectType = ctrl.GetString("objecttype");
 
             if (simpleEditor == "dropdown")
             {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -1527,9 +1527,14 @@ public partial class WasmEditorBridge
         var visibleEntries = new List<KeyValuePair<string, EditableScriptData>>();
         foreach (var kv in scriptData)
         {
+            // "Call function" (appliesto "()") deliberately has an empty <create> string —
+            // the function name and parameters aren't known until the user fills them in,
+            // so EditableScripts.AddNewInternal special-cases an empty/null keyword to build
+            // a blank FunctionCallScript instead of inserting literal text. Every other entry
+            // has a real create string, so this is the one explicit exception to the filter.
             if (!string.IsNullOrEmpty(kv.Value.Category)
                 && await kv.Value.IsVisible()
-                && !string.IsNullOrEmpty(kv.Value.CreateString))
+                && (!string.IsNullOrEmpty(kv.Value.CreateString) || kv.Key == "()"))
             {
                 visibleEntries.Add(kv);
             }


### PR DESCRIPTION
## Summary
- The Quest 5 script adder had a "Call function" command; the new AppShell/WasmEditor Script Adder was missing it.
- **Root cause:** `GetScriptCommandCategories()` filtered out any script-editor entry with an empty `CreateString`. "Call function" (`appliesto` `"()"`) is the one entry in the whole `.aslx` data set with a deliberately empty `<create>` string, since the function name/parameters aren't known ahead of time — `EditableScripts.AddNewInternal` already special-cases an empty/null keyword to build a blank `FunctionCallScript` instead of inserting literal text. The Engine/EditorCore support was already complete (used in production by the `(function)AddToInventory`/`(function)MoveObject` quick-add shortcuts); only the adder's list filter was hiding it. **Fix:** let the `"()"` entry through the filter as an explicit exception.
- **Follow-up 1:** the "With parameters:" control rendered as literal `[list]` text — `BuildScriptControlData` had no case for a script control's `"list"` controltype, and no bridge methods existed to mutate a `FunctionCallScript`'s parameter list. Fixed the read side by reusing the existing `SerializeAttributeValue` helper, and added `AddScriptListItem`/`RemoveScriptListItem`/`UpdateScriptListItem` JSExports for the write side.
- **Follow-up 2:** turned the function-name textbox into a dropdown of the game's user-defined functions, via a dedicated `<functionpicker/>` tag rather than overloading `<objecttype>` (which already has an established, unrelated meaning elsewhere — Quest's real object-type filter).
- **Follow-up 3:** the underlying function list (`GetExpressionFunctions`) was excluding every function defined inside an included library — both the author's own libraries and always-embedded ones like Core's `DiceRoll` — so they showed as "(not found)" in Call function, and were missing from the expression editor's function typeahead too. Removed that filter, and swapped the Call function picker from a plain `<select>` to the existing searchable `Combobox` component now that the pool of functions can be much larger.
- **Follow-up 4:** that same filter removal surfaced a real name collision (`CoreFunctions.aslx`'s `Ask(question, callback)` vs. the native `ExpressionOwner.Ask(caption)`), which crashed the expression typeahead's `{#each}` block (`each_key_duplicate`). Deduped by name, preferring the built-in entry — `NcalcExpressionEvaluator` tries native methods before ever falling through to `WorldModel.Procedure()`, so the built-in always shadows a same-named library function within an expression anyway. Also fixed the Call function picker's `Combobox` dropdown getting clipped to one row by an ancestor's `overflow` — the same problem `ExpressionInput`'s own popover already hit and fixed once before — by giving `Combobox` the same portal-to-`<body>` + fixed-position treatment.

## Test plan
- [x] `dotnet build --configuration Release` (full solution) and `dotnet test --configuration Release` — 329/329 passed
- [x] Verified in-browser via AppShell dev server:
  - "Call function" appears in Scripts → Advanced in the Add Script modal
  - Function-name field is a searchable combobox populated with the game's own functions *and* library functions (e.g. Core's `DiceRoll`), with no clipping and no console errors
  - "With parameters:" shows an editable, addable, removable chip list instead of `[list]`
  - Round-trips through Code view correctly, e.g. `Greet ("World")` and `DiceRoll`
  - Expression typeahead's function list shows a single "Ask" entry (no duplicate-key crash), verified in a fresh browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)