### PR TITLE
feat(AppShell): improve Call function picker UX

### DIFF
--- a/src/AppShell/src/components/Combobox.svelte
+++ b/src/AppShell/src/components/Combobox.svelte
@@ -195,6 +195,9 @@
             class="z-50 max-h-48 overflow-y-auto rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-md"
         >
             {#each filtered as opt, i (opt.value)}
+                {#if opt.group && opt.group !== filtered[i - 1]?.group}
+                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">{opt.group}</div>
+                {/if}
                 <div
                     id="{uid}-opt-{i}"
                     data-idx={i}

--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -108,6 +108,10 @@
     let filteredFunctions = $derived(
         filter === "" ? functions : functions.filter(f => f.name.toLowerCase().includes(filter.toLowerCase()))
     );
+    // Game-authored functions are more likely to be what the author wants to call than a
+    // built-in or library one, so they get their own section ahead of everything else.
+    let filteredGameFunctions = $derived(filteredFunctions.filter(f => f.isUserDefined && !f.isLibrary));
+    let filteredLibraryFunctions = $derived(filteredFunctions.filter(f => !f.isUserDefined || f.isLibrary));
 
     $effect(() => {
         if (!open) return;
@@ -179,9 +183,19 @@
                         >{name}</button>
                     {/each}
                 {/if}
-                {#if filteredFunctions.length > 0}
-                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Functions</div>
-                    {#each filteredFunctions as fn (fn.name)}
+                {#if filteredGameFunctions.length > 0}
+                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Game functions</div>
+                    {#each filteredGameFunctions as fn (fn.name)}
+                        <button
+                            type="button"
+                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                            onclick={() => insertFunction(fn)}
+                        >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
+                    {/each}
+                {/if}
+                {#if filteredLibraryFunctions.length > 0}
+                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">Library &amp; built-in functions</div>
+                    {#each filteredLibraryFunctions as fn (fn.name)}
                         <button
                             type="button"
                             class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -36,6 +36,7 @@
         addScriptListItem,
         removeScriptListItem,
         updateScriptListItem,
+        setScriptListItemCount,
     } from "$lib/editor-store";
     import type {
         ScriptBlockData,
@@ -44,6 +45,7 @@
         ScriptCategoryInfo,
         IfExpressionTemplateData,
         IfExpressionTemplate,
+        ExpressionFunctionInfo,
     } from "$lib/types";
 
     interface Props {
@@ -79,7 +81,11 @@
     const expressionOverrides = new SvelteSet<string>();
     let objectNames = $state<string[]>([]);
     let exitNames = $state<string[]>([]);
-    let functionNames = $state<string[]>([]);
+    // Functions callable from a Call function script (WorldModel.Procedure() only resolves aslx
+    // Function elements, not native built-ins) — kept as full ExpressionFunctionInfo, not just
+    // names, so the picker can group game-authored functions ahead of library ones and the
+    // parameter-list editor can look up a selected function's declared arity/param names.
+    let functionInfos = $state<ExpressionFunctionInfo[]>([]);
     let ifTemplates = $state<IfExpressionTemplate[]>([]);
 
     // Load on mount and whenever scriptVersion bumps (undo/redo)
@@ -104,9 +110,9 @@
             const names = getExitNames();
             if (names && names.length > 0) exitNames = names;
         }
-        if (functionNames.length === 0) {
-            const names = getExpressionFunctions().filter(f => f.isUserDefined).map(f => f.name);
-            if (names.length > 0) functionNames = names;
+        if (functionInfos.length === 0) {
+            const infos = getExpressionFunctions().filter(f => f.isUserDefined);
+            if (infos.length > 0) functionInfos = infos;
         }
         if (ifTemplates.length === 0) {
             const templates = getIfExpressionTemplates();
@@ -318,6 +324,47 @@
 
     function onSetParam(scriptIndex: number, paramName: string, value: string) {
         mutate(() => setScriptParameter(elementKey, attribute, containerPath, scriptIndex, paramName, value));
+    }
+
+    // Game-authored functions first (most likely to be what the author wants to call), then
+    // library/built-in ones — mirrors ExpressionInput's Functions grouping.
+    function functionPickerOptions(): {value: string; label: string; group: string}[] {
+        const game = functionInfos.filter(f => !f.isLibrary);
+        const library = functionInfos.filter(f => f.isLibrary);
+        return [
+            ...game.map(f => ({ value: f.name, label: f.name, group: "Game functions" })),
+            ...library.map(f => ({ value: f.name, label: f.name, group: "Library functions" })),
+        ];
+    }
+
+    // Sets the Call function picker's function-name attribute, then — if the chosen name
+    // matches a known function — resizes the sibling parameter list to that function's declared
+    // arity. Functions have a fixed parameter count (FunctionCallScript matches positionally
+    // against ParamNames, and modern game versions require an exact count), so this is safe:
+    // there's no "variable number of parameters" case to preserve a manual +/- for here, beyond
+    // names the picker doesn't recognise at all (kept on the manual list UI in paramListEditor).
+    function onSelectFunction(scriptIndex: number, paramName: string, siblingControls: ScriptControlData[], value: string) {
+        const paramsCtrl = siblingControls.find(c => c.isFunctionParams);
+        const fn = functionInfos.find(f => f.name === value);
+        mutate(() => {
+            const result = setScriptParameter(elementKey, attribute, containerPath, scriptIndex, paramName, value);
+            if (result !== "ok" || !fn || !paramsCtrl?.attribute) return result;
+            return setScriptListItemCount(elementKey, attribute, containerPath, scriptIndex, paramsCtrl.attribute, fn.parameters.length);
+        });
+    }
+
+    // The function a functionparams list control is currently showing labelled boxes for, or
+    // undefined if it's on the manual +/- fallback (name doesn't match a known function, or the
+    // list hasn't been resized to match yet — see onSelectFunction). Shared by paramListEditor
+    // (which boxes to render) and inlineControl's "With parameters:" label (hidden once the
+    // boxes are self-labelled, since the label adds nothing at that point).
+    function matchedFunctionFor(ctrl: ScriptControlData, siblingControls: ScriptControlData[]): ExpressionFunctionInfo | undefined {
+        if (!ctrl.isFunctionParams) return undefined;
+        const pickerValue = siblingControls.find(c => c.isFunctionPicker)?.value;
+        const fn = functionInfos.find(f => f.name === pickerValue);
+        if (!fn) return undefined;
+        const items = parseListItems(ctrl.value);
+        return fn.parameters.length === items.length ? fn : undefined;
     }
 
     function onAddParam(scriptIndex: number, paramAttribute: string, value: string) {
@@ -538,14 +585,18 @@
 {#snippet normalBlock(script: ScriptNodeData, i: number)}
     <div class="px-2 py-1 pr-16 flex flex-wrap items-center gap-x-1 gap-y-0.5 text-xs">
         {#each script.controls ?? [] as ctrl, ci (ci)}
-            {@render inlineControl(ctrl, i)}
+            {@render inlineControl(ctrl, i, script.controls ?? [], ci)}
         {/each}
     </div>
 {/snippet}
 
-{#snippet inlineControl(ctrl: ScriptControlData, scriptIndex: number)}
+{#snippet inlineControl(ctrl: ScriptControlData, scriptIndex: number, siblingControls: ScriptControlData[], controlIndex: number)}
     {#if ctrl.controlType === "label"}
-        <span class="text-surface-600-400 select-none">{ctrl.caption ?? ""}</span>
+        {@const nextCtrl = siblingControls[controlIndex + 1]}
+        {@const labelIsRedundant = nextCtrl?.isFunctionParams && matchedFunctionFor(nextCtrl, siblingControls) !== undefined}
+        {#if !labelIsRedundant}
+            <span class="text-surface-600-400 select-none">{ctrl.caption ?? ""}</span>
+        {/if}
     {:else if ctrl.controlType === "script" && ctrl.attribute !== null}
         <!-- Nested script block for commands like for/while/foreach/firsttime -->
         <div class="w-full mt-0.5">
@@ -561,11 +612,11 @@
             />
         </div>
     {:else if ctrl.attribute !== null}
-        {@render valueControl(ctrl, scriptIndex)}
+        {@render valueControl(ctrl, scriptIndex, siblingControls)}
     {/if}
 {/snippet}
 
-{#snippet valueControl(ctrl: ScriptControlData, scriptIndex: number)}
+{#snippet valueControl(ctrl: ScriptControlData, scriptIndex: number, siblingControls: ScriptControlData[])}
     {#if ctrl.controlType === "expression" && ctrl.simpleEditor !== null}
         {@const simple = inSimpleMode(ctrl, scriptIndex)}
         {#if ctrl.simpleEditor === "boolean"}
@@ -677,12 +728,13 @@
             class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
         />
     {:else if ctrl.controlType === "textbox" && ctrl.isFunctionPicker}
-        {@const functionOptions = functionNames.map(name => ({ value: name, label: name }))}
+        {@const functionOptions = functionPickerOptions()}
         <Combobox
             value={ctrl.value ?? ""}
             options={functionOptions}
-            onchange={(v) => onSetParam(scriptIndex, ctrl.attribute!, v)}
-            class="input text-xs py-0 px-1 min-w-16 max-w-48"
+            onchange={(v) => onSelectFunction(scriptIndex, ctrl.attribute!, siblingControls, v)}
+            class="input text-xs py-0 px-1"
+            wrapperClass="min-w-32 max-w-96 flex-1"
         />
     {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
         <input
@@ -693,7 +745,7 @@
             onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
         />
     {:else if ctrl.controlType === "list"}
-        {@render paramListEditor(ctrl, scriptIndex)}
+        {@render paramListEditor(ctrl, scriptIndex, siblingControls)}
     {:else if ctrl.controlType === "checkbox"}
         <input
             type="checkbox"
@@ -717,32 +769,52 @@
     {/if}
 {/snippet}
 
-{#snippet paramListEditor(ctrl: ScriptControlData, scriptIndex: number)}
+{#snippet paramListEditor(ctrl: ScriptControlData, scriptIndex: number, siblingControls: ScriptControlData[])}
     {@const items = parseListItems(ctrl.value)}
-    <span class="flex flex-wrap items-center gap-1">
-        {#each items as item (item.key)}
-            <span class="flex items-center gap-0.5">
-                <input
-                    type="text"
-                    autocapitalize="off"
-                    class="input text-xs py-0 px-1 w-20"
-                    value={item.value}
-                    onchange={(e) => onUpdateParam(scriptIndex, ctrl.attribute!, item.key, (e.target as HTMLInputElement).value)}
-                />
-                <button
-                    type="button"
-                    class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
-                    title="Remove parameter"
-                    onclick={() => onRemoveParam(scriptIndex, ctrl.attribute!, item.key)}
-                >×</button>
-            </span>
-        {/each}
-        <button
-            type="button"
-            class="btn btn-sm preset-outlined-primary-500 text-xs py-0 px-1.5 leading-none"
-            onclick={() => onAddParam(scriptIndex, ctrl.attribute!, "")}
-        >+ param</button>
-    </span>
+    {@const matchedFn = matchedFunctionFor(ctrl, siblingControls)}
+    {#if matchedFn}
+        <!-- Known, fixed-arity function (see onSelectFunction): one labelled box per declared
+             parameter, kept in sync with the signature, instead of the generic +/- list. -->
+        <span class="flex flex-wrap items-center gap-2">
+            {#each matchedFn.parameters as paramName, pi (pi)}
+                <span class="flex items-center gap-1">
+                    <span class="text-surface-600-400 text-[10px] whitespace-nowrap">{paramName}:</span>
+                    <input
+                        type="text"
+                        autocapitalize="off"
+                        class="input text-xs py-0 px-1 w-20"
+                        value={items[pi].value}
+                        onchange={(e) => onUpdateParam(scriptIndex, ctrl.attribute!, items[pi].key, (e.target as HTMLInputElement).value)}
+                    />
+                </span>
+            {/each}
+        </span>
+    {:else}
+        <span class="flex flex-wrap items-center gap-1">
+            {#each items as item (item.key)}
+                <span class="flex items-center gap-0.5">
+                    <input
+                        type="text"
+                        autocapitalize="off"
+                        class="input text-xs py-0 px-1 w-20"
+                        value={item.value}
+                        onchange={(e) => onUpdateParam(scriptIndex, ctrl.attribute!, item.key, (e.target as HTMLInputElement).value)}
+                    />
+                    <button
+                        type="button"
+                        class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
+                        title="Remove parameter"
+                        onclick={() => onRemoveParam(scriptIndex, ctrl.attribute!, item.key)}
+                    >×</button>
+                </span>
+            {/each}
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs py-0 px-1.5 leading-none"
+                onclick={() => onAddParam(scriptIndex, ctrl.attribute!, "")}
+            >+ param</button>
+        </span>
+    {/if}
 {/snippet}
 
 {#snippet ifBlock(script: ScriptNodeData, i: number)}

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -880,6 +880,14 @@ export function updateScriptListItem(elementKey: string, attribute: string, cont
     return result;
 }
 
+export function setScriptListItemCount(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, count: number): string {
+    if (!_bridge) return "error";
+    const result = _bridge.SetScriptListItemCount(elementKey, attribute, containerPath, scriptIndex, paramAttribute, count);
+    if (result === "ok") bumpScriptVersion();
+    refreshUndoRedo();
+    return result;
+}
+
 export function setIfExpression(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, expression: string): string {
     if (!_bridge) return "error";
     const result = _bridge.SetIfExpression(elementKey, attribute, containerPath, scriptIndex, expression);

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -10,6 +10,9 @@ export interface TreeNode {
 export interface ControlOption {
   value: string
   label: string
+  // Optional sticky-header grouping for Combobox.svelte, e.g. "Game functions" vs "Library
+  // functions" for the Call function picker. Consumers that don't set it get the old flat list.
+  group?: string
 }
 
 export interface TextProcessorCommand {
@@ -23,6 +26,9 @@ export interface ExpressionFunctionInfo {
   name: string
   parameters: string[]
   isUserDefined: boolean
+  // True for aslx Function elements that came from a library (Core/English or an added one)
+  // rather than the game itself. Only meaningful when isUserDefined is true.
+  isLibrary: boolean
 }
 
 export interface ControlInfo {
@@ -100,6 +106,7 @@ export interface ScriptControlData {
   scripts: ScriptNodeData[] | null
   objectType?: string | null
   isFunctionPicker?: boolean
+  isFunctionParams?: boolean
 }
 
 export interface ElseIfClauseData {

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -53,6 +53,7 @@ export interface WasmBridge {
   AddScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, value: string): string
   RemoveScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, key: string): string
   UpdateScriptListItem(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, key: string, value: string): string
+  SetScriptListItemCount(elementKey: string, attribute: string, containerPath: string, scriptIndex: number, paramAttribute: string, count: number): string
   // Attributes editor API
   GetFullAttributeData(elementKey: string): string | null
   RemoveAttribute(elementKey: string, attribute: string): string

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -2346,17 +2346,20 @@ public sealed class EditorController : IDisposable
     // NOT filtered out here: a library function is exactly as callable as a game-authored one
     // (WorldModel.Procedure() doesn't distinguish them), and both consumers of this list
     // (ExpressionInput's popover, ScriptEditor's Call-function picker) are typeahead-filtered,
-    // so a larger pool isn't the UX problem a flat unfiltered dropdown would make it.
-    public IEnumerable<(string Name, string[] Parameters, bool IsUserDefined)> GetExpressionFunctions()
+    // so a larger pool isn't the UX problem a flat unfiltered dropdown would make it. IsLibrary
+    // lets those consumers group game-authored functions ahead of library/built-in ones, since
+    // a game's own functions are the more likely thing an author wants to call.
+    public IEnumerable<(string Name, string[] Parameters, bool IsUserDefined, bool IsLibrary)> GetExpressionFunctions()
     {
         var builtIn = WorldModel.GetBuiltInFunctionSignatures()
-            .Select(f => (f.Name, f.Parameters, IsUserDefined: false));
+            .Select(f => (f.Name, f.Parameters, IsUserDefined: false, IsLibrary: false));
 
         var userFunctions = WorldModel.Elements.GetElements(ElementType.Function)
             // A freshly-created function has no ParamNames field set yet (only populated by the
             // aslx <function parameters="..."> loader), so Fields[...] is null until the user
             // adds a parameter.
-            .Select(e => (e.Name, e.Fields[FieldDefinitions.ParamNames]?.ToArray() ?? [], IsUserDefined: true));
+            .Select(e => (e.Name, e.Fields[FieldDefinitions.ParamNames]?.ToArray() ?? [], IsUserDefined: true,
+                IsLibrary: e.MetaFields[MetaFieldDefinitions.Library]));
 
         return builtIn.Concat(userFunctions).OrderBy(f => f.Name, StringComparer.Ordinal);
     }

--- a/src/Engine/Core/CoreEditorScriptsScripts.aslx
+++ b/src/Engine/Core/CoreEditorScriptsScripts.aslx
@@ -275,6 +275,7 @@
       <caption>[EditorScriptsScriptsParameters]</caption>
       <attribute>1</attribute>
       <editprompt>[EditorScriptsScriptsPleaseenter2]</editprompt>
+      <functionparams/>
     </control>
   </editor>
 

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -63,7 +63,8 @@ internal record ScriptControlData(
     List<ControlOption>? Options,
     List<ScriptNodeData>? Scripts,
     string? ObjectType = null,
-    bool IsFunctionPicker = false
+    bool IsFunctionPicker = false,
+    bool IsFunctionParams = false
 );
 
 internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
@@ -135,7 +136,7 @@ internal record ExitsData(
 
 internal record VerbInfo(string Attribute, string DisplayPattern);
 
-internal record ExpressionFunctionData(string Name, List<string> Parameters, bool IsUserDefined);
+internal record ExpressionFunctionData(string Name, List<string> Parameters, bool IsUserDefined, bool IsLibrary);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<TreeNodeData>))]
@@ -913,6 +914,50 @@ public partial class WasmEditorBridge
         try
         {
             list.Update(key, value);
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    // Resizes a script parameter list to an exact count, trimming or padding at the end while
+    // leaving surviving indices' values untouched. Used when the Call function picker's chosen
+    // function has a known, fixed arity (see EditorController.GetExpressionFunctions) so the
+    // parameter boxes can be relabelled with real parameter names and kept in sync with the
+    // function's declared signature, instead of requiring the generic +/- item-list UI.
+    [JSExport]
+    public static string SetScriptListItemCount(string elementKey, string attribute, string containerPath,
+        int scriptIndex, string paramAttribute, int count)
+    {
+        if (_controller == null)
+        {
+            return "error";
+        }
+
+        var list = GetScriptParamList(elementKey, attribute, containerPath, scriptIndex, paramAttribute);
+        if (list == null)
+        {
+            return "error";
+        }
+
+        try
+        {
+            var keys = list.ItemsList.Select(i => i.Key).ToList();
+            while (keys.Count > count)
+            {
+                var key = keys[^1];
+                list.Remove(key);
+                keys.RemoveAt(keys.Count - 1);
+            }
+
+            while (keys.Count < count)
+            {
+                list.Add("");
+                keys = list.ItemsList.Select(i => i.Key).ToList();
+            }
+
             return "ok";
         }
         catch (Exception ex)
@@ -2493,7 +2538,7 @@ public partial class WasmEditorBridge
         }
 
         var functions = _controller.GetExpressionFunctions()
-            .Select(f => new ExpressionFunctionData(f.Name, f.Parameters.ToList(), f.IsUserDefined))
+            .Select(f => new ExpressionFunctionData(f.Name, f.Parameters.ToList(), f.IsUserDefined, f.IsLibrary))
             .ToList();
 
         return JsonSerializer.Serialize(functions, WasmEditorJsonContext.Default.ListExpressionFunctionData);
@@ -3318,6 +3363,12 @@ public partial class WasmEditorBridge
         // — functions are ElementType.Function, not ElementType.Object, so that machinery
         // doesn't apply to them and overloading the tag would be misleading.
         var isFunctionPicker = ctrl.GetBool("functionpicker");
+        // Marks Call function's "list" parameter control (as opposed to e.g. rundelegate's,
+        // whose delegate name is a runtime expression so its arity can't be known ahead of
+        // time) so the frontend can relabel each box with the selected function's real
+        // parameter name and auto-size the box count to match its arity, instead of the
+        // generic +/- item list.
+        var isFunctionParams = ctrl.GetBool("functionparams");
 
         if (ctrl.ControlType == "expression")
         {
@@ -3373,7 +3424,8 @@ public partial class WasmEditorBridge
             options,
             nestedScripts,
             objectType,
-            isFunctionPicker
+            isFunctionPicker,
+            isFunctionParams
         );
     }
 


### PR DESCRIPTION
## Summary
Follow-up polish for the Call function script adder ([#1991](https://github.com/textadventures/quest/pull/1991)), based on review feedback:

- **Wider combobox** — the function-name field was capped at `max-w-48` and truncated long names. Root cause: `Combobox.svelte` wraps its `<input>` in its own `<div>`, which is the actual flex item in the row — sizing classes need to go on `wrapperClass`, not `class`, to take effect. Fixed here and widened to `min-w-32 max-w-96 flex-1`.
- **Game vs. library function grouping** — both the Call function picker and the expression editor's function popover (`⚡`) now group results under "Game functions" / "Library functions" headers, since a game's own functions are more likely to be what the author wants to call. `EditorController.GetExpressionFunctions()` now reports an `IsLibrary` flag per function; `Combobox.svelte` gained generic sticky-header grouping support via an optional `group` field on `ControlOption`.
- **Inline parameter names + auto-sizing** — each Call function parameter box is now labelled with its real parameter name (`desc:`, `line:`, etc.) instead of a bare removable box, and the box count auto-syncs to the selected function's declared arity. This is safe because `FunctionCallScript` matches parameters positionally against `ParamNames`, and modern game versions (v520+) require an *exact* count match — there's no variadic case to lose. The manual `+ param`/`×` list remains as a fallback for names that don't match any known function. A new `SetScriptListItemCount` bridge call resizes the underlying list while preserving values at surviving indices.
- **Drop the redundant "With parameters:" label** once the boxes are self-labelled — kept only for the manual fallback case, where it still supplies necessary context.

## Test plan
- [x] `dotnet build --configuration Release` (full solution)
- [x] `dotnet test tests/EditorCoreTests --configuration Release`
- [x] `npm run check` (svelte-check) and `npm run lint` (eslint) in `src/AppShell`
- [x] Manual verification in the AppShell dev server (WasmEditor Debug build): grouped dropdown renders correctly, selecting a known function grows/shrinks the parameter list while preserving surviving values, unrecognized names fall back to the manual +/- list, and the generated `.aslx` script (checked via raw XML view) round-trips correctly, e.g. `AddDescriptionLine ("hello", "world")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)