### PR TITLE
fix(Engine): gate changed<attr> dispatch on an actual value change

### DIFF
--- a/src/Engine/Element.cs
+++ b/src/Engine/Element.cs
@@ -217,8 +217,9 @@ public class Element : IComparable
     internal async Task SetFieldAsync(string fieldName, object value)
     {
         var oldValue = Fields.Get(fieldName);
+        var changed = value == null ? oldValue != null : !value.Equals(oldValue);
         Fields.Set(fieldName, value);
-        if (!m_worldModel.EditMode)
+        if (changed && !m_worldModel.EditMode)
         {
             var changedScriptName = "changed" + fieldName;
             if (Fields.HasType<IScript>(changedScriptName))

--- a/tests/EngineTests/ChangedFieldNoOpTests.cs
+++ b/tests/EngineTests/ChangedFieldNoOpTests.cs
@@ -1,0 +1,35 @@
+using QuestViva.Engine;
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+// Regression test for https://github.com/alexwarren/quest/issues/1988: Element.SetFieldAsync
+// used to dispatch changed<field> unconditionally after every write, even when the new value
+// equalled the old one. Classic Quest 5 only raises AttributeChanged - and so only fires
+// changed<field> - when the value actually changes. A same-value write (e.g. an "enter" script
+// re-running MoveObject into the room the player is already in) would otherwise recurse forever.
+[TestClass]
+public class ChangedFieldNoOpTests
+{
+    [TestMethod]
+    public async Task SameValueWrite_DoesNotFireChangedScript()
+    {
+        var driver = await GameDriver.LoadAsync("recursiontest.aslx");
+
+        await driver.SendCommandAsync("triggernoop");
+
+        var watcher = driver.Model.Elements.Get("watcher");
+        watcher.Fields.Get("hits").ShouldBe(0);
+    }
+
+    [TestMethod]
+    public async Task DifferentValueWrite_StillFiresChangedScript()
+    {
+        var driver = await GameDriver.LoadAsync("recursiontest.aslx");
+
+        await driver.SendCommandAsync("triggerrealchange");
+
+        var watcher = driver.Model.Elements.Get("watcher");
+        watcher.Fields.Get("hits").ShouldBe(1);
+    }
+}

--- a/tests/EngineTests/recursiontest.aslx
+++ b/tests/EngineTests/recursiontest.aslx
@@ -26,4 +26,31 @@
       msg ("after trigger")
     </script>
   </command>
+
+  <!-- Regression fixture: changed<field> must only fire on an actual value change, matching
+       Quest 5 semantics, so a same-value write (e.g. an "enter" script re-running MoveObject
+       into the room the player is already in) doesn't recurse forever. -->
+  <object name="watcher">
+    <hits type="int">0</hits>
+    <flag type="boolean">false</flag>
+    <changedflag type="script">
+      watcher.hits = watcher.hits + 1
+    </changedflag>
+  </object>
+
+  <command name="cmd_trigger_noop_write">
+    <pattern>triggernoop</pattern>
+    <script>
+      watcher.flag = false
+      msg ("after noop write")
+    </script>
+  </command>
+
+  <command name="cmd_trigger_real_change">
+    <pattern>triggerrealchange</pattern>
+    <script>
+      watcher.flag = not watcher.flag
+      msg ("after real change")
+    </script>
+  </command>
 </asl>


### PR DESCRIPTION
## Summary
- `Element.SetFieldAsync` fired `changed<attr>` unconditionally after every field write. Classic Quest 5 (`v5` branch) only fires it from a `Fields.AttributeChanged` subscriber, and `Fields.Set` raises that event **only when the value actually changed**.
- A same-value write — e.g. an `enter`/`onswitchon` script re-running `MoveObject(player, Pool)` when the player is already in `Pool` — recurses forever under the old unconditional dispatch, since the depth-200 recursion guard doesn't catch it (each recursive call runs back through queued `on ready` callbacks at depth 0).
- Fix: compute the same "did this actually change" check `Fields.Set` uses internally (`value == null ? oldValue != null : !value.Equals(oldValue)`) before dispatching `changed<attr>`, matching Quest 5 semantics.

Fixes #1988. Found via independent compatibility testing against real Quest 5 games (see issue for details — [angstsmurf/spatterlight](https://github.com/angstsmurf/spatterlight) diffing transcripts using QuestViva as a ground-truth oracle).

## Test plan
- [x] Added `ChangedFieldNoOpTests.cs` with two regression tests against a new `watcher` fixture in `recursiontest.aslx`: a same-value write no longer fires the `changed<attr>` script, and a real value change still does.
- [x] `dotnet test tests/EngineTests --configuration Release` — 283/283 passed, including the existing `RecursionGuardTests` (unaffected — those use a genuinely-changing counter, so still correctly exercise the depth-guard/circuit-breaker path).
- [x] `dotnet test tests/PlayerCoreTests --configuration Release` — 8/8 passed.
- [x] `dotnet test tests/LegacyTests --configuration Release` — 11/11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)