### PR TITLE
fix(Engine): defer FinishTurn across a wait for pre-v580 games

### DIFF
--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -96,6 +96,25 @@ public partial class WorldModel : IGame, IGameDebug
     private int _pendingCallbackCount;
     private readonly List<(IScript Script, Context Context)> _onReadyQueue = [];
 
+    // Set when a pre-v580 command's (or event's) automatic FinishTurn call is pushed past a
+    // wait/ask/get input/show menu it triggered - see HandleCommandAsyncInternal. Real Quest 5
+    // has the equivalent check (m_callbacks.AnyOutstanding()) inline in its own TryFinishTurn;
+    // ported here as a deferred flag instead, discharged from EndPendingCallbackAsync once
+    // _pendingCallbackCount actually returns to zero (so a wait nested inside another wait's
+    // callback correctly holds the deferral open until both have resolved, not just the first).
+    private bool _finishTurnDeferred;
+
+    private async Task RunDeferredFinishTurnAsync()
+    {
+        if (!_finishTurnDeferred) return;
+        _finishTurnDeferred = false;
+        await TryFinishTurnAsync();
+        if (State != GameState.Finished)
+        {
+            await UpdateListsAsync();
+        }
+    }
+
     // Guards the on-ready drain loop in EndPendingCallbackAsync against re-entry: a queued
     // script can itself synchronously await another prompt (e.g. a synchronous "play sound",
     // or the GetInput()/Ask()/ShowMenu() expression forms), which calls EndPendingCallbackAsync
@@ -381,14 +400,24 @@ public partial class WorldModel : IGame, IGameDebug
                     {"metadata", new QuestDictionary<string>(metadata)}
                 }), false);
 
-                if (Version < WorldModelVersion.v580)
+                if (Version < WorldModelVersion.v580 && _pendingCallbackCount > 0)
                 {
-                    await TryFinishTurnAsync();
+                    // A wait/ask/get input/show menu triggered by this command hasn't resolved
+                    // yet - defer FinishTurn until it does (see _finishTurnDeferred), rather than
+                    // running it now against state the command's own callback hasn't reached.
+                    _finishTurnDeferred = true;
                 }
-
-                if (State != GameState.Finished)
+                else
                 {
-                    await UpdateListsAsync();
+                    if (Version < WorldModelVersion.v580)
+                    {
+                        await TryFinishTurnAsync();
+                    }
+
+                    if (State != GameState.Finished)
+                    {
+                        await UpdateListsAsync();
+                    }
                 }
             }
             else
@@ -446,18 +475,28 @@ public partial class WorldModel : IGame, IGameDebug
 
         await RunProcedureAsync(eventName, parameters, false);
 
-        switch (Version)
+        if (Version < WorldModelVersion.v540)
         {
-            case < WorldModelVersion.v540:
-                return;
-            case < WorldModelVersion.v580:
-                await TryFinishTurnAsync();
-                break;
+            return;
         }
 
-        if (State != GameState.Finished)
+        if (Version < WorldModelVersion.v580 && _pendingCallbackCount > 0)
         {
-            await UpdateListsAsync();
+            // See HandleCommandAsyncInternal - a wait/ask/get input/show menu triggered by this
+            // event hasn't resolved yet, so defer FinishTurn until it does.
+            _finishTurnDeferred = true;
+        }
+        else
+        {
+            if (Version < WorldModelVersion.v580)
+            {
+                await TryFinishTurnAsync();
+            }
+
+            if (State != GameState.Finished)
+            {
+                await UpdateListsAsync();
+            }
         }
 
         SendNextTimerRequest();
@@ -1746,24 +1785,30 @@ public partial class WorldModel : IGame, IGameDebug
         // puzzle loops) can open its next get input/wait/ask/show menu before this one's finally
         // block runs, which keeps _pendingCallbackCount above zero indefinitely; gating the drain
         // on it reaching zero left anything queued while such a loop is active stuck forever.
-        if (_isFlushingOnReadyQueue)
+        if (!_isFlushingOnReadyQueue)
         {
-            return;
-        }
-
-        _isFlushingOnReadyQueue = true;
-        try
-        {
-            while (_onReadyQueue.Count > 0 && State != GameState.Finished)
+            _isFlushingOnReadyQueue = true;
+            try
             {
-                var (script, context) = _onReadyQueue[0];
-                _onReadyQueue.RemoveAt(0);
-                await RunScriptAsync(script, context);
+                while (_onReadyQueue.Count > 0 && State != GameState.Finished)
+                {
+                    var (script, context) = _onReadyQueue[0];
+                    _onReadyQueue.RemoveAt(0);
+                    await RunScriptAsync(script, context);
+                }
+            }
+            finally
+            {
+                _isFlushingOnReadyQueue = false;
             }
         }
-        finally
+
+        // Run any FinishTurn a command/event deferred past this callback (see
+        // _finishTurnDeferred), but only once every wait/ask/get input/show menu from that turn -
+        // including ones nested inside this callback's own script - has actually resolved.
+        if (_pendingCallbackCount == 0)
         {
-            _isFlushingOnReadyQueue = false;
+            await RunDeferredFinishTurnAsync();
         }
     }
 

--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -43,6 +43,9 @@
         <None Update="v500test.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="waitturnscripttest.aslx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="savetest.aslx">
             <SubType>Designer</SubType>
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/tests/EngineTests/V5BlockingTests.cs
+++ b/tests/EngineTests/V5BlockingTests.cs
@@ -130,4 +130,55 @@ public class V5BlockingTests
         phase2.ShouldContain("You said yes");
         phase2.ShouldContain("This is run after asking the question");
     }
+
+    // Regression test for https://github.com/alexwarren/quest/issues/1990: for games below
+    // v580, TryFinishTurnAsync (which runs turnscripts) used to run as soon as
+    // WaitScript.ExecuteAsync returned - before the wait's callback (which moves the player
+    // to room2) had actually run. That fired room1's turnscript for a turn the player had
+    // already left, and never fired room2's turnscript for the turn the player actually
+    // arrived in. FinishTurn must be deferred until the wait callback resolves.
+    [TestMethod]
+    public async Task Wait_TurnScriptsRunAfterCallbackNotBeforeIt()
+    {
+        var driver = await V5BlockingGameDriver.LoadAsync("waitturnscripttest.aslx");
+
+        var phase1 = await driver.SendCommandAsync("movewait");
+        phase1.ShouldContain("before wait");
+        phase1.ShouldNotContain("wait done");
+        phase1.ShouldNotContain("room1 turnscript");
+        phase1.ShouldNotContain("room2 turnscript");
+
+        var phase2 = await driver.FinishWaitAsync();
+        phase2.ShouldContain("wait done");
+        phase2.ShouldNotContain("room1 turnscript");
+        phase2.ShouldContain("room2 turnscript");
+    }
+
+    // A wait callback that opens another wait (e.g. a two-beat cutscene) must resolve each
+    // key press independently, and FinishTurn/turnscripts must wait for both - not just the
+    // first - to resolve. 'wait { }' itself is fire-and-forget regardless of version (matching
+    // real Quest 5: WaitScript.Execute never blocked a thread even pre-580), so "step4" - a
+    // sibling statement after the inner wait{} block, in the same callback - runs immediately
+    // alongside "step2", not deferred until the inner wait resolves.
+    [TestMethod]
+    public async Task Wait_NestedWaitInsideCallback_EachKeyPressResolvesItsOwnStage()
+    {
+        var driver = await V5BlockingGameDriver.LoadAsync("waitturnscripttest.aslx");
+
+        var phase1 = await driver.SendCommandAsync("movewaitnested");
+        phase1.ShouldContain("step1");
+        phase1.ShouldNotContain("step2");
+
+        var phase2 = await driver.FinishWaitAsync();
+        phase2.ShouldContain("step2");
+        phase2.ShouldContain("step4");
+        phase2.ShouldNotContain("step3");
+        phase2.ShouldNotContain("room1 turnscript");
+        phase2.ShouldNotContain("room2 turnscript");
+
+        var phase3 = await driver.FinishWaitAsync();
+        phase3.ShouldContain("step3");
+        phase3.ShouldNotContain("room1 turnscript");
+        phase3.ShouldContain("room2 turnscript");
+    }
 }

--- a/tests/EngineTests/waitturnscripttest.aslx
+++ b/tests/EngineTests/waitturnscripttest.aslx
@@ -1,0 +1,158 @@
+<asl version="500">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="waitturnscripttest"/>
+
+  <!-- Published pre-v580 games are fully self-contained (no <include>s - the whole library is
+       flattened into the .aslx at publish time), so they carry whatever CoreParser.aslx/Core.aslx
+       looked like when the game was published - not today's engine's copy. Verified against a
+       real Quest 5.4 (2013) game published .aslx: its FinishTurn is unconditional, and its
+       ResolveNextName has no "game.runturnscripts=true; FinishTurn" call at all - that call was
+       only added to the shared library "as of Quest 5.8" (per CoreParser.aslx's own comment).
+       Since this test <include>s today's Core.aslx (there's no other practical way to get a full
+       command parser here), override both functions back to their authentic pre-580 shape so this
+       accurately represents a real pre-580 game instead of an inconsistent hybrid. -->
+  <function name="FinishTurn">
+    RunTurnScripts
+    UpdateStatusAttributes
+    CheckDarkness
+    UpdateObjectLinks
+  </function>
+  <function name="ResolveNextName">
+    <![CDATA[
+    resolvedall = false
+    queuetype = TypeOf(game.pov, "currentcommandvarlistqueue")
+    if (queuetype = "stringlist") {
+      queuelength = ListCount(game.pov.currentcommandvarlistqueue)
+      if (queuelength > 0) {
+        var = StringListItem(game.pov.currentcommandvarlistqueue, 0)
+        if (queuelength = 1) {
+          game.pov.currentcommandvarlistqueue = null
+        }
+        else {
+          newqueue = NewStringList()
+          for (i, 1, queuelength - 1) {
+            list add (newqueue, StringListItem(game.pov.currentcommandvarlistqueue, i))
+          }
+          game.pov.currentcommandvarlistqueue = newqueue
+        }
+        value = StringDictionaryItem(game.pov.currentcommandvarlist, var)
+        if (value <> "") {
+          result = null
+          if (StartsWith(var, "object")) {
+            result = ResolveName(var, value, "object")
+          }
+          else if (StartsWith(var, "exit")) {
+            result = ResolveName(var, value, "exit")
+          }
+          else if (StartsWith(var, "text")) {
+            result = StringDictionaryItem(game.pov.currentcommandvarlist, var)
+          }
+          else {
+            error ("Unhandled command variable '" + var + "' - command variable names must begin with 'object', 'exit' or 'text'")
+          }
+          if (result = null) {
+            if (LengthOf(GetString(game.pov, "currentcommandpendingvariable")) = 0) {
+              UnresolvedCommand (value, var)
+            }
+          }
+          else {
+            AddToResolvedNames (var, result)
+          }
+        }
+        else {
+          ResolveNextName
+        }
+      }
+      else {
+        resolvedall = true
+      }
+    }
+    else if (queuetype = "null") {
+      resolvedall = true
+    }
+    else {
+      error ("Invalid queue type")
+    }
+    if (resolvedall) {
+      game.lastobjects = game.pov.currentcommandresolvedobjects
+      if (not DictionaryContains(game.pov.currentcommandresolvedelements, "multiple")) {
+        dictionary add (game.pov.currentcommandresolvedelements, "multiple", false)
+      }
+      if (not GetBoolean(game.pov.currentcommandpattern, "isundo")) {
+        if (LengthOf(game.pov.currentcommand) > 0) {
+          start transaction (game.pov.currentcommand)
+        }
+      }
+      if (not GetBoolean(game.pov.currentcommandpattern, "isoops")) {
+        game.unresolvedcommand = null
+        game.unresolvedcommandvarlist = null
+        game.unresolvedcommandkey = null
+      }
+      if (DictionaryContains(game.pov.currentcommandresolvedelements, "object")) {
+        game.text_processor_this = ObjectDictionaryItem(game.pov.currentcommandresolvedelements, "object")
+      }
+      else if (DictionaryContains(game.pov.currentcommandresolvedelements, "object1")) {
+        game.text_processor_this = ObjectDictionaryItem(game.pov.currentcommandresolvedelements, "object1")
+      }
+      if (HasScript(game.pov.currentcommandpattern, "script")) {
+        do (game.pov.currentcommandpattern, "script", game.pov.currentcommandresolvedelements)
+      }
+      HandleNextCommandQueueItem
+    }
+    ]]>
+  </function>
+
+  <object name="room1">
+    <turnscript name="room1turn">
+      <enabled type="boolean">true</enabled>
+      <script>
+        msg ("room1 turnscript")
+      </script>
+    </turnscript>
+    <object name="player">
+      <inherit name="defaultplayer" />
+    </object>
+  </object>
+
+  <object name="room2">
+    <turnscript name="room2turn">
+      <enabled type="boolean">true</enabled>
+      <script>
+        msg ("room2 turnscript")
+      </script>
+    </turnscript>
+  </object>
+
+  <!-- The wait callback moves the player to room2, but only once the wait actually
+       resolves (key press / FinishWait). FinishTurn/RunTurnScripts must not run until
+       after that move, otherwise room1's turnscript incorrectly fires for a turn where
+       the player has already left, and room2's correctly-scoped turnscript never fires. -->
+  <command name="cmd_movewait">
+    <pattern>movewait</pattern>
+    <script>
+      msg ("before wait")
+      wait {
+        MovePlayer (room2)
+        msg ("wait done")
+      }
+    </script>
+  </command>
+
+  <!-- A wait callback that itself opens another wait (e.g. a cutscene with two key presses).
+       Each key press should only resolve its own wait; FinishTurn must wait for both. -->
+  <command name="cmd_movewait_nested">
+    <pattern>movewaitnested</pattern>
+    <script>
+      msg ("step1")
+      wait {
+        MovePlayer (room2)
+        msg ("step2")
+        wait {
+          msg ("step3")
+        }
+        msg ("step4")
+      }
+    </script>
+  </command>
+</asl>


### PR DESCRIPTION
## Summary
- Below v580, the engine auto-runs `FinishTurn` (and hence turnscripts) via `TryFinishTurnAsync` once a command's script finishes. `wait{}` is fire-and-forget, so a command that starts a `wait` let that automatic `FinishTurn` call run *before* the wait's callback resolved — racing turnscripts against state the callback hadn't reached yet (e.g. a room the callback was about to move the player out of).
- Fix: when a command (or event) finishes with a wait/ask/get input/show menu still pending, defer that `FinishTurn` call instead of running it immediately. `EndPendingCallbackAsync` discharges the deferred call once `_pendingCallbackCount` actually returns to zero, so a wait nested inside another wait's callback correctly waits for both before `FinishTurn` runs.
- No changes needed to `WaitScript`/`AskScript`/`GetInputScript`/`ShowMenuScript` themselves — the fix is centralized in the shared pending-callback bookkeeping they already call into.

## Context
Found via [spatterlight](https://github.com/angstsmurf/spatterlight)'s independent compatibility testing, which uses a headless QuestViva build as a ground-truth oracle against ~70 real Quest 5 games. The published `.quest` file for the affected game (craigdutton's "The Legend of Robin Hood", ASL 540, 2013) is fully self-contained — it never pulls in today's `Core.aslx`, which added an additional inline `FinishTurn` call "as of Quest 5.8" — so the only `FinishTurn` call that ever fires for a real pre-580 game is the one this PR gates.

## Test plan
- [x] New regression tests in `V5BlockingTests.cs` against a purpose-built v500 fixture (`waitturnscripttest.aslx`, with `ResolveNextName`/`FinishTurn` overridden back to their authentic pre-580 shape): turnscript-race repro, and a nested-wait-inside-a-wait-callback case.
- [x] `dotnet test --configuration Release` — full solution passes (285 EngineTests + all other suites).
- [x] Verified end-to-end against the actual real-world game: loaded the published game live via textadventures.co.uk's API, drove it through its real 170-command community walkthrough — fails at exactly the reported bug (turnscript fires the failure ending) with the fix reverted, reaches the true epilogue with the fix applied. (Harness lives in a separate private repo, [textadventures/quest-e2e-tests](https://github.com/textadventures/quest-e2e-tests), not part of this PR.)

Fixes #1990