### PR TITLE
fix(AppShell): correct console banner text and version on play.questviva.com

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm ci && npm run build
         working-directory: src/AppShell
         env:
-          PUBLIC_APPSHELL_VERSION: ${{ github.sha }}
+          PUBLIC_APPSHELL_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
           PUBLIC_HAS_SERVER: false
           PUBLIC_SHOW_HOME: true
 

--- a/src/AppShell/src/routes/+layout.svelte
+++ b/src/AppShell/src/routes/+layout.svelte
@@ -46,7 +46,7 @@
     // Printed once on load, same style as WasmPlayer's console banner — the
     // header no longer shows the version, so this is the only place to find it.
     console.log(
-        "%cQuest Viva Editor %c" + (PUBLIC_APPSHELL_VERSION || "dev") + "\n%chttps://questviva.com",
+        "%cQuest Viva %c" + (PUBLIC_APPSHELL_VERSION || "dev") + "\n%chttps://questviva.com",
         "font-weight:700;font-size:14px;color:#0ea5e9",
         "font-weight:400;color:#64748b",
         "color:#64748b"


### PR DESCRIPTION
## Summary
- The startup console banner on play.questviva.com read "Quest Viva Editor" — a leftover from before AppShell grew a game browser alongside the editor. Changed to "Quest Viva".
- The `play.questviva.com` build step in `deploy-play.yml` was setting `PUBLIC_APPSHELL_VERSION` unconditionally to `github.sha`, so the console banner showed a commit hash instead of the release version. The `textadventures.co.uk` build step right below it already correctly uses `github.ref_name` on tag pushes; this brings the two in line while still falling back to `github.sha` for non-tag `workflow_dispatch` runs.

## Test plan
- [x] Ran the AppShell dev server and confirmed the console now logs `Quest Viva 6.0.0-beta.48` (version sourced from the local `VERSION` file fallback)
- [ ] Confirm on the next tagged release that play.questviva.com's console banner shows the release version instead of a commit hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)