### PR TITLE
feat(AppShell): add Included Library upload flow, sync asset/element deletes

### DIFF
--- a/src/AppShell/src/components/AddLibraryModal.svelte
+++ b/src/AppShell/src/components/AddLibraryModal.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+    import { treeNodes, uploadAsset } from "$lib/editor-store";
+    import FileIcon from "@lucide/svelte/icons/file";
+
+    interface Props {
+        onconfirm: (filename: string) => void;
+        oncancel: () => void;
+    }
+
+    const { onconfirm, oncancel }: Props = $props();
+
+    let filename = $state("");
+    let uploading = $state(false);
+    let error = $state("");
+    let inputEl: HTMLInputElement;
+
+    // .aslx files already pointed to by another Included Library — each library element needs
+    // its own file (filename is locked once set; see CoreEditorIncludedLibrary's
+    // <lockedaftercreate/>), so uploading the same name here would silently overwrite that
+    // element's content out from under it. An Included Library node's tree label is exactly its
+    // filename (EditorController.GetDisplayName), so this needs no extra bridge call.
+    let alreadyUsed = $derived(new Set($treeNodes.filter(n => n.nodeType === "include").map(n => n.text)));
+
+    async function handleUpload(e: Event) {
+        const target = e.target as HTMLInputElement;
+        const file = target.files?.[0];
+        target.value = "";
+        if (!file) return;
+        if (alreadyUsed.has(file.name)) {
+            error = `"${file.name}" is already used by another Included Library.`;
+            return;
+        }
+        uploading = true;
+        error = "";
+        try {
+            await uploadAsset(file);
+            filename = file.name;
+        } catch (err) {
+            error = String(err);
+        } finally {
+            uploading = false;
+        }
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") oncancel();
+    }
+
+    function onBackdropClick(e: MouseEvent) {
+        if (e.target === e.currentTarget) oncancel();
+    }
+
+    function confirm() {
+        if (!filename || uploading) return;
+        onconfirm(filename);
+    }
+</script>
+
+<div
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
+    onclick={onBackdropClick}
+    onkeydown={handleKeydown}
+>
+    <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-96 p-6 flex flex-col gap-4">
+        <h2 class="text-base font-semibold">Add Included Library</h2>
+
+        <div class="flex flex-col gap-1">
+            <span class="text-xs text-surface-600-400">
+                Upload a .aslx library file.
+            </span>
+            <div class="flex items-center gap-1.5 min-w-0">
+                {#if filename}
+                    <span class="shrink-0 opacity-70"><FileIcon size={14} aria-hidden="true" /></span>
+                    <span class="text-xs truncate flex-1 min-w-0" title={filename}>{filename}</span>
+                {:else}
+                    <span class="text-xs text-surface-600-400 flex-1 min-w-0">No file chosen</span>
+                {/if}
+                <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500 text-xs px-1.5 py-0.5 whitespace-nowrap shrink-0"
+                    onclick={() => inputEl.click()}
+                    disabled={uploading}
+                >{uploading ? "Uploading…" : filename ? "Change…" : "Upload…"}</button>
+                <input bind:this={inputEl} type="file" accept=".aslx" class="hidden" onchange={handleUpload} />
+            </div>
+            {#if error}<p class="text-xs text-error-500">{error}</p>{/if}
+        </div>
+
+        <div class="flex justify-end gap-2">
+            <button class="btn btn-sm preset-tonal" onclick={oncancel}>Cancel</button>
+            <button
+                class="btn btn-sm preset-filled-primary-500"
+                onclick={confirm}
+                disabled={!filename || uploading}
+            >
+                Add Library
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/AppShell/src/components/AssetManagerModal.svelte
+++ b/src/AppShell/src/components/AssetManagerModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { assets, refreshAssets, uploadAsset, deleteAssetByKey, resolveAssetUrl, isImageAsset } from "$lib/editor-store";
+    import { assets, treeNodes, refreshAssets, uploadAsset, deleteAssetAndOwner, resolveAssetUrl, isImageAsset } from "$lib/editor-store";
+    import { confirmDialog } from "$lib/confirm";
 
     interface Props {
         oncancel: () => void;
@@ -45,7 +46,17 @@
     }
 
     async function handleDelete(key: string) {
-        await deleteAssetByKey(key);
+        // Unlike model edits (covered by Quest's own Undo), a deleted asset is gone for good —
+        // always confirm, and call out a Javascript/Included Library element that owns this file
+        // specifically, since deleting it here takes that element down with it too (see
+        // deleteAssetAndOwner) rather than leaving it pointing at a missing file.
+        const owner = $treeNodes.find(n => (n.nodeType === "javascript" || n.nodeType === "include") && n.text === key);
+        const usageNote = owner
+            ? ` It's currently used by ${owner.nodeType === "javascript" ? "a JavaScript" : "an Included Library"} element — deleting it here will also delete that element.`
+            : "";
+        const ok = await confirmDialog(`Delete "${key}"?${usageNote} This can't be undone.`, { confirmLabel: "Delete", danger: true });
+        if (!ok) return;
+        await deleteAssetAndOwner(key);
         if (key in thumbUrls) {
             const rest = { ...thumbUrls };
             delete rest[key];

--- a/src/AppShell/src/components/ElementsList.svelte
+++ b/src/AppShell/src/components/ElementsList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { SvelteSet } from "svelte/reactivity";
-    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createTurnScript, createIncludedLibrary, openAddJavascriptModal, swapElements } from "$lib/editor-store";
+    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createTurnScript, openAddLibraryModal, openAddJavascriptModal, swapElements } from "$lib/editor-store";
 
     interface Props {
         elementKey: string;
@@ -79,7 +79,7 @@
         else if (nodeTypes.includes("template")) openAddModal("template", null);
         else if (nodeTypes.includes("dynamictemplate")) openAddModal("dynamictemplate", null);
         else if (nodeTypes.includes("type")) openAddModal("type", null);
-        else if (nodeTypes.includes("include")) createIncludedLibrary();
+        else if (nodeTypes.includes("include")) openAddLibraryModal();
         else if (nodeTypes.includes("javascript")) openAddJavascriptModal();
         else if (isObjectList) openAddModal("object", parent);
     }

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, setSelectedFilter, addDictItem, removeDictItem, updateDictItem, getObjectNames, getExitNames, selectNode, createObjectSilent, openAddModal, createIncludedLibrary, openAddJavascriptModal, getAssetText, putAssetText } from "$lib/editor-store";
+    import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, setSelectedFilter, addDictItem, removeDictItem, updateDictItem, getObjectNames, getExitNames, selectNode, createObjectSilent, openAddModal, openAddLibraryModal, openAddJavascriptModal, getAssetText, putAssetText } from "$lib/editor-store";
     import { showToast } from "$lib/toast";
     import type { ControlInfo, ControlOption, TextProcessorCommand } from "$lib/types";
     import type { TreeNode } from "$lib/types";
@@ -57,7 +57,7 @@
         { label: "Add Function", action: () => openAddModal("function", null), gamebook: true },
         { label: "Add Timer", action: () => openAddModal("timer", null), gamebook: false },
         { label: "Add Walkthrough", action: () => openAddModal("walkthrough", null), gamebook: false },
-        { label: "Add Library", action: () => createIncludedLibrary(), gamebook: true },
+        { label: "Add Library", action: () => openAddLibraryModal(), gamebook: true },
         { label: "Add Template", action: () => openAddModal("template", null), gamebook: false },
         { label: "Add Dynamic Template", action: () => openAddModal("dynamictemplate", null), gamebook: false },
         { label: "Add Type", action: () => openAddModal("type", null), gamebook: false },

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -10,7 +10,7 @@
     import {
         treeNodes, selectedKey, selectNode, isGamebook,
         openAddModal, createExit, createTurnScript, createCommand, createVerb,
-        createIncludedLibrary, openAddJavascriptModal,
+        openAddLibraryModal, openAddJavascriptModal,
         deleteElement,
         canMoveElement, openMoveModal, copyElements, cutElements, canPasteElements, pasteElements,
         clipboardVersion, cutElementKeys,
@@ -302,7 +302,7 @@
             else if (id === "_template") opts.push({ label: "Add Template", action: () => openAddModal("template", null) });
             else if (id === "_dynamictemplate") opts.push({ label: "Add Dynamic Template", action: () => openAddModal("dynamictemplate", null) });
             else if (id === "_objecttype") opts.push({ label: "Add Type", action: () => openAddModal("type", null) });
-            else if (id === "_include") opts.push({ label: "Add Library", action: () => createIncludedLibrary() });
+            else if (id === "_include") opts.push({ label: "Add Library", action: () => openAddLibraryModal() });
             else if (id === "_javascript") opts.push({ label: "Add JavaScript", action: () => openAddJavascriptModal() });
         } else if (nt === "room") {
             opts.push(

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -7,6 +7,8 @@ import type { AssetInfo, FileAdapter } from "./filesystem/types";
 import { LocalDraftAdapter, shouldShowBackupBanner, markBackupBannerResolved } from "./filesystem/local-adapter";
 import { ServerFileAdapter } from "./filesystem/server-adapter";
 import { triggerDownload } from "./filesystem/download";
+import { confirmDialog } from "./confirm";
+import { showToast } from "./toast";
 import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData, ExitsData, VerbInfo, ExpressionFunctionInfo } from "./types";
 
 export type AddElementModalState = { type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
@@ -33,6 +35,15 @@ export function openAddModal(type: "room" | "object" | "page" | "function" | "ti
 export const addJavascriptModalOpen = writable(false);
 export function openAddJavascriptModal() {
     addJavascriptModalOpen.set(true);
+}
+// An Included Library's filename can't be changed after creation either (same
+// lockedaftercreate as Javascript's src — see CoreEditorIncludedLibrary.aslx) and, unlike
+// Javascript, it can *only* ever point at an existing/uploaded file (a blank .aslx isn't a
+// useful library), so its adder is the same up-front-modal shape but without JS's "type a
+// new name to create a blank one" affordance.
+export const addLibraryModalOpen = writable(false);
+export function openAddLibraryModal() {
+    addLibraryModalOpen.set(true);
 }
 // Holds the key of the element currently being moved, or null when the modal is closed.
 export const moveElementModal = writable<string | null>(null);
@@ -581,20 +592,49 @@ export async function publishGame(includeWalkthrough: boolean): Promise<void> {
     triggerDownload(packageBytes, publishName);
 }
 
+// Keys of every Javascript/Included Library element currently in the tree — undo()/redo() diff
+// this before/after to find ones that just reappeared, so the missing-asset check below only
+// fires for elements the undo/redo itself brought back, not any pre-existing breakage elsewhere
+// in the game (e.g. a hand-edited or legacy save).
+function assetOwningKeys(): Set<string> {
+    return new Set(get(treeNodes).filter(n => ASSET_OWNING_NODE_TYPES.has(n.nodeType)).map(n => n.key));
+}
+
+// deleteElement()'s asset cascade (see below) happens outside WorldModel's undo system entirely —
+// undoing the element's own deletion is all Quest's Undo can do, so if that file is gone for good,
+// undo/redo can resurrect an element whose filename now points at nothing. Can't fix that (the
+// file really is gone), so at least surface it instead of leaving a silently broken element sitting
+// in the tree.
+async function warnAboutDetachedAssetOwners(beforeKeys: Set<string>): Promise<void> {
+    if (!_adapter) return;
+    const reappeared = get(treeNodes).filter(n => ASSET_OWNING_NODE_TYPES.has(n.nodeType) && !beforeKeys.has(n.key));
+    for (const node of reappeared) {
+        if (!node.text || node.text === NO_FILENAME_PLACEHOLDER) continue;
+        const blob = await _adapter.getAsset(node.text);
+        if (!blob) {
+            showToast(`"${node.text}" was restored, but its file was permanently deleted and can't be recovered — delete this element or add a new file.`);
+        }
+    }
+}
+
 export async function undo() {
+    const beforeKeys = assetOwningKeys();
     if (_bridge) await _bridge.Undo();
     refreshTree();
     refreshSelectedData();
     refreshUndoRedo();
     scriptVersion.update(n => n + 1);
+    void warnAboutDetachedAssetOwners(beforeKeys);
 }
 
 export function redo() {
+    const beforeKeys = assetOwningKeys();
     _bridge?.Redo();
     refreshTree();
     refreshSelectedData();
     refreshUndoRedo();
     scriptVersion.update(n => n + 1);
+    void warnAboutDetachedAssetOwners(beforeKeys);
 }
 
 // ── Assets ───────────────────────────────────────────────────────────────────
@@ -1158,9 +1198,9 @@ export function createObjectType(name: string): string {
     return afterCreate(_bridge.CreateObjectType(name));
 }
 
-export function createIncludedLibrary(): string {
+export function createIncludedLibrary(filename: string): string {
     if (!_bridge) return "error:not loaded";
-    return afterCreate(_bridge.CreateIncludedLibrary());
+    return afterCreate(_bridge.CreateIncludedLibrary(filename));
 }
 
 export function createJavascript(src: string): string {
@@ -1168,7 +1208,58 @@ export function createJavascript(src: string): string {
     return afterCreate(_bridge.CreateJavascript(src));
 }
 
-export function deleteElement(key: string) {
+// Javascript's src and Included Library's filename are the only element attributes that own an
+// asset outright (lockedaftercreate, one file per element — see AddJavascriptModal/AddLibraryModal),
+// and the tree label mirrors that filename exactly (EditorController.GetDisplayName), so the asset
+// key for one of these nodes is just its own text.
+const ASSET_OWNING_NODE_TYPES = new Set(["javascript", "include"]);
+
+// Finds another element of the same asset-owning type still pointing at the same file — deleting
+// this element shouldn't take the asset out from under it.
+function assetStillReferenced(key: string, nodeType: string, assetKey: string): boolean {
+    return get(treeNodes).some(n => n.key !== key && n.nodeType === nodeType && n.text === assetKey);
+}
+
+const NO_FILENAME_PLACEHOLDER = "(filename not set)"; // EditorController.GetDisplayName's fallback
+
+export async function deleteElement(key: string): Promise<void> {
+    if (!_bridge) return;
+    const node = get(treeNodes).find(n => n.key === key);
+    // Model edits are covered by Quest's own Undo, but an asset file lives outside that — its
+    // deletion is permanent, so confirm before an element delete would take one out with it. Both
+    // owning types are lockedaftercreate and only ever created with a real uploaded file (see
+    // AddJavascriptModal/AddLibraryModal), so a set filename is trusted here rather than checked
+    // against the `assets` store — included-library .aslx files are deliberately excluded from
+    // that store's listing on most adapters (LocalDraftAdapter/BrowserFileAdapter/ElectronAdapter
+    // all filter `.aslx` out of listAssets() to avoid ever surfacing the game's own file as a
+    // generic asset), so they'd never match there even though the file is real.
+    if (node && ASSET_OWNING_NODE_TYPES.has(node.nodeType) && node.text && node.text !== NO_FILENAME_PLACEHOLDER
+        && !assetStillReferenced(key, node.nodeType, node.text)) {
+        const ok = await confirmDialog(
+            `Delete "${node.text}"? This will also permanently delete that file from your assets — this can't be undone.`,
+            { confirmLabel: "Delete", danger: true },
+        );
+        if (!ok) return;
+        performDeleteElement(key);
+        // Best-effort: some adapters (e.g. ServerFileAdapter) throw on a delete that 404s, which
+        // shouldn't block the element delete above from having already gone through.
+        try { await deleteAssetByKey(node.text); } catch { /* already gone, or adapter-side 404 */ }
+        return;
+    }
+    performDeleteElement(key);
+}
+
+// Asset Manager's delete, for an asset owned by a Javascript/Included Library element — removes
+// that element too rather than leaving it pointing at a now-missing file, keeping the two in sync
+// regardless of which side (element or asset) the delete was triggered from. No confirm here: the
+// caller (AssetManagerModal) already confirmed, naming the owning element in its own message.
+export async function deleteAssetAndOwner(key: string): Promise<void> {
+    const owner = get(treeNodes).find(n => ASSET_OWNING_NODE_TYPES.has(n.nodeType) && n.text === key);
+    if (owner) performDeleteElement(owner.key);
+    await deleteAssetByKey(key);
+}
+
+function performDeleteElement(key: string) {
     if (!_bridge) return;
     _bridge.DeleteElement(key);
     selectedKey.set(null);

--- a/src/AppShell/src/lib/filesystem/local-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/local-adapter.ts
@@ -253,9 +253,13 @@ export class LocalDraftAdapter implements FileAdapter {
         if (!dir) return [];
         const assets: AssetInfo[] = [];
         for await (const [name, handle] of dir as unknown as AsyncIterable<[string, FileSystemHandle]>) {
-            // Sibling .aslx files (split-file games, included libraries) aren't
-            // assets, same as BrowserFileAdapter's directory-mode listAssets.
-            if (handle.kind !== "file" || name === "meta.json" || name.toLowerCase().endsWith(".aslx")) continue;
+            // Unlike BrowserFileAdapter/ElectronAdapter (arbitrary real folders that could contain
+            // other, unrelated .aslx files a blanket filter is right to hide), this OPFS directory
+            // is exclusively owned by this one draft — the only .aslx that can ever be in here
+            // besides an uploaded Included Library file is the draft's own main file, so exclude
+            // just that by name rather than every .aslx (which used to hide library files too,
+            // leaving them untracked and un-cleanable — see AddLibraryModal/deleteElement).
+            if (handle.kind !== "file" || name === "meta.json" || name === this._filename) continue;
             assets.push({ key: name, url: "" });
         }
         return assets;

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -92,7 +92,7 @@ export interface WasmBridge {
   CreateTemplate(name: string): string
   CreateDynamicTemplate(name: string): string
   CreateObjectType(name: string): string
-  CreateIncludedLibrary(): string
+  CreateIncludedLibrary(filename: string): string
   CreateJavascript(src: string): string
   DeleteElement(key: string): void
   DeleteElements(keysJson: string): void

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -4,7 +4,7 @@
     import { goto } from "$app/navigation";
     import { base } from "$app/paths";
     import { get } from "svelte/store";
-    import { isLoaded, isDirty, isEditingField, markFieldEditing, clearFieldEditing, saveGame, loadingStatus, addElementModal, addJavascriptModalOpen, assetManagerOpen, publishModalOpen, codeViewPanelOpen, openGame, lastOpenGameError, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType, createJavascript, moveElementModal, moveElement } from "$lib/editor-store";
+    import { isLoaded, isDirty, isEditingField, markFieldEditing, clearFieldEditing, saveGame, loadingStatus, addElementModal, addJavascriptModalOpen, addLibraryModalOpen, assetManagerOpen, publishModalOpen, codeViewPanelOpen, openGame, lastOpenGameError, createRoom, createObject, createFunction, createTimer, createWalkthrough, createTemplate, createDynamicTemplate, createObjectType, createJavascript, createIncludedLibrary, moveElementModal, moveElement } from "$lib/editor-store";
     import { loadFromServer } from "$lib/filesystem/server-adapter";
     import Toolbar from "$components/Toolbar.svelte";
     import BackupBanner from "$components/BackupBanner.svelte";
@@ -14,6 +14,7 @@
     import { isNarrow } from "$lib/layout.svelte";
     import AddElementModal from "$components/AddElementModal.svelte";
     import AddJavascriptModal from "$components/AddJavascriptModal.svelte";
+    import AddLibraryModal from "$components/AddLibraryModal.svelte";
     import MoveElementModal from "$components/MoveElementModal.svelte";
     import AssetManagerModal from "$components/AssetManagerModal.svelte";
     import PublishModal from "$components/PublishModal.svelte";
@@ -186,6 +187,13 @@
         <AddJavascriptModal
             onconfirm={(src) => { addJavascriptModalOpen.set(false); createJavascript(src); }}
             oncancel={() => addJavascriptModalOpen.set(false)}
+        />
+    {/if}
+
+    {#if $addLibraryModalOpen}
+        <AddLibraryModal
+            onconfirm={(filename) => { addLibraryModalOpen.set(false); createIncludedLibrary(filename); }}
+            oncancel={() => addLibraryModalOpen.set(false)}
         />
     {/if}
 

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -1653,9 +1653,10 @@ public sealed class EditorController : IDisposable
         CreateNewElement(ElementType.Walkthrough, "walkthrough", name, parent);
     }
 
-    public string CreateNewIncludedLibrary()
+    public string CreateNewIncludedLibrary(string filename)
     {
-        return CreateNewElement(ElementType.IncludedLibrary, "included library", null);
+        return CreateNewElement(ElementType.IncludedLibrary, "included library", null,
+            initialFields: new Dictionary<string, object> {{"filename", filename}});
     }
 
     public string CreateNewTemplate(string name)

--- a/src/Engine/Core/CoreEditorIncludedLibrary.aslx
+++ b/src/Engine/Core/CoreEditorIncludedLibrary.aslx
@@ -8,9 +8,10 @@
         <controltype>file</controltype>
         <attribute>filename</attribute>
         <caption>[EditorIncludedLibraryFilename]</caption>
-        <source>libraries</source>
+        <source>*.aslx</source>
         <width>300</width>
         <filefiltername>Libraries</filefiltername>
+        <lockedaftercreate/>
       </control>
     </tab>
   </editor>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -2370,7 +2370,7 @@ public partial class WasmEditorBridge
     }
 
     [JSExport]
-    public static string CreateIncludedLibrary()
+    public static string CreateIncludedLibrary(string filename)
     {
         if (_controller == null)
         {
@@ -2379,7 +2379,7 @@ public partial class WasmEditorBridge
 
         try
         {
-            return _controller.CreateNewIncludedLibrary();
+            return _controller.CreateNewIncludedLibrary(filename);
         }
         catch (Exception ex)
         {

--- a/tests/EditorCoreTests/IncludedLibraryTests.cs
+++ b/tests/EditorCoreTests/IncludedLibraryTests.cs
@@ -32,7 +32,7 @@ public class IncludedLibraryTests
         // A library the game author added themselves (not shipped with the engine) is unaffected
         // by the built-in-library guard and should remain deletable.
         var controller = await LoadTemplateController("English");
-        var key = controller.CreateNewIncludedLibrary();
+        var key = controller.CreateNewIncludedLibrary("custom.aslx");
 
         Assert.IsTrue(controller.CanDelete(key), "A custom, non-built-in library should be deletable");
 


### PR DESCRIPTION
## Summary

- Included Library elements had no proper "add" flow — the manual file picker was broken (`<source>libraries</source>` in `CoreEditorIncludedLibrary.aslx` didn't match any real extension), so the only affordance was creating a blank element and hoping the property panel worked. New `AddLibraryModal` (upload-only, since a library can only ever come from an existing file, unlike Javascript's "type a new name" option) plumbs a filename through at creation time, matching the JS element's `lockedaftercreate` shape.
- Deleting a Javascript/Included Library element now cascades to delete its underlying asset too (with a confirmation, since asset deletes live outside Quest's undo system and are permanent) — previously the file was silently orphaned. The reverse direction also works: deleting the file from the Asset Manager now removes the owning element instead of leaving it pointing at a missing file.
- Found and fixed a related bug along the way: `LocalDraftAdapter.listAssets()` blanket-excluded every `.aslx` file (to hide the game's own file), which also hid library files — silently breaking both the delete cascade and the "pick an existing library" picker. Narrowed the exclusion to just the draft's own filename, since that OPFS directory is exclusively app-owned. Left `BrowserFileAdapter`/`ElectronAdapter` as-is, since a real folder can legitimately contain unrelated `.aslx` files.
- `undo()`/`redo()` now detect when Quest's own undo restores an element whose file was cascade-deleted outside that system (undo only rewinds the WorldModel transaction, not the out-of-band asset delete) and toast a warning instead of leaving a silently broken element sitting in the tree.

## Test plan

- [x] `dotnet build --configuration Release` — clean
- [x] `dotnet test tests/EditorCoreTests` — all passing, including updated `IncludedLibraryTests`
- [x] `svelte-check` / `eslint` in `src/AppShell` — clean
- [x] Manually verified in-browser (WasmEditor Debug build + AppShell dev server): add-library-from-upload, add-library-from-existing-picker, delete-with-confirm cascading the asset, cancel preserves both, Asset-Manager-side delete removing the owning element, and the undo-after-cascade-delete toast — all working; built-in libraries (`Core.aslx`/`English.aslx`) remain protected throughout