### PR TITLE
feat(AppShell): show cached cover art for local Play tab recents

### DIFF
--- a/src/AppShell/src/components/LocalFileRecentCard.svelte
+++ b/src/AppShell/src/components/LocalFileRecentCard.svelte
@@ -1,10 +1,30 @@
 <script lang="ts">
     import type { RecentGame } from "$lib/filesystem/electron-adapter";
+    import { resolveAndCacheCover } from "$lib/local-cover";
     import Gamepad2 from "@lucide/svelte/icons/gamepad-2";
 
     // Electron only — there's no browser equivalent (see PlayCatalog.svelte),
     // so unlike RecentGameCard this never needs a non-Electron branch.
     let { game, onplay, onremove }: { game: RecentGame; onplay: () => void; onremove: () => void } = $props();
+
+    // game.coverDataUrl is cached on the RecentGame record (resolved once at play time, or
+    // here as a one-off self-heal for a legacy entry — see local-cover.ts) — the common case
+    // is a synchronous read, no engine boot needed. undefined (never resolved yet) is the only
+    // case that falls back to resolving live; starts null so the Gamepad2 placeholder below
+    // shows while that's in flight. Keyed off dirPath+filename so a change of `game` (grid
+    // re-sorted by recency) re-checks rather than keeping a stale image.
+    let coverUrl = $state<string | null>(null);
+    $effect(() => {
+        const { dirPath, filename, coverDataUrl } = game;
+        if (coverDataUrl !== undefined) {
+            coverUrl = coverDataUrl;
+            return;
+        }
+        coverUrl = null;
+        void resolveAndCacheCover(dirPath, filename).then((url) => {
+            if (game.dirPath === dirPath && game.filename === filename) coverUrl = url;
+        });
+    });
 
     function folderName(dirPath: string): string {
         return dirPath.split(/[\\/]/).pop() || dirPath;
@@ -33,7 +53,11 @@
         class="flex flex-col w-full text-left rounded-lg border border-surface-800 overflow-hidden hover:border-primary-500 transition-colors"
     >
         <div class="aspect-[3/4] bg-surface-800 flex items-center justify-center overflow-hidden">
-            <Gamepad2 size={40} class="text-surface-600" />
+            {#if coverUrl}
+                <img src={coverUrl} alt="" loading="lazy" class="w-full h-full object-cover" />
+            {:else}
+                <Gamepad2 size={40} class="text-surface-600" />
+            {/if}
         </div>
         <div class="p-2 flex flex-col gap-1">
             <div class="text-sm font-semibold truncate">{game.filename}</div>

--- a/src/AppShell/src/components/PlayCatalog.svelte
+++ b/src/AppShell/src/components/PlayCatalog.svelte
@@ -40,11 +40,19 @@
     // recent-catalog-plays.ts, works everywhere) and local files (Electron only — tracked
     // via electron-adapter.ts's "play"-kind RecentGame list; there's no persistent file
     // handle across sessions in a plain browser to track this with). Both render as cards
-    // in the same grid (RecentGameCard / LocalFileRecentCard) — catalog entries first,
-    // local files after, not interleaved by timestamp (the two lists come from unrelated
-    // sources with no shared ordering guarantee worth relying on).
+    // in the same grid (RecentGameCard / LocalFileRecentCard), interleaved by timestamp —
+    // lastPlayed and lastOpened are both plain Date.now() epoch-ms, so they compare directly.
     let recentCatalogPlays = $state<RecentCatalogPlay[]>([]);
     let recentLocalPlays = $state<RecentGame[]>([]);
+
+    type RecentEntry =
+        | { kind: "catalog"; key: string; timestamp: number; game: RecentCatalogPlay }
+        | { kind: "local"; key: string; timestamp: number; game: RecentGame };
+
+    const recentEntries = $derived<RecentEntry[]>([
+        ...recentCatalogPlays.map((game): RecentEntry => ({ kind: "catalog", key: game.id, timestamp: game.lastPlayed, game })),
+        ...recentLocalPlays.map((game): RecentEntry => ({ kind: "local", key: game.dirPath + "/" + game.filename, timestamp: game.lastOpened, game })),
+    ].sort((a, b) => b.timestamp - a.timestamp));
 
     function refreshRecentCatalogPlays() {
         recentCatalogPlays = listRecentCatalogPlays();
@@ -310,18 +318,17 @@
             <p class="text-error-500 text-sm text-center">{startError}</p>
         {/if}
 
-        {#if recentCatalogPlays.length > 0 || (isElectronApp && recentLocalPlays.length > 0)}
+        {#if recentEntries.length > 0}
             <section>
-                <h2 class="text-lg font-semibold mb-3">Recently played</h2>
+                <h2 class="text-lg font-semibold mb-3">Recently Played</h2>
                 <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
-                    {#each recentCatalogPlays as game (game.id)}
-                        <RecentGameCard {game} onremove={() => handleRemoveRecentCatalog(game.id)} />
+                    {#each recentEntries as entry (entry.key)}
+                        {#if entry.kind === "catalog"}
+                            <RecentGameCard game={entry.game} onremove={() => handleRemoveRecentCatalog(entry.game.id)} />
+                        {:else}
+                            <LocalFileRecentCard game={entry.game} onplay={() => playLocalRecent(entry.game)} onremove={() => handleRemoveRecentLocal(entry.game)} />
+                        {/if}
                     {/each}
-                    {#if isElectronApp}
-                        {#each recentLocalPlays as game (game.dirPath + "/" + game.filename)}
-                            <LocalFileRecentCard {game} onplay={() => playLocalRecent(game)} onremove={() => handleRemoveRecentLocal(game)} />
-                        {/each}
-                    {/if}
                 </div>
             </section>
         {/if}

--- a/src/AppShell/src/lib/electron-types.d.ts
+++ b/src/AppShell/src/lib/electron-types.d.ts
@@ -41,6 +41,9 @@ interface ElectronRecentGame {
     dirPath: string;
     filename: string;
     lastOpened: number;
+    // "play"-kind only — see ElectronApp's recent-games.ts. undefined = never resolved;
+    // null = resolved, no cover; string = the resolved cover as a data: URL.
+    coverDataUrl?: string | null;
 }
 
 // "edit" = opened/created/saved-as through the editor (File > Open Recent,
@@ -51,8 +54,11 @@ type ElectronRecentKind = "edit" | "play";
 
 interface ElectronRecentApi {
     list(kind: ElectronRecentKind): Promise<ElectronRecentGame[]>;
-    add(kind: ElectronRecentKind, dirPath: string, filename: string): Promise<ElectronRecentGame[]>;
+    add(kind: ElectronRecentKind, dirPath: string, filename: string, coverDataUrl?: string | null): Promise<ElectronRecentGame[]>;
     remove(kind: ElectronRecentKind, dirPath: string, filename: string): Promise<ElectronRecentGame[]>;
+    // Patches an existing entry's coverDataUrl in place — unlike add(), doesn't bump
+    // lastOpened or reorder. Used to self-heal a legacy/unresolved entry in the background.
+    setCover(kind: ElectronRecentKind, dirPath: string, filename: string, coverDataUrl: string | null): Promise<ElectronRecentGame[]>;
     onChanged(callback: (kind: ElectronRecentKind) => void): () => void;
 }
 

--- a/src/AppShell/src/lib/filesystem/electron-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/electron-adapter.ts
@@ -48,6 +48,9 @@ export interface RecentGame {
     dirPath: string;
     filename: string;
     lastOpened: number;
+    // "play"-kind only — see ElectronApp's recent-games.ts. undefined = never resolved;
+    // null = resolved, no cover; string = the resolved cover as a data: URL.
+    coverDataUrl?: string | null;
 }
 
 // Mirrors ElectronRecentKind. "edit" (the default below) is every editor
@@ -64,6 +67,15 @@ export async function listRecentGames(kind: RecentKind = "edit"): Promise<Recent
 
 export async function removeRecentGame(dirPath: string, filename: string, kind: RecentKind = "edit"): Promise<void> {
     await electronApp().recent.remove(kind, dirPath, filename);
+}
+
+export async function setRecentGameCover(
+    dirPath: string,
+    filename: string,
+    coverDataUrl: string | null,
+    kind: RecentKind = "play",
+): Promise<void> {
+    await electronApp().recent.setCover(kind, dirPath, filename, coverDataUrl);
 }
 
 // Best-effort: the recent list is a convenience, so a tracking failure should

--- a/src/AppShell/src/lib/filesystem/local-play.ts
+++ b/src/AppShell/src/lib/filesystem/local-play.ts
@@ -1,4 +1,5 @@
-import { loadElectronFile, openElectronPlayFile } from "./electron-adapter";
+import { loadElectronFile, openElectronPlayFile, listRecentGames } from "./electron-adapter";
+import { resolveAndCacheCover } from "../local-cover";
 
 function blobToDataUrl(blob: Blob): Promise<string> {
     return new Promise((resolve) => {
@@ -27,6 +28,8 @@ export async function playElectronFile(dirPath: string, filename: string, onPlay
     const { bytes, adapter } = await loadElectronFile(dirPath, filename, "play");
     onPlayed?.();
 
+    void resolveCoverIfNeeded(dirPath, filename);
+
     closeLocalPlayChannel();
     const bc = new BroadcastChannel("quest-play-local");
     playChannel = bc;
@@ -47,6 +50,21 @@ export async function playElectronFile(dirPath: string, filename: string, onPlay
         bc.close();
         playChannel = null;
         throw new Error("Couldn't open the player window.");
+    }
+}
+
+// Fire-and-forget, deliberately not awaited by playElectronFile — cover resolution boots the
+// full engine just to read one field (see local-cover.ts), which must never delay the player
+// window opening. Runs in this (the main AppShell) renderer, a separate OS process from the
+// player window it just opened, so it can't make that window janky either. Skipped when this
+// file's cover is already cached — addRecentGame's carry-forward (see recent-games.ts) means
+// replaying an already-resolved game leaves its coverDataUrl untouched, so this only ever does
+// real work the first time a given local file is played.
+async function resolveCoverIfNeeded(dirPath: string, filename: string): Promise<void> {
+    const recents = await listRecentGames("play");
+    const entry = recents.find((g) => g.dirPath === dirPath && g.filename === filename);
+    if (entry && entry.coverDataUrl === undefined) {
+        await resolveAndCacheCover(dirPath, filename);
     }
 }
 

--- a/src/AppShell/src/lib/local-cover.ts
+++ b/src/AppShell/src/lib/local-cover.ts
@@ -1,0 +1,77 @@
+import { loadWasm } from "./wasm";
+import { ElectronFileAdapter, setRecentGameCover } from "./filesystem/electron-adapter";
+
+interface LocalCoverResult {
+    name: string;
+    dataUrl: string | null;
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+    return new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.readAsDataURL(blob);
+    });
+}
+
+// Computing a local play file's cover art means booting the full engine just to read one field
+// (see WasmEditorBridge.ResolveLocalCover) — too expensive to redo on every app startup. The
+// result is cached on the RecentGame record itself (coverDataUrl, persisted to disk — see
+// ElectronApp's recent-games.ts), resolved once via resolveAndCacheCover below, either when the
+// game is played (local-play.ts) or, for a legacy/never-resolved entry, the first time its card
+// is shown (LocalFileRecentCard.svelte). Neither caller needs an in-memory result cache of its
+// own on top of that — this module only guards against two callers racing to resolve the same
+// entry concurrently (e.g. a Play-tab re-render overlapping a play-time resolution).
+const inFlight = new Map<string, Promise<string | null>>();
+
+function cacheKey(dirPath: string, filename: string): string {
+    return dirPath + "/" + filename;
+}
+
+// Best-effort: a malformed/unsupported local file, or one with no cover attribute set, must
+// never break the Recently Played list — any failure here resolves to null, same as "no cover".
+function resolveLocalCoverUrl(dirPath: string, filename: string): Promise<string | null> {
+    const key = cacheKey(dirPath, filename);
+    const existing = inFlight.get(key);
+    if (existing) return existing;
+
+    const promise = resolveUncached(dirPath, filename).finally(() => {
+        if (inFlight.get(key) === promise) inFlight.delete(key);
+    });
+    inFlight.set(key, promise);
+    return promise;
+}
+
+async function resolveUncached(dirPath: string, filename: string): Promise<string | null> {
+    try {
+        const bytes = await window.electronApp!.fs.readFile(window.electronApp!.path.join(dirPath, filename));
+        const bridge = await loadWasm();
+        const resultJson = await bridge.ResolveLocalCover(bytes, filename);
+        if (!resultJson) return null;
+        const { name, dataUrl } = JSON.parse(resultJson) as LocalCoverResult;
+
+        // Embedded (a .quest package, or a self-contained legacy .asl/.cas) — the bridge
+        // already extracted and base64-encoded the bytes from the game's own archive, so
+        // dataUrl is directly usable as an <img src> and safe to cache to disk as-is.
+        // Otherwise (a plain unpacked .aslx) the cover is a sibling file on disk — also
+        // converted to a data: URL rather than an object URL, since this result gets
+        // persisted on the RecentGame record and object URLs don't survive past the page
+        // that created them.
+        if (dataUrl) return dataUrl;
+
+        const adapter = new ElectronFileAdapter(dirPath, filename);
+        const blob = await adapter.getAsset(name);
+        return blob ? await blobToDataUrl(blob) : null;
+    } catch {
+        return null;
+    }
+}
+
+// Resolves (if not already in flight) and persists a local play file's cover onto its
+// RecentGame record — the one-stop call every caller should use, so resolving never happens
+// without also being cached for next time.
+export async function resolveAndCacheCover(dirPath: string, filename: string): Promise<string | null> {
+    const url = await resolveLocalCoverUrl(dirPath, filename);
+    await setRecentGameCover(dirPath, filename, url);
+    return url;
+}

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -108,27 +108,51 @@ export interface WasmBridge {
   // New game
   GetGameTemplates(): string
   CreateGameFromTemplate(templateId: string, gameName: string): string
+  // Play tab "Recently played" cover art — see WasmEditorBridge.ResolveLocalCover. Return
+  // value is a JSON-encoded LocalCoverResult ({ name, dataUrl }) or null, not a bare string —
+  // multiple of these can be in flight at once (one per recent-local-play card), so unlike
+  // most of the "returns a name, fetch the rest via a second synchronous call" pairs above,
+  // this can't stash its result in shared state between the two calls without racing.
+  ResolveLocalCover(gameFileBytes: Uint8Array, filename: string): Promise<string | null>
 }
 
 let _bridge: WasmBridge | null = null;
+// The in-flight load itself, not just its result — dotnet.js's runtime module can only be
+// created once per page (a second concurrent dotnet.create() throws "Runtime module already
+// loaded", and _bridge never gets set, permanently wedging every later caller too). A plain
+// `if (_bridge) return` guard only protects callers that arrive after the first load has
+// already finished; two callers arriving before then (e.g. several LocalFileRecentCard
+// instances resolving cover art on the same Play-tab render) would each see _bridge still
+// null and race to call create() themselves. Caching the promise makes every concurrent
+// caller await the same single load instead.
+let _loading: Promise<WasmBridge> | null = null;
 
 export async function loadWasm(): Promise<WasmBridge> {
     if (_bridge) return _bridge;
+    if (_loading) return _loading;
 
-    // dotnet.js is served at runtime by the Vite AppBundle middleware (vite.config.ts).
-    // Use new Function to prevent Vite's import-analysis plugin from trying to resolve
-    // the URL at build time — it only exists as a runtime-served file.
-    const loadModule = new Function("url", "return import(url)");
-    const { dotnet } = (await loadModule("/AppBundle/_framework/dotnet.js")) as { dotnet: any };
+    _loading = (async () => {
+        // dotnet.js is served at runtime by the Vite AppBundle middleware (vite.config.ts).
+        // Use new Function to prevent Vite's import-analysis plugin from trying to resolve
+        // the URL at build time — it only exists as a runtime-served file.
+        const loadModule = new Function("url", "return import(url)");
+        const { dotnet } = (await loadModule("/AppBundle/_framework/dotnet.js")) as { dotnet: any };
 
-    const { getAssemblyExports, getConfig, runMain } = await dotnet
-        .withDiagnosticTracing(false)
-        .create();
+        const { getAssemblyExports, getConfig, runMain } = await dotnet
+            .withDiagnosticTracing(false)
+            .create();
 
-    await runMain();
+        await runMain();
 
-    const config = getConfig();
-    const exports = await getAssemblyExports(config.mainAssemblyName);
-    _bridge = exports.QuestViva.WasmEditor.WasmEditorBridge as WasmBridge;
-    return _bridge;
+        const config = getConfig();
+        const exports = await getAssemblyExports(config.mainAssemblyName);
+        _bridge = exports.QuestViva.WasmEditor.WasmEditorBridge as WasmBridge;
+        return _bridge;
+    })();
+
+    try {
+        return await _loading;
+    } finally {
+        _loading = null;
+    }
 }

--- a/src/ElectronApp/src/ipc/recent.ts
+++ b/src/ElectronApp/src/ipc/recent.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from "electron";
-import { listRecentGames, addRecentGame, removeRecentGame, type RecentKind } from "../recent-games";
+import { listRecentGames, addRecentGame, removeRecentGame, setRecentGameCover, type RecentKind } from "../recent-games";
 
 // Backs window.electronApp.recent in preload.ts. Every call carries a
 // RecentKind ("edit" vs "play" — see recent-games.ts) since the two lists are
@@ -10,14 +10,23 @@ import { listRecentGames, addRecentGame, removeRecentGame, type RecentKind } fro
 export function registerRecentHandlers(onChange: (kind: RecentKind) => void): void {
     ipcMain.handle("recent:list", async (_event, kind: RecentKind) => listRecentGames(kind));
 
-    ipcMain.handle("recent:add", async (_event, kind: RecentKind, dirPath: string, filename: string) => {
-        const games = await addRecentGame(kind, dirPath, filename);
+    ipcMain.handle("recent:add", async (_event, kind: RecentKind, dirPath: string, filename: string, coverDataUrl?: string | null) => {
+        const games = await addRecentGame(kind, dirPath, filename, coverDataUrl);
         onChange(kind);
         return games;
     });
 
     ipcMain.handle("recent:remove", async (_event, kind: RecentKind, dirPath: string, filename: string) => {
         const games = await removeRecentGame(kind, dirPath, filename);
+        onChange(kind);
+        return games;
+    });
+
+    // Patches a cached cover onto an existing entry — see recent-games.ts's setRecentGameCover.
+    // Fires onChange like the other mutations so a Recently Played list open in another window
+    // picks up the newly-resolved cover too.
+    ipcMain.handle("recent:setCover", async (_event, kind: RecentKind, dirPath: string, filename: string, coverDataUrl: string | null) => {
+        const games = await setRecentGameCover(kind, dirPath, filename, coverDataUrl);
         onChange(kind);
         return games;
     });

--- a/src/ElectronApp/src/preload.ts
+++ b/src/ElectronApp/src/preload.ts
@@ -79,10 +79,12 @@ contextBridge.exposeInMainWorld("electronApp", {
         // playing a game never pollutes the list File > Open Recent loads
         // into the editor, and vice versa.
         list: (kind: RecentKind): Promise<RecentGame[]> => ipcRenderer.invoke("recent:list", kind),
-        add: (kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> =>
-            ipcRenderer.invoke("recent:add", kind, dirPath, filename),
+        add: (kind: RecentKind, dirPath: string, filename: string, coverDataUrl?: string | null): Promise<RecentGame[]> =>
+            ipcRenderer.invoke("recent:add", kind, dirPath, filename, coverDataUrl),
         remove: (kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> =>
             ipcRenderer.invoke("recent:remove", kind, dirPath, filename),
+        setCover: (kind: RecentKind, dirPath: string, filename: string, coverDataUrl: string | null): Promise<RecentGame[]> =>
+            ipcRenderer.invoke("recent:setCover", kind, dirPath, filename, coverDataUrl),
         // Fires whenever a recent list changes from outside the page that's
         // showing it — e.g. the native "Clear Recent" menu item (edit-kind
         // only), which mutates the list entirely in the main process with no

--- a/src/ElectronApp/src/recent-games.ts
+++ b/src/ElectronApp/src/recent-games.ts
@@ -6,6 +6,13 @@ export interface RecentGame {
     dirPath: string;
     filename: string;
     lastOpened: number;
+    // "play"-kind only — the game's cover art (a data: URL), resolved once when the game is
+    // played and cached here so the Play tab's Recently Played list never has to re-derive it
+    // (a full engine boot) on every app startup. Three states: undefined = never resolved yet
+    // (a legacy entry, or this session's very first add before play-time resolution finishes);
+    // null = resolved once, confirmed the game has no cover; string = the resolved data URL.
+    // See AppShell's local-cover.ts and local-play.ts.
+    coverDataUrl?: string | null;
 }
 
 // "edit" = opened/created/saved-as through the editor (/open) — backs the
@@ -37,30 +44,104 @@ async function readAll(kind: RecentKind): Promise<RecentGame[]> {
     }
 }
 
+// Writes to a temp file and renames over the real one — rename() is atomic at the OS level, so
+// a reader (readAll, possibly from a different Electron process) can never observe a
+// partially-written file, even for a large one (a cover art data: URL can be several hundred
+// KB — see RecentGame.coverDataUrl). This alone doesn't stop two of *this* process's own writes
+// from racing each other (see enqueue below for that), but it does stop a crash or a second
+// instance mid-write from corrupting the file others still read.
 async function writeAll(kind: RecentKind, games: RecentGame[]): Promise<void> {
-    await fs.writeFile(storePath(kind), JSON.stringify(games));
+    const finalPath = storePath(kind);
+    const tmpPath = `${finalPath}.tmp-${process.pid}-${Date.now()}`;
+    await fs.writeFile(tmpPath, JSON.stringify(games));
+    await fs.rename(tmpPath, finalPath);
 }
 
-export async function listRecentGames(kind: RecentKind): Promise<RecentGame[]> {
-    return readAll(kind);
+// Every read-modify-write cycle below (add/setCover/remove/clear) for a given kind is chained
+// onto this per-kind queue, so at most one is ever in flight at a time. Without this, two
+// overlapping cycles — e.g. two LocalFileRecentCards each self-healing their own cover at
+// nearly the same moment — read the same starting snapshot and then both write it back
+// separately: not just a lost update, but (before the atomic rename above) their two
+// fs.writeFile calls could genuinely interleave at the OS level and corrupt the file outright
+// (a short write's bytes followed by a stray tail fragment of a longer concurrent one — this is
+// exactly what happened once in testing: valid JSON followed by ~700KB of leaked raw base64,
+// which readAll's catch-all then silently turned into "no recent games at all").
+const writeQueues = new Map<RecentKind, Promise<unknown>>();
+
+function enqueue<T>(kind: RecentKind, task: () => Promise<T>): Promise<T> {
+    const previous = writeQueues.get(kind) ?? Promise.resolve();
+    const next = previous.then(task, task);
+    // A rejected task must not wedge the queue for later callers — but that rejection still
+    // needs to go somewhere, or Node logs an unhandled rejection warning for it. `next` itself
+    // (returned below) is that "somewhere": each caller awaits its own `next` and sees the
+    // error, so this second, ignored chain off `next` exists only to keep the *queue's* stored
+    // promise perpetually resolved for whoever chains after it.
+    writeQueues.set(kind, next.catch(() => undefined));
+    return next;
 }
 
-// Upserts by (dirPath, filename) and moves it to the front — entries are
-// always written most-recent-first, so callers don't need to re-sort.
-export async function addRecentGame(kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> {
-    const games = (await readAll(kind)).filter((g) => !(g.dirPath === dirPath && g.filename === filename));
-    games.unshift({ dirPath, filename, lastOpened: Date.now() });
-    const capped = games.slice(0, MAX_RECENT);
-    await writeAll(kind, capped);
-    return capped;
+// Reads are queued too — otherwise one could still land in the middle of another, unrelated
+// write's temp-file swap and briefly see a torn/former version. Queuing costs nothing here
+// (reads are cheap) and removes that window entirely.
+export function listRecentGames(kind: RecentKind): Promise<RecentGame[]> {
+    return enqueue(kind, () => readAll(kind));
 }
 
-export async function removeRecentGame(kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> {
-    const games = (await readAll(kind)).filter((g) => !(g.dirPath === dirPath && g.filename === filename));
-    await writeAll(kind, games);
-    return games;
+// Upserts by (dirPath, filename) and moves it to the front — entries are always written
+// most-recent-first, so callers don't need to re-sort. coverDataUrl carries forward from the
+// existing entry (if any) when replaying an already-cached game without re-resolving its cover;
+// pass it explicitly to set/refresh it (e.g. local-play.ts's play-time resolution).
+export function addRecentGame(
+    kind: RecentKind,
+    dirPath: string,
+    filename: string,
+    coverDataUrl?: string | null,
+): Promise<RecentGame[]> {
+    return enqueue(kind, async () => {
+        const games = await readAll(kind);
+        const existing = games.find((g) => g.dirPath === dirPath && g.filename === filename);
+        const remaining = games.filter((g) => g !== existing);
+        remaining.unshift({
+            dirPath,
+            filename,
+            lastOpened: Date.now(),
+            coverDataUrl: coverDataUrl !== undefined ? coverDataUrl : existing?.coverDataUrl,
+        });
+        const capped = remaining.slice(0, MAX_RECENT);
+        await writeAll(kind, capped);
+        return capped;
+    });
 }
 
-export async function clearRecentGames(kind: RecentKind): Promise<void> {
-    await writeAll(kind, []);
+// Patches just coverDataUrl on an existing entry — unlike addRecentGame, doesn't touch
+// lastOpened or reorder the list. Used to self-heal a legacy/unresolved entry (coverDataUrl
+// undefined) found sitting anywhere in the list, not just the one just played. No-op if the
+// entry's gone (e.g. removed from Recently Played while resolution was still in flight).
+export function setRecentGameCover(
+    kind: RecentKind,
+    dirPath: string,
+    filename: string,
+    coverDataUrl: string | null,
+): Promise<RecentGame[]> {
+    return enqueue(kind, async () => {
+        const games = await readAll(kind);
+        const entry = games.find((g) => g.dirPath === dirPath && g.filename === filename);
+        if (entry) {
+            entry.coverDataUrl = coverDataUrl;
+            await writeAll(kind, games);
+        }
+        return games;
+    });
+}
+
+export function removeRecentGame(kind: RecentKind, dirPath: string, filename: string): Promise<RecentGame[]> {
+    return enqueue(kind, async () => {
+        const games = (await readAll(kind)).filter((g) => !(g.dirPath === dirPath && g.filename === filename));
+        await writeAll(kind, games);
+        return games;
+    });
+}
+
+export function clearRecentGames(kind: RecentKind): Promise<void> {
+    return enqueue(kind, () => writeAll(kind, []));
 }

--- a/src/PlayerCore/GameQuery.cs
+++ b/src/PlayerCore/GameQuery.cs
@@ -4,7 +4,11 @@ using QuestViva.Legacy;
 
 namespace QuestViva.PlayerCore;
 
-public class GameQuery(string filename)
+// bytes is null for the WebPlayer dev Query page's normal file-path usage (reads straight off
+// disk via FileGameDataProvider); WasmEditorBridge's cover-art lookup runs in-browser with no
+// filesystem access, so it passes the game's already-read bytes and gets a ByteArrayGameDataProvider
+// instead — same GameData shape either way, just a different source stream.
+public class GameQuery(string filename, byte[] bytes = null)
 {
     private readonly GameQueryUi _dummyUi = new();
     private readonly List<string> _errors = [];
@@ -198,7 +202,9 @@ public class GameQuery(string filename)
 
     public async Task<bool> Initialise()
     {
-        var gameDataProvider = new FileGameDataProvider(filename);
+        IGameDataProvider gameDataProvider = bytes != null
+            ? new ByteArrayGameDataProvider(bytes, filename)
+            : new FileGameDataProvider(filename);
         var gameData = await gameDataProvider.GetData();
 
         if (gameData == null)

--- a/src/WasmEditor/WasmEditor.csproj
+++ b/src/WasmEditor/WasmEditor.csproj
@@ -20,5 +20,6 @@
     <ItemGroup>
         <ProjectReference Include="..\EditorCore\EditorCore.csproj"/>
         <ProjectReference Include="..\Common\Common.csproj"/>
+        <ProjectReference Include="..\PlayerCore\PlayerCore.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -13,6 +13,7 @@ using QuestViva.Common;
 using QuestViva.EditorCore;
 using QuestViva.Engine;
 using QuestViva.Engine.Types;
+using QuestViva.PlayerCore;
 
 namespace QuestViva.WasmEditor;
 
@@ -46,6 +47,10 @@ internal record ControlInfo(
     bool LockedAfterCreate = false);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
+
+// See WasmEditorBridge.ResolveLocalCover — DataUrl is null when Name is only a resource name
+// the caller must resolve itself (a plain unpacked .aslx's sibling-file cover).
+internal record LocalCoverResult(string Name, string? DataUrl);
 
 internal record EditorDataResponse(
     Dictionary<string, string?> Attributes,
@@ -155,6 +160,7 @@ internal record ExpressionFunctionData(string Name, List<string> Parameters, boo
 [JsonSerializable(typeof(ExitsData))]
 [JsonSerializable(typeof(List<VerbInfo>))]
 [JsonSerializable(typeof(List<ExpressionFunctionData>))]
+[JsonSerializable(typeof(LocalCoverResult))]
 internal partial class WasmEditorJsonContext : JsonSerializerContext
 {
 }
@@ -590,6 +596,49 @@ public partial class WasmEditorBridge
 
     [JSExport]
     public static bool IsGamebook() => _controller?.EditorStyle == EditorStyle.GameBook;
+
+    // Play tab "Recently played" cover art for local files — entirely independent of
+    // _controller (doesn't touch the currently-open editor session), a fresh GameQuery per
+    // call instead. Several of these can be in flight at once (one per recent-local-play
+    // card, resolved concurrently on the Play tab), so unlike PrepareSaveGame/GetSaveGameBytes
+    // above this can't stash its result in a shared static field for a synchronous follow-up
+    // call to collect — two overlapping calls would race over that field. Instead the whole
+    // result comes back in one shot, as a JSON LocalCoverResult: DataUrl is set when the game
+    // format embeds its own resources (.quest package, legacy .asl/.cas) and the cover was
+    // found inside; otherwise (a plain unpacked .aslx, where the cover lives as a sibling file
+    // GetResourceStream can't see — ByteArrayGameDataProvider has no filesystem access) DataUrl
+    // is null and the caller resolves Name itself via its own FileAdapter.
+    [JSExport]
+    public static async Task<string?> ResolveLocalCover(byte[] gameFileBytes, string filename)
+    {
+        try
+        {
+            var query = new GameQuery(filename, gameFileBytes);
+            if (!await query.Initialise()) return null;
+
+            var coverName = query.CoverResourceName;
+            if (string.IsNullOrEmpty(coverName)) return null;
+
+            string? dataUrl = null;
+            using (var stream = query.GetResource(coverName))
+            {
+                if (stream != null)
+                {
+                    using var ms = new MemoryStream();
+                    await stream.CopyToAsync(ms);
+                    dataUrl = $"data:{PlayerHelper.GetContentType(coverName)};base64,{Convert.ToBase64String(ms.ToArray())}";
+                }
+            }
+
+            return JsonSerializer.Serialize(new LocalCoverResult(coverName, dataUrl), WasmEditorJsonContext.Default.LocalCoverResult);
+        }
+        catch
+        {
+            // Best-effort: a malformed/unsupported local file must never break the
+            // Recently Played list, it should just keep the placeholder icon.
+            return null;
+        }
+    }
 
     // [JSExport] can't marshal an array of blobs in one call, so assets are staged one
     // at a time (same shape as the dirty-flag polling above) then consumed by


### PR DESCRIPTION
## Summary

- Local "Recently Played" entries (Electron only) now show their actual game cover art instead of a generic icon, resolved via a new engine-backed query (`WasmEditorBridge.ResolveLocalCover`, mirroring `PlayerCore.GameQuery`) that handles both embedded-resource covers (`.quest` package, legacy `.asl`/`.cas`) and sibling-file covers (a plain unpacked `.aslx`).
- The result is cached on the `RecentGame` record (`coverDataUrl`, persisted to `recent-played.json`) — resolved once at play time (fire-and-forget, off the critical path of opening the player window) or lazily as a one-time self-heal for a legacy/never-resolved entry — since resolving a cover means booting the full engine just to read one field, too expensive to redo on every app startup.
- Also capitalizes the "Recently Played" heading to match the site's other section titles.

## Bug fixes found while testing this live

- **`wasm.ts`'s `loadWasm()` self-race**: multiple local recents resolving their covers concurrently on mount could each see the WASM bridge not yet loaded and call `dotnet.create()` a second time ("Runtime module already loaded"), permanently breaking the editor for the rest of that session. Fixed by caching the in-flight load *promise*, not just its eventual result.
- **`recent-games.ts` file corruption**: the read-modify-write cycle behind `add`/`setCover`/`remove`/`clear` had no synchronization across concurrent calls, so two cards self-healing their covers at once could have their `fs.writeFile` calls genuinely interleave at the OS level and corrupt `recent-played.json` outright (a short write's bytes followed by a stray tail fragment of a longer concurrent one) — silently wiping the entire Recently Played list on next read (`JSON.parse` throws, caught, falls back to `[]`). Fixed with a per-kind write queue plus atomic temp-file+rename.

## Test plan

- [x] `dotnet build --configuration Release` (full solution) and `dotnet test --configuration Release` — all 336 tests pass
- [x] `npx svelte-check` / `npm run lint` / `tsc -p tsconfig.json` (ElectronApp) — all clean
- [x] Standalone Node harness exercising `recent-games.ts` directly: carry-forward on replay, in-place cover patch without reordering/timestamp bump, explicit overwrite, no-op on a removed entry, and the exact concurrent-write race that previously corrupted the file (now produces valid JSON with both entries intact regardless of timing)
- [x] Live browser probes against the built `WasmEditorBridge`/`loadWasm` confirming concurrent `ResolveLocalCover` calls resolve correctly with no cross-contamination, and that `loadWasm()` no longer throws when called concurrently
- [x] Manually verified against real local `.quest` files (a published package with an embedded cover, and one with no cover set) in a running Electron build

🤖 Generated with [Claude Code](https://claude.com/claude-code)