### PR TITLE
feat(Engine): introduce WorldModelVersion 600, restore sync script support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,18 @@ EditorCore ───────────────────────
 
 **Test projects in `tests/`:** EngineTests, PlayerCoreTests, EditorCoreTests, UtilityTests, LegacyTests
 
+## Core Library Semantics (Core.aslx and friends)
+
+`Engine/Core/*.aslx` (Core.aslx, CoreOutput.aslx, CoreTimers.aslx, GamebookCore.aslx, per-language libraries, etc.) are **inlined into the game file at publish time**, not referenced live. `Packager.CreatePackage` → `WorldModel.Save(SaveMode.Package, ...)` → `GameSaver.CanSave` (`src/Engine/GameLoader/GameSaver.cs`) keeps every library-origin object/function in the saved `.quest` package except the `IncludedLibrary` reference element itself (no longer needed once its contents are inlined) — see also the `MakeElementLocal` comment in `EditorController.cs`. The same applies to the Editor's own in-progress save (`SaveMode.Editor`), which is how "library overriding" works: editing a library function makes a local copy that shadows the original from then on.
+
+**Practical consequence: a published `.quest` file is a frozen snapshot of Core library code as it existed when that game was last saved, not a live pointer to whatever ships with the current engine.** This is deliberate — it's what lets games written for old Quest/WorldModel versions keep working unmodified on newer engines/players, even after a Core library function's current body has changed, been deprecated, or been deleted outright.
+
+Implications when working on `Engine/Core/*.aslx`:
+
+- **There is no such thing as "a pre-existing bug in a published game" caused by a current Core.aslx function.** If a function's current implementation looks broken (e.g. an unconditional `error("...is obsolete...")` body, or the function missing entirely), that is very likely deliberate deprecation for *newly authored/saved* games, not a regression affecting existing ones — old games carry their own working copy of the old function, inlined at the point they were last published. Check the function's git history before describing a change as "fixing a bug" — it may instead be *undeprecating* something, which is a different, narrower claim.
+- A fix/restoration to a Core.aslx function only affects games saved (in the Editor) or newly created *after* the change lands. It cannot retroactively repair or break anything already inlined into a previously published `.quest` file.
+- Conversely, current Core.aslx bugs *do* matter for anyone editing or creating a game right now (before it's published) — the Editor loads library functions live and only inlines them on save/publish. So "restore this broken current-Core.aslx function" is a real, valid fix for the authoring experience — just describe it as that, not as a bug affecting already-shipped games.
+
 ## Git Workflow
 
 `main` is a protected branch (required status check `build_and_test`, required PR review, `enforce_admins` on) — direct pushes are rejected outright, including from repo admins. All changes, however small, go through a feature branch + PR.

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -29,8 +29,8 @@
         getScriptCommandCategories,
         getObjectNames,
         getExitNames,
-        getIfExpressionTemplates,
-        getIfExpressionTemplateData,
+        getExpressionTemplates,
+        getExpressionTemplateData,
         makeScriptEditable,
         getExpressionFunctions,
         addScriptListItem,
@@ -43,8 +43,8 @@
         ScriptNodeData,
         ScriptControlData,
         ScriptCategoryInfo,
-        IfExpressionTemplateData,
-        IfExpressionTemplate,
+        ExpressionTemplateData,
+        ExpressionTemplate,
         ExpressionFunctionInfo,
     } from "$lib/types";
 
@@ -86,7 +86,16 @@
     // names, so the picker can group game-authored functions ahead of library ones and the
     // parameter-list editor can look up a selected function's declared arity/param names.
     let functionInfos = $state<ExpressionFunctionInfo[]>([]);
-    let ifTemplates = $state<IfExpressionTemplate[]>([]);
+    // Expression templates ("insert a common expression" pickers), keyed by expressionType.
+    // "if" is synthesized by IfExpressionControlDefinition for if/else-if conditions; "set" and
+    // "foreach" come from <usetemplates> on ordinary "expression" controls (e.g. "Set variable"'s
+    // value, "for each"'s list) - see CoreEditorScriptsVariables.aslx / CoreEditorScriptsScripts.aslx.
+    const EXPRESSION_TEMPLATE_TYPES = ["if", "set", "foreach"];
+    let templatesByType = $state<Record<string, ExpressionTemplate[]>>({});
+
+    function templatesFor(expressionType: string | null | undefined): ExpressionTemplate[] {
+        return (expressionType && templatesByType[expressionType]) || [];
+    }
 
     // Load on mount and whenever scriptVersion bumps (undo/redo)
     $effect(() => {
@@ -114,9 +123,11 @@
             const infos = getExpressionFunctions().filter(f => f.isUserDefined);
             if (infos.length > 0) functionInfos = infos;
         }
-        if (ifTemplates.length === 0) {
-            const templates = getIfExpressionTemplates();
-            if (templates && templates.length > 0) ifTemplates = templates;
+        for (const type of EXPRESSION_TEMPLATE_TYPES) {
+            if (!(type in templatesByType)) {
+                const templates = getExpressionTemplates(type);
+                if (templates) templatesByType[type] = templates;
+            }
         }
     });
 
@@ -238,7 +249,7 @@
         onSetParam(scriptIndex, ctrl.attribute!, fromSimpleToExpression(simpleValue, ctrl.simpleEditor!));
     }
 
-    function buildTemplateExpression(tmpl: IfExpressionTemplateData, changedName: string, changedValue: string): string {
+    function buildTemplateExpression(tmpl: ExpressionTemplateData, changedName: string, changedValue: string): string {
         let result = tmpl.originalPattern;
         for (const ctrl of tmpl.controls) {
             const value = ctrl.name === changedName ? changedValue : (ctrl.value ?? "");
@@ -721,12 +732,13 @@
             {/if}
         {/if}
     {:else if ctrl.controlType === "expression"}
-        <ExpressionInput
-            value={ctrl.value ?? ""}
-            onchange={(v) => onSetParam(scriptIndex, ctrl.attribute!, v)}
-            {objectNames}
-            class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
-        />
+        {@render expressionField(
+            ctrl.value ?? "",
+            (v) => onSetParam(scriptIndex, ctrl.attribute!, v),
+            ctrl.useTemplates ?? null,
+            exprKey(scriptIndex, ctrl.attribute!),
+            "input text-xs py-0 px-1 min-w-16 max-w-48 flex-1",
+        )}
     {:else if ctrl.controlType === "textbox" && ctrl.isFunctionPicker}
         {@const functionOptions = functionPickerOptions()}
         <Combobox
@@ -817,75 +829,86 @@
     {/if}
 {/snippet}
 
+{#snippet expressionField(
+    value: string,
+    onchange: (v: string) => void,
+    expressionType: string | null,
+    overrideKey: string,
+    inputClass: string,
+)}
+    {@const templates = templatesFor(expressionType)}
+    {@const tmplData = expressionType && templates.length > 0 ? getExpressionTemplateData(value, expressionType) : null}
+    {@const inTemplateMode = tmplData !== null && !expressionOverrides.has(overrideKey)}
+    {#if templates.length > 0}
+        <!-- Template / expression mode toggle -->
+        <select
+            class="select text-xs py-0 px-1 max-w-40"
+            value={inTemplateMode ? tmplData!.templateName : "expression"}
+            onchange={(e) => {
+                const v = (e.target as HTMLSelectElement).value;
+                if (v === "expression") {
+                    expressionOverrides.add(overrideKey);
+                } else {
+                    expressionOverrides.delete(overrideKey);
+                    const tpl = templates.find(t => t.name === v);
+                    if (tpl) onchange(tpl.createExpression);
+                }
+            }}
+        >
+            <option value="expression">expression</option>
+            {#each templates as tpl (tpl.name)}
+                <option value={tpl.name}>{tpl.name}</option>
+            {/each}
+        </select>
+    {/if}
+    {#if inTemplateMode && tmplData}
+        <!-- Template controls (e.g. object picker for Got(#object#)) -->
+        {#each tmplData.controls as ctrl (ctrl.name)}
+            {#if ctrl.simpleEditor === "objects"}
+                <select
+                    class="select text-xs py-0 px-1 max-w-40"
+                    value={ctrl.value ?? ""}
+                    onchange={(e) => {
+                        const newVal = (e.target as HTMLSelectElement).value;
+                        onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                    }}
+                >
+                    <option value=""></option>
+                    {#each objectNames as name (name)}
+                        <option value={name}>{name}</option>
+                    {/each}
+                </select>
+            {:else}
+                <input
+                    type="text"
+                    autocapitalize="off"
+                    class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
+                    placeholder={ctrl.simpleLabel ?? ctrl.name}
+                    value={ctrl.value ?? ""}
+                    onchange={(e) => {
+                        const newVal = (e.target as HTMLInputElement).value;
+                        onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                    }}
+                />
+            {/if}
+        {/each}
+    {:else}
+        <ExpressionInput {value} {onchange} {objectNames} class={inputClass} />
+    {/if}
+{/snippet}
+
 {#snippet ifBlock(script: ScriptNodeData, i: number)}
-    {@const tmplData = getIfExpressionTemplateData(script.expression ?? "")}
-    {@const exprKey = `if/${i}`}
-    {@const inTemplateMode = tmplData !== null && !expressionOverrides.has(exprKey)}
     <div class="px-2 py-1 pr-16 text-xs">
         <!-- If condition -->
         <div class="flex items-center gap-1 flex-wrap">
             <span class="text-surface-600-400 font-medium select-none">if</span>
-            {#if ifTemplates.length > 0}
-                <!-- Template / expression mode toggle -->
-                <select
-                    class="select text-xs py-0 px-1 max-w-40"
-                    value={inTemplateMode ? tmplData!.templateName : "expression"}
-                    onchange={(e) => {
-                        const v = (e.target as HTMLSelectElement).value;
-                        if (v === "expression") {
-                            expressionOverrides.add(exprKey);
-                        } else {
-                            expressionOverrides.delete(exprKey);
-                            const tpl = ifTemplates.find(t => t.name === v);
-                            if (tpl) onSetIfExpr(i, tpl.createExpression);
-                        }
-                    }}
-                >
-                    <option value="expression">expression</option>
-                    {#each ifTemplates as tpl (tpl.name)}
-                        <option value={tpl.name}>{tpl.name}</option>
-                    {/each}
-                </select>
-            {/if}
-            {#if inTemplateMode && tmplData}
-                <!-- Template controls (e.g. object picker for Got(#object#)) -->
-                {#each tmplData.controls as ctrl (ctrl.name)}
-                    {#if ctrl.simpleEditor === "objects"}
-                        <select
-                            class="select text-xs py-0 px-1 max-w-40"
-                            value={ctrl.value ?? ""}
-                            onchange={(e) => {
-                                const newVal = (e.target as HTMLSelectElement).value;
-                                onSetIfExpr(i, buildTemplateExpression(tmplData!, ctrl.name, newVal));
-                            }}
-                        >
-                            <option value=""></option>
-                            {#each objectNames as name (name)}
-                                <option value={name}>{name}</option>
-                            {/each}
-                        </select>
-                    {:else}
-                        <input
-                            type="text"
-                            autocapitalize="off"
-                            class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
-                            placeholder={ctrl.simpleLabel ?? ctrl.name}
-                            value={ctrl.value ?? ""}
-                            onchange={(e) => {
-                                const newVal = (e.target as HTMLInputElement).value;
-                                onSetIfExpr(i, buildTemplateExpression(tmplData!, ctrl.name, newVal));
-                            }}
-                        />
-                    {/if}
-                {/each}
-            {:else}
-                <ExpressionInput
-                    value={script.expression ?? ""}
-                    onchange={(v) => onSetIfExpr(i, v)}
-                    {objectNames}
-                    class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
-                />
-            {/if}
+            {@render expressionField(
+                script.expression ?? "",
+                (v) => onSetIfExpr(i, v),
+                "if",
+                `if/${i}`,
+                "input text-xs py-0 px-1 min-w-24 max-w-64 flex-1",
+            )}
             <span class="text-surface-600-400 select-none">then</span>
         </div>
 
@@ -902,70 +925,15 @@
 
         <!-- Else-if blocks -->
         {#each script.elseIfClauses ?? [] as elseIf, ei (elseIf.id)}
-            {@const eiTmplData = getIfExpressionTemplateData(elseIf.expression ?? "")}
-            {@const eiExprKey = `elseif/${i}/${ei}`}
-            {@const eiInTemplateMode = eiTmplData !== null && !expressionOverrides.has(eiExprKey)}
             <div class="mt-1 flex items-center gap-1 flex-wrap">
                 <span class="text-surface-600-400 font-medium select-none">else if</span>
-                {#if ifTemplates.length > 0}
-                    <select
-                        class="select text-xs py-0 px-1 max-w-40"
-                        value={eiInTemplateMode ? eiTmplData!.templateName : "expression"}
-                        onchange={(e) => {
-                            const v = (e.target as HTMLSelectElement).value;
-                            if (v === "expression") {
-                                expressionOverrides.add(eiExprKey);
-                            } else {
-                                expressionOverrides.delete(eiExprKey);
-                                const tpl = ifTemplates.find(t => t.name === v);
-                                if (tpl) onSetElseIfExpr(i, ei, tpl.createExpression);
-                            }
-                        }}
-                    >
-                        <option value="expression">expression</option>
-                        {#each ifTemplates as tpl (tpl.name)}
-                            <option value={tpl.name}>{tpl.name}</option>
-                        {/each}
-                    </select>
-                {/if}
-                {#if eiInTemplateMode && eiTmplData}
-                    {#each eiTmplData.controls as ctrl (ctrl.name)}
-                        {#if ctrl.simpleEditor === "objects"}
-                            <select
-                                class="select text-xs py-0 px-1 max-w-40"
-                                value={ctrl.value ?? ""}
-                                onchange={(e) => {
-                                    const newVal = (e.target as HTMLSelectElement).value;
-                                    onSetElseIfExpr(i, ei, buildTemplateExpression(eiTmplData!, ctrl.name, newVal));
-                                }}
-                            >
-                                <option value=""></option>
-                                {#each objectNames as name (name)}
-                                    <option value={name}>{name}</option>
-                                {/each}
-                            </select>
-                        {:else}
-                            <input
-                                type="text"
-                                autocapitalize="off"
-                                class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
-                                placeholder={ctrl.simpleLabel ?? ctrl.name}
-                                value={ctrl.value ?? ""}
-                                onchange={(e) => {
-                                    const newVal = (e.target as HTMLInputElement).value;
-                                    onSetElseIfExpr(i, ei, buildTemplateExpression(eiTmplData!, ctrl.name, newVal));
-                                }}
-                            />
-                        {/if}
-                    {/each}
-                {:else}
-                    <ExpressionInput
-                        value={elseIf.expression ?? ""}
-                        onchange={(v) => onSetElseIfExpr(i, ei, v)}
-                        {objectNames}
-                        class="input text-xs py-0 px-1 min-w-24 max-w-64 flex-1"
-                    />
-                {/if}
+                {@render expressionField(
+                    elseIf.expression ?? "",
+                    (v) => onSetElseIfExpr(i, ei, v),
+                    "if",
+                    `elseif/${i}/${ei}`,
+                    "input text-xs py-0 px-1 min-w-24 max-w-64 flex-1",
+                )}
                 <span class="text-surface-600-400 select-none">then</span>
                 <button
                     type="button"

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -9,7 +9,7 @@ import { ServerFileAdapter } from "./filesystem/server-adapter";
 import { triggerDownload } from "./filesystem/download";
 import { confirmDialog } from "./confirm";
 import { showToast } from "./toast";
-import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, IfExpressionTemplateData, IfExpressionTemplate, FullAttributeData, ExitsData, VerbInfo, ExpressionFunctionInfo } from "./types";
+import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, ExpressionTemplateData, ExpressionTemplate, FullAttributeData, ExitsData, VerbInfo, ExpressionFunctionInfo } from "./types";
 
 export type AddElementModalState = { type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
 
@@ -1078,17 +1078,17 @@ export function getExitNames(): string[] | null {
     } catch { return null; }
 }
 
-export function getIfExpressionTemplates(): IfExpressionTemplate[] | null {
+export function getExpressionTemplates(expressionType: string): ExpressionTemplate[] | null {
     if (!_bridge) return null;
     try {
-        return JSON.parse(_bridge.GetIfExpressionTemplates());
+        return JSON.parse(_bridge.GetExpressionTemplates(expressionType));
     } catch { return null; }
 }
 
-export function getIfExpressionTemplateData(expression: string): IfExpressionTemplateData | null {
+export function getExpressionTemplateData(expression: string, expressionType: string): ExpressionTemplateData | null {
     if (!_bridge) return null;
     try {
-        const json = _bridge.GetIfExpressionTemplateData(expression);
+        const json = _bridge.GetExpressionTemplateData(expression, expressionType);
         return json ? JSON.parse(json) : null;
     } catch { return null; }
 }

--- a/src/AppShell/src/lib/home-catalog.ts
+++ b/src/AppShell/src/lib/home-catalog.ts
@@ -76,8 +76,8 @@ const API_ROOT = "https://textadventures.co.uk/api";
 
 // The highest ASL version this build's WasmPlayer can load — must track the
 // `Versions` dictionary in src/Engine/GameLoader/GameLoader.cs (currently maxing
-// out at 580); bump this alongside any Engine change that adds a new version.
-const MAX_ASL_VERSION = 580;
+// out at 600); bump this alongside any Engine change that adds a new version.
+const MAX_ASL_VERSION = 600;
 
 // Attached to catalog/details requests as analytics metadata (see ClientInfo
 // on textadventures.co.uk's ApiController). source/platform are free strings,

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -113,6 +113,10 @@ export interface ScriptControlData {
   objectType?: string | null
   isFunctionPicker?: boolean
   isFunctionParams?: boolean
+  // The expressionType (e.g. "set", "foreach") this control's <usetemplates> declares - see
+  // ExpressionField.svelte, which renders a template picker instead of a plain ExpressionInput
+  // when this is set and templates exist for that type.
+  useTemplates?: string | null
 }
 
 export interface ElseIfClauseData {
@@ -162,13 +166,13 @@ export interface ExpressionTemplateControlData {
   options: ControlOption[] | null
 }
 
-export interface IfExpressionTemplateData {
+export interface ExpressionTemplateData {
   templateName: string
   originalPattern: string
   controls: ExpressionTemplateControlData[]
 }
 
-export interface IfExpressionTemplate {
+export interface ExpressionTemplate {
   name: string
   createExpression: string
 }

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -43,8 +43,8 @@ export interface WasmBridge {
   GetScriptCommandCategories(): Promise<string>
   GetObjectNames(): string
   GetExitNames(): string
-  GetIfExpressionTemplates(): string
-  GetIfExpressionTemplateData(expression: string): string | null
+  GetExpressionTemplates(expressionType: string): string
+  GetExpressionTemplateData(expression: string, expressionType: string): string | null
   // List editor API
   AddListItem(elementKey: string, attribute: string, value: string): string
   RemoveListItem(elementKey: string, attribute: string, key: string): string

--- a/src/Engine/Core/CoreEditorExpressions.aslx
+++ b/src/Engine/Core/CoreEditorExpressions.aslx
@@ -416,7 +416,20 @@
       <caption>[EditorExpressionsofthetime]</caption>
     </control>
   </editor>
-  
+
+  <editor>
+    <pattern>Ask(#question#)</pattern>
+    <create>Ask("")</create>
+    <description>[EditorExpressionsplayeranswersquestion]</description>
+    <expressiontype>if</expressiontype>
+
+    <control>
+      <controltype>expression</controltype>
+      <simple>question</simple>
+      <attribute>question</attribute>
+    </control>
+  </editor>
+
   <!-- Templates for "set" -->
 
   <editor>
@@ -424,6 +437,39 @@
     <create>NewStringList()</create>
     <description>[EditorExpressionsnewstringlist]</description>
     <expressiontype>set</expressiontype>
+  </editor>
+
+  <editor>
+    <pattern>GetInput()</pattern>
+    <create>GetInput()</create>
+    <description>[EditorExpressionsgetplayerinput]</description>
+    <expressiontype>set</expressiontype>
+  </editor>
+
+  <editor>
+    <pattern><![CDATA[ShowMenu(#caption#,#options#,#allowcancel#)]]></pattern>
+    <create><![CDATA[ShowMenu("", NewStringList(), false)]]></create>
+    <description>[EditorExpressionsplayerchoosesfrommenu]</description>
+    <expressiontype>set</expressiontype>
+
+    <control>
+      <controltype>expression</controltype>
+      <simple>caption</simple>
+      <attribute>caption</attribute>
+    </control>
+
+    <control>
+      <controltype>expression</controltype>
+      <simple>options</simple>
+      <attribute>options</attribute>
+    </control>
+
+    <control>
+      <controltype>expression</controltype>
+      <simple>allow cancel</simple>
+      <simpleeditor>boolean</simpleeditor>
+      <attribute>allowcancel</attribute>
+    </control>
   </editor>
 
   <editor>

--- a/src/Engine/Core/CoreEditorScriptsOutput.aslx
+++ b/src/Engine/Core/CoreEditorScriptsOutput.aslx
@@ -472,10 +472,12 @@
  
  
  
-  <!-- synchronous wait function is deprecated, so can no longer be added, but still needs a friendly display for older games -->
   <editor>
     <appliesto>(function)WaitForKeyPress</appliesto>
     <display>Wait for key press</display>
+    <category>[EditorScriptsOutputOutput]</category>
+    <create>WaitForKeyPress</create>
+    <add>[EditorScriptsOutputWaitforkey]</add>
 
     <control>
       <controltype>label</controltype>
@@ -505,14 +507,6 @@
       <caption>[EditorScriptsOutputRunscript]</caption>
       <breakbefore/>
     </control>
-  </editor>
-
-  <editor>
-    <appliesto>requestwait</appliesto>
-    <display>Wait for key press</display>
-    <category>[EditorScriptsOutputOutput]</category>
-    <create>request (Wait, "")</create>
-    <add>[EditorScriptsOutputWaitforkey]</add>
   </editor>
 
   <editor>

--- a/src/Engine/Core/CoreEditorScriptsOutput.aslx
+++ b/src/Engine/Core/CoreEditorScriptsOutput.aslx
@@ -484,9 +484,11 @@
   </editor>
 
   <editor>
+    <!-- Removed from adder: superseded by the synchronous "request (Wait, "")" form
+         below, which doesn't need a nested callback block - the script just continues
+         on the next line once the key is pressed. Still fully editable if already present. -->
     <appliesto>wait</appliesto>
     <display>Wait for key press</display>
-    <category>[EditorScriptsOutputOutput]</category>
     <create>wait { }</create>
     <add>[EditorScriptsOutputWaitforkey]</add>
     <advanced/>
@@ -506,9 +508,20 @@
   </editor>
 
   <editor>
+    <appliesto>requestwait</appliesto>
+    <display>Wait for key press</display>
+    <category>[EditorScriptsOutputOutput]</category>
+    <create>request (Wait, "")</create>
+    <add>[EditorScriptsOutputWaitforkey]</add>
+  </editor>
+
+  <editor>
+    <!-- Removed from adder: superseded by the synchronous "GetInput()" expression form, now
+         reachable via the "set variable" value field's "player's typed input" template (see
+         CoreEditorExpressions.aslx and WasmEditorBridge.GetExpressionTemplates("set")). Still
+         fully editable if already present. -->
     <appliesto>get input</appliesto>
     <display>Get input</display>
-    <category>[EditorScriptsOutputOutput]</category>
     <create>get input { }</create>
     <add>[EditorScriptsOutputGetinput]</add>
     <advanced/>
@@ -527,9 +540,10 @@
   </editor>
 
   <editor>
+    <!-- Removed from adder: see "get input" above - the synchronous "GetInput()" form now has
+         a proper picker regardless of editor style. -->
     <appliesto>(function)GetInput</appliesto>
     <display>Get input</display>
-    <category>[EditorScriptsOutputOutput]</category>
     <create>GetInput () { }</create>
     <add>[EditorScriptsOutputGetinput]</add>
     <advanced/>
@@ -596,9 +610,12 @@
   </editor>
 
   <editor>
+    <!-- Removed from adder: superseded by the synchronous "ShowMenu(...)" expression form, now
+         reachable via the "set variable" value field's "player's choice from a menu" template
+         (see CoreEditorExpressions.aslx and WasmEditorBridge.GetExpressionTemplates("set")).
+         Still fully editable if already present. -->
     <appliesto>(function)ShowMenu</appliesto>
     <display>Show a menu</display>
-    <category>[EditorScriptsOutputOutput]</category>
     <create>ShowMenu ("",,true) { }</create>
     <add>[EditorScriptsOutputShowamenu]</add>
 
@@ -670,9 +687,12 @@
   </editor>
 
   <editor>
+    <!-- Removed from adder: unlike GetInput()/ShowMenu() (still addable above - see their
+         comments), the synchronous "Ask(...)" expression form already has a proper picker -
+         it's a CoreEditorExpressions.aslx "if condition" template, reachable today via the
+         if-condition builder's "insert template" UI. Still fully editable if already present. -->
     <appliesto>(function)Ask</appliesto>
     <display>Ask a question</display>
-    <category>[EditorScriptsOutputOutput]</category>
     <create>Ask ("") { }</create>
     <add>[EditorScriptsOutputAskaquestion]</add>
     <onlydisplayif>GetString(game, "_editorstyle") = null</onlydisplayif>

--- a/src/Engine/Core/CoreEditorScriptsOutput.aslx
+++ b/src/Engine/Core/CoreEditorScriptsOutput.aslx
@@ -604,12 +604,17 @@
   </editor>
 
   <editor>
-    <!-- Removed from adder: superseded by the synchronous "ShowMenu(...)" expression form, now
-         reachable via the "set variable" value field's "player's choice from a menu" template
-         (see CoreEditorExpressions.aslx and WasmEditorBridge.GetExpressionTemplates("set")).
-         Still fully editable if already present. -->
+    <!-- NOT superseded by the synchronous "ShowMenu(...)" expression form (reachable via the
+         "set variable" value field's "player's choice from a menu" template) - they render
+         differently, not just sync-vs-async. This "ShowMenu (...) { }" form calls the ASLX
+         ShowMenu function in CoreFunctions.aslx (the same one the parser's disambiguation
+         prompt uses), which prints numbered "cmdlink" hyperlinks inline in the transcript. The
+         expression form instead goes through ExpressionOwner.ShowMenu -> PlayerUi.ShowMenu,
+         a jQuery UI popup dialog - see docs/issue about modernising that popup. Kept addable so
+         authors can still reach the nicer inline-link rendering. -->
     <appliesto>(function)ShowMenu</appliesto>
     <display>Show a menu</display>
+    <category>[EditorScriptsOutputOutput]</category>
     <create>ShowMenu ("",,true) { }</create>
     <add>[EditorScriptsOutputShowamenu]</add>
 
@@ -681,12 +686,15 @@
   </editor>
 
   <editor>
-    <!-- Removed from adder: unlike GetInput()/ShowMenu() (still addable above - see their
-         comments), the synchronous "Ask(...)" expression form already has a proper picker -
-         it's a CoreEditorExpressions.aslx "if condition" template, reachable today via the
-         if-condition builder's "insert template" UI. Still fully editable if already present. -->
+    <!-- NOT superseded by the synchronous "Ask(...)" expression form (reachable via the
+         if-condition builder's "player answers a yes/no question" template) - same reasoning as
+         ShowMenu above (Ask's CoreFunctions.aslx implementation just calls ShowMenu internally
+         with Yes/No options): this "Ask (...) { }" form renders inline cmdlinks, the expression
+         form pops a jQuery UI dialog via ExpressionOwner.Ask -> PlayerUi.ShowQuestion. Kept
+         addable for the nicer inline rendering. -->
     <appliesto>(function)Ask</appliesto>
     <display>Ask a question</display>
+    <category>[EditorScriptsOutputOutput]</category>
     <create>Ask ("") { }</create>
     <add>[EditorScriptsOutputAskaquestion]</add>
     <onlydisplayif>GetString(game, "_editorstyle") = null</onlydisplayif>

--- a/src/Engine/Core/CoreEditorScriptsTimers.aslx
+++ b/src/Engine/Core/CoreEditorScriptsTimers.aslx
@@ -193,10 +193,12 @@
     </control>
   </editor>
 
-  <!-- deprecated -->
   <editor>
     <appliesto>(function)Pause</appliesto>
     <display>Pause for #0 seconds</display>
+    <category>[EditorScriptsTimersTimers]</category>
+    <create>Pause (1)</create>
+    <add>[EditorScriptsTimersPausethegame]</add>
 
     <control>
       <controltype>label</controltype>

--- a/src/Engine/Core/CoreOutput.aslx
+++ b/src/Engine/Core/CoreOutput.aslx
@@ -847,6 +847,10 @@
     JS.AddVimeo(id)
   </function>
 
+  <function name="WaitForKeyPress">
+    request (Wait, "")
+  </function>
+
   <function name="DisplayHttpLink" parameters="text, url, https">
     <![CDATA[
     pos = Instr(url, "://")

--- a/src/Engine/Core/CoreTimers.aslx
+++ b/src/Engine/Core/CoreTimers.aslx
@@ -47,7 +47,7 @@
   </function>
 
   <function name="Pause" parameters="interval">
-    error("The Pause function is obsolete as of Quest 5.5")
+    request (Pause, ToString(interval * 1000))
   </function>
   
 </library>

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -694,6 +694,7 @@
   <template name="EditorScriptsTimersRunscriptafterName">Skript nach angegebenen Sekunden starten (mit Namen)</template>    
   <template name="EditorScriptsTimersName">Name</template>
   <template name="EditorScriptsTimersPausefor">Pause für</template>
+  <template name="EditorScriptsTimersPausethegame">Das Spiel pausieren</template>
   <template name="EditorScriptsTimersCreateatimer">Erstelle einen Timer</template>
   <template name="EditorScriptsTimersCreatetimer">Erstelle Timer</template>
   <template name="EditorScriptsTurnScriptsTurnScripts">Turn-Skripte</template>
@@ -793,11 +794,14 @@
   <template name="EditorExpressionsobjecthasattribute">Objekt besitzt Attribut</template>
   <template name="EditorExpressionsobjectattribute">Objektattributvergleich</template>
   <template name="EditorExpressionsrandomchance">Zufallsereignis</template>
+  <template name="EditorExpressionsplayeranswersquestion">Spieler beantwortet eine Ja/Nein-Frage</template>
   <template name="EditorExpressionsnewstringlist">Neue Stringliste</template>
   <template name="EditorExpressionsnewobjectlist">Neue Objektliste</template>
   <template name="EditorExpressionsnewstringdictionary">Neues String-Wörterbuch</template>
   <template name="EditorExpressionsnewobjectdictionary">Neues Objekt-Wörterbuch</template>
   <template name="EditorExpressionsrandomnumber">Zufallszahl</template>
+  <template name="EditorExpressionsgetplayerinput">die Eingabe des Spielers</template>
+  <template name="EditorExpressionsplayerchoosesfrommenu">die Auswahl des Spielers aus einem Menü</template>
   <template name="EditorExpressionsallobjects">Alle Objekte</template>
   <template name="EditorExpressionsallvisible">Alle sichtbaren Objekte</template>
   <template name="EditorExpressionstheinventory">Das Inventar</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -697,6 +697,7 @@
   <template name="EditorScriptsTimersRunscriptafterName">Run script after a number of seconds (with name)</template>    
   <template name="EditorScriptsTimersName">Name:</template>
   <template name="EditorScriptsTimersPausefor">Pause for</template>
+  <template name="EditorScriptsTimersPausethegame">Pause the game</template>
   <template name="EditorScriptsTimersCreateatimer">Create a timer</template>
   <template name="EditorScriptsTimersCreatetimer">Create timer</template>
   <template name="EditorScriptsTurnScriptsTurnScripts">Turn Scripts</template>
@@ -796,11 +797,14 @@
   <template name="EditorExpressionsobjecthasattribute">object has attribute</template>
   <template name="EditorExpressionsobjectattribute">object attribute equals</template>
   <template name="EditorExpressionsrandomchance">random chance</template>
+  <template name="EditorExpressionsplayeranswersquestion">player answers a yes/no question</template>
   <template name="EditorExpressionsnewstringlist">new string list</template>
   <template name="EditorExpressionsnewobjectlist">new object list</template>
   <template name="EditorExpressionsnewstringdictionary">new string dictionary</template>
   <template name="EditorExpressionsnewobjectdictionary">new object dictionary</template>
   <template name="EditorExpressionsrandomnumber">random number</template>
+  <template name="EditorExpressionsgetplayerinput">player's typed input</template>
+  <template name="EditorExpressionsplayerchoosesfrommenu">player's choice from a menu</template>
   <template name="EditorExpressionsallobjects">all objects</template>
   <template name="EditorExpressionsallvisible">all visible objects</template>
   <template name="EditorExpressionstheinventory">the inventory</template>

--- a/src/Engine/Core/Languages/EditorEspanol.aslx
+++ b/src/Engine/Core/Languages/EditorEspanol.aslx
@@ -633,6 +633,7 @@
   <template name="EditorScriptsTimersRunscriptafterName">Ejecutar progrma después de un número de segundos (con nombre)</template>    
   <template name="EditorScriptsTimersName">Nombre:</template>
   <template name="EditorScriptsTimersPausefor">Pausar por</template>
+  <template name="EditorScriptsTimersPausethegame">Pausar el juego</template>
   <template name="EditorScriptsTimersCreateatimer">Crear un temporizador</template>
   <template name="EditorScriptsTimersCreatetimer">Crear temporizador</template>
   <template name="EditorScriptsTurnScriptsTurnScripts">Programas por turno</template>
@@ -733,11 +734,14 @@
   <template name="EditorExpressionsobjecthasattribute">el objeto tiene el atributo</template>
   <template name="EditorExpressionsobjectattribute">el atributo del objeto es igual a</template>
   <template name="EditorExpressionsrandomchance">al azar</template>
+  <template name="EditorExpressionsplayeranswersquestion">el jugador responde a una pregunta de sí/no</template>
   <template name="EditorExpressionsnewstringlist">nueva lista de textos</template>
   <template name="EditorExpressionsnewobjectlist">nueva lista de objetos</template>
   <template name="EditorExpressionsnewstringdictionary">nuevo diccionario de textos</template>
   <template name="EditorExpressionsnewobjectdictionary">nuevo diccionario de objetos</template>
   <template name="EditorExpressionsrandomnumber">número aleatorio</template>
+  <template name="EditorExpressionsgetplayerinput">el texto escrito por el jugador</template>
+  <template name="EditorExpressionsplayerchoosesfrommenu">la opción elegida por el jugador en un menú</template>
   <template name="EditorExpressionsallobjects">todos los objetos</template>
   <template name="EditorExpressionsallvisible">todos los objetos visibles</template>
   <template name="EditorExpressionstheinventory">el inventario</template>

--- a/src/Engine/Core/Templates/Dansk.template
+++ b/src/Engine/Core/Templates/Dansk.template
@@ -1,4 +1,4 @@
-﻿<asl version="580">
+﻿<asl version="600">
 
   <include ref="Dansk.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Deutsch.template
+++ b/src/Engine/Core/Templates/Deutsch.template
@@ -1,4 +1,4 @@
-﻿<asl version="580">
+﻿<asl version="600">
 
   <include ref="Deutsch.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/English.template
+++ b/src/Engine/Core/Templates/English.template
@@ -1,4 +1,4 @@
-﻿<asl version="580">
+﻿<asl version="600">
 
   <include ref="English.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Espanol.template
+++ b/src/Engine/Core/Templates/Espanol.template
@@ -1,4 +1,4 @@
-﻿<asl version="580" template="Español">
+﻿<asl version="600" template="Español">
 
   <include ref="Espanol.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Esperanto.template
+++ b/src/Engine/Core/Templates/Esperanto.template
@@ -1,4 +1,4 @@
-<asl version="580">
+<asl version="600">
 
   <include ref="Esperanto.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Francais.template
+++ b/src/Engine/Core/Templates/Francais.template
@@ -1,4 +1,4 @@
-﻿<asl version="580" template="Français">
+﻿<asl version="600" template="Français">
 
   <include ref="Francais.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Gamebook.template
+++ b/src/Engine/Core/Templates/Gamebook.template
@@ -1,4 +1,4 @@
-﻿<asl version="580" templatetype="gamebook">
+﻿<asl version="600" templatetype="gamebook">
 
   <include ref="GamebookCore.aslx"/>
 

--- a/src/Engine/Core/Templates/Greek.template
+++ b/src/Engine/Core/Templates/Greek.template
@@ -1,4 +1,4 @@
-﻿<asl version="580" template="Greek">
+﻿<asl version="600" template="Greek">
 
   <include ref="Greek.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Icelandic.template
+++ b/src/Engine/Core/Templates/Icelandic.template
@@ -1,4 +1,4 @@
-﻿<asl version="580">
+﻿<asl version="600">
 
   <include ref="Icelandic.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Italiano.template
+++ b/src/Engine/Core/Templates/Italiano.template
@@ -1,4 +1,4 @@
-﻿<asl version="580" template="Italiano">
+﻿<asl version="600" template="Italiano">
 
   <include ref="Italiano.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Nederlands.template
+++ b/src/Engine/Core/Templates/Nederlands.template
@@ -1,4 +1,4 @@
-﻿<asl version="580">
+﻿<asl version="600">
 
   <include ref="Nederlands.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Norsk.template
+++ b/src/Engine/Core/Templates/Norsk.template
@@ -1,4 +1,4 @@
-﻿<asl version="580">
+﻿<asl version="600">
 
   <include ref="Norsk.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Portugues-Portugal.template
+++ b/src/Engine/Core/Templates/Portugues-Portugal.template
@@ -1,4 +1,4 @@
-<asl version="580" template="Português (Portugal)">
+<asl version="600" template="Português (Portugal)">
 
   <include ref="Portugues-Portugal.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Portugues.template
+++ b/src/Engine/Core/Templates/Portugues.template
@@ -1,4 +1,4 @@
-<asl version="580" template="Português (Brasil)">
+<asl version="600" template="Português (Brasil)">
 
   <include ref="Portugues.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Romana.template
+++ b/src/Engine/Core/Templates/Romana.template
@@ -1,4 +1,4 @@
-﻿<asl version="580" template="Română">
+﻿<asl version="600" template="Română">
 
   <include ref="Romana.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Core/Templates/Russian.template
+++ b/src/Engine/Core/Templates/Russian.template
@@ -1,4 +1,4 @@
-<asl version="580" template="Русский">
+<asl version="600" template="Русский">
 
   <include ref="Russian.aslx"/>
   <include ref="Core.aslx"/>

--- a/src/Engine/Enums.cs
+++ b/src/Engine/Enums.cs
@@ -22,5 +22,6 @@ public enum WorldModelVersion
     v530,
     v540,
     v550,
-    v580
+    v580,
+    v600
 }

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -498,7 +498,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         if (worldModel.Version >= WorldModelVersion.v540 && worldModel.Version < WorldModelVersion.v600)
         {
             throw new Exception(
-                "The 'ShowMenu' function is not supported for games written for Quest 5.4 or later. Use the 'show menu' script command instead, or set the game's WorldModel version to 600 or later.");
+                "The 'ShowMenu' function is not supported for games with WorldModel version 540–580. Use the 'show menu' script command instead, or set the game's WorldModel version to 600 or later.");
         }
 
         await worldModel.PrintAsync(caption);
@@ -592,7 +592,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         if (worldModel.Version >= WorldModelVersion.v540 && worldModel.Version < WorldModelVersion.v600)
         {
             throw new Exception(
-                "The 'GetInput' function is not supported for games written for Quest 5.4 or later. Use the 'get input' script command instead, or set the game's WorldModel version to 600 or later.");
+                "The 'GetInput' function is not supported for games with WorldModel version 540–580. Use the 'get input' script command instead, or set the game's WorldModel version to 600 or later.");
         }
 
         worldModel._commandOverride = true;
@@ -649,7 +649,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         if (worldModel.Version >= WorldModelVersion.v540 && worldModel.Version < WorldModelVersion.v600)
         {
             throw new Exception(
-                "The 'Ask' function is not supported for games written for Quest 5.4 or later. Use the 'ask' script command instead, or set the game's WorldModel version to 600 or later.");
+                "The 'Ask' function is not supported for games with WorldModel version 540–580. Use the 'ask' script command instead, or set the game's WorldModel version to 600 or later.");
         }
 
         worldModel.PlayerUi.ShowQuestion(caption);

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -494,6 +494,13 @@ internal class ExpressionOwner(WorldModel worldModel)
     {
         ArgumentNullException.ThrowIfNull(caption);
         ArgumentNullException.ThrowIfNull(options);
+
+        if (worldModel.Version >= WorldModelVersion.v540 && worldModel.Version < WorldModelVersion.v600)
+        {
+            throw new Exception(
+                "The 'ShowMenu' function is not supported for games written for Quest 5.4 or later. Use the 'show menu' script command instead, or set the game's WorldModel version to 600 or later.");
+        }
+
         await worldModel.PrintAsync(caption);
         var menuData = new MenuData(caption, options, allowCancel);
         worldModel.PlayerUi.ShowMenu(menuData);
@@ -582,6 +589,12 @@ internal class ExpressionOwner(WorldModel worldModel)
 
     public async Task<string> GetInput()
     {
+        if (worldModel.Version >= WorldModelVersion.v540 && worldModel.Version < WorldModelVersion.v600)
+        {
+            throw new Exception(
+                "The 'GetInput' function is not supported for games written for Quest 5.4 or later. Use the 'get input' script command instead, or set the game's WorldModel version to 600 or later.");
+        }
+
         worldModel._commandOverride = true;
         var tcs = WorldModel.BeginPrompt(ref worldModel._commandInputTcs);
         worldModel.BeginPendingCallback();
@@ -632,6 +645,13 @@ internal class ExpressionOwner(WorldModel worldModel)
     public async Task<bool> Ask(string? caption)
     {
         ArgumentNullException.ThrowIfNull(caption);
+
+        if (worldModel.Version >= WorldModelVersion.v540 && worldModel.Version < WorldModelVersion.v600)
+        {
+            throw new Exception(
+                "The 'Ask' function is not supported for games written for Quest 5.4 or later. Use the 'ask' script command instead, or set the game's WorldModel version to 600 or later.");
+        }
+
         worldModel.PlayerUi.ShowQuestion(caption);
         var tcs = WorldModel.BeginPrompt(ref worldModel._questionTcs);
         worldModel.BeginPendingCallback();

--- a/src/Engine/GameLoader/GameLoader.cs
+++ b/src/Engine/GameLoader/GameLoader.cs
@@ -22,7 +22,8 @@ internal partial class GameLoader
         {"530", WorldModelVersion.v530},
         {"540", WorldModelVersion.v540},
         {"550", WorldModelVersion.v550},
-        {"580", WorldModelVersion.v580}
+        {"580", WorldModelVersion.v580},
+        {"600", WorldModelVersion.v600}
     };
 
     private readonly Stack<FileData> _currentFile = new();

--- a/src/Engine/GameLoader/GameSaver.cs
+++ b/src/Engine/GameLoader/GameSaver.cs
@@ -83,8 +83,8 @@ internal partial class GameSaver
         writer.WriteStartElement("asl");
         if (mode == SaveMode.Editor)
         {
-            _worldModel.Version = WorldModelVersion.v580;
-            _worldModel.VersionString = "580";
+            _worldModel.Version = WorldModelVersion.v600;
+            _worldModel.VersionString = "600";
         }
 
         writer.WriteAttributeString("version", _worldModel.VersionString);

--- a/src/Engine/Scripts/InsertScript.cs
+++ b/src/Engine/Scripts/InsertScript.cs
@@ -43,7 +43,7 @@ public class InsertScript : ScriptBase
         if (m_worldModel.Version >= WorldModelVersion.v540)
         {
             throw new Exception(
-                "The 'insert' script command is not supported for games written for Quest 5.4 or later. You can output HTML directly using the 'msg' command instead.");
+                "The 'insert' script command is not supported for games with WorldModel version 540 or later. You can output HTML directly using the 'msg' command instead.");
         }
 
         var filename = await m_filename.ExecuteAsync(c);

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -177,10 +177,10 @@ public class RequestScript : ScriptBase
                 m_worldModel.PlayerUi.SetStatusText(data.Replace("\n", Environment.NewLine));
                 break;
             case Request.Pause:
-                if (m_worldModel.Version >= WorldModelVersion.v550)
+                if (m_worldModel.Version >= WorldModelVersion.v550 && m_worldModel.Version < WorldModelVersion.v600)
                 {
                     throw new Exception(
-                        "The 'Pause' request is not supported for games written for Quest 5.5 or later. Use the 'SetTimeout' function instead.");
+                        "The 'Pause' request is not supported for games written for Quest 5.5 or later. Use the 'SetTimeout' function instead, or set the game's WorldModel version to 600 or later.");
                 }
 
                 int ms;
@@ -191,10 +191,10 @@ public class RequestScript : ScriptBase
 
                 break;
             case Request.Wait:
-                if (m_worldModel.Version >= WorldModelVersion.v540)
+                if (m_worldModel.Version >= WorldModelVersion.v540 && m_worldModel.Version < WorldModelVersion.v600)
                 {
                     throw new Exception(
-                        "The 'Wait' request is not supported for games written for Quest 5.4 or later. Use the 'wait' script command instead.");
+                        "The 'Wait' request is not supported for games written for Quest 5.4 or later. Use the 'wait' script command instead, or set the game's WorldModel version to 600 or later.");
                 }
 
                 await m_worldModel.DoWaitAsync();

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -145,7 +145,7 @@ public class RequestScript : ScriptBase
                 if (m_worldModel.Version >= WorldModelVersion.v540)
                 {
                     throw new InvalidOperationException(
-                        "FontName request is not supported for games written for Quest 5.4 or later.");
+                        "FontName request is not supported for games with WorldModel version 540 or later.");
                 }
 
                 m_worldModel.PlayerUi.SetFont(data);
@@ -155,7 +155,7 @@ public class RequestScript : ScriptBase
                 if (m_worldModel.Version >= WorldModelVersion.v540)
                 {
                     throw new InvalidOperationException(
-                        "FontSize request is not supported for games written for Quest 5.4 or later.");
+                        "FontSize request is not supported for games with WorldModel version 540 or later.");
                 }
 
                 m_worldModel.PlayerUi.SetFontSize(data);
@@ -180,7 +180,7 @@ public class RequestScript : ScriptBase
                 if (m_worldModel.Version >= WorldModelVersion.v550 && m_worldModel.Version < WorldModelVersion.v600)
                 {
                     throw new Exception(
-                        "The 'Pause' request is not supported for games written for Quest 5.5 or later. Use the 'SetTimeout' function instead, or set the game's WorldModel version to 600 or later.");
+                        "The 'Pause' request is not supported for games with WorldModel version 550–580. Use the 'SetTimeout' function instead, or set the game's WorldModel version to 600 or later.");
                 }
 
                 int ms;
@@ -194,7 +194,7 @@ public class RequestScript : ScriptBase
                 if (m_worldModel.Version >= WorldModelVersion.v540 && m_worldModel.Version < WorldModelVersion.v600)
                 {
                     throw new Exception(
-                        "The 'Wait' request is not supported for games written for Quest 5.4 or later. Use the 'wait' script command instead, or set the game's WorldModel version to 600 or later.");
+                        "The 'Wait' request is not supported for games with WorldModel version 540–580. Use the 'wait' script command instead, or set the game's WorldModel version to 600 or later.");
                 }
 
                 await m_worldModel.DoWaitAsync();

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -71,7 +71,14 @@ internal record ScriptControlData(
     List<ScriptNodeData>? Scripts,
     string? ObjectType = null,
     bool IsFunctionPicker = false,
-    bool IsFunctionParams = false
+    bool IsFunctionParams = false,
+    // The expressionType (e.g. "set", "foreach") this control's <usetemplates> declares - see
+    // CoreEditorScriptsVariables.aslx's "=" value control and CoreEditorScriptsScripts.aslx's
+    // "foreach" list control. Null for the vast majority of "expression" controls, which have no
+    // template picker (e.g. msg's text, MoveObject's destination). "if" conditions are a special
+    // case (ScriptNodeData.Expression, not a Controls entry) but use the same "if" expressionType
+    // and the same frontend picker, via IfExpressionControlDefinition.
+    string? UseTemplates = null
 );
 
 internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
@@ -103,13 +110,13 @@ internal record ExpressionTemplateControlData(
     List<ControlOption>? Options
 );
 
-internal record IfExpressionTemplateData(
+internal record ExpressionTemplateData(
     string TemplateName,
     string OriginalPattern,
     List<ExpressionTemplateControlData> Controls
 );
 
-internal record IfExpressionTemplate(string Name, string CreateExpression);
+internal record ExpressionTemplate(string Name, string CreateExpression);
 
 internal record ListItemData(string Key, string Value);
 
@@ -151,8 +158,8 @@ internal record ExpressionFunctionData(string Name, List<string> Parameters, boo
 [JsonSerializable(typeof(ScriptBlockData))]
 [JsonSerializable(typeof(ScriptCommandCategoriesData))]
 [JsonSerializable(typeof(List<string>))]
-[JsonSerializable(typeof(List<IfExpressionTemplate>))]
-[JsonSerializable(typeof(IfExpressionTemplateData))]
+[JsonSerializable(typeof(List<ExpressionTemplate>))]
+[JsonSerializable(typeof(ExpressionTemplateData))]
 [JsonSerializable(typeof(int[]))]
 [JsonSerializable(typeof(List<ListItemData>))]
 [JsonSerializable(typeof(FullAttributeData))]
@@ -1853,28 +1860,28 @@ public partial class WasmEditorBridge
     }
 
     [JSExport]
-    public static string GetIfExpressionTemplates()
+    public static string GetExpressionTemplates(string expressionType)
     {
         if (_controller == null)
         {
             return "[]";
         }
 
-        var templates = _controller.GetExpressionEditorNames("if")
-            .Select(name => new IfExpressionTemplate(name, _controller.GetNewExpression(name)))
+        var templates = _controller.GetExpressionEditorNames(expressionType)
+            .Select(name => new ExpressionTemplate(name, _controller.GetNewExpression(name)))
             .ToList();
-        return JsonSerializer.Serialize(templates, WasmEditorJsonContext.Default.ListIfExpressionTemplate);
+        return JsonSerializer.Serialize(templates, WasmEditorJsonContext.Default.ListExpressionTemplate);
     }
 
     [JSExport]
-    public static string? GetIfExpressionTemplateData(string expression)
+    public static string? GetExpressionTemplateData(string expression, string expressionType)
     {
         if (_controller == null || string.IsNullOrEmpty(expression))
         {
             return null;
         }
 
-        var definition = _controller.GetExpressionEditorDefinition(expression, "if");
+        var definition = _controller.GetExpressionEditorDefinition(expression, expressionType);
         if (definition == null)
         {
             return null;
@@ -1883,7 +1890,7 @@ public partial class WasmEditorBridge
         IEditorData templateData;
         try
         {
-            templateData = _controller.GetExpressionEditorData(expression, "if", null!);
+            templateData = _controller.GetExpressionEditorData(expression, expressionType, null!);
         }
         catch
         {
@@ -1937,12 +1944,12 @@ public partial class WasmEditorBridge
             .ToList();
 
         return JsonSerializer.Serialize(
-            new IfExpressionTemplateData(
+            new ExpressionTemplateData(
                 definition.Description,
                 definition.OriginalPattern,
                 controls
             ),
-            WasmEditorJsonContext.Default.IfExpressionTemplateData
+            WasmEditorJsonContext.Default.ExpressionTemplateData
         );
     }
 
@@ -3483,6 +3490,8 @@ public partial class WasmEditorBridge
         // generic +/- item list.
         var isFunctionParams = ctrl.GetBool("functionparams");
 
+        string? useTemplates = null;
+
         if (ctrl.ControlType == "expression")
         {
             simpleLabel = ctrl.GetString("simple");
@@ -3491,6 +3500,7 @@ public partial class WasmEditorBridge
             simpleEditor = simpleEditorTag ?? (simpleLabel != null ? "textbox" : null);
             source = ctrl.GetString("source");
             objectType = ctrl.GetString("objecttype");
+            useTemplates = ctrl.GetString("usetemplates");
 
             if (simpleEditor == "dropdown")
             {
@@ -3538,7 +3548,8 @@ public partial class WasmEditorBridge
             nestedScripts,
             objectType,
             isFunctionPicker,
-            isFunctionParams
+            isFunctionParams,
+            useTemplates
         );
     }
 

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -8,8 +8,10 @@ using Shouldly;
 namespace QuestViva.EngineTests;
 
 /// <summary>
-/// Drives a v580+ WorldModel and captures output one interaction step at a time, so tests can
-/// assert that specific text appeared before vs. after a wait / get-input / etc.
+/// Drives a v600 WorldModel and captures output one interaction step at a time, so tests can
+/// assert that specific text appeared before vs. after a wait / get-input / etc. v600 is used
+/// (rather than v580) because this fixture also exercises the GetInput()/Ask()/ShowMenu()
+/// expression-function forms, which are gated off for v540-v580 games (see V540UndeprecationTests).
 /// For v580+ games, text reaches the player via IPlayer.RunScriptAsync("addText", [html]) rather than
 /// the PrintText event, so we intercept the mock player to capture it.
 /// </summary>
@@ -97,6 +99,33 @@ internal sealed class GameDriver
         _scriptError = null;
         RequestedTimerTicks.Clear();
         await _worldModel.FinishWait();
+        return TakeBatch();
+    }
+
+    public async Task<IReadOnlyList<string>> FinishPauseAsync()
+    {
+        _batch = [];
+        _scriptError = null;
+        RequestedTimerTicks.Clear();
+        await _worldModel.FinishPause();
+        return TakeBatch();
+    }
+
+    public async Task<IReadOnlyList<string>> SetQuestionResponseAsync(bool response)
+    {
+        _batch = [];
+        _scriptError = null;
+        RequestedTimerTicks.Clear();
+        await _worldModel.SetQuestionResponse(response);
+        return TakeBatch();
+    }
+
+    public async Task<IReadOnlyList<string>> SetMenuResponseAsync(string response)
+    {
+        _batch = [];
+        _scriptError = null;
+        RequestedTimerTicks.Clear();
+        await _worldModel.SetMenuResponse(response);
         return TakeBatch();
     }
 

--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -46,6 +46,9 @@
         <None Update="waitturnscripttest.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="versiongatetest.aslx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="savetest.aslx">
             <SubType>Designer</SubType>
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/tests/EngineTests/V5BlockingTests.cs
+++ b/tests/EngineTests/V5BlockingTests.cs
@@ -17,6 +17,8 @@ internal sealed class V5BlockingGameDriver
     private readonly WorldModel _worldModel;
     private List<string> _batch = [];
 
+    public WorldModel Model => _worldModel;
+
     private static readonly Regex OutputTag =
         new(@"<output[^>]*>(.*?)</output>", RegexOptions.Singleline | RegexOptions.Compiled);
 

--- a/tests/EngineTests/V600UndeprecationTests.cs
+++ b/tests/EngineTests/V600UndeprecationTests.cs
@@ -31,7 +31,7 @@ public class V600UndeprecationTests
             var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("getinputfn"));
             ex.InnerException.ShouldNotBeNull();
             ex.InnerException.Message.ShouldContain(
-                "'GetInput' function is not supported for games written for Quest 5.4 or later");
+                "'GetInput' function is not supported for games with WorldModel version 540");
         }
 
         // v530 (pre-v580) output routes through the PrintText event rather than
@@ -61,7 +61,7 @@ public class V600UndeprecationTests
             var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("askfn"));
             ex.InnerException.ShouldNotBeNull();
             ex.InnerException.Message.ShouldContain(
-                "'Ask' function is not supported for games written for Quest 5.4 or later");
+                "'Ask' function is not supported for games with WorldModel version 540");
         }
 
         var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
@@ -82,7 +82,7 @@ public class V600UndeprecationTests
             var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("menufn"));
             ex.InnerException.ShouldNotBeNull();
             ex.InnerException.Message.ShouldContain(
-                "'ShowMenu' function is not supported for games written for Quest 5.4 or later");
+                "'ShowMenu' function is not supported for games with WorldModel version 540");
         }
 
         var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
@@ -103,7 +103,7 @@ public class V600UndeprecationTests
             var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("waitrequest"));
             ex.InnerException.ShouldNotBeNull();
             ex.InnerException.Message.ShouldContain(
-                "'Wait' request is not supported for games written for Quest 5.4 or later");
+                "'Wait' request is not supported for games with WorldModel version 540");
         }
 
         var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
@@ -125,7 +125,7 @@ public class V600UndeprecationTests
             var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("pauserequest"));
             ex.InnerException.ShouldNotBeNull();
             ex.InnerException.Message.ShouldContain(
-                "'Pause' request is not supported for games written for Quest 5.5 or later");
+                "'Pause' request is not supported for games with WorldModel version 550");
         }
 
         var v540Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
@@ -157,7 +157,7 @@ public class V600UndeprecationTests
             var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("pausefunction"));
             ex.InnerException.ShouldNotBeNull();
             ex.InnerException.Message.ShouldContain(
-                "'Pause' request is not supported for games written for Quest 5.5 or later");
+                "'Pause' request is not supported for games with WorldModel version 550");
         }
 
         var v540Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
@@ -188,7 +188,7 @@ public class V600UndeprecationTests
             var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("waitforkeypressfunction"));
             ex.InnerException.ShouldNotBeNull();
             ex.InnerException.Message.ShouldContain(
-                "'Wait' request is not supported for games written for Quest 5.4 or later");
+                "'Wait' request is not supported for games with WorldModel version 540");
         }
 
         var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");

--- a/tests/EngineTests/V600UndeprecationTests.cs
+++ b/tests/EngineTests/V600UndeprecationTests.cs
@@ -1,0 +1,144 @@
+using QuestViva.Engine;
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+// The real Quest 5 engine rejected the ExpressionOwner.GetInput()/Ask()/ShowMenu() expression-function
+// forms and the request(Wait)/request(Pause) script forms for games declaring WorldModel version 5.4+/
+// 5.5+, in favour of their callback-based replacements ('get input'/'ask'/'show menu'/'wait' script
+// commands, 'SetTimeout'). The 2026-06-26 asyncification of the engine (converting these from
+// Monitor-based thread blocking to TaskCompletionSource-based async blocking) accidentally dropped the
+// version guard from the three ExpressionOwner functions ("un-deprecated" per that commit's message),
+// while the RequestScript guards for Wait/Pause survived untouched - an inconsistency, not a deliberate
+// decision. These tests restore v5 parity for v540-v580 games, and cover WorldModelVersion.v600 as the
+// version where all five are deliberately re-enabled: now that they're backed by TCS-based async
+// blocking rather than a real blocked thread, they're genuinely more usable than the callback
+// replacements they were originally deprecated in favour of.
+[TestClass]
+public class V600UndeprecationTests
+{
+    private static readonly WorldModelVersion[] GatedVersions =
+        [WorldModelVersion.v540, WorldModelVersion.v550, WorldModelVersion.v580];
+
+    [TestMethod]
+    public async Task GetInputFunction_ThrowsForV540ThroughV580_WorksBelowV540AndAtV600()
+    {
+        foreach (var version in GatedVersions)
+        {
+            var driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+            driver.Model.Version = version;
+
+            var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("getinputfn"));
+            ex.InnerException.ShouldNotBeNull();
+            ex.InnerException.Message.ShouldContain(
+                "'GetInput' function is not supported for games written for Quest 5.4 or later");
+        }
+
+        // v530 (pre-v580) output routes through the PrintText event rather than
+        // RunScriptAsync("addText", ...), so V5BlockingGameDriver is needed here instead of GameDriver.
+        var belowThresholdDriver = await V5BlockingGameDriver.LoadAsync("versiongatetest.aslx");
+        belowThresholdDriver.Model.Version = WorldModelVersion.v530;
+        var belowPhase1 = await belowThresholdDriver.SendCommandAsync("getinputfn");
+        belowPhase1.ShouldNotContain("got: John");
+        var belowPhase2 = await belowThresholdDriver.SendCommandAsync("John");
+        belowPhase2.ShouldContain("got: John");
+
+        var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx"); // defaults to v600
+        var phase1 = await v600Driver.SendCommandAsync("getinputfn");
+        phase1.ShouldNotContain("got: John");
+        var phase2 = await v600Driver.SendCommandAsync("John");
+        phase2.ShouldContain("got: John");
+    }
+
+    [TestMethod]
+    public async Task AskFunction_ThrowsForV540ThroughV580_WorksAtV600()
+    {
+        foreach (var version in GatedVersions)
+        {
+            var driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+            driver.Model.Version = version;
+
+            var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("askfn"));
+            ex.InnerException.ShouldNotBeNull();
+            ex.InnerException.Message.ShouldContain(
+                "'Ask' function is not supported for games written for Quest 5.4 or later");
+        }
+
+        var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+        var phase1 = await v600Driver.SendCommandAsync("askfn");
+        phase1.ShouldNotContain("ask: yes");
+        var phase2 = await v600Driver.SetQuestionResponseAsync(true);
+        phase2.ShouldContain("ask: yes");
+    }
+
+    [TestMethod]
+    public async Task ShowMenuFunction_ThrowsForV540ThroughV580_WorksAtV600()
+    {
+        foreach (var version in GatedVersions)
+        {
+            var driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+            driver.Model.Version = version;
+
+            var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("menufn"));
+            ex.InnerException.ShouldNotBeNull();
+            ex.InnerException.Message.ShouldContain(
+                "'ShowMenu' function is not supported for games written for Quest 5.4 or later");
+        }
+
+        var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+        var phase1 = await v600Driver.SendCommandAsync("menufn");
+        phase1.ShouldNotContain("menu: optiona");
+        var phase2 = await v600Driver.SetMenuResponseAsync("optiona");
+        phase2.ShouldContain("menu: optiona");
+    }
+
+    [TestMethod]
+    public async Task WaitRequest_ThrowsForV540ThroughV580_WorksAtV600()
+    {
+        foreach (var version in GatedVersions)
+        {
+            var driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+            driver.Model.Version = version;
+
+            var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("waitrequest"));
+            ex.InnerException.ShouldNotBeNull();
+            ex.InnerException.Message.ShouldContain(
+                "'Wait' request is not supported for games written for Quest 5.4 or later");
+        }
+
+        var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+        var phase1 = await v600Driver.SendCommandAsync("waitrequest");
+        phase1.ShouldNotContain("wait done");
+        var phase2 = await v600Driver.FinishWaitAsync();
+        phase2.ShouldContain("wait done");
+    }
+
+    // Pause's threshold is v550 (Wait/GetInput/Ask/ShowMenu are v540), so v540 itself must still work.
+    [TestMethod]
+    public async Task PauseRequest_ThrowsForV550AndV580_WorksAtV540AndV600()
+    {
+        foreach (var version in new[] {WorldModelVersion.v550, WorldModelVersion.v580})
+        {
+            var driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+            driver.Model.Version = version;
+
+            var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("pauserequest"));
+            ex.InnerException.ShouldNotBeNull();
+            ex.InnerException.Message.ShouldContain(
+                "'Pause' request is not supported for games written for Quest 5.5 or later");
+        }
+
+        var v540Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+        v540Driver.Model.Version = WorldModelVersion.v540;
+        var v540Phase1 = await v540Driver.SendCommandAsync("pauserequest");
+        v540Phase1.ShouldNotContain("pause done");
+        var v540Phase2 = await v540Driver.FinishPauseAsync();
+        v540Phase2.ShouldContain("pause done");
+
+        var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+        var phase1 = await v600Driver.SendCommandAsync("pauserequest");
+        phase1.ShouldNotContain("pause done");
+        var phase2 = await v600Driver.FinishPauseAsync();
+        phase2.ShouldContain("pause done");
+    }
+}

--- a/tests/EngineTests/V600UndeprecationTests.cs
+++ b/tests/EngineTests/V600UndeprecationTests.cs
@@ -141,4 +141,36 @@ public class V600UndeprecationTests
         var phase2 = await v600Driver.FinishPauseAsync();
         phase2.ShouldContain("pause done");
     }
+
+    // Regression test: the Pause() Core.aslx function used to unconditionally call
+    // error("The Pause function is obsolete as of Quest 5.5") regardless of WorldModel
+    // version. It's been restored to just delegate to request (Pause, ...), so it must be
+    // gated identically to the raw request form - not hardcoded broken for every version.
+    [TestMethod]
+    public async Task PauseFunction_ThrowsForV550AndV580_WorksAtV540AndV600()
+    {
+        foreach (var version in new[] {WorldModelVersion.v550, WorldModelVersion.v580})
+        {
+            var driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+            driver.Model.Version = version;
+
+            var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("pausefunction"));
+            ex.InnerException.ShouldNotBeNull();
+            ex.InnerException.Message.ShouldContain(
+                "'Pause' request is not supported for games written for Quest 5.5 or later");
+        }
+
+        var v540Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+        v540Driver.Model.Version = WorldModelVersion.v540;
+        var v540Phase1 = await v540Driver.SendCommandAsync("pausefunction");
+        v540Phase1.ShouldNotContain("pause function done");
+        var v540Phase2 = await v540Driver.FinishPauseAsync();
+        v540Phase2.ShouldContain("pause function done");
+
+        var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+        var phase1 = await v600Driver.SendCommandAsync("pausefunction");
+        phase1.ShouldNotContain("pause function done");
+        var phase2 = await v600Driver.FinishPauseAsync();
+        phase2.ShouldContain("pause function done");
+    }
 }

--- a/tests/EngineTests/V600UndeprecationTests.cs
+++ b/tests/EngineTests/V600UndeprecationTests.cs
@@ -173,4 +173,28 @@ public class V600UndeprecationTests
         var phase2 = await v600Driver.FinishPauseAsync();
         phase2.ShouldContain("pause function done");
     }
+
+    // Regression test: WaitForKeyPress() was a Core.aslx function until it was deleted outright
+    // in 2018 (unlike Pause(), which survived but was hardcoded broken). Restored to delegate to
+    // request (Wait, ""), so it must be gated identically to the raw request form.
+    [TestMethod]
+    public async Task WaitForKeyPressFunction_ThrowsForV540ThroughV580_WorksAtV600()
+    {
+        foreach (var version in GatedVersions)
+        {
+            var driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+            driver.Model.Version = version;
+
+            var ex = await Should.ThrowAsync<Exception>(() => driver.SendCommandAsync("waitforkeypressfunction"));
+            ex.InnerException.ShouldNotBeNull();
+            ex.InnerException.Message.ShouldContain(
+                "'Wait' request is not supported for games written for Quest 5.4 or later");
+        }
+
+        var v600Driver = await GameDriver.LoadAsync("versiongatetest.aslx");
+        var phase1 = await v600Driver.SendCommandAsync("waitforkeypressfunction");
+        phase1.ShouldNotContain("wait for key press function done");
+        var phase2 = await v600Driver.FinishWaitAsync();
+        phase2.ShouldContain("wait for key press function done");
+    }
 }

--- a/tests/EngineTests/callbacktest.aslx
+++ b/tests/EngineTests/callbacktest.aslx
@@ -1,4 +1,4 @@
-<asl version="580">
+<asl version="600">
   <include ref="English.aslx" />
   <include ref="Core.aslx" />
   <game name="callbacktest"/>

--- a/tests/EngineTests/versiongatetest.aslx
+++ b/tests/EngineTests/versiongatetest.aslx
@@ -1,0 +1,58 @@
+<asl version="600">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="versiongatetest"/>
+  <object name="start">
+    <object name="player">
+      <inherit name="defaultplayer" />
+    </object>
+  </object>
+
+  <!-- ExpressionOwner.GetInput() -->
+  <command name="cmd_getinputfn">
+    <pattern>getinputfn</pattern>
+    <script>
+      x = GetInput()
+      msg ("got: " + x)
+    </script>
+  </command>
+
+  <!-- ExpressionOwner.Ask() -->
+  <command name="cmd_askfn">
+    <pattern>askfn</pattern>
+    <script>
+      if (Ask("Some question?")) {
+        msg ("ask: yes")
+      }
+      else {
+        msg ("ask: no")
+      }
+    </script>
+  </command>
+
+  <!-- ExpressionOwner.ShowMenu() -->
+  <command name="cmd_menufn">
+    <pattern>menufn</pattern>
+    <script>
+      msg ("menu: " + ShowMenu("Pick one", Split("optiona;optionb", ";"), false))
+    </script>
+  </command>
+
+  <!-- request (Wait, "") -->
+  <command name="cmd_waitrequest">
+    <pattern>waitrequest</pattern>
+    <script>
+      request (Wait, "")
+      msg ("wait done")
+    </script>
+  </command>
+
+  <!-- request (Pause, ms) -->
+  <command name="cmd_pauserequest">
+    <pattern>pauserequest</pattern>
+    <script>
+      request (Pause, "10")
+      msg ("pause done")
+    </script>
+  </command>
+</asl>

--- a/tests/EngineTests/versiongatetest.aslx
+++ b/tests/EngineTests/versiongatetest.aslx
@@ -65,4 +65,15 @@
       msg ("pause function done")
     </script>
   </command>
+
+  <!-- WaitForKeyPress() Core.aslx function - just delegates to request (Wait, ""), same as
+       Pause() above. Also exercises calling a zero-parameter aslx-defined Function element as
+       a bare-identifier script statement (no parentheses), matching its original 2011 form. -->
+  <command name="cmd_waitforkeypressfunction">
+    <pattern>waitforkeypressfunction</pattern>
+    <script>
+      WaitForKeyPress
+      msg ("wait for key press function done")
+    </script>
+  </command>
 </asl>

--- a/tests/EngineTests/versiongatetest.aslx
+++ b/tests/EngineTests/versiongatetest.aslx
@@ -55,4 +55,14 @@
       msg ("pause done")
     </script>
   </command>
+
+  <!-- Pause() Core.aslx function - just delegates to request (Pause, ...), so it should be
+       gated identically (no version check of its own; RequestScript's own guard applies). -->
+  <command name="cmd_pausefunction">
+    <pattern>pausefunction</pattern>
+    <script>
+      Pause(1)
+      msg ("pause function done")
+    </script>
+  </command>
 </asl>

--- a/tests/e2e/fixtures/save-turn-pending-test.aslx
+++ b/tests/e2e/fixtures/save-turn-pending-test.aslx
@@ -1,4 +1,4 @@
-<asl version="580">
+<asl version="600">
 
   <include ref="English.aslx"/>
   <include ref="Core.aslx"/>


### PR DESCRIPTION
## Summary

- Restores v5-parity WorldModel version gating: `GetInput()`/`Ask()`/`ShowMenu()` (the plain expression forms) had their `>= v540` guard silently dropped during the async/TCS migration, un-deprecating them for every game regardless of declared version. Restored the guard for `v540 <= version < v600`.
- Introduces a new `WorldModelVersion.v600` where these synchronous forms — along with `request(Wait)`/`request(Pause)` — are deliberately re-enabled, since they're now backed by `TaskCompletionSource`-based async blocking rather than real thread blocking and are genuinely more usable than their callback replacements for many authors. New/edited games from the Editor now save as v600.
- Also un-deprecates two more Core.aslx convenience functions in the same spirit: `Pause()` and `WaitForKeyPress()` had their bodies swapped for an unconditional `error("...is obsolete...")` / deleted outright back when the sync-blocking approach was deprecated in favour of callback-based scripts. Since v600 makes the underlying sync-style blocking safe again (TCS-based, not a real thread block), restored both, with their original Script Adder entries, so the Adder shows a proper "Pause for N seconds" / "Wait for key press" control instead of the generic "Raise UI request" panel.
  - Note: this is *not* a bug fix for already-published games — Core.aslx functions are inlined into a game's `.quest` file at publish time (see `Packager`/`GameSaver.CanSave`), so a game published while `Pause()`/`WaitForKeyPress()` were deprecated already carries its own working copy of the old function body and was never broken. The change only affects the authoring experience: games created or edited in the Editor from now on get the restored functions instead of the deprecation stub. See the new "Core Library Semantics" section in `CLAUDE.md`.
- Restores the "set"/"foreach" expression-template picker that existed in the pre-WASM Quest 5 editor but was never ported to the WASM/AppShell frontend — only "if" templates had a picker UI. Generalized `WasmEditorBridge`'s if-only plumbing (`GetIfExpressionTemplates`/`GetIfExpressionTemplateData`) into type-parameterized `GetExpressionTemplates(expressionType)`/`GetExpressionTemplateData(expr, expressionType)`, and factored `ScriptEditor.svelte`'s duplicated if/else-if template-picker markup into one shared snippet reused by the generic expression-control renderer. This gives `GetInput()`/`ShowMenu()` a real "set variable" picker entry ("player's typed input" / "player's choice from a menu").
- Along the way, discovered that `(function)Ask`/`(function)ShowMenu` (the Script Adder's callback-sugar forms) aren't redundant with the sync expression forms — they render completely differently (inline numbered hyperlinks via `CoreFunctions.aslx`, vs. a jQuery UI popup dialog for the expression forms). Kept both addable. Filed #2006 to track modernizing that popup separately.

## Test plan

- [x] `dotnet build --configuration Release` — clean
- [x] `dotnet test --configuration Release` — 343/343 passing, including new `V600UndeprecationTests` covering version gating for `GetInput`/`Ask`/`ShowMenu`/`request(Wait)`/`request(Pause)`/`Pause()`/`WaitForKeyPress()` across v530/v540/v550/v580/v600
- [x] `svelte-check` / `eslint` in `src/AppShell` — clean
- [x] Manually verified in the running WasmEditor Script Adder: "Wait for key press" and "Pause for a number of milliseconds" show proper controls (not the generic "Raise UI request" panel); "Get input"/"Show a menu" are gone in favor of the "set variable" template picker; "Ask a question"/"Show a menu" callback forms remain addable; inserted scripts produce the expected literal script text in Code view for each case

🤖 Generated with [Claude Code](https://claude.com/claude-code)
