### PR TITLE
fix(PlayerCore): disable autocapitalize on game command input

### DIFF
--- a/src/PlayerCore/Resources/playercore.htm
+++ b/src/PlayerCore/Resources/playercore.htm
@@ -188,6 +188,7 @@
                 <span id="txtCommandPrompt"></span>
                 <input autofocus id="txtCommand" onkeydown="return commandKey(event);" placeholder="Type here..."
                        type="text"
+                       autocapitalize="off"
                        x-webkit-speech/>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- iOS Safari was auto-capitalizing the first letter typed into the gameplay command box (`#txtCommand` in `playercore.htm`), which is shared by both WebPlayer and WasmPlayer
- Adds `autocapitalize="off"` to that input, mirroring the fix already applied to the editor's text inputs (`autocapitalize="off"` on `<body>` in `src/AppShell/src/app.html`, #1910)

## Test plan
- [x] Rebuilt WasmPlayer (`dotnet build src/WasmPlayer/WasmPlayer.csproj`) and confirmed via the dev server that the rendered `#txtCommand` input includes `autocapitalize="off"`
- [ ] Manual check on an iOS Safari device that the on-screen keyboard no longer capitalizes the first letter of a typed command

🤖 Generated with [Claude Code](https://claude.com/claude-code)