### PR TITLE
fix: fix two unrelated e2e test flakes found in a manual run

### DIFF
--- a/tests/e2e/verify-appshell-empty-advanced-categories.mjs
+++ b/tests/e2e/verify-appshell-empty-advanced-categories.mjs
@@ -85,12 +85,13 @@ try {
     }
     console.log('PASS: other still-empty categories remain hidden');
 
-    // "+ Add JavaScript" lives under the "Advanced" node too (creates directly, no
-    // name modal) and should make the "Javascript" header reappear, same as
-    // Functions did above. Selection moved to the new function above, so
-    // re-select "Advanced" first.
+    // "+ Add JavaScript" lives under the "Advanced" node too and should make the
+    // "Javascript" header reappear, same as Functions did above, once its confirm
+    // modal (see AddJavascriptModal) is accepted with the pre-filled filename.
+    // Selection moved to the new function above, so re-select "Advanced" first.
     await tree.getByText('Advanced', { exact: true }).click();
     await page.getByRole('button', { name: '+ Add JavaScript', exact: true }).click();
+    await page.getByRole('button', { name: 'Add JavaScript', exact: true }).click();
     await tree.getByText('Javascript', { exact: true }).waitFor({ state: 'visible', timeout: 5000 });
     console.log('PASS: "Javascript" header appears after adding via the "Advanced" node');
 

--- a/tests/e2e/verify-electron-unsaved-close-dialog.mjs
+++ b/tests/e2e/verify-electron-unsaved-close-dialog.mjs
@@ -47,9 +47,16 @@ async function withFreshApp(fn) {
         await win.waitForSelector('a:has-text("Create"), a:has-text("Play")', { timeout: 30000 });
         return await fn(app, win);
     } finally {
-        app?.process().kill('SIGKILL');
-        // SIGKILL doesn't wait for Chromium to finish its disk-cache writeback, so an immediate
-        // rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
+        const proc = app?.process();
+        if (proc && proc.exitCode === null) {
+            // kill() only sends the signal — it doesn't wait for the process to actually
+            // terminate, so without this the rmSync below could race a still-running process.
+            const exited = new Promise(resolve => proc.once('exit', resolve));
+            proc.kill('SIGKILL');
+            await exited;
+        }
+        // Even after exit, Chromium's disk-cache writeback can still be finishing up, so an
+        // immediate rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
         rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
     }
 }


### PR DESCRIPTION
## Summary
Two unrelated failures showed up in a manual [e2e run](https://github.com/textadventures/quest/actions/runs/31320107720):

- **`appshell_chromium`** — `verify-appshell-empty-advanced-categories.mjs` was stale against #1996, which reworked JavaScript-element creation to go through an `AddJavascriptModal` confirm step instead of creating directly. The test clicked "+ Add JavaScript" and then waited for the "Javascript" tree header to reappear without ever confirming the modal.
- **`electron`** — `verify-electron-unsaved-close-dialog.mjs` intermittently hit `ENOTEMPTY` cleaning up its temp userdata directory. `proc.kill('SIGKILL')` only sends the signal — it doesn't wait for the process to actually exit — so the cleanup's `rmSync` could race a still-running Electron process. The existing `maxRetries`/`retryDelay` (added in #1978 for this same flake class) masked it most of the time but wasn't reliable under CI load.

## Fix
- Click the `AddJavascriptModal`'s confirm button before waiting for the header.
- Await the Electron process's `exit` event before attempting `rmSync`, keeping the existing retry logic as a backstop for Chromium's disk-cache writeback lag after exit.

## Test plan
- [x] Ran `verify-appshell-empty-advanced-categories.mjs` locally against real WasmEditor/WasmPlayer/AppShell dev servers — passes end-to-end.
- [x] Ran `verify-electron-unsaved-close-dialog.mjs` locally (macOS, built ElectronApp/AppShell as CI does) 4 times in a row — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)