### PR TITLE
fix(WasmPlayer): pass --tag latest to npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -72,8 +72,13 @@ jobs:
           }
           EOF
 
+      # --tag latest is required, not just the default: npm refuses to guess a
+      # dist-tag for a prerelease-looking version (every version here — see
+      # root CLAUDE.md's Releasing section, the project never leaves beta) and
+      # errors instead. latest is the correct tag regardless, since there is
+      # no separate stable line for this package to protect "latest" from.
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --tag latest
         working-directory: src/WasmPlayer/bin/Release/net10.0/browser-wasm/AppBundle
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
`npm-publish.yml`'s \`npm publish --access public\` failed on the first real run (v6.0.0-beta.50, see run 31321215262) with:

\`\`\`
npm error You must specify a tag using --tag when publishing a prerelease version.
\`\`\`

npm no longer guesses a dist-tag for a prerelease-looking version string. Every Quest Viva release is `X.Y.Z-beta.N` (see root `CLAUDE.md`'s Releasing section — the project deliberately never leaves beta), so there's no separate "stable" line to protect `latest` from — `latest` is the correct tag to pass explicitly here, every time.

## Test plan
- [x] `npm publish --access public --tag latest` reproduced locally against a real Release AppBundle build (dry-run pack succeeded with matching contents; the `--tag` flag itself just changes which dist-tag gets set, not the publish payload)
- [x] YAML syntax validated