### PR TITLE
fix(AppShell): resolve custom Included Library content on reload

### DIFF
--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -143,6 +143,22 @@ function refreshUndoRedo() {
 // "ok"/"error:{message}" convention in WasmEditorBridge.cs.
 export const lastOpenGameError = writable<string | null>(null);
 
+// An Included Library element only stores its filename (<include ref="lib.aslx"/>) — the
+// library's actual content lives in the adapter's asset storage, not in the game bytes, so the
+// engine can't resolve it on its own when (re)loading. AddLibraryModal only ever uploads
+// .aslx files, so every asset with that extension is a candidate; stage them all into the WASM
+// side (WasmEditorBridge.AddAdjacentFile) before Initialise/SetGameXml runs the load that needs
+// them (see WorldModel.GetLibraryStream / ByteArrayGameDataProvider).
+async function preloadAdjacentLibraryAssets(adapter: FileAdapter): Promise<void> {
+    const assets = await adapter.listAssets();
+    for (const asset of assets) {
+        if (!asset.key.toLowerCase().endsWith(".aslx")) continue;
+        const blob = await adapter.getAsset(asset.key);
+        if (!blob) continue;
+        _bridge!.AddAdjacentFile(asset.key, new Uint8Array(await blob.arrayBuffer()));
+    }
+}
+
 export async function openGame(bytes: Uint8Array, filename: string, adapter: FileAdapter): Promise<boolean> {
     // Defensive reset: callers that switch games mid-session (Electron's menu
     // actions) already await saveGame() to flush the previous game first, so
@@ -160,6 +176,7 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
     canPublishToServer.set(adapter instanceof ServerFileAdapter);
     showBackupBanner.set(adapter instanceof LocalDraftAdapter && await shouldShowBackupBanner(adapter.gameId));
     loadingStatus.set("Loading game…");
+    await preloadAdjacentLibraryAssets(adapter);
     // Double rAF ensures the browser actually paints the status update before
     // Initialise blocks the JS thread (C# WASM calls are synchronous).
     await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
@@ -204,6 +221,7 @@ export function getGameXml(): string {
 export async function setGameXml(xml: string): Promise<string> {
     if (!_bridge) return "error";
     cancelPendingAutosave();
+    if (_adapter) await preloadAdjacentLibraryAssets(_adapter);
     // Double rAF ensures the browser actually paints the caller's "Applying…" state before
     // SetGameXml's Initialise() call blocks the JS thread (C# WASM calls are synchronous) — same
     // pattern openGame() uses below for the equivalent reason.

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -1,4 +1,5 @@
 export interface WasmBridge {
+  AddAdjacentFile(filename: string, data: Uint8Array): void
   Initialise(bytes: Uint8Array, filename: string): Promise<string>
   GetTreeNodes(): string
   SetShowLibraryElements(show: boolean): void

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -135,7 +135,7 @@
 
 {#if serverLoadError}
     <main class="flex flex-col items-center justify-center min-h-svh gap-6 p-8">
-        <p class="text-error-500 max-w-[40ch] text-center">{serverLoadError}</p>
+        <p class="text-error-500 max-w-[40ch] text-center whitespace-pre-wrap">{serverLoadError}</p>
     </main>
 {:else if $loadingStatus}
     <main class="flex flex-col items-center justify-center min-h-svh gap-6 p-8">

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -520,7 +520,7 @@
             {/if}
 
             {#if error}
-                <p class="text-error-500 text-sm">{error}</p>
+                <p class="text-error-500 text-sm whitespace-pre-wrap">{error}</p>
             {/if}
 
             {#if isElectronApp && recentGames.length > 0}
@@ -694,7 +694,7 @@
                     {/if}
 
                     {#if createLocalError}
-                        <p class="text-error-500 text-sm">{createLocalError}</p>
+                        <p class="text-error-500 text-sm whitespace-pre-wrap">{createLocalError}</p>
                     {/if}
                 </div>
             {/if}

--- a/src/Common/ByteArrayGameDataProvider.cs
+++ b/src/Common/ByteArrayGameDataProvider.cs
@@ -1,11 +1,26 @@
 namespace QuestViva.Common;
 
-public class ByteArrayGameDataProvider(byte[] data, string filename) : IGameDataProvider
+// adjacentFiles lets callers with no filesystem access (e.g. WasmEditorBridge, which runs
+// in-browser) supply the bytes of files an Included Library's <include ref="..."/> needs to
+// resolve at load time (see WorldModel.GetLibraryStream) — those files live as separate
+// "assets" in the host's own storage, not inside gameFileBytes itself, so they must be handed
+// over explicitly rather than discovered via a real filesystem lookup.
+public class ByteArrayGameDataProvider(
+    byte[] data,
+    string filename,
+    IReadOnlyDictionary<string, byte[]>? adjacentFiles = null) : IGameDataProvider
 {
     public Task<GameData?> GetData()
     {
         var stream = new MemoryStream(data);
         var gameId = Path.GetFileName(filename);
         return Task.FromResult<GameData?>(new GameData(stream, gameId, filename, this));
+    }
+
+    public Stream? GetAdjacentFile(string file)
+    {
+        return adjacentFiles != null && adjacentFiles.TryGetValue(file, out var bytes)
+            ? new MemoryStream(bytes)
+            : null;
     }
 }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -253,7 +253,7 @@ public partial class WasmEditorBridge
         AttachControllerEvents(controller);
         _controller = controller;
 
-        var provider = new ByteArrayGameDataProvider(gameFileBytes, filename);
+        var provider = new ByteArrayGameDataProvider(gameFileBytes, filename, TakePendingAdjacentFiles());
 
         bool ok;
         try
@@ -312,7 +312,7 @@ public partial class WasmEditorBridge
 
         var filename = _controller.Filename;
         var bytes = System.Text.Encoding.UTF8.GetBytes(xml);
-        var provider = new ByteArrayGameDataProvider(bytes, filename);
+        var provider = new ByteArrayGameDataProvider(bytes, filename, TakePendingAdjacentFiles());
 
         // Parse into a throwaway controller first — the shared TreeNodes cache and _isDirty flag
         // must not be touched (see AttachControllerEvents) and the live _controller must not be
@@ -645,6 +645,29 @@ public partial class WasmEditorBridge
             // Recently Played list, it should just keep the placeholder icon.
             return null;
         }
+    }
+
+    // Included Library elements only store a filename (<include ref="lib.aslx"/> — see
+    // IncludeSaver); the library's actual content lives in the host's asset storage (IndexedDB,
+    // OPFS, disk, ...), which this WASM module has no access to itself. So before every
+    // (re)load, the JS side fetches each candidate asset's bytes and stages them here one at a
+    // time ([JSExport] can't marshal an array of blobs in one call), the same way
+    // AddPublishAsset/PendingPublishAssets stage assets for CreatePublishPackage below.
+    // Initialise/SetGameXml consume and clear this before constructing their
+    // ByteArrayGameDataProvider, regardless of whether the load succeeds.
+    private static readonly Dictionary<string, byte[]> PendingAdjacentFiles = new();
+
+    [JSExport]
+    public static void AddAdjacentFile(string filename, byte[] data)
+    {
+        PendingAdjacentFiles[filename] = data;
+    }
+
+    private static Dictionary<string, byte[]> TakePendingAdjacentFiles()
+    {
+        var files = new Dictionary<string, byte[]>(PendingAdjacentFiles);
+        PendingAdjacentFiles.Clear();
+        return files;
     }
 
     // [JSExport] can't marshal an array of blobs in one call, so assets are staged one

--- a/tests/EditorCoreTests/IncludedLibraryTests.cs
+++ b/tests/EditorCoreTests/IncludedLibraryTests.cs
@@ -39,6 +39,55 @@ public class IncludedLibraryTests
         controller.Uninitialise();
     }
 
+    // Regression test for a bug where adding a custom Included Library, saving, then reloading
+    // failed with "Library file not found" — CreateNewIncludedLibrary only records the filename
+    // (see IncludeSaver, which writes <include ref="custom.aslx"/>, not the library's content), so
+    // reloading has to fetch that content again via GetAdjacentFile. WasmEditorBridge fed
+    // ByteArrayGameDataProvider with no adjacent-file lookup at all, so any non-built-in library
+    // failed to resolve on every reload after the initial (content-free) creation.
+    [TestMethod]
+    public async Task TestCustomLibraryFailsToReloadWithoutAdjacentFileBytes()
+    {
+        var savedXml = await CreateGameWithCustomLibraryAndSave();
+        var savedBytes = Encoding.UTF8.GetBytes(savedXml);
+
+        var reloadController = new EditorController();
+        string errorMessage = null;
+        reloadController.ShowMessage += (_, e) => errorMessage = e.Message;
+
+        var ok = await reloadController.Initialise(new ByteArrayGameDataProvider(savedBytes, "test.aslx"));
+
+        Assert.IsFalse(ok, "Reload should fail when the custom library's bytes aren't supplied");
+        StringAssert.Contains(errorMessage, "Library file not found: custom.aslx");
+    }
+
+    [TestMethod]
+    public async Task TestCustomLibraryReloadsWhenAdjacentFileBytesAreSupplied()
+    {
+        var savedXml = await CreateGameWithCustomLibraryAndSave();
+        var savedBytes = Encoding.UTF8.GetBytes(savedXml);
+        var adjacentFiles = new Dictionary<string, byte[]>
+        {
+            ["custom.aslx"] = Encoding.UTF8.GetBytes("<library></library>")
+        };
+
+        var reloadController = new EditorController();
+        var ok = await reloadController.Initialise(
+            new ByteArrayGameDataProvider(savedBytes, "test.aslx", adjacentFiles));
+
+        Assert.IsTrue(ok, "Reload should succeed once the custom library's bytes are supplied");
+        reloadController.Uninitialise();
+    }
+
+    private static async Task<string> CreateGameWithCustomLibraryAndSave()
+    {
+        var controller = await LoadTemplateController("English");
+        controller.CreateNewIncludedLibrary("custom.aslx");
+        var xml = controller.Save();
+        controller.Uninitialise();
+        return xml;
+    }
+
     private static async Task AssertBuiltInLibrariesProtected(string templateName, params string[] libraryFilenames)
     {
         var keysByText = new Dictionary<string, string>();


### PR DESCRIPTION
## Summary

- Fixes a bug where adding a custom Included Library in the editor, saving, and reopening the game failed with `Failed to load game due to the following errors: * Error: Library file not found: lib.aslx` — reproducible in both the browser and Electron.
- Also fixes the same error message rendering as a single squashed line (no visible bullet/line breaks) on the editor's Open/reload screens.

## Root cause

An Included Library element only stores its filename on save (`<include ref="lib.aslx"/>` — see `IncludeSaver`), not its content. The engine re-fetches the library's content from `IGameDataProvider.GetAdjacentFile` on every load (`WorldModel.GetLibraryStream`). `WasmEditorBridge` always loaded games through `ByteArrayGameDataProvider`, which had no `GetAdjacentFile` implementation at all, so any non-built-in library failed to resolve as soon as the game was reloaded — even though the library file was correctly stored as an asset and shown in the tree.

(Published `.quest` packages aren't affected — `GameSaver` inlines all library content and drops the `<include>` reference at publish time, so there's nothing left to resolve at play time. This is specific to the Editor's live-reference save mode.)

## Fix

- `ByteArrayGameDataProvider` now accepts an optional `adjacentFiles` map and implements `GetAdjacentFile` from it.
- `WasmEditorBridge` gets a new `AddAdjacentFile` JSExport (mirrors the existing `AddPublishAsset` staging pattern); `Initialise`/`SetGameXml` consume the staged files when building the provider.
- `editor-store.ts` preloads every `.aslx` asset from the adapter before `Initialise`/`SetGameXml` — this is a single choke point so it covers browser, Electron, and server storage.

Separately: the multi-line "Failed to load game due to the following errors:" message was collapsing onto one line in the UI because the `<p>` tags rendering it had no `white-space` styling — `CodeViewPanel.svelte`'s equivalent error banner already used `whitespace-pre-wrap`, so the same class was added to the other three render sites (`open/+page.svelte` ×2, `edit/+page.svelte`).

## Test plan

- [x] Added two regression tests to `IncludedLibraryTests.cs` (reload fails without adjacent bytes, succeeds with them) — reproduces the exact reported error message.
- [x] `dotnet build --configuration Release` (full solution) and `dotnet test --configuration Release` (292+ tests) both pass.
- [x] `npm run check` (svelte-check) and `npm run lint` (eslint) in `src/AppShell` both pass.
- [x] Verified live in the AppShell dev server: created a game, added a custom library, saved, reloaded — previously failed, now loads correctly.
- [x] Verified the error-formatting fix live by importing a game with a broken library reference and confirming the message now renders on separate lines instead of squashed onto one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)