### PR TITLE
fix(Engine): don't crash on a duplicate key in a simple dictionary attribute

### DIFF
--- a/src/Engine/GameLoader/AttributeLoaders.cs
+++ b/src/Engine/GameLoader/AttributeLoaders.cs
@@ -417,6 +417,18 @@ internal partial class GameLoader
 
                 var key = trimmedPair[..splitPos].Trim();
                 var dictValue = trimmedPair[(splitPos + 1)..].Trim();
+                if (result.ContainsKey(key))
+                {
+                    // QuestDictionary.Add throws ArgumentException ("Argument_AddingDuplicateWithKey")
+                    // on a duplicate key, which would otherwise escape uncaught all the way past
+                    // WorldModel.InitialiseEdit() as a raw, untranslated exception (AOT trimming
+                    // strips its message resources - see WasmEditorBridge.Initialise) instead of a
+                    // friendly, actionable error like the one immediately below for a missing '='.
+                    GameLoader.AddError(
+                        $"Duplicate key '{key}' in dictionary element '{trimmedPair}' in '{element.Name}.{attribute}'");
+                    return;
+                }
+
                 result.Add(key, dictValue);
             }
 
@@ -451,6 +463,15 @@ internal partial class GameLoader
 
                 var key = trimmedPair[..splitPos].Trim();
                 var dictValue = trimmedPair[(splitPos + 1)..].Trim();
+                if (result.ContainsKey(key))
+                {
+                    // Same duplicate-key crash risk as SimpleStringDictionaryLoader above -
+                    // Dictionary.Add throws uncaught on a repeated key instead of a friendly error.
+                    GameLoader.AddError(
+                        $"Duplicate key '{key}' in dictionary element '{trimmedPair}' in '{element.Name}.{attribute}'");
+                    return;
+                }
+
                 result.Add(key, dictValue);
             }
 

--- a/tests/EngineTests/AttributeLoaderTests.cs
+++ b/tests/EngineTests/AttributeLoaderTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using Moq;
+using QuestViva.Common;
+using QuestViva.Engine;
+
+namespace QuestViva.EngineTests;
+
+[TestClass]
+public class AttributeLoaderTests
+{
+    // Regression test for a bug found in a third-party library (RunCommand.aslx) whose
+    // simplestringdictionary attribute repeated the same key twice. QuestDictionary.Add /
+    // Dictionary.Add throw ArgumentException ("Argument_AddingDuplicateWithKey") on a duplicate
+    // key, and nothing between SimpleStringDictionaryLoader.Load and the caller
+    // (WasmEditorBridge.Initialise) catches that specific exception type - so instead of a
+    // friendly "Failed to load game due to the following errors" message, the user saw a raw,
+    // untranslated exception (AOT trimming strips the resource string for
+    // Argument_AddingDuplicateWithKey). The fix makes the loader record a normal load error
+    // instead of throwing, matching how a missing '=' is already handled a few lines above it.
+    [TestMethod]
+    public async Task TestDuplicateKeyInSimpleStringDictionaryIsAGracefulLoadError()
+    {
+        var (worldModel, ok) = await LoadGameWithDictionaryAttribute(
+            "stringdictionaryattr",
+            "type=\"simplestringdictionary\"",
+            "\"on\"=on;\"to\"=to;\"to\"=to");
+
+        Assert.IsFalse(ok, "Game with a duplicate dictionary key should fail to load");
+        // The key includes literal quote characters, matching Quest's quoted-key dictionary syntax
+        // ("to"=to) - this is what the user's reported raw exception ("Argument_AddingDuplicateWithKey,
+        // \"to\"") was actually showing before this fix.
+        Assert.IsTrue(
+            worldModel.Errors.Any(e => e.Contains("Duplicate key '\"to\"'") && e.Contains("stringdictionaryattr")),
+            "Expected a friendly duplicate-key error; got: " + string.Join("; ", worldModel.Errors));
+    }
+
+    [TestMethod]
+    public async Task TestDuplicateKeyInSimpleObjectDictionaryIsAGracefulLoadError()
+    {
+        var (worldModel, ok) = await LoadGameWithDictionaryAttribute(
+            "objectdictionaryattr",
+            "type=\"simpleobjectdictionary\"",
+            "key1=room;key1=room");
+
+        Assert.IsFalse(ok, "Game with a duplicate dictionary key should fail to load");
+        Assert.IsTrue(
+            worldModel.Errors.Any(e => e.Contains("Duplicate key 'key1'") && e.Contains("objectdictionaryattr")),
+            "Expected a friendly duplicate-key error; got: " + string.Join("; ", worldModel.Errors));
+    }
+
+    private static async Task<(WorldModel worldModel, bool ok)> LoadGameWithDictionaryAttribute(
+        string attributeName, string typeAttr, string attributeValue)
+    {
+        var xml = $"""
+                   <asl version="580">
+                     <include ref="English.aslx" />
+                     <include ref="Core.aslx" />
+                     <game name="test"/>
+                     <object name="room">
+                       <object name="player">
+                         <inherit name="defaultplayer" />
+                       </object>
+                       <{attributeName} {typeAttr}>{attributeValue}</{attributeName}>
+                     </object>
+                   </asl>
+                   """;
+
+        var provider = new ByteArrayGameDataProvider(Encoding.UTF8.GetBytes(xml), "test.aslx");
+        var gameData = await provider.GetData();
+        var worldModel = Helpers.CreateWorldModel(gameData);
+
+        var player = new Mock<IPlayer>();
+        var ok = await worldModel.Initialise(player.Object);
+        return (worldModel, ok);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up found while investigating a user report about the RunCommand.aslx library (from EightOne, a popular community library): loading a game that includes it fails with `Error: Argument_AddingDuplicateWithKey, "to"` instead of the friendly "Failed to load game due to the following errors" message.

## Root cause

`RunCommand.aslx`'s `EditorScriptsScriptsRunCommandPrePositions` template lists the `"to"` mapping twice:

```
"on"=on;"in"=in;"from"=from;"to"=to;"with"=with;"about"=about;"to"=to
```

That string is parsed as a `simplestringdictionary` editor `<validvalues>` attribute by `SimpleStringDictionaryLoader.Load` (`src/Engine/GameLoader/AttributeLoaders.cs`), which called `QuestDictionary<string>.Add(key, value)` for every entry with no duplicate check. `Dictionary.Add` throws `ArgumentException` ("Argument_AddingDuplicateWithKey") on a repeated key, and nothing between there and the WASM boundary (`WasmEditorBridge.Initialise`) catches that specific exception type as a normal load error — it falls into the generic `catch (Exception ex)` instead, and because WasmEditor is AOT-trimmed, `ex.Message` loses its resource string and becomes the bare, untranslated resource key.

This is a bug in that particular library file's data (a copy-paste duplicate), not something introduced by quest itself — but the engine crashing ungracefully on malformed dictionary data, with a cryptic message, is a real robustness gap: **any** third-party library (or hand-edited game) with a duplicate key in a `simplestringdictionary`/`simpleobjectdictionary` attribute hits the same crash today.

## Fix

`SimpleStringDictionaryLoader` and its sibling `SimpleObjectDictionaryLoader` (same copy-pasted parsing loop, same latent bug) now check for a duplicate key before adding and record a normal, friendly load error instead — exactly mirroring the existing handling for a missing `=` a few lines above in the same method. The game still fails to load (the dictionary is genuinely ambiguous), but with a clear, actionable message pointing at the offending element/attribute instead of a raw exception.

## Test plan

- [x] Added `AttributeLoaderTests.cs` with regression tests for both loaders: a duplicate key now produces a friendly `WorldModel.Errors` entry (`Duplicate key '"to"' in dictionary element ...`) instead of an uncaught exception — the assertion text matches the user's exact reported quoted-key format.
- [x] `dotnet build --configuration Release` (full solution) and `dotnet test --configuration Release` (294+ tests) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)