### PR TITLE
feat(ElectronApp): reveal recent files in Finder, detect external file changes

### DIFF
--- a/src/AppShell/src/app.css
+++ b/src/AppShell/src/app.css
@@ -7,6 +7,27 @@
     background: light-dark(white, var(--color-surface-800));
 }
 
+/* Works around a still-open Electron/Chromium bug on macOS where a `title`
+   attribute's native tooltip shows once, then almost never again on repeat
+   hovers — https://github.com/electron/electron/issues/49843. A relatively
+   positioned, zero-content ::after covering the element's own box resets
+   Chromium's hover hit-testing enough for the tooltip to keep firing.
+   Inert (and harmless) outside Electron, where native tooltips already work
+   fine on their own — so this is applied globally rather than gated behind
+   isElectron(). The :not() list skips forcing `relative` onto anything that
+   already establishes its own positioning context (e.g. LocalFileRecentCard/
+   RecentGameCard's `absolute top-1 right-1` remove button) — forcing it
+   there would override their actual placement; the ::after below still
+   anchors correctly off whatever positioning context an element already has. */
+[title]:not(.absolute):not(.fixed):not(.sticky):not(.relative) {
+    position: relative;
+}
+[title]::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+}
+
 /* The default 1rem top+bottom padding is a bigger cost on a short viewport
    than it's worth — shrink it whenever there isn't much height to spare.
    Keyed on height (max-height), not just the isNarrow *width* breakpoint

--- a/src/AppShell/src/components/FileChangedExternallyBanner.svelte
+++ b/src/AppShell/src/components/FileChangedExternallyBanner.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+    import { showFileChangedExternallyBanner, dismissFileChangedExternallyBanner, reloadGameFromDisk } from "$lib/editor-store";
+
+    let reloading = $state(false);
+
+    async function handleReload() {
+        reloading = true;
+        try {
+            // Only dismisses on an actual reload — a cancelled discard-confirm
+            // (unsaved edits) leaves the banner up, since the file is still
+            // out of sync with what's on screen.
+            if (await reloadGameFromDisk()) dismissFileChangedExternallyBanner();
+        } finally {
+            reloading = false;
+        }
+    }
+</script>
+
+{#if $showFileChangedExternallyBanner}
+    <div class="flex items-center gap-3 px-4 py-2 bg-warning-100-900 border-b border-warning-300-700 text-sm">
+        <span class="flex-1">This file was changed outside the editor, by another program.</span>
+        <button
+            type="button"
+            class="btn btn-sm preset-filled-warning-500"
+            onclick={handleReload}
+            disabled={reloading}
+        >{reloading ? "Reloading…" : "Reload from disk"}</button>
+        <button type="button" class="btn btn-sm preset-tonal" onclick={dismissFileChangedExternallyBanner}>Dismiss</button>
+    </div>
+{/if}

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -62,6 +62,23 @@ export const showLibraryReloadBanner = writable(false);
 export function dismissLibraryReloadBanner() {
     showLibraryReloadBanner.set(false);
 }
+
+// Set when Electron's main-process file watcher (ipc/file-watch.ts, armed by
+// electron-adapter.ts) reports the currently-open game file or one of its
+// included libraries was changed by something other than this app — e.g. an
+// external text editor. Electron-only; other adapters have no equivalent of
+// "another program touched this file". See FileChangedExternallyBanner.svelte.
+export const showFileChangedExternallyBanner = writable(false);
+export function dismissFileChangedExternallyBanner() {
+    showFileChangedExternallyBanner.set(false);
+}
+// Called from +layout.svelte's electronApp().fileWatch.onChanged listener.
+// Guarded on isLoaded so a notification that arrives after the game/window
+// has already moved on (e.g. mid-navigation) doesn't pop a banner for
+// nothing to reload.
+export function markFileChangedExternally() {
+    if (get(isLoaded)) showFileChangedExternallyBanner.set(true);
+}
 export const canPublishToServer = writable(false);
 export const treeNodes = writable<TreeNode[]>([]);
 export const showLibraryElements = writable(false);
@@ -216,6 +233,7 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
         treeNodes.set(nodes);
         showLibraryElements.set(false);
         showLibraryReloadBanner.set(false);
+        showFileChangedExternallyBanner.set(false);
         isLoaded.set(true);
         gameFilename.set(filename);
         refreshUndoRedo();
@@ -243,6 +261,26 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
 export async function reloadGame(): Promise<boolean> {
     if (!_adapter) return false;
     await saveGame();
+    const bytes = await _adapter.reload();
+    return openGame(bytes, _adapter.filename, _adapter);
+}
+
+// Backs FileChangedExternallyBanner's Reload action. Deliberately does NOT
+// call saveGame() first like reloadGame() above does — the whole point here
+// is that the on-disk copy (changed by something outside this app) should
+// win, not get silently clobbered by whatever's still in memory. Confirms
+// first if there are unsaved in-editor edits, since those are what's about
+// to be discarded; openGame()'s own refreshUndoRedo() call resets isDirty
+// once the fresh copy is loaded.
+export async function reloadGameFromDisk(): Promise<boolean> {
+    if (!_adapter) return false;
+    if (get(isDirty)) {
+        const ok = await confirmDialog(
+            "This file was changed outside the editor. Reloading now will discard your unsaved changes here and load the version from disk. Continue?",
+            { confirmLabel: "Reload from disk", danger: true },
+        );
+        if (!ok) return false;
+    }
     const bytes = await _adapter.reload();
     return openGame(bytes, _adapter.filename, _adapter);
 }

--- a/src/AppShell/src/lib/electron-types.d.ts
+++ b/src/AppShell/src/lib/electron-types.d.ts
@@ -26,6 +26,13 @@ interface ElectronDialogApi {
 
 interface ElectronShellApi {
     openExternal(url: string): Promise<void>;
+    showItemInFolder(path: string): Promise<void>;
+}
+
+interface ElectronFileWatchApi {
+    watch(dirPath: string, filenames: string[]): Promise<void>;
+    unwatch(): Promise<void>;
+    onChanged(callback: (filenames: string[]) => void): () => void;
 }
 
 interface ElectronPathApi {
@@ -91,6 +98,7 @@ interface ElectronApi {
     path: ElectronPathApi;
     paths: ElectronPathsApi;
     recent: ElectronRecentApi;
+    fileWatch: ElectronFileWatchApi;
     menu: ElectronMenuApi;
     player: ElectronPlayerApi;
     // Populated by preload.ts from process.platform (main/preload only —

--- a/src/AppShell/src/lib/filesystem/electron-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/electron-adapter.ts
@@ -88,6 +88,34 @@ async function trackRecent(dirPath: string, filename: string, kind: RecentKind =
     }
 }
 
+// The main file plus any adjacent .aslx files — the same "any sibling .aslx
+// is a candidate included library" rule editor-store.ts's
+// preloadAdjacentLibraryAssets uses, just not filtered through listAssets()
+// (which deliberately excludes .aslx — see its own filter below).
+async function computeWatchList(dirPath: string, mainFilename: string): Promise<string[]> {
+    const entries = await electronApp().fs.readDir(dirPath);
+    const libraries = entries
+        .filter((e) => e.isFile && e.name.toLowerCase().endsWith(".aslx") && e.name !== mainFilename)
+        .map((e) => e.name);
+    return [mainFilename, ...libraries];
+}
+
+// Best-effort: (re)arms the main process's external-change watch for this
+// file and its included libraries (see ElectronApp's ipc/file-watch.ts),
+// resetting its baseline to the current on-disk state. Called after every
+// point where this adapter's own view of the file syncs with disk — initial
+// load, save, save-as, and reload — so the app's own writes are never
+// mistaken for an external change. A failure here just means external
+// changes won't be detected until the next call; not worth surfacing.
+async function armFileWatch(dirPath: string, filename: string): Promise<void> {
+    try {
+        const filenames = await computeWatchList(dirPath, filename);
+        await electronApp().fileWatch.watch(dirPath, filenames);
+    } catch {
+        // ignore
+    }
+}
+
 /**
  * FileAdapter backed by Electron's contextBridge (Node fs via IPC), for the
  * desktop app. Same flat single-directory model as BrowserFileAdapter — no
@@ -130,6 +158,7 @@ export class ElectronFileAdapter implements FileAdapter {
 
     async saveFile(data: Uint8Array | string): Promise<void> {
         await electronApp().fs.writeFile(this.resolve(this._filename), data);
+        await armFileWatch(this.dirPath, this._filename);
     }
 
     async saveFileAs(data: Uint8Array | string, suggestedName?: string): Promise<string | null> {
@@ -141,6 +170,7 @@ export class ElectronFileAdapter implements FileAdapter {
         await electronApp().fs.writeFile(path, data);
         this._filename = basename(path);
         await trackRecent(dirname(path), this._filename);
+        await armFileWatch(dirname(path), this._filename);
         return this._filename;
     }
 
@@ -169,8 +199,16 @@ export class ElectronFileAdapter implements FileAdapter {
     }
 
     async reload(): Promise<Uint8Array> {
-        return electronApp().fs.readFile(this.resolve(this._filename));
+        const bytes = await electronApp().fs.readFile(this.resolve(this._filename));
+        await armFileWatch(this.dirPath, this._filename);
+        return bytes;
     }
+}
+
+// Reveals a recent-list or currently-open game file in Finder/Explorer/the
+// platform file manager.
+export async function showItemInFolder(dirPath: string, filename: string): Promise<void> {
+    await electronApp().shell.showItemInFolder(electronApp().path.join(dirPath, filename));
 }
 
 /**
@@ -209,6 +247,7 @@ export async function loadElectronFile(
 ): Promise<{ bytes: Uint8Array; adapter: ElectronFileAdapter }> {
     const bytes = await electronApp().fs.readFile(electronApp().path.join(dirPath, filename));
     await trackRecent(dirPath, filename, kind);
+    if (kind === "edit") await armFileWatch(dirPath, filename);
     return { bytes, adapter: new ElectronFileAdapter(dirPath, filename) };
 }
 
@@ -260,5 +299,6 @@ export async function createElectronGame(
     const filePath = electronApp().path.join(dirPath, filename);
     await electronApp().fs.writeFile(filePath, content);
     await trackRecent(dirPath, filename);
+    await armFileWatch(dirPath, filename);
     return { bytes: new TextEncoder().encode(content), adapter: new ElectronFileAdapter(dirPath, filename) };
 }

--- a/src/AppShell/src/routes/+layout.svelte
+++ b/src/AppShell/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
     import { base } from "$app/paths";
     import { page } from "$app/state";
     import { PUBLIC_APPSHELL_VERSION, PUBLIC_SHOW_HOME } from "$env/static/public";
-    import { isLoaded, saveGame, saveGameAs, undo, redo, canUndo, canRedo } from "$lib/editor-store";
+    import { isLoaded, saveGame, saveGameAs, undo, redo, canUndo, canRedo, markFileChangedExternally } from "$lib/editor-store";
     import { isElectron } from "$lib/runtime";
     import HomeHeader from "$components/HomeHeader.svelte";
     import HomeTabs from "$components/HomeTabs.svelte";
@@ -121,10 +121,15 @@
             const query = `?action=play-file&dir=${encodeURIComponent(file.dirPath)}&file=${encodeURIComponent(file.filename)}&t=${Date.now()}`;
             void goto(`${rootPath}${query}`);
         });
+        // Main-process file watcher (ElectronApp's ipc/file-watch.ts, armed by
+        // electron-adapter.ts) — see FileChangedExternallyBanner.svelte for
+        // the actual banner UI, rendered from edit/+page.svelte.
+        const unsubscribeFileChanged = window.electronApp!.fileWatch.onChanged(() => markFileChangedExternally());
         return () => {
             unsubscribeAction();
             unsubscribeRecent();
             unsubscribePlayFile();
+            unsubscribeFileChanged();
         };
     });
 </script>

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -9,6 +9,7 @@
     import Toolbar from "$components/Toolbar.svelte";
     import BackupBanner from "$components/BackupBanner.svelte";
     import LibraryReloadBanner from "$components/LibraryReloadBanner.svelte";
+    import FileChangedExternallyBanner from "$components/FileChangedExternallyBanner.svelte";
     import TreePanel from "$components/TreePanel.svelte";
     import PropertyEditor from "$components/PropertyEditor.svelte";
     import CodeViewPanel from "$components/CodeViewPanel.svelte";
@@ -148,6 +149,7 @@
         <Toolbar />
         <BackupBanner />
         <LibraryReloadBanner />
+        <FileChangedExternallyBanner />
         <div class="flex flex-1 overflow-hidden" oninput={handleFieldInput} onfocusout={clearFieldEditing}>
             {#if $codeViewPanelOpen}
                 <CodeViewPanel onclose={() => codeViewPanelOpen.set(false)} />

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -10,7 +10,7 @@
     import { hasFSA, openDirectory, loadFileFromDirectory, createLocalGame } from "$lib/filesystem/browser-adapter";
     import {
         openElectronFile, loadElectronFile, createElectronGame, getDefaultGamesDir, pickGameLocation,
-        listRecentGames, removeRecentGame,
+        listRecentGames, removeRecentGame, showItemInFolder,
     } from "$lib/filesystem/electron-adapter";
     import type { RecentGame } from "$lib/filesystem/electron-adapter";
     import { isElectron } from "$lib/runtime";
@@ -25,6 +25,9 @@
     import { loadWasm } from "$lib/wasm";
     import { triggerDownload } from "$lib/filesystem/download";
     import { zipSync } from "fflate";
+    import FolderOpen from "@lucide/svelte/icons/folder-open";
+    import Trash2 from "@lucide/svelte/icons/trash-2";
+    import Download from "@lucide/svelte/icons/download";
 
     const hasServer = PUBLIC_HAS_SERVER === "true";
 
@@ -146,6 +149,13 @@
     function folderName(dirPath: string): string {
         return dirPath.split(/[\\/]/).pop() || dirPath;
     }
+
+    // Matches each platform's own term for its file manager, same as any
+    // native app's "Show in Finder"/"Show in Explorer" context-menu item.
+    const electronPlatform = typeof window !== "undefined" ? window.electronApp?.platform : undefined;
+    const showInFolderLabel = electronPlatform === "Mac" ? "Show in Finder"
+        : electronPlatform === "Windows" ? "Show in Explorer"
+        : "Show in folder";
 
     // Create new game form (shared)
     let createName = $state("");
@@ -539,10 +549,18 @@
                             </button>
                             <button
                                 type="button"
-                                class="btn btn-sm preset-outlined-error-500"
+                                class="btn-icon btn-icon-sm preset-outlined-surface-500 shrink-0"
+                                title={showInFolderLabel}
+                                aria-label={showInFolderLabel}
+                                onclick={() => showItemInFolder(game.dirPath, game.filename)}
+                            ><FolderOpen size={14} /></button>
+                            <button
+                                type="button"
+                                class="btn-icon btn-icon-sm preset-outlined-error-500 shrink-0"
                                 title="Remove from Recent"
+                                aria-label="Remove from Recent"
                                 onclick={() => handleRemoveRecent(game)}
-                            >Remove</button>
+                            ><Trash2 size={14} /></button>
                         </div>
                     {/each}
                 </div>
@@ -556,24 +574,26 @@
                         <div class="flex items-center gap-2 w-full">
                             <button
                                 type="button"
-                                class="btn btn-sm preset-outlined-primary-500 flex-1 justify-between"
+                                class="btn btn-sm preset-outlined-primary-500 flex-1 min-w-0 justify-between"
                                 onclick={() => handleOpenDraft(draft.gameId)}
                             >
-                                <span>{draft.filename}</span>
-                                <span class="text-surface-600-400">{relativeTime(draft.lastModified)}</span>
+                                <span class="truncate min-w-0">{draft.filename}</span>
+                                <span class="text-surface-600-400 shrink-0">{relativeTime(draft.lastModified)}</span>
                             </button>
                             <button
                                 type="button"
-                                class="btn btn-sm preset-outlined-surface-500"
+                                class="btn-icon btn-icon-sm preset-outlined-surface-500 shrink-0"
                                 title="Download this draft as a .zip (game file + assets) — works even if it fails to open"
+                                aria-label="Download this draft as a .zip"
                                 onclick={() => handleDownloadDraft(draft.gameId, draft.filename)}
-                            >Download</button>
+                            ><Download size={14} /></button>
                             <button
                                 type="button"
-                                class="btn btn-sm preset-outlined-error-500"
+                                class="btn-icon btn-icon-sm preset-outlined-error-500 shrink-0"
                                 title="Delete draft"
+                                aria-label="Delete draft"
                                 onclick={() => handleDeleteDraft(draft.gameId, draft.filename)}
-                            >Delete</button>
+                            ><Trash2 size={14} /></button>
                         </div>
                     {/each}
                 </div>

--- a/src/ElectronApp/src/ipc/file-watch.ts
+++ b/src/ElectronApp/src/ipc/file-watch.ts
@@ -1,0 +1,82 @@
+import { ipcMain } from "electron";
+import { promises as fs, watch as fsWatch, type FSWatcher } from "node:fs";
+import * as path from "node:path";
+
+// Debounces a burst of fs.watch events (many editors emit several writes per
+// save) into a single restat/notify pass.
+const DEBOUNCE_MS = 400;
+
+let watchedDir: string | null = null;
+let watcher: FSWatcher | null = null;
+let baseline = new Map<string, number>(); // filename -> mtimeMs, both relative to watchedDir
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function stopWatching(): void {
+    watcher?.close();
+    watcher = null;
+    watchedDir = null;
+    baseline = new Map();
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+    }
+}
+
+async function statMtime(fullPath: string): Promise<number | null> {
+    try {
+        return (await fs.stat(fullPath)).mtimeMs;
+    } catch {
+        // Deleted/renamed mid-edit (e.g. an external editor's atomic-save swap
+        // caught between unlink and rename) — best effort, a later event will
+        // restat successfully once the file settles.
+        return null;
+    }
+}
+
+async function checkForChanges(dirPath: string, onChanged: (filenames: string[]) => void): Promise<void> {
+    if (watchedDir !== dirPath) return; // superseded by a newer watch() call
+    const changed: string[] = [];
+    for (const [filename, knownMtime] of baseline) {
+        const mtime = await statMtime(path.join(dirPath, filename));
+        if (mtime !== null && mtime > knownMtime) {
+            baseline.set(filename, mtime);
+            changed.push(filename);
+        }
+    }
+    if (changed.length > 0) onChanged(changed);
+}
+
+// Backs window.electronApp.fileWatch in preload.ts — lets the renderer flag
+// when the currently-open game file (or one of its included-library .aslx
+// siblings) was modified by something other than this app, e.g. an external
+// text editor. Renderer-driven, not adapter-driven: electron-adapter.ts calls
+// watch() every time it loads/saves/reloads a file, which both arms the
+// watch and re-baselines it so the app's own writes never self-trigger.
+// Single active watch at a time, matching ElectronApp's single-editor-window
+// model — a new watch() call always supersedes whatever was watched before.
+export function registerFileWatchHandlers(onChanged: (filenames: string[]) => void): void {
+    ipcMain.handle("fileWatch:watch", async (_event, dirPath: string, filenames: string[]) => {
+        stopWatching();
+        watchedDir = dirPath;
+        for (const filename of filenames) {
+            const mtime = await statMtime(path.join(dirPath, filename));
+            baseline.set(filename, mtime ?? 0);
+        }
+        try {
+            watcher = fsWatch(dirPath, () => {
+                if (debounceTimer) clearTimeout(debounceTimer);
+                debounceTimer = setTimeout(() => {
+                    debounceTimer = null;
+                    void checkForChanges(dirPath, onChanged);
+                }, DEBOUNCE_MS);
+            });
+        } catch {
+            // Directory unwatchable (e.g. removable media ejected mid-session)
+            // — editing still works, just without external-change detection.
+        }
+    });
+
+    ipcMain.handle("fileWatch:unwatch", () => {
+        stopWatching();
+    });
+}

--- a/src/ElectronApp/src/ipc/shell.ts
+++ b/src/ElectronApp/src/ipc/shell.ts
@@ -5,4 +5,12 @@ export function registerShellHandlers(): void {
     ipcMain.handle("shell:openExternal", async (_event, url: string) => {
         await shell.openExternal(url);
     });
+
+    // Reveals a file in Finder/Explorer/the platform file manager — used by
+    // the /open page's Recent list. showItemInFolder is synchronous in
+    // Electron's API; wrapped in handle() only for a consistent invoke-based
+    // call shape with the rest of this namespace.
+    ipcMain.handle("shell:showItemInFolder", (_event, fullPath: string) => {
+        shell.showItemInFolder(fullPath);
+    });
 }

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -7,6 +7,7 @@ import { registerShellHandlers } from "./ipc/shell";
 import { registerPathsHandlers } from "./ipc/paths";
 import { registerRecentHandlers } from "./ipc/recent";
 import { registerPlayerHandlers } from "./ipc/player";
+import { registerFileWatchHandlers } from "./ipc/file-watch";
 import { listRecentGames, clearRecentGames, type RecentGame, type RecentKind } from "./recent-games";
 
 let editorWindow: BrowserWindow | null = null;
@@ -574,6 +575,11 @@ if (!gotLock) {
             broadcastRecentChanged(kind);
         });
         registerPlayerHandlers(() => (staticServer ? `http://127.0.0.1:${staticServer.port}` : null));
+        // Renderer-armed (see electron-adapter.ts's arm calls) — this only ever
+        // notifies about whatever file(s) the renderer last asked to watch.
+        registerFileWatchHandlers((filenames) => {
+            editorWindow?.webContents.send("file-changed-externally", filenames);
+        });
         await refreshMenu();
 
         const root = staticRoot();

--- a/src/ElectronApp/src/preload.ts
+++ b/src/ElectronApp/src/preload.ts
@@ -65,6 +65,7 @@ contextBridge.exposeInMainWorld("electronApp", {
     },
     shell: {
         openExternal: (url: string): Promise<void> => ipcRenderer.invoke("shell:openExternal", url),
+        showItemInFolder: (path: string): Promise<void> => ipcRenderer.invoke("shell:showItemInFolder", path),
     },
     path: {
         join: joinPath,
@@ -116,6 +117,23 @@ contextBridge.exposeInMainWorld("electronApp", {
             const listener = (_event: Electron.IpcRendererEvent, game: { dirPath: string; filename: string }) => callback(game);
             ipcRenderer.on("open-recent-game", listener);
             return () => ipcRenderer.removeListener("open-recent-game", listener);
+        },
+    },
+    fileWatch: {
+        // filenames are relative to dirPath: the currently-open game file plus
+        // any adjacent .aslx included-library files (see electron-adapter.ts's
+        // computeWatchList). Each call replaces whatever was previously
+        // watched and re-baselines it against the files' current mtimes, so
+        // the app's own reads/writes never trigger a false "changed
+        // externally" notification.
+        watch: (dirPath: string, filenames: string[]): Promise<void> => ipcRenderer.invoke("fileWatch:watch", dirPath, filenames),
+        unwatch: (): Promise<void> => ipcRenderer.invoke("fileWatch:unwatch"),
+        // filenames is whichever of the watched files changed — usually just
+        // the main game file, but could be an included library instead.
+        onChanged: (callback: (filenames: string[]) => void): (() => void) => {
+            const listener = (_event: Electron.IpcRendererEvent, filenames: string[]) => callback(filenames);
+            ipcRenderer.on("file-changed-externally", listener);
+            return () => ipcRenderer.removeListener("file-changed-externally", listener);
         },
     },
     player: {


### PR DESCRIPTION
## Summary
- Adds a "Show in Finder"/"Show in Explorer" action to each entry in the Create tab's Recent list (new `shell:showItemInFolder` IPC handler).
- Watches the currently-open game file and its included libraries for changes made outside the editor (e.g. an external text editor) — arms/re-arms on load/save/save-as/reload so the app's own writes never false-positive — and shows a reload-from-disk banner when something else touches the file.
- Fixes the Recent/local-drafts list rows overflowing on narrow viewports (missing `min-w-0`), and switches their action buttons to compact icon buttons.
- Works around a still-open Electron/Chromium bug ([electron/electron#49843](https://github.com/electron/electron/issues/49843)) where `title`-attribute tooltips on macOS stop firing after the first hover.

## Test plan
- [x] `svelte-check`, `eslint`, and `tsc` (ElectronApp) all pass
- [x] Verified in the Browser pane: local-drafts row no longer overflows at 375px mobile width; full editor renders with no layout regression from the global tooltip CSS fix
- [ ] Manual pass in the packaged Electron app: reveal-in-Finder, external-change banner, and tooltip fix (native window/dialogs aren't reachable from this session's browser automation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)