### PR TITLE
fix(AppShell): resolve Included Library content for Electron and FSA folders

### DIFF
--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -156,14 +156,17 @@ export const lastOpenGameError = writable<string | null>(null);
 // engine can't resolve it on its own when (re)loading. AddLibraryModal only ever uploads
 // .aslx files, so every asset with that extension is a candidate; stage them all into the WASM
 // side (WasmEditorBridge.AddAdjacentFile) before Initialise/SetGameXml runs the load that needs
-// them (see WorldModel.GetLibraryStream / ByteArrayGameDataProvider).
+// them (see WorldModel.GetLibraryStream / ByteArrayGameDataProvider). Candidate discovery goes
+// through listLibraryCandidates() rather than listAssets() — see its own comment on
+// FileAdapter for why the two can't be the same list.
 async function preloadAdjacentLibraryAssets(adapter: FileAdapter): Promise<void> {
-    const assets = await adapter.listAssets();
-    for (const asset of assets) {
-        if (!asset.key.toLowerCase().endsWith(".aslx")) continue;
-        const blob = await adapter.getAsset(asset.key);
+    const candidates = adapter.listLibraryCandidates
+        ? await adapter.listLibraryCandidates()
+        : (await adapter.listAssets()).map(a => a.key).filter(key => key.toLowerCase().endsWith(".aslx"));
+    for (const key of candidates) {
+        const blob = await adapter.getAsset(key);
         if (!blob) continue;
-        _bridge!.AddAdjacentFile(asset.key, new Uint8Array(await blob.arrayBuffer()));
+        _bridge!.AddAdjacentFile(key, new Uint8Array(await blob.arrayBuffer()));
     }
 }
 

--- a/src/AppShell/src/lib/filesystem/browser-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/browser-adapter.ts
@@ -149,6 +149,25 @@ export class BrowserFileAdapter implements FileAdapter {
         }
     }
 
+    // See FileAdapter.listLibraryCandidates's own comment for why this can't just be a filtered
+    // listAssets() — this directory is an arbitrary real folder the user picked via FSA, so
+    // listAssets() has to hide every .aslx (an unrelated game sharing it would otherwise show up
+    // as a deletable "asset" of this one), but that means it can never also double as library
+    // discovery.
+    async listLibraryCandidates(): Promise<string[]> {
+        try {
+            const libraries: string[] = [];
+            for await (const [name, handle] of this._dir) {
+                if (handle.kind === "file" && name.toLowerCase().endsWith(".aslx") && name !== this._filename) {
+                    libraries.push(name);
+                }
+            }
+            return libraries;
+        } catch {
+            return [];
+        }
+    }
+
     async deleteAsset(key: string): Promise<void> {
         await this._dir.removeEntry(key);
     }

--- a/src/AppShell/src/lib/filesystem/electron-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/electron-adapter.ts
@@ -164,6 +164,17 @@ export class ElectronFileAdapter implements FileAdapter {
             .map((e) => ({ key: e.name, url: "" }));
     }
 
+    // See FileAdapter.listLibraryCandidates's own comment for why this can't just be a filtered
+    // listAssets() — this folder is an arbitrary real one the user picked, so listAssets() has to
+    // hide every .aslx (an unrelated game sharing it would otherwise show up as a deletable
+    // "asset" of this one), but that means it can never also double as library discovery.
+    async listLibraryCandidates(): Promise<string[]> {
+        const entries = await electronApp().fs.readDir(this.dirPath);
+        return entries
+            .filter((e) => e.isFile && e.name.toLowerCase().endsWith(".aslx") && e.name !== this._filename)
+            .map((e) => e.name);
+    }
+
     async deleteAsset(key: string): Promise<void> {
         await electronApp().fs.unlink(this.resolve(key));
     }

--- a/src/AppShell/src/lib/filesystem/types.ts
+++ b/src/AppShell/src/lib/filesystem/types.ts
@@ -13,6 +13,17 @@ export interface FileAdapter {
     getAsset(key: string): Promise<Blob | null>;
     listAssets(): Promise<AssetInfo[]>;
     deleteAsset(key: string): Promise<void>;
+    // Every .aslx sibling of this game's own main file — i.e. every candidate Included Library
+    // editor-store.ts's preloadAdjacentLibraryAssets needs to stage via AddAdjacentFile before a
+    // (re)load can resolve <include ref="..."/> elements. Deliberately separate from
+    // listAssets(): adapters over a real, arbitrary folder (BrowserFileAdapter, ElectronFileAdapter)
+    // must hide .aslx there so an unrelated game sharing that folder never shows up as a
+    // deletable "asset" of this one — but that same filtering, if reused for library discovery,
+    // silently breaks loading any game with a custom Included Library (it did, for both — see
+    // git history). Optional: adapters whose listAssets() already surfaces every .aslx
+    // unfiltered (LocalDraftAdapter, ServerFileAdapter) don't need their own implementation —
+    // preloadAdjacentLibraryAssets() falls back to filtering listAssets() itself when absent.
+    listLibraryCandidates?(): Promise<string[]>;
     // Only implemented by adapters keyed by GameId (LocalDraftAdapter) — moves
     // storage to a new key when the game's gameid field changes mid-edit.
     rekey?(newGameId: string): Promise<void>;


### PR DESCRIPTION
## Summary
- `preloadAdjacentLibraryAssets()` discovers candidate library `.aslx` files by filtering `listAssets()` — but `ElectronFileAdapter` and `BrowserFileAdapter` (FSA) both unconditionally strip `.aslx` out of `listAssets()` itself, so it could never find any. Same root cause #2017 already fixed for local (OPFS) drafts, just never carried over to Electron's "Open game folder" or a browser's FSA folder picker.
- Adds a separate `FileAdapter.listLibraryCandidates()`, kept apart from `listAssets()` on purpose: an arbitrary real folder could contain another, unrelated game's `.aslx` file, which must stay hidden from the Asset Manager's delete list — so `listAssets()` can't just start including `.aslx` the way OPFS's exclusively-owned directory safely can.

## Test plan
- [x] `svelte-check` and `eslint` pass
- [ ] Manual pass: create a game with a custom Included Library via Electron's "Open game folder" (and via a browser's FSA folder picker), save, reload, confirm the library still resolves — native folder pickers aren't reachable from this session's browser automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)