### PR TITLE
fix(AppShell): hide library files when opening, repair missing gameid on import

### DIFF
--- a/src/AppShell/src/lib/filesystem/browser-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/browser-adapter.ts
@@ -1,4 +1,4 @@
-import { isJunkAssetName, type AssetInfo, type FileAdapter, type LoadedFile } from "./types";
+import { isJunkAssetName, isLibraryAslxContent, type AssetInfo, type FileAdapter, type LoadedFile } from "./types";
 import { toBlob, triggerDownload } from "./download";
 
 // FSA globals — not in the TS DOM lib at this target version
@@ -27,15 +27,16 @@ export function hasFSA(): boolean {
 
 /**
  * FSA path: opens a directory picker and returns the handle plus all .aslx
- * filenames found inside. The caller is responsible for picking which file to
- * load if there are multiple (e.g. a multi-file game or split libraries).
+ * filenames found inside, minus any Included Library files (not directly
+ * openable as a game — see isLibraryAslxContent). The caller is responsible
+ * for picking which file to load if there are multiple (e.g. a multi-file game).
  */
 export async function openDirectory(): Promise<{ dir: FileSystemDirectoryHandle; files: string[] } | null> {
     try {
         const dir = await showDirectoryPicker({ mode: "readwrite" });
         const files: string[] = [];
         for await (const [name, handle] of dir) {
-            if (handle.kind === "file" && name.toLowerCase().endsWith(".aslx")) {
+            if (handle.kind === "file" && name.toLowerCase().endsWith(".aslx") && !(await isLibraryHandle(handle))) {
                 files.push(name);
             }
         }
@@ -43,6 +44,15 @@ export async function openDirectory(): Promise<{ dir: FileSystemDirectoryHandle;
     } catch (err: unknown) {
         if (err instanceof Error && err.name === "AbortError") return null;
         throw err;
+    }
+}
+
+// Only needs the first few hundred bytes to see the root element name.
+async function isLibraryHandle(handle: FileSystemFileHandle): Promise<boolean> {
+    try {
+        return isLibraryAslxContent(await handle.getFile().then(f => f.slice(0, 512).text()));
+    } catch {
+        return false;
     }
 }
 

--- a/src/AppShell/src/lib/filesystem/local-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/local-adapter.ts
@@ -1,5 +1,5 @@
 import { unzipSync } from "fflate";
-import { isJunkAssetName, type AssetInfo, type FileAdapter } from "./types";
+import { isJunkAssetName, isLibraryAslxContent, type AssetInfo, type FileAdapter } from "./types";
 import { resolveOpfsDir, removeOpfsFile, removeOpfsDir, writeOpfsFile } from "./opfs-writer";
 
 // Local drafts live in OPFS under games/<gameId>/, alongside the game's own asset
@@ -135,15 +135,15 @@ export async function createLocalDraftFromFile(file: File): Promise<
     const raw = new Uint8Array(await file.arrayBuffer());
 
     if (!file.name.toLowerCase().endsWith(".zip")) {
-        const gameId = parseGameIdFromAslx(new TextDecoder().decode(raw));
-        if (!gameId) throw new Error("Could not find a gameid in the imported file.");
-        const adapter = await createLocalDraft(gameId, file.name, raw);
-        return { kind: "opened", bytes: raw, adapter };
+        const { bytes, gameId } = ensureGameId(raw);
+        const adapter = await createLocalDraft(gameId, file.name, bytes);
+        return { kind: "opened", bytes, adapter };
     }
 
     const entries = unzipSync(raw);
     const names = Object.keys(entries)
         .filter(name => !name.endsWith("/") && !isMacZipJunk(name) && name.toLowerCase().endsWith(".aslx"))
+        .filter(name => !isLibraryAslxContent(new TextDecoder().decode(entries[name].slice(0, 512))))
         .sort();
     if (names.length === 0) throw new Error("No .aslx game file found in the zip.");
     if (names.length > 1) return { kind: "chooseEntry", entries, names };
@@ -163,10 +163,9 @@ async function openZipEntry(
     gameEntryName: string,
     displayFilename: string = gameEntryName,
 ): Promise<{ bytes: Uint8Array; adapter: LocalDraftAdapter }> {
-    const gameBytes = entries[gameEntryName];
-    if (!gameBytes) throw new Error(`Zip is missing ${gameEntryName}.`);
-    const gameId = parseGameIdFromAslx(new TextDecoder().decode(gameBytes));
-    if (!gameId) throw new Error("Could not find a gameid in the imported file.");
+    const rawGameBytes = entries[gameEntryName];
+    if (!rawGameBytes) throw new Error(`Zip is missing ${gameEntryName}.`);
+    const { bytes: gameBytes, gameId } = ensureGameId(rawGameBytes);
 
     const adapter = await createLocalDraft(gameId, displayFilename, gameBytes);
     for (const [name, bytes] of Object.entries(entries)) {
@@ -186,6 +185,28 @@ export function parseGameIdFromAslx(xmlText: string): string | null {
     } catch {
         return null;
     }
+}
+
+// Older games (pre-v500-ish exports, or anything hand-assembled) can be missing
+// <gameid> entirely — EditorController.cs does the same repair once a game is
+// already loaded through WASM (WorldModelVersion.v500 check), but the OPFS
+// draft needs a gameid up front, before WASM ever sees the file. Rather than
+// hard-erroring on import, mint one the same way the "Generate" button in
+// PropertyEditor.svelte does (crypto.randomUUID(), same v4-UUID shape as the
+// C# side's Guid.NewGuid()) and splice it into the raw XML as the first child
+// of <game>, leaving everything else in the file untouched.
+export function ensureGameId(raw: Uint8Array): { bytes: Uint8Array; gameId: string } {
+    const text = new TextDecoder().decode(raw);
+    const existing = parseGameIdFromAslx(text);
+    if (existing) return { bytes: raw, gameId: existing };
+
+    const gameTag = text.match(/<game\b[^>]*>/);
+    if (!gameTag || gameTag.index === undefined) throw new Error("Could not find a gameid in the imported file.");
+
+    const gameId = crypto.randomUUID();
+    const insertAt = gameTag.index + gameTag[0].length;
+    const patched = text.slice(0, insertAt) + `<gameid>${gameId}</gameid>` + text.slice(insertAt);
+    return { bytes: new TextEncoder().encode(patched), gameId };
 }
 
 let _persistRequested = false;

--- a/src/AppShell/src/lib/filesystem/types.ts
+++ b/src/AppShell/src/lib/filesystem/types.ts
@@ -47,3 +47,14 @@ export interface LoadedFile {
 export function isJunkAssetName(name: string): boolean {
     return name === ".DS_Store" || name.startsWith("._");
 }
+
+// Included Library files are their own standalone .aslx with a <library> root
+// (no <asl>/<game> wrapper) — see GameLoader's own "not a library"/"must begin
+// with an ASL element" checks (src/Engine/GameLoader/ElementLoaders.cs,
+// GameLoader.cs). Not directly openable/playable as a game, so callers building
+// a "pick which file to open" list can use this to hide them. A plain regex
+// for the first element tag is enough here — no need for a full XML parse just
+// to read one tag name.
+export function isLibraryAslxContent(text: string): boolean {
+    return text.match(/<([a-zA-Z][\w:-]*)/)?.[1] === "library";
+}


### PR DESCRIPTION
## Summary
- Filters Included Library `.aslx` files (root `<library>` element, per `GameLoader.cs`/`ElementLoaders.cs`'s own asl-vs-library checks) out of the "choose which file to open" list, for both the FSA folder-open picker and multi-`.aslx` zip imports — so a folder/zip containing a game plus its library no longer forces the user to pick between them.
- Stops the "Import game file" flow from hard-erroring when a raw `.aslx` has no `<gameid>`. Instead it mints a new one with `crypto.randomUUID()` (same v4-UUID shape as the existing "Generate" button in `PropertyEditor.svelte`, and as C#'s `Guid.NewGuid()`) and splices it into the file as the first child of `<game>`, mirroring the repair `EditorController.cs` already performs post-load for old `v500` games — just done earlier, since the OPFS draft needs a gameid up front to pick a storage key.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx svelte-check` — 0 errors/warnings
- [x] `npm run lint` — clean
- [x] Verified the new `isLibraryAslxContent`/`ensureGameId` regex logic against sample XML (with BOM+CRLF) in a standalone script
- [ ] Manual click-through of the FSA folder-open and file-import dialogs (native picker UI, not practical to drive headlessly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)