### PR TITLE
fix: flatten native input chrome and tighten tree filter icon spacing

### DIFF
--- a/src/AppShell/src/app.css
+++ b/src/AppShell/src/app.css
@@ -102,3 +102,23 @@ select.select:active {
     border-color: var(--color-primary-500);
     outline: none;
 }
+
+/* Safari also renders native chrome around plain text/search inputs, showing
+   through the .input box-shadow ring as an extra 3D bezel that Chrome doesn't
+   have. As above, disable native appearance and use a real border instead,
+   keyed off the same states Skeleton's ring uses for focus. [type=color] and
+   [type=range] keep their own native look and are left alone. */
+input.input:not([type='color']):not([type='range']) {
+    -webkit-appearance: none;
+    appearance: none;
+    border-width: 1px;
+    border-color: var(--color-surface-200-800);
+    box-shadow: none;
+}
+
+input.input:not([type='color']):not([type='range']):focus,
+input.input:not([type='color']):not([type='range']):focus-within,
+input.input:not([type='color']):not([type='range']):active {
+    border-color: var(--color-primary-500);
+    outline: none;
+}

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -369,7 +369,7 @@
     </div>
     <div class="p-1.5 border-b border-surface-200-800 flex items-center gap-1">
         <div class="relative flex-1">
-            <Search class="absolute left-3.5 top-1/2 -translate-y-1/2 size-3.5 text-surface-400 pointer-events-none" />
+            <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-surface-400 pointer-events-none" />
             <input
                 bind:this={filterInputEl}
                 type="text"
@@ -377,13 +377,13 @@
                 bind:value={filterText}
                 placeholder="Filter..."
                 aria-label="Filter game objects"
-                class="input text-xs py-1 pl-7 pr-6 w-full"
+                class="input text-xs py-1 pl-8 pr-7 w-full"
                 onkeydown={(e) => { if (e.key === "Escape" && filterText) { e.stopPropagation(); clearFilter(); } }}
             />
             {#if filterText}
                 <button
                     type="button"
-                    class="absolute right-3 top-1/2 -translate-y-1/2 size-4 flex items-center justify-center text-surface-400 hover:text-surface-900-50"
+                    class="absolute right-2 top-1/2 -translate-y-1/2 size-4 flex items-center justify-center text-surface-400 hover:text-surface-900-50"
                     onclick={clearFilter}
                     aria-label="Clear filter"
                 ><X class="size-3.5" /></button>

--- a/src/PlayerCore/Resources/playercore.css
+++ b/src/PlayerCore/Resources/playercore.css
@@ -155,6 +155,19 @@ div#txtCommandContainer {
     vertical-align: bottom;
     padding: 6px;
     flex-grow: 1;
+    /* Reset the browser's native inset/bevel text-field chrome (most visible
+       as a chunky border in Safari, but present — just subtler — everywhere)
+       with a flat, single-tone border instead. */
+    -webkit-appearance: none;
+    appearance: none;
+    border: 1px solid #999;
+    border-radius: 3px;
+    outline: none;
+}
+
+#txtCommand:focus {
+    border-color: #4a90d9;
+    box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.25);
 }
 
 #txtCommandSpacer {


### PR DESCRIPTION
## Summary
- Reset native browser `<input>` chrome (appearance + inset/bevel border) to a flat, single-tone border with a consistent focus style, applied to:
  - the AppShell `.input` utility (`src/AppShell/src/app.css`) — used by every text/search field in the editor
  - the player's command textbox `#txtCommand` (`src/PlayerCore/Resources/playercore.css`), shared by WebPlayer and WasmPlayer
- Fixes the editor's tree-view "Filter..." box: a structural change in #1961 (adding the "Show Library Elements" toggle button) moved the padded row div out from under the search icon's positioning context, so the row's own padding got added on top of the icon's inset — pushing the magnifying glass and clear (X) button further right than intended. Tightened back to match the equivalent filter box in `AddScriptModal.svelte`.

## Why
The native `border-style: inset` default that browsers apply to text inputs is much more pronounced in Safari than Chromium, making text fields look chunky/3D there — but it's not actually Safari-specific, just more visible. Chromium's native `appearance: auto` chrome was also hiding a pre-existing box-shadow ring from Skeleton's `.input` utility, so turning off `appearance` alone (without also flattening `border-style`) would have made the bezel show up in Chrome too. This also gives Safari a smaller, flatter focus ring instead of its default chunky one.

## Test plan
- [x] `npm run lint` in `src/AppShell` passes
- [x] Verified in the browser preview: AppShell filter box icon/clear-button spacing now matches `AddScriptModal.svelte`, and computed styles confirm `border-style: solid`, `box-shadow: none`, `appearance: none` on `.input`
- [x] Rebuilt the Debug WasmPlayer AppBundle and confirmed `#txtCommand` renders with a flat border, and a flat blue focus ring instead of the native inset bezel

🤖 Generated with [Claude Code](https://claude.com/claude-code)