### PR TITLE
fix(AppShell): translate remaining strings and fix Create-tab button overflow

### DIFF
--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -31,6 +31,30 @@
     }
 
 
+    // Synthetic header nodes (key starts with "_", see WasmEditorBridge.GetNodeType) carry
+    // their label as plain English text straight from EditorController.AddTreeHeader/OnAddedNode
+    // in C#, which has no access to the frontend's i18n messages. Translate by fixed id here
+    // instead; anything not in this map (there shouldn't be any) falls back to the C# text.
+    const HEADER_LABEL_KEYS: Record<string, string> = {
+        _advanced: "common.advanced",
+        _functions: "treePanel.header.functions",
+        _timers: "treePanel.header.timers",
+        _walkthrough: "treePanel.header.walkthrough",
+        _include: "treePanel.header.includedLibraries",
+        _template: "treePanel.header.templates",
+        _dynamictemplate: "treePanel.header.dynamicTemplates",
+        _objecttype: "treePanel.header.objectTypes",
+        _javascript: "treePanel.header.javascript",
+        _gameVerbs: "verbsEditor.header",
+        _gameCommands: "treePanel.header.commands",
+    };
+
+    function headerText(node: TreeNode): string {
+        if (node.key === "_objects") return $isGamebook ? t("treePanel.header.pages") : t("treePanel.header.objects");
+        const key = HEADER_LABEL_KEYS[node.key];
+        return key ? t(key) : node.text;
+    }
+
     // Build HierNode tree from flat list
     function buildHierTree(nodes: TreeNode[]): HierNode[] {
         // Deduplicate by key (last write wins, matching C# upsert behaviour in OnAddedNode)
@@ -49,7 +73,7 @@
             const children = byParent.get(node.key);
             return {
                 id: node.key,
-                text: node.text,
+                text: node.nodeType === "header" ? headerText(node) : node.text,
                 nodeType: node.nodeType,
                 isLibrary: node.isLibrary,
                 canDelete: node.canDelete,

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -9,6 +9,7 @@ import { ServerFileAdapter } from "./filesystem/server-adapter";
 import { triggerDownload } from "./filesystem/download";
 import { confirmDialog } from "./confirm";
 import { showToast } from "./toast";
+import { t } from "./i18n";
 import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, ExpressionTemplateData, ExpressionTemplate, FullAttributeData, ExitsData, VerbInfo, ExpressionFunctionInfo } from "./types";
 
 export type AddElementModalState = { type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
@@ -204,14 +205,14 @@ export async function openGame(bytes: Uint8Array, filename: string, adapter: Fil
     isSaving.set(false);
     saveError.set(null);
     lastOpenGameError.set(null);
-    loadingStatus.set("Starting editor…");
+    loadingStatus.set(t("editorStore.startingEditor"));
     _bridge = await loadWasm();
     _adapter = adapter;
     canSaveAs.set(adapter.canSaveAs);
     canBackup.set(adapter instanceof LocalDraftAdapter);
     canPublishToServer.set(adapter instanceof ServerFileAdapter);
     showBackupBanner.set(adapter instanceof LocalDraftAdapter && await shouldShowBackupBanner(adapter.gameId));
-    loadingStatus.set("Loading game…");
+    loadingStatus.set(t("editorStore.loadingGame"));
     await preloadAdjacentLibraryAssets(adapter);
     // Double rAF ensures the browser actually paints the status update before
     // Initialise blocks the JS thread (C# WASM calls are synchronous).

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -28,7 +28,7 @@
     import FolderOpen from "@lucide/svelte/icons/folder-open";
     import Trash2 from "@lucide/svelte/icons/trash-2";
     import Download from "@lucide/svelte/icons/download";
-    import { t } from "$lib/i18n";
+    import { t, locale } from "$lib/i18n";
 
     const hasServer = PUBLIC_HAS_SERVER === "true";
 
@@ -194,12 +194,23 @@
         if (picked) electronParentDir = picked;
     }
 
+    // Game templates are labelled by their own language's name (e.g. "Deutsch", not "German" —
+    // see EditorController.AddTemplateData's stem/`template=` attribute fallback), so the UI
+    // locale needs mapping to the matching template label. Only covers locales this UI actually
+    // offers (see SUPPORTED_LOCALES); anything else falls back to English.
+    const TEMPLATE_LABEL_BY_LOCALE: Record<string, string> = { en: "English", de: "Deutsch" };
+
+    function defaultTemplateLabel(): string {
+        return TEMPLATE_LABEL_BY_LOCALE[get(locale)] ?? "English";
+    }
+
     async function ensureTemplates() {
         if (templates.length > 0 || templatesLoading) return;
         templatesLoading = true;
         try {
             templates = await getGameTemplates();
-            const defaultTemplate = templates.find(tpl => tpl.label === "English") ?? templates[0];
+            const defaultTemplate = templates.find(tpl => tpl.label === defaultTemplateLabel())
+                ?? templates.find(tpl => tpl.label === "English") ?? templates[0];
             if (defaultTemplate) selectedTemplateId = defaultTemplate.id;
         } catch (err) {
             templatesError = String(err);
@@ -646,8 +657,9 @@
                                                     selectedTemplateId = gamebookTemplates[0]?.id ?? "";
                                                 } else {
                                                     const preferred = textAdventureTemplates.find(tpl => tpl.id === lastTextAdventureTemplateId);
-                                                    const english = textAdventureTemplates.find(tpl => tpl.label === "English");
-                                                    selectedTemplateId = (preferred ?? english ?? textAdventureTemplates[0])?.id ?? "";
+                                                    const localeDefault = textAdventureTemplates.find(tpl => tpl.label === defaultTemplateLabel())
+                                                        ?? textAdventureTemplates.find(tpl => tpl.label === "English");
+                                                    selectedTemplateId = (preferred ?? localeDefault ?? textAdventureTemplates[0])?.id ?? "";
                                                 }
                                             }}
                                         />
@@ -673,10 +685,10 @@
                         </div>
                     {:else}
                         <div class="flex gap-2">
-                            <div class="flex flex-col gap-1 flex-1">
+                            <div class="flex flex-col gap-1 flex-1 min-w-0">
                                 <button
                                     type="button"
-                                    class="btn preset-filled-primary-500 w-full"
+                                    class="btn preset-filled-primary-500 w-full whitespace-normal h-auto"
                                     onclick={handleCreateLocal}
                                     disabled={!createName.trim()}
                                     title={isElectronApp ? t("openPage.createFolderTitle") : t("openPage.createLocalDraftTitle")}
@@ -688,10 +700,10 @@
                                 {/if}
                             </div>
                             {#if canUseFSA}
-                                <div class="flex flex-col gap-1 flex-1">
+                                <div class="flex flex-col gap-1 flex-1 min-w-0">
                                     <button
                                         type="button"
-                                        class="btn preset-outlined-primary-500 w-full"
+                                        class="btn preset-outlined-primary-500 w-full whitespace-normal h-auto"
                                         onclick={handleCreateLocalFolder}
                                         disabled={!createName.trim()}
                                         title={t("openPage.saveToFolderTitle")}

--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -41,6 +41,9 @@
     "toolbar.publish": "Veröffentlichen…",
     "toolbar.exportSingleFile": "Export als einzelne Datei…",
 
+    "editorStore.startingEditor": "Editor wird gestartet…",
+    "editorStore.loadingGame": "Spiel wird geladen…",
+
     "addElementModal.labels.room": "Raum",
     "addElementModal.labels.object": "Objekt",
     "addElementModal.labels.page": "Seite",
@@ -123,6 +126,17 @@
     "treePanel.nodeOptions": "Optionen",
     "treePanel.expand": "Aufklappen",
     "treePanel.collapse": "Zuklappen",
+    "treePanel.header.objects": "Objekte",
+    "treePanel.header.pages": "Seiten",
+    "treePanel.header.functions": "Funktionen",
+    "treePanel.header.timers": "Timer",
+    "treePanel.header.walkthrough": "Komplettlösung",
+    "treePanel.header.includedLibraries": "Eingebundene Bibliotheken",
+    "treePanel.header.templates": "Vorlagen",
+    "treePanel.header.dynamicTemplates": "Dynamische Vorlagen",
+    "treePanel.header.objectTypes": "Objekttypen",
+    "treePanel.header.javascript": "Javascript",
+    "treePanel.header.commands": "Befehle",
 
     "elementsList.noItems": "Keine Elemente.",
     "elementsList.cannotDelete": "Dies kann nicht gelöscht werden",

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -41,6 +41,9 @@
     "toolbar.publish": "Publish…",
     "toolbar.exportSingleFile": "Export as single file…",
 
+    "editorStore.startingEditor": "Starting editor…",
+    "editorStore.loadingGame": "Loading game…",
+
     "addElementModal.labels.room": "Room",
     "addElementModal.labels.object": "Object",
     "addElementModal.labels.page": "Page",
@@ -123,6 +126,17 @@
     "treePanel.nodeOptions": "Options",
     "treePanel.expand": "Expand",
     "treePanel.collapse": "Collapse",
+    "treePanel.header.objects": "Objects",
+    "treePanel.header.pages": "Pages",
+    "treePanel.header.functions": "Functions",
+    "treePanel.header.timers": "Timers",
+    "treePanel.header.walkthrough": "Walkthrough",
+    "treePanel.header.includedLibraries": "Included Libraries",
+    "treePanel.header.templates": "Templates",
+    "treePanel.header.dynamicTemplates": "Dynamic Templates",
+    "treePanel.header.objectTypes": "Object Types",
+    "treePanel.header.javascript": "Javascript",
+    "treePanel.header.commands": "Commands",
 
     "elementsList.noItems": "No items.",
     "elementsList.cannotDelete": "This can't be deleted",


### PR DESCRIPTION
## Summary

Follow-ups from eyeballing the newly-added German translation (#2030):

- **Editor tree headers untranslated** — "Objects", "Advanced", "Included Libraries", "Functions", "Timers", etc. come straight from `EditorController.AddTreeHeader` in C# (see `_objects`/`_advanced`/`_include`/... keys, `WasmEditorBridge.GetNodeType`), which has no access to the frontend's i18n messages. `TreePanel.svelte` now maps each synthetic header node to a translated label by its fixed id, falling back to the C# text for anything unmapped.
- **"Loading game…" untranslated** — `editor-store.ts` set `loadingStatus` to hardcoded English strings; now routed through `t()` with new `editorStore.startingEditor`/`editorStore.loadingGame` keys (same pattern already used in `confirm.ts`).
- **Create-tab buttons overflow their container** — the two buttons under "Neues Spiel erstellen" (`flex-1` inside a `max-w-sm` container) don't shrink below their content's intrinsic width by default, and Skeleton's `.btn` forces `white-space: nowrap`, so the longer German labels ("Lokalen Entwurf erstellen") pushed the row past the container edge. Added `min-w-0` to the flex wrappers and `whitespace-normal h-auto` to the buttons so long labels wrap onto two lines instead of overflowing.
- **New-game language dropdown always defaulted to English** — regardless of UI language. It now maps the active UI locale to the matching template label (e.g. `de` → `"Deutsch"`, template labels come from each `.template` file's own language name), applied on initial load and when switching game type back to "Textadventure".

## Test plan

- [x] `svelte-check` — 0 errors/warnings
- [x] `eslint src` — clean
- [x] Built `WasmEditor` (Debug) and ran the AppShell dev server; switched UI language to Deutsch and verified:
  - Create tab: new-game buttons wrap cleanly, no overflow past the container
  - Create tab: template dropdown defaults to "Deutsch"
  - Created a game and confirmed tree headers render translated ("Objekte", "Fortgeschritten", "Eingebundene Bibliotheken", "Verben", "Befehle")
  - Confirmed `de.json` serves the new `editorStore.*` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)