### PR TITLE
fix(AppShell): Spanish gamebook template, locale capitalization, picker labels

### DIFF
--- a/src/AppShell/src/components/SettingsModal.svelte
+++ b/src/AppShell/src/components/SettingsModal.svelte
@@ -3,11 +3,16 @@
     import { locale, setLocale, SUPPORTED_LOCALES, t } from "$lib/i18n";
 
     function displayName(code: string): string {
+        let name: string;
         try {
-            return new Intl.DisplayNames([code], { type: "language" }).of(code) ?? code;
+            name = new Intl.DisplayNames([code], { type: "language" }).of(code) ?? code;
         } catch {
-            return code;
+            name = code;
         }
+        // CLDR autonyms aren't capitalized for every language (e.g. "español"),
+        // but this list is presented like a proper-noun menu ("English", "Deutsch"),
+        // so normalize every entry to match.
+        return name.charAt(0).toUpperCase() + name.slice(1);
     }
 
     function close() {

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -216,6 +216,15 @@
         return GAMEBOOK_TEMPLATE_LABEL_BY_LOCALE[get(locale)] ?? "Gamebook";
     }
 
+    // The "Gamebook" stem in a template's underlying label (see comment above) is redundant once
+    // it's showing in a list that's already scoped to the Gamebook radio option — display just the
+    // language part, matching how the Text Adventure list shows "English"/"Deutsch"/"Español" alone.
+    function gamebookTemplateDisplayLabel(label: string): string {
+        const match = /^Gamebook(?:\s*\(([^)]+)\))?$/.exec(label);
+        if (!match) return label;
+        return match[1] ?? "English";
+    }
+
     async function ensureTemplates() {
         if (templates.length > 0 || templatesLoading) return;
         templatesLoading = true;
@@ -693,7 +702,7 @@
                         {:else if selectedTemplate?.type === "gamebook" && gamebookTemplates.length > 1}
                             <select class="select" bind:value={selectedTemplateId} disabled={creating}>
                                 {#each gamebookTemplates as tpl (tpl.id)}
-                                    <option value={tpl.id}>{tpl.label}</option>
+                                    <option value={tpl.id}>{gamebookTemplateDisplayLabel(tpl.label)}</option>
                                 {/each}
                             </select>
                         {/if}

--- a/src/Engine/Engine.csproj
+++ b/src/Engine/Engine.csproj
@@ -452,6 +452,10 @@
         <EmbeddedResource Include="Core\Templates\Gamebook-Deutsch.template">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </EmbeddedResource>
+        <None Remove="Core\Templates\Gamebook-Espanol.template" />
+        <EmbeddedResource Include="Core\Templates\Gamebook-Espanol.template">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </EmbeddedResource>
         <None Remove="Core\Templates\Greek.template" />
         <EmbeddedResource Include="Core\Templates\Greek.template">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/tests/e2e/verify-appshell-gamebook-language-picker.mjs
+++ b/tests/e2e/verify-appshell-gamebook-language-picker.mjs
@@ -53,7 +53,7 @@ async function createGame(name, { locale, templateLabel }) {
 }
 
 async function run() {
-    // --- German UI locale: Gamebook picker should default to "Gamebook (Deutsch)" ---
+    // --- German UI locale: Gamebook picker should default to "Deutsch" ---
     await page.goto(`${baseUrl}/open`);
     await page.evaluate(() => localStorage.setItem('questviva-ui-language', 'de'));
     await page.reload();
@@ -64,12 +64,12 @@ async function run() {
     await page.waitForSelector('select', { timeout: 10000 });
     const options = await page.$$eval('select option', els => els.map(el => el.textContent ?? ''));
     assertEqual('Gamebook template option count', options.length, 2);
-    if (!options.includes('Gamebook') || !options.includes('Gamebook (Deutsch)')) {
+    if (!options.includes('English') || !options.includes('Deutsch')) {
         throw new Error(`Gamebook template options missing expected labels: ${JSON.stringify(options)}`);
     }
     console.log(`PASS: [Gamebook template options] ${JSON.stringify(options)}`);
     const selectedLabel = await page.$eval('select', el => el.selectedOptions[0]?.textContent ?? '');
-    assertEqual('Gamebook template default (de locale)', selectedLabel, 'Gamebook (Deutsch)');
+    assertEqual('Gamebook template default (de locale)', selectedLabel, 'Deutsch');
 
     await page.locator('button.preset-filled-primary-500').last().click();
     await page.waitForSelector('header .toolbar-icon-btn', { timeout: 30000 });
@@ -114,8 +114,8 @@ async function run() {
     }
     console.log(`PASS: [German gamebook Page2 description] "${page2Text.trim()}"`);
 
-    // --- English UI locale + explicit "Gamebook" (English) template ---
-    await createGame('EnglishGamebookTest', { locale: 'en', templateLabel: 'Gamebook' });
+    // --- English UI locale + explicit "English" Gamebook template ---
+    await createGame('EnglishGamebookTest', { locale: 'en', templateLabel: 'English' });
     const enLangValue = await page.evaluate(() => {
         const inputs = Array.from(document.querySelectorAll('input[type="text"]'));
         const match = inputs.find(i => i.value === 'en');


### PR DESCRIPTION
## Summary

Three small Spanish-localisation follow-ups discovered after #2035 brought Spanish to full parity:

- **Lowercase "español" in the settings language dropdown.** `SettingsModal.svelte` derives display names via `Intl.DisplayNames`, whose CLDR autonym for Spanish is lowercase (`español`) unlike English/German in the same list. Now capitalizes the first letter of the returned name for consistency.
- **Spanish Gamebook template missing from the "Create new game" dropdown.** `Gamebook-Espanol.template` existed on disk but was never added to `Engine.csproj`'s `EmbeddedResource` list, so `EditorController.GetAvailableTemplates()` (which enumerates embedded resources) never saw it. Added the missing entry.
- **Redundant "Gamebook" prefix in the Gamebook template picker.** It showed "Gamebook" / "Gamebook (Deutsch)" / "Gamebook (Español)", which is redundant once "Gamebook" is already selected via the game-type radio button. The dropdown now shows just the language name ("English" / "Deutsch" / "Español"), matching the Text Adventure picker. Only the *displayed* label changed — the underlying template labels used for default-selection matching (and referenced by `IncludedLibraryTests.cs`) are untouched.

## Test plan

- [x] `dotnet build --configuration Release src/Engine/Engine.csproj`
- [x] `dotnet test tests/EditorCoreTests --filter "FullyQualifiedName~TemplateTests|FullyQualifiedName~IncludedLibraryTests"` — passes
- [x] `npm run lint` / `npm run check` in `src/AppShell` — clean
- [x] Verified live in-browser (AppShell dev server + WasmEditor Debug build): settings dropdown shows "Español"; Gamebook picker shows "English"/"Deutsch"/"Español" with no prefix; selecting Spanish UI locale creates a game from `Gamebook-Espanol.template` with Spanish field labels and `Idioma: es`
- [x] Updated `tests/e2e/verify-appshell-gamebook-language-picker.mjs` to match the new picker labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)