### PR TITLE
fix(WasmPlayer): resolve custom Included Library content in Preview/Play

### DIFF
--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -172,19 +172,29 @@ export const lastOpenGameError = writable<string | null>(null);
 // An Included Library element only stores its filename (<include ref="lib.aslx"/>) — the
 // library's actual content lives in the adapter's asset storage, not in the game bytes, so the
 // engine can't resolve it on its own when (re)loading. AddLibraryModal only ever uploads
-// .aslx files, so every asset with that extension is a candidate; stage them all into the WASM
-// side (WasmEditorBridge.AddAdjacentFile) before Initialise/SetGameXml runs the load that needs
-// them (see WorldModel.GetLibraryStream / ByteArrayGameDataProvider). Candidate discovery goes
+// .aslx files, so every asset with that extension is a candidate. Candidate discovery goes
 // through listLibraryCandidates() rather than listAssets() — see its own comment on
 // FileAdapter for why the two can't be the same list.
-async function preloadAdjacentLibraryAssets(adapter: FileAdapter): Promise<void> {
+async function resolveLibraryCandidateFiles(adapter: FileAdapter): Promise<Record<string, Uint8Array>> {
     const candidates = adapter.listLibraryCandidates
         ? await adapter.listLibraryCandidates()
         : (await adapter.listAssets()).map(a => a.key).filter(key => key.toLowerCase().endsWith(".aslx"));
+    const files: Record<string, Uint8Array> = {};
     for (const key of candidates) {
         const blob = await adapter.getAsset(key);
         if (!blob) continue;
-        _bridge!.AddAdjacentFile(key, new Uint8Array(await blob.arrayBuffer()));
+        files[key] = new Uint8Array(await blob.arrayBuffer());
+    }
+    return files;
+}
+
+// Stages resolveLibraryCandidateFiles()'s result into the WASM side (WasmEditorBridge.AddAdjacentFile)
+// before Initialise/SetGameXml runs the load that needs them (see WorldModel.GetLibraryStream /
+// ByteArrayGameDataProvider).
+async function preloadAdjacentLibraryAssets(adapter: FileAdapter): Promise<void> {
+    const files = await resolveLibraryCandidateFiles(adapter);
+    for (const [key, bytes] of Object.entries(files)) {
+        _bridge!.AddAdjacentFile(key, bytes);
     }
 }
 
@@ -454,10 +464,18 @@ export async function previewInWasmPlayer(wasmPlayerUrl: string, opts?: { record
             // Serialize fresh on every 'ready' so WasmPlayer refreshes also pick up latest edits.
             if (!_bridge) return;
             const bytes = new TextEncoder().encode(_bridge.Save());
+            // The Editor's own save (SaveMode.Editor) excludes unmodified library-origin
+            // elements, leaving only <include ref="..."/> behind (see preloadAdjacentLibraryAssets)
+            // — WasmPlayer runs in its own separate WASM module with no adapter of its own, so
+            // any custom (non-built-in) library's content has to be handed over here too, or its
+            // <include> fails to resolve with "Library file not found" as soon as the player
+            // tries to load these bytes.
+            const adjacentFiles = await resolveLibraryCandidateFiles(adapter);
             bc.postMessage({
                 type: "game",
                 bytes,
                 filename,
+                adjacentFiles,
                 recordWalkthrough: opts?.recordWalkthrough ?? null,
                 runWalkthrough: opts?.runWalkthrough ?? null,
             });

--- a/src/AppShell/src/lib/filesystem/local-play.ts
+++ b/src/AppShell/src/lib/filesystem/local-play.ts
@@ -1,4 +1,5 @@
 import { loadElectronFile, openElectronPlayFile, listRecentGames } from "./electron-adapter";
+import type { FileAdapter } from "./types";
 import { resolveAndCacheCover } from "../local-cover";
 
 function blobToDataUrl(blob: Blob): Promise<string> {
@@ -7,6 +8,24 @@ function blobToDataUrl(blob: Blob): Promise<string> {
         reader.onload = () => resolve(reader.result as string);
         reader.readAsDataURL(blob);
     });
+}
+
+// An unpublished .aslx on disk can contain <include ref="custom.aslx"/> for a custom Included
+// Library, whose content lives in a sibling file rather than the game bytes themselves — same
+// situation editor-store.ts's preloadAdjacentLibraryAssets resolves for the editor. The player
+// window here runs as its own separate WASM module with no filesystem access, so those bytes
+// have to be resolved here and handed over alongside the game bytes (see WorldModel.GetLibraryStream).
+async function resolveAdjacentLibraryFiles(adapter: FileAdapter): Promise<Record<string, Uint8Array>> {
+    const candidates = adapter.listLibraryCandidates
+        ? await adapter.listLibraryCandidates()
+        : [];
+    const files: Record<string, Uint8Array> = {};
+    for (const key of candidates) {
+        const blob = await adapter.getAsset(key);
+        if (!blob) continue;
+        files[key] = new Uint8Array(await blob.arrayBuffer());
+    }
+    return files;
 }
 
 // Singleton, not per-caller — only one channel is ever "the current answerer" at a time
@@ -35,7 +54,8 @@ export async function playElectronFile(dirPath: string, filename: string, onPlay
     playChannel = bc;
     bc.onmessage = async ({ data }) => {
         if (data.type === "ready") {
-            bc.postMessage({ type: "game", bytes, filename });
+            const adjacentFiles = await resolveAdjacentLibraryFiles(adapter);
+            bc.postMessage({ type: "game", bytes, filename, adjacentFiles });
         } else if (data.type === "resource-request") {
             const blob = await adapter.getAsset(data.name);
             if (blob) {

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -26,7 +26,7 @@ public partial class WasmPlayerBridge
     [JSExport]
     public static async Task<bool> Initialise(byte[] gameFileBytes, string filename)
     {
-        var provider = new ByteArrayGameDataProvider(gameFileBytes, filename);
+        var provider = new ByteArrayGameDataProvider(gameFileBytes, filename, TakePendingAdjacentFiles());
         var gameData = await provider.GetData();
         if (gameData == null) return false;
 
@@ -41,12 +41,35 @@ public partial class WasmPlayerBridge
     [JSExport]
     public static async Task<bool> InitialiseWithSave(byte[] gameFileBytes, string filename, byte[] saveBytes)
     {
-        var provider = new ByteArrayGameDataProvider(gameFileBytes, filename);
+        var provider = new ByteArrayGameDataProvider(gameFileBytes, filename, TakePendingAdjacentFiles());
         var gameData = await provider.GetData();
         if (gameData == null) return false;
 
         using var saveStream = new MemoryStream(saveBytes);
         return await InitialiseCore(gameData, saveStream);
+    }
+
+    // An Included Library element only stores a filename (<include ref="lib.aslx"/> — see
+    // IncludeSaver); a custom (non-built-in) library's actual content lives in whichever host
+    // supplied the game bytes (the editor tab's adapter, an on-disk folder, ...), which this WASM
+    // module has no access to itself — see editor-store.ts's previewInWasmPlayer /
+    // local-play.ts's resolveAdjacentLibraryFiles. wasm-player.js stages each candidate's bytes
+    // here, one at a time ([JSExport] can't marshal an array of blobs in one call — mirrors
+    // WasmEditorBridge's identical AddAdjacentFile), before every Initialise/InitialiseWithSave
+    // call (including a restart), which consumes and clears this regardless of outcome.
+    private static readonly Dictionary<string, byte[]> PendingAdjacentFiles = new();
+
+    [JSExport]
+    public static void AddAdjacentFile(string filename, byte[] data)
+    {
+        PendingAdjacentFiles[filename] = data;
+    }
+
+    private static Dictionary<string, byte[]> TakePendingAdjacentFiles()
+    {
+        var files = new Dictionary<string, byte[]>(PendingAdjacentFiles);
+        PendingAdjacentFiles.Clear();
+        return files;
     }
 
     private static readonly string[] AudioExtensions = [".mp3", ".wav", ".ogg"];

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -161,6 +161,12 @@ window.addEventListener('pagehide', () => {
 // and never reassigned by a slot/file load.
 let originalGameBytes = null;
 let originalGameFilename = null;
+// Bytes for every custom (non-built-in) Included Library the game's <include ref="..."/>
+// elements need — see startGame's adjacentFiles param. Re-staged via stageAdjacentFiles()
+// before every Bridge.Initialise/InitialiseWithSave call (initial boot and restartGameCore
+// alike), since WasmPlayerBridge's own pending-file dictionary is consumed and cleared on
+// each load.
+let originalAdjacentFiles = null;
 // The pristine player chrome markup (playercore.htm), fetched once at boot
 // and reused verbatim by restartGame() so a mid-session restart gets exactly
 // the same clean slate as the initial boot, instead of the previous game's
@@ -202,6 +208,17 @@ function getResourceUrl(name) {
         });
         editorChannel.postMessage({ type: 'resource-request', name, id });
     });
+}
+
+// Stages every custom Included Library's bytes into WasmPlayerBridge (one at a time — same
+// [JSExport] array-marshalling limit as AddPublishAsset elsewhere) so the next
+// Initialise/InitialiseWithSave call can resolve <include ref="..."/> elements the Editor's
+// save left un-inlined (see WorldModel.GetLibraryStream). A no-op when the game has none.
+function stageAdjacentFiles(files) {
+    if (!files) return;
+    for (const [name, bytes] of Object.entries(files)) {
+        Bridge.AddAdjacentFile(name, bytes);
+    }
 }
 
 function ui_init() { }
@@ -443,7 +460,7 @@ function swapInPlayerUi() {
 // beginning"/Load in an editor-preview session.
 let currentIsPreview = false;
 
-async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null) {
+async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null) {
     currentIsPreview = isPreview;
     const dotnetJsUrl = wasmPlayerScriptUrl
         ? new URL('_framework/dotnet.js', wasmPlayerScriptUrl).href
@@ -529,6 +546,7 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
     // behaviour is unchanged.
     const startScreenEl = swapInPlayerUi();
 
+    stageAdjacentFiles(adjacentFiles);
     const ok = saveBytes
         ? await Bridge.InitialiseWithSave(gameBytes, filename, saveBytes)
         : await Bridge.Initialise(gameBytes, filename);
@@ -635,6 +653,7 @@ async function restartGameCore(saveBytes) {
     await nextPaint();
 
     try {
+        stageAdjacentFiles(originalAdjacentFiles);
         const ok = saveBytes
             ? await Bridge.InitialiseWithSave(originalGameBytes, originalGameFilename, saveBytes)
             : await Bridge.Initialise(originalGameBytes, originalGameFilename);
@@ -666,9 +685,10 @@ async function restartGameCore(saveBytes) {
 // Wraps initWasmPlayer with the boot-time "Continue / New Game" prompt: if
 // saves already exist for this game, ask before committing to either the
 // fresh game or a chosen save. Used by all boot entry points below.
-async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null) {
+async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null) {
     originalGameBytes = bytes;
     originalGameFilename = filename;
+    originalAdjacentFiles = adjacentFiles;
     // gameIdOverride lets callers with a stronger identity than the filename
     // (e.g. the Text Adventures API's stable game id) use it instead.
     const gameId = gameIdOverride || computeGameId(filename);
@@ -691,7 +711,7 @@ async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPr
         }
     }
 
-    await initWasmPlayer(bytes, filename, bc, saveBytes, isPreview, recordWalkthrough, runWalkthrough);
+    await initWasmPlayer(bytes, filename, bc, saveBytes, isPreview, recordWalkthrough, runWalkthrough, adjacentFiles);
 }
 
 // ── Start screen helpers ──────────────────────────────────────────────────────
@@ -1923,7 +1943,7 @@ async function fetchGameBytes(url) {
         bc.onmessage = async ({ data }) => {
             if (data.type === 'game') {
                 bc.onmessage = null;
-                await startGame(data.bytes, data.filename, bc, null, true, data.recordWalkthrough ?? null, data.runWalkthrough ?? null);
+                await startGame(data.bytes, data.filename, bc, null, true, data.recordWalkthrough ?? null, data.runWalkthrough ?? null, data.adjacentFiles ?? null);
             }
         };
         return;
@@ -1961,7 +1981,7 @@ async function fetchGameBytes(url) {
                 // reassigns bc.onmessage itself to keep answering
                 // 'resource-response' messages for the rest of the session.
                 bc.onmessage = null;
-                await startGame(data.bytes, data.filename, bc);
+                await startGame(data.bytes, data.filename, bc, null, false, null, null, data.adjacentFiles ?? null);
             }
         };
         return;

--- a/tests/e2e/verify-preview-custom-library.mjs
+++ b/tests/e2e/verify-preview-custom-library.mjs
@@ -1,0 +1,102 @@
+// Regression test: after the recent Included-Library editor fixes (SaveMode.Editor now excludes
+// unmodified library-origin elements, leaving <include ref="..."/> for the engine to resolve at
+// load time — see WorldModel.GetLibraryStream), clicking Preview on a game with a *custom*
+// (uploaded, non-built-in) Included Library sent WasmPlayer just the game bytes with no way to
+// resolve that <include>, so WasmPlayerBridge.Initialise failed with "Library file not found".
+// Fixed by having editor-store.ts's previewInWasmPlayer resolve the library's bytes (same
+// candidate discovery preloadAdjacentLibraryAssets uses for the editor's own reload) and hand
+// them to WasmPlayer over the same BroadcastChannel handoff, which stages them into
+// WasmPlayerBridge via a new AddAdjacentFile JSExport before Initialise runs.
+//
+// Requires both dev servers running (./dev.sh): AppShell on 5174 (proxies /player to WasmPlayer
+// on 5175, so BroadcastChannel — same-origin only — actually works between the two tabs).
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const CUSTOM_LIBRARY_ASLX = `<library>
+  <function name="CustomLibraryFunction"><![CDATA[
+    msg ("CUSTOM_LIBRARY_LOADED_OK")
+  ]]></function>
+</library>`;
+
+const browser = await chromium.launch();
+
+try {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await ctx.newPage();
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on('pageerror', err => pageErrors.push(err.message));
+    page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Preview Custom Library Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Preview game"]', { timeout: 30000 });
+    await page.waitForSelector('.save-chip-saved', { timeout: 10000 });
+    console.log('PASS: local draft created');
+
+    // "Included Libraries" stays hidden from the tree until the game has its first one
+    // (TreePanel's HIDE_WHEN_EMPTY) — "Advanced" is the documented entry point for adding the
+    // very first element of any such category (see PropertyEditor's ADVANCED_ADDERS comment).
+    await page.click('text=Advanced');
+    await page.click('button:has-text("+ Add Library")');
+    console.log('PASS: Add Included Library modal opened');
+
+    await page.waitForSelector('text=Add Included Library', { timeout: 5000 });
+    const fileInput = page.locator('input[type="file"][accept=".aslx"]');
+    await fileInput.setInputFiles({
+        name: 'custom.aslx',
+        mimeType: 'application/octet-stream',
+        buffer: Buffer.from(CUSTOM_LIBRARY_ASLX, 'utf8'),
+    });
+    await page.waitForSelector('text=custom.aslx', { timeout: 5000 });
+    await page.click('div[role="dialog"] button:has-text("Add Library"):not([disabled])');
+    await page.waitForSelector('text=Add Included Library', { state: 'detached', timeout: 5000 });
+    console.log('PASS: custom.aslx uploaded and Included Library element created');
+
+    await page.waitForSelector('.save-chip-saved', { timeout: 10000 });
+
+    // Preview opens a new tab (window.open) — capture it.
+    const [previewPage] = await Promise.all([
+        ctx.waitForEvent('page'),
+        page.click('button[title="Preview game"]'),
+    ]);
+    const previewErrors = [];
+    const previewConsoleErrors = [];
+    previewPage.on('pageerror', err => previewErrors.push(err.message));
+    previewPage.on('console', msg => { if (msg.type() === 'error') previewConsoleErrors.push(msg.text()); });
+
+    await previewPage.waitForLoadState('domcontentloaded');
+
+    // Wait for either the game's command box to show up (success) or a reasonable timeout.
+    let booted = false;
+    try {
+        await previewPage.waitForSelector('#txtCommandDiv', { state: 'visible', timeout: 15000 });
+        booted = true;
+    } catch {
+        booted = false;
+    }
+
+    const allErrors = [...previewErrors, ...previewConsoleErrors];
+    const libraryError = allErrors.find(e => e.includes('Library file not found') || e.includes('Failed to initialise game'));
+
+    if (libraryError) {
+        throw new Error(`Preview failed to load the game with a custom Included Library: ${libraryError}`);
+    }
+    if (!booted) {
+        throw new Error(`Preview never reached a booted game UI (#txtCommandDiv). Errors seen: ${JSON.stringify(allErrors)}`);
+    }
+    console.log('PASS: Preview booted the game with a custom Included Library, no "Library file not found" error');
+
+    await previewPage.close();
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Preview and Play (Electron's local file open) failed to boot any game with a custom (uploaded, non-built-in) Included Library, erroring with `Library file not found: <name>.aslx`.
- Root cause: the recent Included Library editor fixes (#2017/#2019/#2021/#2022) reworked `SaveMode.Editor` to stop inlining unmodified library-origin elements — it now leaves a bare `<include ref="..."/>` for the loader to resolve at load time (`WorldModel.GetLibraryStream`, which falls back to embedded resources for built-ins, or "adjacent file" bytes for custom libraries). `WasmEditorBridge` was updated to supply those adjacent bytes before every editor (re)load, but the Preview/Play handoff to WasmPlayer never got the same treatment — it only ever sent the raw game bytes.
- Fix mirrors the existing `WasmEditorBridge.AddAdjacentFile` pattern on the player side:
  - `WasmPlayerBridge.cs`: new `AddAdjacentFile` JSExport staging bytes for the next `Initialise`/`InitialiseWithSave` call.
  - `wasm-player.js`: threads `adjacentFiles` through `startGame`/`initWasmPlayer`/`restartGameCore`, re-staging before every load (initial boot and a mid-session restart both re-parse from scratch).
  - `editor-store.ts`: `previewInWasmPlayer` resolves the same library candidate files `preloadAdjacentLibraryAssets` already does for the editor, and sends them alongside the game bytes over the preview `BroadcastChannel`.
  - `local-play.ts`: same fix for Electron's direct "Play" of an on-disk `.aslx`, which hits an identical unresolved-`<include>`-at-load problem.

## Test plan
- [x] `dotnet build --configuration Release` — clean
- [x] `dotnet test --configuration Release` — 347/347 passing
- [x] `svelte-check` / `eslint` in `src/AppShell` — clean
- [x] Added `tests/e2e/verify-preview-custom-library.mjs` (Playwright): creates a local draft, uploads a custom Included Library, clicks Preview, asserts the game boots. Confirmed it reproduces `Failed to initialise game` / `Library file not found` on the pre-fix code (`git stash`) and passes with the fix restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)