### PR TITLE
fix(AppShell): stop import loading spinner from dropping early

### DIFF
--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -341,8 +341,8 @@
             if (!file) return;
             loading = true;
             const result = await createLocalDraftFromFile(file);
-            loading = false;
             if (result.kind === "chooseEntry") {
+                loading = false;
                 pendingZip = result.entries;
                 pendingFiles = result.names;
                 return;


### PR DESCRIPTION
## Summary
- `handleImportFile()` in `src/AppShell/src/routes/open/+page.svelte` (Create tab → "Import game file") cleared the `loading` flag right after `createLocalDraftFromFile()` resolved, but *before* the actually-slow `openGame()` (WASM load) call ran.
- That let the Create tab re-render while `openGame()` was still working in the background, producing a brief spinner flash, then apparent inaction (Create tab reappears), then the editor suddenly popping in once the load finished a second or two later.
- Fix: only clear `loading` early on the (unrelated) multi-file-chooser branch; otherwise keep it true through the whole import, matching the pattern already used by `handleOpenDraft` / `loadFromElectron` elsewhere in the same file.

## Test plan
- [x] Verified in-browser by driving the actual import flow with a real game file (`rbc.zip`) — spinner now stays visible continuously until the editor loads, no more flash/gap/pop-in.
- [ ] `dotnet build` / `dotnet test` unaffected (frontend-only change, no .NET code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)