### PR TITLE
fix(AppShell): trim superfluous clause from download draft tooltip

### DIFF
--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -389,7 +389,7 @@
     "openPage.recent": "Zuletzt verwendet",
     "openPage.removeFromRecent": "Aus \"Zuletzt verwendet\" entfernen",
     "openPage.yourLocalDrafts": "Deine lokalen Entwürfe",
-    "openPage.downloadDraftTitle": "Diesen Entwurf als .zip herunterladen (Spieldatei + Ressourcen) — funktioniert auch, wenn er sich nicht öffnen lässt",
+    "openPage.downloadDraftTitle": "Diesen Entwurf als .zip herunterladen (Spieldatei + Ressourcen)",
     "openPage.downloadDraftAriaLabel": "Diesen Entwurf als .zip herunterladen",
     "openPage.deleteDraft": "Entwurf löschen",
     "openPage.safariWarning": "Safari kann lokale Entwürfe löschen, wenn du diese Seite eine Woche oder länger nicht öffnest — exportiere ein Backup von allem Wichtigen.",

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -389,7 +389,7 @@
     "openPage.recent": "Recent",
     "openPage.removeFromRecent": "Remove from Recent",
     "openPage.yourLocalDrafts": "Your local drafts",
-    "openPage.downloadDraftTitle": "Download this draft as a .zip (game file + assets) — works even if it fails to open",
+    "openPage.downloadDraftTitle": "Download this draft as a .zip (game file + assets)",
     "openPage.downloadDraftAriaLabel": "Download this draft as a .zip",
     "openPage.deleteDraft": "Delete draft",
     "openPage.safariWarning": "Safari may clear local drafts if you don't open this site for a week or more — export a backup of anything important.",

--- a/src/AppShell/static/locales/es.json
+++ b/src/AppShell/static/locales/es.json
@@ -389,7 +389,7 @@
     "openPage.recent": "Reciente",
     "openPage.removeFromRecent": "Quitar de Recientes",
     "openPage.yourLocalDrafts": "Tus borradores locales",
-    "openPage.downloadDraftTitle": "Descarga este borrador como .zip (archivo del juego + recursos) — funciona incluso si no se puede abrir",
+    "openPage.downloadDraftTitle": "Descarga este borrador como .zip (archivo del juego + recursos)",
     "openPage.downloadDraftAriaLabel": "Descargar este borrador como .zip",
     "openPage.deleteDraft": "Eliminar borrador",
     "openPage.safariWarning": "Safari puede eliminar los borradores locales si no abres este sitio durante una semana o más — exporta un backup de todo lo importante.",

--- a/src/AppShell/static/locales/xx.json
+++ b/src/AppShell/static/locales/xx.json
@@ -329,7 +329,7 @@
     "openPage.recent": "[Récént]",
     "openPage.removeFromRecent": "[Rémóvé fróm Récént]",
     "openPage.yourLocalDrafts": "[Yóúr lócál dráfts]",
-    "openPage.downloadDraftTitle": "[Dównlóád thís dráft ás á .zíp (gámé fílé + ásséts) — wórks évén íf ít fáíls tó ópén]",
+    "openPage.downloadDraftTitle": "[Dównlóád thís dráft ás á .zíp (gámé fílé + ásséts)]",
     "openPage.downloadDraftAriaLabel": "[Dównlóád thís dráft ás á .zíp]",
     "openPage.deleteDraft": "[Délété dráft]",
     "openPage.safariWarning": "[Sáfárí máy cléár lócál dráfts íf yóú dón't ópén thís síté fór á wéék ór móré — éxpórt á báckúp óf ánythíng ímpórtánt.]",


### PR DESCRIPTION
## Summary
- Removed the "— works even if it fails to open" clause from the Download draft button tooltip (`openPage.downloadDraftTitle`)
- Applied across all locales: en, de, es, and the xx pseudo-locale

## Why
The clause read as superfluous noise on the tooltip.

## Test plan
- [x] Verified no other source occurrences of the removed phrase