### PR TITLE
fix(AppShell): show Paste on nested Add script buttons, fix if/then layout

### DIFF
--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -143,7 +143,7 @@
     });
 </script>
 
-<div class="flex items-center gap-1 min-w-0 flex-1">
+<div class="flex items-center gap-1 min-w-0">
     <input
         bind:this={inputEl}
         type="text"

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -568,7 +568,7 @@
             {:else if !codeViewMode && isRoot}
                 <span class="text-xs text-surface-600-400 italic">{t("scriptEditor.loadingCommands")}</span>
             {/if}
-            {#if isRoot && $scriptClipboardHasContent && !codeViewMode}
+            {#if $scriptClipboardHasContent && !codeViewMode}
                 <button
                     type="button"
                     class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"


### PR DESCRIPTION
## Summary
- Script Editor's **Paste** button next to "Add script" only appeared at the root of a script list — nested contexts (the `then`/`else`/`else if` branches of an `if`, or `for`/`while`/etc. bodies) never showed it, even though `onPaste`/`containerPath` already resolve correctly per nesting level. Removed the stray `isRoot &&` guard so Paste shows anywhere the clipboard has content.
- While verifying that, spotted that the `then` label on an `if` row (and any expression field that isn't the last item in its row) rendered pushed far to the right, separated from the expression input by a large gap. Root cause: `ExpressionInput`'s own wrapper `<div>` carried an uncapped `flex-1` in addition to the `<input>` inside already having a capped `flex-1` (via the `class` prop). The wrapper silently ate all remaining row space, shoving whatever came after it (e.g. `then`) to the far edge. Removed the wrapper's `flex-1` so it sizes to its content instead.

## Test plan
- [x] Verified in-browser (AppShell dev server): created an `if` block, copied it to the script clipboard, confirmed the nested "Add script" inside the `then` branch now shows a working Paste button that pastes into the correct nested container.
- [x] Verified in-browser: the `if` row now reads `wenn [expression] 🪄 dann` as one compact line instead of `dann` being stranded far to the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)