### PR TITLE
feat(WasmPlayer): port TranscriptViewer to WasmPlayer, fix Electron access

### DIFF
--- a/src/ElectronApp/src/ipc/player.ts
+++ b/src/ElectronApp/src/ipc/player.ts
@@ -46,10 +46,44 @@ export function registerPlayerHandlers(getOrigin: () => string | null): void {
         // Games can't open further windows of their own — same-origin
         // player navigation isn't a thing a game needs, and anything else
         // (a game script's window.open to some external URL) goes to the OS
-        // browser instead of spawning another in-app window.
+        // browser instead of spawning another in-app window. The one
+        // exception is the "view transcript" link JS.showTranscript() prints
+        // (playercore.js's transcriptUrl, a same-origin relative link to
+        // TranscriptViewer/index.html): that page reads the transcript data
+        // straight out of this session's localStorage, so it has to open as
+        // an in-app window on this same origin — sending it to the OS
+        // browser would land on a *different* browser's storage jar (or, if
+        // that browser happens to be Chromium-based and somehow shared,
+        // still the wrong origin, since static-server.ts binds a fresh
+        // random port every launch) and always show "no transcripts".
         win.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
+            if (targetUrl.startsWith(`${origin}/player/TranscriptViewer/`)) {
+                return {
+                    action: "allow",
+                    overrideBrowserWindowOptions: {
+                        width: 640,
+                        height: 480,
+                        webPreferences: {
+                            contextIsolation: true,
+                            nodeIntegration: false,
+                        },
+                    },
+                };
+            }
             void shell.openExternal(targetUrl);
             return { action: "deny" };
+        });
+        // TranscriptViewer/index.html's own OPEN button does
+        // window.open("about:blank", ...) + document.write(...) to display a
+        // transcript's contents — that's a *second* window.open, from the
+        // TranscriptViewer window's webContents rather than this one, so it
+        // needs its own handler. Trusted first-party content (shipped by us,
+        // not game- or web-supplied), so allow it unconditionally rather
+        // than pattern-matching about:blank.
+        win.webContents.on("did-create-window", (childWindow, details) => {
+            if (details.url.startsWith(`${origin}/player/TranscriptViewer/`)) {
+                childWindow.webContents.setWindowOpenHandler(() => ({ action: "allow" }));
+            }
         });
         // playercore.js's beforeunload handler calls e.preventDefault() once
         // hasUnsavedProgress is set (i.e. after a turn) — a real browser

--- a/src/ElectronApp/src/static-server.ts
+++ b/src/ElectronApp/src/static-server.ts
@@ -60,6 +60,23 @@ async function resolveFile(root: string, urlPath: string, spaFallback: boolean):
     return null;
 }
 
+// Tried first, before falling back to an OS-assigned ephemeral port. Chosen
+// arbitrarily (high, unregistered, not used elsewhere in this repo) — it
+// only needs to be *a* stable port, not any particular one.
+//
+// Why this matters: this server's origin (http://127.0.0.1:{port}) is what
+// localStorage/IndexedDB partition by. A random port every launch means a
+// fresh, empty storage partition every launch too — WasmPlayer's IndexedDB
+// game saves and the "script on" transcript feature (localStorage) would
+// both silently lose all data the moment the app restarts, since the
+// previous launch's data is still on disk but under an origin nothing will
+// ever request again. Keeping the port stable across launches keeps the
+// origin (and thus that data) stable too. Falling back to an ephemeral port
+// on conflict trades that stability away only in the rare case something
+// else on the machine already holds this exact port — same behavior as
+// before this fallback existed.
+const PREFERRED_PORT = 47893;
+
 export function startStaticServer(roots: StaticServerRoots): Promise<StaticServerHandle> {
     const server = http.createServer((req, res) => {
         void (async () => {
@@ -90,18 +107,32 @@ export function startStaticServer(roots: StaticServerRoots): Promise<StaticServe
         })();
     });
 
-    return new Promise((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => {
-            const address = server.address();
-            if (!address || typeof address === "string") {
-                reject(new Error("Failed to determine static server port"));
-                return;
-            }
-            resolve({
-                port: address.port,
-                close: () => new Promise((res) => server.close(() => res())),
-            });
+    function listen(port: number): Promise<StaticServerHandle> {
+        return new Promise((resolve, reject) => {
+            const onError = (err: NodeJS.ErrnoException) => {
+                server.removeListener("listening", onListening);
+                reject(err);
+            };
+            const onListening = () => {
+                server.removeListener("error", onError);
+                const address = server.address();
+                if (!address || typeof address === "string") {
+                    reject(new Error("Failed to determine static server port"));
+                    return;
+                }
+                resolve({
+                    port: address.port,
+                    close: () => new Promise((res) => server.close(() => res())),
+                });
+            };
+            server.once("error", onError);
+            server.once("listening", onListening);
+            server.listen(port, "127.0.0.1");
         });
+    }
+
+    return listen(PREFERRED_PORT).catch((err: NodeJS.ErrnoException) => {
+        if (err.code !== "EADDRINUSE") throw err;
+        return listen(0);
     });
 }

--- a/src/WasmPlayer/TranscriptViewer/index.html
+++ b/src/WasmPlayer/TranscriptViewer/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>Quest Viva | Your Transcripts</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+</head>
+<body onload="loadTable()">
+<table id="transcript-table"
+       style="margin: 0 auto; font-family: Source Sans Pro, Calibri, Candara, Arial, sans-serif; color: #333333; border-collapse:collapse;">
+    <tbody id="transcript-tbody">
+    <tr>
+        <th colspan="4" id="transcript-table-header"
+            style="text-align: center; border: 1px solid black; background: #5c9ccc">Loading...
+        </th>
+    </tr>
+    <!-- PLACEHOLDER -->
+    </tbody>
+</table>
+<br/>
+</body>
+<script>
+    var questTranscriptsVersion = "1.0.9";
+
+    var wnd;
+
+    var tName = "";
+
+    var choices = {};
+
+    function getSafeHtmlId(fixme) {
+        return (fixme.replace(/ /g, "___SPACE___").replace(/'/g, "___SINGLE_QUOTE___").replace(/"/g, "___DOUBLE_QUOTE___").replace(/:/g, "___COLON___").replace(/\./g, "___DOT___").replace(/\#/g, "___HASH___"));
+    }
+
+    function reverseSafeHtmlId(unfixme) {
+        return (unfixme.replace(/___SPACE___/g, " ").replace(/___SINGLE_QUOTE___/g, "'").replace(/___DOUBLE_QUOTE___/g, "\"").replace(/___COLON___/g, ":").replace(/___DOT___/g, ".").replace(/___HASH___/g, "#"));
+    }
+
+    function downloadTranscript(tsn) {
+        event.stopPropagation();
+        var tscriptData = localStorage.getItem("questtranscript-" + reverseSafeHtmlId(tsn)).replace(/@@@NEW_LINE@@@/g, "\r\n") || "No transcript data found.";
+        let link = document.createElement('a');
+        link.download = reverseSafeHtmlId(tsn) + '.txt';
+        let blob = new Blob([tscriptData], {type: 'text/plain'});
+        link.href = URL.createObjectURL(blob);
+        link.click();
+        URL.revokeObjectURL(link.href);
+    }
+
+    function openTranscript(tsn) {
+        event.stopPropagation();
+        var tscriptData = localStorage.getItem("questtranscript-" + reverseSafeHtmlId(tsn)).replace(/@@@NEW_LINE@@@/g, "<br/>") || "No transcript data found.";
+        wnd = window.open("about:blank", "", "_blank");
+        wnd.document.write(tscriptData);
+        wnd.document.title = reverseSafeHtmlId(tsn).replace(/questtranscript-/, "") + " - Transcript";
+    }
+
+    function removeTscript(tscript) {
+        event.stopPropagation();
+        var result = window.confirm("Delete this transcript?");
+        if (result) {
+            /* console.log(tscript); */
+            localStorage.removeItem("questtranscript-" + reverseSafeHtmlId(tscript));
+            document.getElementById(tscript).style.display = "none";
+            delete choices[tscript.replace(/questtranscript-/, "")];
+        }
+        if (Object.keys(choices).length < 1) {
+            document.getElementById("transcript-table-header").innerHTML = "You have no transcripts.";
+        }
+    }
+
+    var tScriptTemplate = "<tr id=\"TRANSCRIPT_NAME\" class=\"transcript-entry-holder\" style=\"border:1px solid black; padding: 4px;\"><td class=\"transcript-name\" style=\"padding:4px\">TRANSCRIPT_DISPLAYED_NAME</td><td class=\"transcript-open-link-holder\"><button href=\"#\"  name=\"TRANSCRIPT_NAME\" onclick=\"openTranscript(this.name);\" class=\"transcript-open-link\">OPEN</button></td><td class=\"transcript-download-link-holder\"><button href=\"#\"  name=\"TRANSCRIPT_NAME\" onclick=\"downloadTranscript(this.name);\" class=\"transcript-download-link\">DOWNLOAD</button></td><td class=\"transcript-download-link-holder\"><button href=\"#\"  name=\"TRANSCRIPT_NAME\" onclick=\"removeTscript(this.name);\" class=\"transcript-delete-link\">DELETE</button></td></tr>";
+
+    function loadTable() {
+        if (Object.keys(choices).length > 0) {
+            console.log("Ignoring call to load table. `choices` already exists.");
+            return;
+        }
+        if (!isLocalStorageAvailable()) {
+            document.getElementById("transcript-table-header").innerHTML = "The transcript feature is not available in this browser.";
+            return;
+        }
+        document.getElementById("transcript-table-header").innerHTML = "Loading...";
+        for (var e in localStorage) {
+            if (e.startsWith("questtranscript-")) {
+                var eName = e.replace(/questtranscript-/, "");
+                var safeName = getSafeHtmlId(eName);
+                choices[safeName] = tScriptTemplate.replace(/TRANSCRIPT_NAME/g, safeName).replace(/TRANSCRIPT_DISPLAYED_NAME/g, eName);
+            }
+        }
+        if (Object.keys(choices).length > 0) {
+            document.getElementById("transcript-table-header").innerHTML = "Your Transcripts";
+            for (var tname in choices) {
+                document.getElementById("transcript-tbody").innerHTML += choices[tname];
+            }
+        } else {
+            document.getElementById("transcript-table-header").innerHTML = "<strong style=\"color:white;\">You have no transcripts.</strong>";
+        }
+    }
+
+    /* https://stackoverflow.com/a/16427747 */
+    function isLocalStorageAvailable() {
+        var test = 'test';
+        try {
+            localStorage.setItem(test, test);
+            localStorage.removeItem(test);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+</script>
+</html>

--- a/src/WasmPlayer/WasmPlayer.csproj
+++ b/src/WasmPlayer/WasmPlayer.csproj
@@ -52,9 +52,11 @@
             <_LibAssets Include="$(_PCRes)lib\jquery.multi-open-accordion-1.5.3.js"/>
             <_LibAssets Include="$(_PCRes)lib\paper.js"/>
             <_ImageAssets Include="$(_PCRes)lib\images\*.png"/>
+            <_TranscriptViewerAssets Include="$(MSBuildThisFileDirectory)TranscriptViewer\index.html"/>
         </ItemGroup>
         <Copy SourceFiles="@(_FlatAssets)" DestinationFolder="$(WasmAppDir)"/>
         <Copy SourceFiles="@(_LibAssets)" DestinationFolder="$(WasmAppDir)lib\"/>
         <Copy SourceFiles="@(_ImageAssets)" DestinationFolder="$(WasmAppDir)lib\images\"/>
+        <Copy SourceFiles="@(_TranscriptViewerAssets)" DestinationFolder="$(WasmAppDir)TranscriptViewer\"/>
     </Target>
 </Project>


### PR DESCRIPTION
## Summary

- Ports `TranscriptViewer` (the "your transcripts" localStorage-based list/open/download/delete page behind the `script`/`view transcript` commands) from WebPlayer's `wwwroot` to WasmPlayer, rebranded (favicon/title) and wired into `WasmPlayer.csproj`'s asset-copy target. The underlying `playercore.js`/`player.js` transcript functions were already bundled into WasmPlayer's AppBundle — only the viewer page itself was missing, so the link 404'd.
- Fixes Electron: the player window's `setWindowOpenHandler` previously sent every `window.open` (including this same-origin transcript link) to the OS's default browser, which has no access to the Electron app's `localStorage` — the viewer always showed "no transcripts". Now the transcript link opens as an in-app `BrowserWindow` on the correct origin instead, with a `did-create-window` hook so the viewer's own OPEN button (a second `window.open` for `about:blank`) still works from that window too.
- Fixes a related, pre-existing issue this surfaced: `static-server.ts`'s loopback server bound an OS-assigned ephemeral port on every launch, so the app's origin — and therefore anything keyed to it, including this transcript feature and WasmPlayer's IndexedDB game saves — didn't survive an app restart. It now tries a fixed port first, falling back to an ephemeral one only on conflict, so the origin (and that data) stays stable across normal restarts.

## Not in scope

The fixed port is a mitigation, not a full fix — a genuine port conflict still silently resets the origin. The more complete fix (moving this storage off port-keyed browser storage entirely, the way `recent-games.ts` already does via plain files under `userData`) is filed as separate follow-up work, since it also touches the existing multi-slot game-save feature and is a bigger, riskier change to bundle in here.

## Test plan

- [x] `dotnet build src/WasmPlayer/WasmPlayer.csproj` — confirmed `TranscriptViewer/index.html` lands in the AppBundle
- [x] Loaded the built WasmPlayer dev server in-browser: empty state renders, a seeded `questtranscript-*` localStorage entry lists correctly, open/download/delete handlers run without errors
- [x] `npx tsc --noEmit` in `src/ElectronApp` — clean
- [x] `npm run build` in `src/ElectronApp` — confirms `TranscriptViewer/` flows into the Electron player bundle
- [x] Standalone script exercising `startStaticServer`'s fixed-port/fallback/reclaim behavior directly — all three cases pass
- [ ] Manual smoke test in the actual Electron app (no Electron/native-window automation tool was available in this session): play a game, `script on`, a turn, `script off`, `view transcript` — link should open in-app; quit and relaunch, transcript should still be there

🤖 Generated with [Claude Code](https://claude.com/claude-code)