### PR TITLE
fix(Engine): correct Spanish Scripts tab translations

### DIFF
--- a/docs/i18n-style-guide.md
+++ b/docs/i18n-style-guide.md
@@ -41,6 +41,22 @@ translations before this backfill (`puedes`, `No puedes ir por ahí`, etc.)
 with it. "Tú" is also the norm for Spanish gaming/hobbyist software (Steam,
 Duolingo), matching the same reasoning as German above.
 
+**Glossary: "script"/"scripts" → "programa"/"programas".** Not "guión"
+(that word is the film/theatre sense of "script", not the programming
+one). Keep English's singular/plural distinction where a control's
+content is genuinely one script vs. several, but note that the Game
+editor's `EditorGameScript` tab and the Room editor's
+`EditorObjectScriptsScripts` tab both hold multiple named scripts despite
+English calling one of them "Script" - translate both as the plural
+"Programas" to match what the tab actually contains, not the English
+label literally.
+
+Found via user report 2026-08: `EditorObjectScriptsScripts` had drifted to
+"Guiones" (wrong word) while the sibling key `EditorScriptsScriptsScripts`
+- same English source text, "Scripts" - correctly said "Programas". See
+the "terminology consistency" section below for the general version of
+this failure mode and the tooling that now catches it.
+
 ## English (en)
 
 The baseline every other language is diffed against - not itself a
@@ -55,3 +71,40 @@ by checking what mainstream gaming/hobbyist software in that language
 actually uses (the same reasoning as German above), not by asking an LLM
 to guess in isolation per-string - that's exactly the failure mode that
 prompted this file.
+
+## Terminology consistency
+
+The `.aslx` language files repeat plain English words like "Scripts",
+"Background", or "Text" across dozens of unrelated `<template>` keys
+(tab captions, control labels, category names, ...). Because each key is
+translated independently - by different AI-assisted passes over time, or
+by different human contributors - the same English source text can drift
+to different words in the target language even though nothing about the
+English changed. That's what happened to Spanish's `EditorObjectScriptsScripts`
+above: it and `EditorScriptsScriptsScripts` are both literally "Scripts"
+in English, but only one of them got translated as "Programas".
+
+`tools/i18n/audit.mjs` now groups baseline keys by identical source text
+and reports, per supported language, any group whose translations don't
+all match (a "Terminology" column in the summary table, with the specific
+keys/values listed below it). This is **informational, not enforced** -
+many groups are legitimate false positives, because the same English word
+can need different translations for different grammatical contexts (e.g.
+German's "Objekt ist verschlossen" vs. "Verschlossen" for two different
+"Locked" controls, or gendered/case agreement). Treat a hit as "worth a
+second look", not "must fix":
+
+- If the surrounding context is the same concept (a tab caption vs. a
+  category caption for the same feature, like the Scripts example) -
+  it's very likely a real inconsistency. Fix it and add a glossary line
+  above so it doesn't drift back.
+- If the contexts genuinely differ (a UI verb vs. a noun, or a different
+  grammatical case/gender is required) - it's a legitimate difference.
+  No fix needed, and no need to silence it in the tool; the report is
+  cheap to skim per language.
+
+When translating (or reviewing an AI-assisted pass over) a batch of keys,
+run `node tools/i18n/audit.mjs` and check the Terminology section for the
+language you touched before calling the pass done - it's the mechanical
+check for exactly the class of bug a per-string reviewer tends to miss,
+since no single diff shows two unrelated keys side by side.

--- a/src/Engine/Core/Languages/EditorEspanol.aslx
+++ b/src/Engine/Core/Languages/EditorEspanol.aslx
@@ -217,7 +217,7 @@
   <template name="EditorGameRight">Derecha</template>
   <template name="EditorGameOptions">Opciones</template>
   <template name="EditorGameClearpicture">Quitar panel de imagen si el lugar no tiene imagen</template>
-  <template name="EditorGameScript">Programa</template>
+  <template name="EditorGameScript">Programas</template>
   <template name="EditorGameAdvancedScript">Programas Avanzados</template>
   <template name="EditorGameStartscript">Programa inicial</template>
   <template name="EditorGameTurnscripts">Programas por turno - se corren después de cada movida del jugador durante este juego</template>
@@ -421,7 +421,7 @@
   <template name="EditorObjectRoomObjectslist">Prefijo lista de objetos</template>
   <template name="EditorObjectRoomDropDestination">Objetos dejados aquí se van para</template>
   <template name="EditorObjectRoomDescription">Descripción</template>
-  <template name="EditorObjectScriptsScripts">Guiones</template>
+  <template name="EditorObjectScriptsScripts">Programas</template>
   <template name="EditorObjectScriptsBeforeentering">Antes de entrar al lugar</template>
   <template name="EditorObjectScriptsAfterentering">Después de entrar al lugar</template>
   <template name="EditorObjectScriptsAfterleaving">Después de salir del lugar</template>

--- a/tools/i18n/audit.mjs
+++ b/tools/i18n/audit.mjs
@@ -79,9 +79,28 @@ function extractJsonEntries(filePath) {
   return Object.entries(obj).map(([key, value]) => ({ key, value: String(value) }));
 }
 
+// Groups baseline (English) keys that share the exact same source text, e.g.
+// EditorObjectScriptsScripts and EditorScriptsScriptsScripts both being
+// "Scripts". A translation that renders one of these as "Programas" and the
+// other as "Guiones" is very likely an inconsistency, not an intentional
+// distinction - same source term, different tabs/contexts, should still read
+// as the same word to a player/author. This is a heuristic, not a hard rule:
+// some groups legitimately need context-dependent translations, so it's
+// reported for human review rather than folded into --strict.
+function buildValueGroups(baselineEntries) {
+  const byValue = new Map();
+  for (const { key, value } of baselineEntries) {
+    if (!value) continue;
+    if (!byValue.has(value)) byValue.set(value, []);
+    byValue.get(value).push(key);
+  }
+  return [...byValue.entries()].filter(([, keys]) => keys.length > 1);
+}
+
 function analyzeLayer(layerName, baselineFile, fileField, extractFn) {
   const baselineEntries = extractFn(baselineFile);
   const baselineKeys = new Set(baselineEntries.map((e) => e.key));
+  const valueGroups = buildValueGroups(baselineEntries);
 
   const rows = [];
   for (const lang of languages) {
@@ -116,6 +135,22 @@ function analyzeLayer(layerName, baselineFile, fileField, extractFn) {
 
     const coverage = baselineKeys.size === 0 ? 100 : (100 * (baselineKeys.size - missing.length)) / baselineKeys.size;
 
+    // Last occurrence wins at runtime (see file header comment), so that's
+    // what a terminology check should compare too.
+    const lastValueByKey = new Map([...byKey.entries()].map(([k, vs]) => [k, vs[vs.length - 1]]));
+    const terminologyInconsistencies = [];
+    for (const [sourceValue, keys] of valueGroups) {
+      const present = keys.filter((k) => lastValueByKey.has(k));
+      if (present.length < 2) continue;
+      const translated = present.map((k) => lastValueByKey.get(k));
+      if (new Set(translated).size > 1) {
+        terminologyInconsistencies.push({
+          sourceValue,
+          entries: present.map((k) => ({ key: k, value: lastValueByKey.get(k) })),
+        });
+      }
+    }
+
     rows.push({
       id: lang.id,
       displayName: lang.displayName,
@@ -127,6 +162,7 @@ function analyzeLayer(layerName, baselineFile, fileField, extractFn) {
       extra,
       duplicates,
       coverage,
+      terminologyInconsistencies,
     });
   }
 
@@ -146,23 +182,36 @@ function pct(n) {
 function printMarkdown() {
   for (const layer of layers) {
     console.log(`\n## ${layer.layerName} (baseline: ${layer.baselineSize} keys)\n`);
-    console.log('| Language | Present | Coverage | Missing | Extra | Duplicates |');
-    console.log('|---|---|---|---|---|---|');
+    console.log('| Language | Present | Coverage | Missing | Extra | Duplicates | Terminology |');
+    console.log('|---|---|---|---|---|---|---|');
     for (const row of layer.rows) {
       if (!row.present) {
-        console.log(`| ${row.displayName} | ${row.missingFile ? `file missing: ${row.missingFile}` : 'no'} | — | — | — | — |`);
+        console.log(`| ${row.displayName} | ${row.missingFile ? `file missing: ${row.missingFile}` : 'no'} | — | — | — | — | — |`);
         continue;
       }
       const dupSummary = row.duplicates.length === 0
         ? '—'
         : row.duplicates.map((d) => `${d.key}${d.harmless ? '' : ' ⚠️differs'}`).join(', ');
-      console.log(`| ${row.displayName} | yes | ${pct(row.coverage)} | ${row.missingCount} | ${row.extraCount} | ${dupSummary} |`);
+      const termSummary = row.terminologyInconsistencies.length === 0 ? '—' : `${row.terminologyInconsistencies.length} ⚠️`;
+      console.log(`| ${row.displayName} | yes | ${pct(row.coverage)} | ${row.missingCount} | ${row.extraCount} | ${dupSummary} | ${termSummary} |`);
+    }
+
+    for (const row of layer.rows) {
+      if (!row.present || row.terminologyInconsistencies.length === 0) continue;
+      console.log(`\n**${row.displayName} terminology inconsistencies** (same English source text, differing translations - review for consistency, not necessarily a bug):\n`);
+      for (const { sourceValue, entries } of row.terminologyInconsistencies) {
+        const rendered = entries.map((e) => `${e.key}=${JSON.stringify(e.value)}`).join(', ');
+        console.log(`- "${sourceValue}": ${rendered}`);
+      }
     }
   }
 
   console.log('\n(Duplicates marked "⚠️differs" have occurrences with different text — the earlier one is silently');
   console.log('shadowed by the later one at runtime and is worth a human look. Duplicates without the marker have');
   console.log('identical text in every occurrence and are harmless dead weight.)');
+  console.log('\n(Terminology inconsistencies: two or more keys share identical English source text but were');
+  console.log('translated differently - often a sign one translation used a different word for the same concept.');
+  console.log('See docs/i18n-style-guide.md\'s glossary section. Informational only, not part of --strict.)');
 }
 
 // --strict only asserts the regression guard that a single checkout can know


### PR DESCRIPTION
## Summary
- Fixes a Spanish translation bug reported by a user: the Room editor's "Scripts" tab said **"Guiones"** (the film/theatre sense of "script"), while the Game editor's "Script" tab said **"Programa"** (singular). Both hold multiple named scripts, and a sibling key (`EditorScriptsScriptsScripts`, same English source text "Scripts") already correctly used the plural **"Programas"**. Both are now fixed to "Programas".
- Adds a glossary entry to `docs/i18n-style-guide.md` for Spanish (`script`/`scripts` → `programa`/`programas`, never `guión`) so this doesn't drift back.
- Extends `tools/i18n/audit.mjs` with a general **terminology consistency** check: it groups translation keys that share identical English source text (there are ~94 such groups in the Editor layer alone) and flags, per supported language, any group whose translations disagree with each other. This is the mechanical version of the bug class the user hit — the same English word translated differently across unrelated keys because each key was translated independently over time. Reported informationally (new "Terminology" column + detail list in the audit's markdown/JSON output) rather than folded into `--strict`, since many hits are legitimate grammatical variants (gender/case agreement, different parts of speech) rather than bugs.

## Test plan
- [x] `node tools/i18n/audit.mjs` runs cleanly; confirmed the Spanish "Scripts" terminology inconsistency is gone after the fix.
- [x] `node tools/i18n/audit.mjs --strict` still exits 0 (coverage-only gate unaffected).
- [x] `node tools/i18n/audit.mjs --json` still parses and `compare-duplicates.mjs` (which only reads the untouched `duplicates` field) is unaffected.
- [ ] Manual check in the Editor UI that the Room "Scripts" tab and Game "Script" tab now both read "Programas" in Spanish (only affects games saved/created after this change, per Core.aslx inlining semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)