### PR TITLE
feat: translate the Save/Load dialog via per-language .aslx templates

### DIFF
--- a/src/ElectronApp/src/ipc/gamesave.ts
+++ b/src/ElectronApp/src/ipc/gamesave.ts
@@ -10,8 +10,14 @@ export function registerGameSaveHandlers(): void {
 
     ipcMain.handle(
         "gamesave:save",
-        async (_event, gameId: string, slotIndex: number, data: Uint8Array, name: string | null) =>
-            saveGame(gameId, slotIndex, data, name),
+        async (
+            _event,
+            gameId: string,
+            slotIndex: number,
+            data: Uint8Array,
+            name: string | null,
+            chromeStrings?: Record<string, string> | null,
+        ) => saveGame(gameId, slotIndex, data, name, chromeStrings),
     );
 
     ipcMain.handle("gamesave:load", async (_event, gameId: string, slotIndex: number) => loadGame(gameId, slotIndex));

--- a/src/ElectronApp/src/player-preload.ts
+++ b/src/ElectronApp/src/player-preload.ts
@@ -28,10 +28,17 @@ contextBridge.exposeInMainWorld("electronTranscripts", {
 });
 
 contextBridge.exposeInMainWorld("electronGameSaves", {
-    list: (gameId: string): Promise<{ slotIndex: number; name: string | null; timestamp: number | null }[]> =>
+    list: (
+        gameId: string,
+    ): Promise<{ slotIndex: number; name: string | null; timestamp: number | null; chromeStrings: Record<string, string> | null }[]> =>
         ipcRenderer.invoke("gamesave:list", gameId),
-    save: (gameId: string, slotIndex: number, data: Uint8Array, name: string | null): Promise<void> =>
-        ipcRenderer.invoke("gamesave:save", gameId, slotIndex, data, name),
+    save: (
+        gameId: string,
+        slotIndex: number,
+        data: Uint8Array,
+        name: string | null,
+        chromeStrings?: Record<string, string> | null,
+    ): Promise<void> => ipcRenderer.invoke("gamesave:save", gameId, slotIndex, data, name, chromeStrings),
     load: (gameId: string, slotIndex: number): Promise<Uint8Array | null> =>
         ipcRenderer.invoke("gamesave:load", gameId, slotIndex),
     delete: (gameId: string, slotIndex: number): Promise<void> => ipcRenderer.invoke("gamesave:delete", gameId, slotIndex),

--- a/src/ElectronApp/src/save-store.ts
+++ b/src/ElectronApp/src/save-store.ts
@@ -12,6 +12,13 @@ export interface SaveSlot {
     slotIndex: number;
     name: string | null;
     timestamp: number | null;
+    // Snapshot of the game's own translated chrome strings at the moment it
+    // was saved (see ChromeStrings.Resolve in PlayerCore) — lets the boot-time
+    // "Continue your game?" prompt show the right language next session,
+    // before anything is parsed into a WorldModel. Absent on saves made
+    // before this field existed, and on non-Electron (IndexedDB) saves — both
+    // fall back to English, no version/schema handling needed.
+    chromeStrings?: Record<string, string> | null;
 }
 
 const MANIFEST_FILE = "manifest.json";
@@ -74,13 +81,19 @@ export function listSaves(gameId: string): Promise<SaveSlot[]> {
     return enqueue(gameDirName(gameId), () => readManifest(gameId));
 }
 
-export function saveGame(gameId: string, slotIndex: number, data: Uint8Array, name: string | null): Promise<void> {
+export function saveGame(
+    gameId: string,
+    slotIndex: number,
+    data: Uint8Array,
+    name: string | null,
+    chromeStrings?: Record<string, string> | null,
+): Promise<void> {
     return enqueue(gameDirName(gameId), async () => {
         await fs.mkdir(gameDir(gameId), { recursive: true });
         await fs.writeFile(blobPath(gameId, slotIndex), data);
         const slots = await readManifest(gameId);
         const remaining = slots.filter((s) => s.slotIndex !== slotIndex);
-        remaining.push({ slotIndex, name, timestamp: Date.now() });
+        remaining.push({ slotIndex, name, timestamp: Date.now(), chromeStrings: chromeStrings ?? null });
         await writeManifest(gameId, remaining);
     });
 }

--- a/src/Engine/Core/Languages/Deutsch.aslx
+++ b/src/Engine/Core/Languages/Deutsch.aslx
@@ -563,6 +563,25 @@
   <template name="Noted">Vermerkt.</template>
   <template name="ShowMenuResponsePrompt">>> </template>
 
+  <!-- Player-chrome Save/Load dialog strings (WebPlayer/WasmPlayer) -->
+  <template name="SaveLoadTitle">Speichern / Laden</template>
+  <template name="ContinueYourGamePrompt">Möchtest du dein Spiel fortsetzen?</template>
+  <template name="StartFromBeginning">Von vorne beginnen</template>
+  <template name="SavedGamesHeading">Gespeicherte Spiele</template>
+  <template name="NoSavedGamesYet">Noch keine gespeicherten Spiele.</template>
+  <template name="DeleteSave">Löschen</template>
+  <template name="SaveNamePlaceholder">Name des Spielstands</template>
+  <template name="SaveNew">Neu speichern</template>
+  <template name="SaveToFile">In Datei speichern</template>
+  <template name="LoadFromFile">Aus Datei laden</template>
+  <template name="UnnamedSave">diesen Spielstand</template>
+  <template name="SaveWrongGame">Dieser Spielstand gehört zu einem anderen Spiel — öffne zuerst das passende Spiel und versuche es erneut.</template>
+  <template name="CloseDialog">Schließen</template>
+  <template name="SavingBusy">Speichert…</template>
+  <template name="RestartingBusy">Startet neu…</template>
+  <template name="DeleteSaveConfirm">„[name]“ löschen? Das kann nicht rückgängig gemacht werden.</template>
+  <template name="SavedGameDefaultLabel">Spielstand — [timestamp]</template>
+
   <!-- Explicit copies of English.aslx's own values (both already reached via
        the <include ref="English.aslx"/> above, so this changes nothing at
        runtime) - kept explicit so this file's own key coverage is complete

--- a/src/Engine/Core/Languages/English.aslx
+++ b/src/Engine/Core/Languages/English.aslx
@@ -508,4 +508,23 @@
   <template name="Noted">Noted.</template>
   <template name="ShowMenuResponsePrompt">>> </template>
 
+  <!-- Player-chrome Save/Load dialog strings (WebPlayer/WasmPlayer) -->
+  <template name="SaveLoadTitle">Save / Load</template>
+  <template name="ContinueYourGamePrompt">Continue your game?</template>
+  <template name="StartFromBeginning">Start from the beginning</template>
+  <template name="SavedGamesHeading">Saved games</template>
+  <template name="NoSavedGamesYet">No saved games yet.</template>
+  <template name="DeleteSave">Delete</template>
+  <template name="SaveNamePlaceholder">Save name</template>
+  <template name="SaveNew">Save new</template>
+  <template name="SaveToFile">Save to file</template>
+  <template name="LoadFromFile">Load from file</template>
+  <template name="UnnamedSave">this save</template>
+  <template name="SaveWrongGame">This save is for a different game — open that game first, then try again.</template>
+  <template name="CloseDialog">Close</template>
+  <template name="SavingBusy">Saving…</template>
+  <template name="RestartingBusy">Restarting…</template>
+  <template name="DeleteSaveConfirm">Delete "[name]"? This can't be undone.</template>
+  <template name="SavedGameDefaultLabel">Saved game — [timestamp]</template>
+
 </library>

--- a/src/Engine/Core/Languages/Espanol.aslx
+++ b/src/Engine/Core/Languages/Espanol.aslx
@@ -717,4 +717,23 @@
     <template name="Noted">Anotado.</template>
     <template name="ShowMenuResponsePrompt">>> </template>
 
+    <!-- Player-chrome Save/Load dialog strings (WebPlayer/WasmPlayer) -->
+    <template name="SaveLoadTitle">Guardar / Cargar</template>
+    <template name="ContinueYourGamePrompt">¿Quieres continuar tu partida?</template>
+    <template name="StartFromBeginning">Empezar desde el principio</template>
+    <template name="SavedGamesHeading">Partidas guardadas</template>
+    <template name="NoSavedGamesYet">Todavía no hay partidas guardadas.</template>
+    <template name="DeleteSave">Eliminar</template>
+    <template name="SaveNamePlaceholder">Nombre de la partida</template>
+    <template name="SaveNew">Guardar nueva</template>
+    <template name="SaveToFile">Guardar en archivo</template>
+    <template name="LoadFromFile">Cargar desde archivo</template>
+    <template name="UnnamedSave">esta partida</template>
+    <template name="SaveWrongGame">Esta partida guardada es de otro juego — abre primero ese juego y vuelve a intentarlo.</template>
+    <template name="CloseDialog">Cerrar</template>
+    <template name="SavingBusy">Guardando…</template>
+    <template name="RestartingBusy">Reiniciando…</template>
+    <template name="DeleteSaveConfirm">¿Eliminar «[name]»? Esto no se puede deshacer.</template>
+    <template name="SavedGameDefaultLabel">Partida guardada — [timestamp]</template>
+
 </library>

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -240,6 +240,7 @@ public partial class WorldModel : IGame, IGameDebug
     public string Cover => Game.Fields[FieldDefinitions.Cover];
     public bool IsGamebook => Game.Fields[FieldDefinitions.EditorStyle] == "gamebook";
     public string? LanguageId => Template.GetText("LanguageId", false);
+    public string? GetTemplateText(string name) => Template.GetText(name, false);
     public event Action<int>? RequestNextTimerTick;
     public event PrintTextHandler? PrintText;
     public event UpdateListHandler? UpdateList;

--- a/src/PlayerCore/ChromeStrings.cs
+++ b/src/PlayerCore/ChromeStrings.cs
@@ -1,0 +1,49 @@
+using QuestViva.Engine;
+
+namespace QuestViva.PlayerCore;
+
+// Player-chrome UI strings (the Save/Load dialog) sourced from the game's own
+// per-language Core library templates (src/Engine/Core/Languages/*.aslx), so a
+// translation added there is baked into every game published from then on -
+// see WorldModel.GetTemplateText. Defaults here match today's hardcoded
+// English markup exactly, so Resolve(null) (no game loaded yet, or a legacy
+// V4 .asl/.cas game with no WorldModel/template system at all) and an old
+// already-published game missing these keys both fall back to unchanged
+// behaviour.
+public static class ChromeStrings
+{
+    public static readonly IReadOnlyDictionary<string, string> Defaults = new Dictionary<string, string>
+    {
+        ["SaveLoadTitle"] = "Save / Load",
+        ["ContinueYourGamePrompt"] = "Continue your game?",
+        ["StartFromBeginning"] = "Start from the beginning",
+        ["SavedGamesHeading"] = "Saved games",
+        ["NoSavedGamesYet"] = "No saved games yet.",
+        ["DeleteSave"] = "Delete",
+        ["SaveNamePlaceholder"] = "Save name",
+        ["SaveNew"] = "Save new",
+        ["SaveToFile"] = "Save to file",
+        ["LoadFromFile"] = "Load from file",
+        ["UnnamedSave"] = "this save",
+        ["SaveWrongGame"] = "This save is for a different game — open that game first, then try again.",
+        ["CloseDialog"] = "Close",
+        ["SavingBusy"] = "Saving…",
+        ["RestartingBusy"] = "Restarting…",
+        ["DeleteSaveConfirm"] = "Delete \"[name]\"? This can't be undone.",
+        ["SavedGameDefaultLabel"] = "Saved game — [timestamp]",
+    };
+
+    public static Dictionary<string, string> Resolve(WorldModel worldModel)
+    {
+        var result = new Dictionary<string, string>(Defaults);
+        if (worldModel == null) return result;
+
+        foreach (var key in Defaults.Keys)
+        {
+            var value = worldModel.GetTemplateText(key);
+            if (value != null) result[key] = value;
+        }
+
+        return result;
+    }
+}

--- a/src/PlayerCore/Resources/playercore.htm
+++ b/src/PlayerCore/Resources/playercore.htm
@@ -2,7 +2,7 @@
     <div class="ui-widget-header" id="qv-status">
         <div id="controlButtons">
             <button id="cmdDebug" style="display: none" type="button">Debug</button>
-            <button id="cmdSave" type="button">Save</button>
+            <button id="cmdSave" type="button" data-chrome-key="SaveLoadTitle">Save / Load</button>
             <button id="cmdShowPanes" type="button">&#9776;</button>
         </div>
         <div id="location">

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -2495,6 +2495,31 @@ function whereAmI() {
 
 var platform = "desktop";
 
+// Applies a resolved chrome-strings dictionary (see ChromeStrings.Resolve in
+// PlayerCore, surfaced via WebPlayer.setChromeStrings/Bridge.GetChromeStringsJson,
+// or a save's snapshot - see GameSaver.save below) to every chrome element
+// tagged with a data-chrome-key* attribute, e.g. the #cmdSave button and the
+// #qv-saves/Slots dialog. dict is always fully populated (every key defaults
+// to English), so a missing key here just means dict itself is null/undefined
+// (no game loaded, no snapshot available) - existing markup is left untouched
+// in that case. Shared by both players (playercore.htm's chrome is common to
+// both), called from wasm-player.js and from WebPlayer.setChromeStrings below.
+function applyChromeStrings(dict) {
+    if (!dict) return;
+    document.querySelectorAll('[data-chrome-key]').forEach(el => {
+        const value = dict[el.dataset.chromeKey];
+        if (value) el.textContent = value;
+    });
+    document.querySelectorAll('[data-chrome-key-placeholder]').forEach(el => {
+        const value = dict[el.dataset.chromeKeyPlaceholder];
+        if (value) el.placeholder = value;
+    });
+    document.querySelectorAll('[data-chrome-key-aria-label]').forEach(el => {
+        const value = dict[el.dataset.chromeKeyAriaLabel];
+        if (value) el.setAttribute('aria-label', value);
+    });
+}
+
 const GameSaver = (() => {
     // Electron: file storage under userData rather than IndexedDB, since
     // this window's origin (a local loopback port) isn't guaranteed to stay

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -2542,8 +2542,9 @@ const GameSaver = (() => {
     }
 
     async function saveGame(gameId, slotIndex, dataUint8Array, name) {
+        const chromeStrings = window.WebPlayer?.chromeStrings ?? null;
         if (useElectronGameSaves()) {
-            await window.electronGameSaves.save(gameId, slotIndex, dataUint8Array, name || null);
+            await window.electronGameSaves.save(gameId, slotIndex, dataUint8Array, name || null, chromeStrings);
             return;
         }
         const db = await openDatabase();
@@ -2555,7 +2556,12 @@ const GameSaver = (() => {
             slotIndex,
             data: dataUint8Array,
             name,
-            timestamp: new Date()
+            timestamp: new Date(),
+            // Snapshot of the game's own chrome-string translations at the moment
+            // it was saved - lets the boot-time "Continue your game?" prompt show
+            // the right language next session, before anything is parsed into a
+            // WorldModel (see WebPlayer.setChromeStrings / Bridge.GetChromeStringsJson).
+            chromeStrings
         };
 
         store.put(entry);
@@ -2584,6 +2590,7 @@ const GameSaver = (() => {
                         slotIndex: entry.slotIndex,
                         name: entry.name || null,
                         timestamp: entry.timestamp || null,
+                        chromeStrings: entry.chromeStrings || null,
                     }));
 
                 resolve(slots);
@@ -2638,7 +2645,8 @@ const GameSaver = (() => {
             const slotIndex = await nextSlotIndex(gameId);
             // Locale-formatted (not ISO) so it reads naturally wherever it's shown —
             // WebPlayer's Slots list shows only the name, with no separate timestamp.
-            const label = name || "Saved game — " + new Date().toLocaleString();
+            const labelTemplate = window.WebPlayer?.chromeStrings?.SavedGameDefaultLabel || "Saved game — [timestamp]";
+            const label = name || labelTemplate.replace('[timestamp]', new Date().toLocaleString());
             await saveGame(gameId, slotIndex, result, label);
             addText("Game saved.<br>");
             clearUnsavedProgress();

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -176,6 +176,14 @@ public partial class WasmPlayerBridge
     [JSExport]
     public static string GetGameIfid() => _game?.GameID ?? string.Empty;
 
+    // Player-chrome Save/Load dialog strings, sourced from the game's own
+    // per-language Core library templates when available (see
+    // ChromeStrings.Resolve) - always returns every key, English by default,
+    // so JS never needs its own fallback table.
+    [JSExport]
+    public static string GetChromeStringsJson() =>
+        JsonSerializer.Serialize(ChromeStrings.Resolve(_game as WorldModel), WasmJsonContext.Default.DictionaryStringString);
+
     [JSExport]
     public static async Task Begin()
     {

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -134,16 +134,16 @@
          Chrome), so the sprite must live in the same document as its <use>s. -->
     <div class="card preset-filled-surface-100-900 w-full p-6 space-y-4" data-theme="wintry">
         <div class="flex items-start justify-between gap-4">
-            <h2 class="h3" data-mode-text="boot">Continue your game?</h2>
-            <h2 class="h3 qv-manage-only" data-mode-text="manage">Save / Load</h2>
-            <button id="qv-saves-close" type="button" class="qv-manage-only btn-icon preset-tonal-surface" aria-label="Close">
+            <h2 class="h3" data-mode-text="boot" data-chrome-key="ContinueYourGamePrompt">Continue your game?</h2>
+            <h2 class="h3 qv-manage-only" data-mode-text="manage" data-chrome-key="SaveLoadTitle">Save / Load</h2>
+            <button id="qv-saves-close" type="button" class="qv-manage-only btn-icon preset-tonal-surface" aria-label="Close" data-chrome-key-aria-label="CloseDialog">
                 <svg class="qv-icon" aria-hidden="true"><use href="#x"></use></svg>
             </button>
         </div>
 
         <div id="qv-saves-error" class="hidden card preset-tonal-error p-3 text-sm"></div>
 
-        <button id="qv-saves-start-new" type="button" class="btn preset-tonal-primary w-full justify-start">
+        <button id="qv-saves-start-new" type="button" class="btn preset-tonal-primary w-full justify-start" data-chrome-key="StartFromBeginning">
             Start from the beginning
         </button>
 
@@ -152,12 +152,12 @@
         <div class="qv-manage-only space-y-3">
             <hr class="hr">
             <div class="flex gap-2">
-                <input id="qv-saves-name-input" class="input" type="text" placeholder="Save name" autocomplete="off">
-                <button id="qv-saves-save-new" type="button" class="btn preset-filled-primary-500">Save new</button>
+                <input id="qv-saves-name-input" class="input" type="text" placeholder="Save name" autocomplete="off" data-chrome-key-placeholder="SaveNamePlaceholder">
+                <button id="qv-saves-save-new" type="button" class="btn preset-filled-primary-500" data-chrome-key="SaveNew">Save new</button>
             </div>
             <div class="flex gap-2">
-                <button id="qv-saves-download" type="button" class="btn preset-tonal-primary flex-1">Save to file</button>
-                <button id="qv-saves-upload-btn" type="button" class="btn preset-tonal-primary flex-1">Load from file</button>
+                <button id="qv-saves-download" type="button" class="btn preset-tonal-primary flex-1" data-chrome-key="SaveToFile">Save to file</button>
+                <button id="qv-saves-upload-btn" type="button" class="btn preset-tonal-primary flex-1" data-chrome-key="LoadFromFile">Load from file</button>
                 <input type="file" id="qv-saves-file-input" class="hidden" accept=".quest-save">
             </div>
         </div>

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -749,29 +749,6 @@ function _esc(str) {
 let savesDialogWired = false;
 let bootChoiceResolve = null;
 
-// Applies a resolved chrome-strings dictionary (see ChromeStrings.Resolve in
-// PlayerCore/WasmPlayerBridge.GetChromeStringsJson, or a save's snapshot -
-// see GameSaver.save in playercore.js) to every #qv-saves element tagged
-// with a data-chrome-key* attribute. dict is always fully populated (every
-// key defaults to English), so a missing key here just means dict itself is
-// null/undefined (no game loaded, no snapshot available) - existing markup
-// is left untouched in that case.
-function applyChromeStrings(dict) {
-    if (!dict) return;
-    document.querySelectorAll('[data-chrome-key]').forEach(el => {
-        const value = dict[el.dataset.chromeKey];
-        if (value) el.textContent = value;
-    });
-    document.querySelectorAll('[data-chrome-key-placeholder]').forEach(el => {
-        const value = dict[el.dataset.chromeKeyPlaceholder];
-        if (value) el.placeholder = value;
-    });
-    document.querySelectorAll('[data-chrome-key-aria-label]').forEach(el => {
-        const value = dict[el.dataset.chromeKeyAriaLabel];
-        if (value) el.setAttribute('aria-label', value);
-    });
-}
-
 // Waits for the browser to actually paint the current frame. WasmPlayer's
 // WASM runtime is single-threaded and the engine's SaveAsync does its work
 // synchronously (no genuine await inside it) — so a DOM update made right

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -335,6 +335,7 @@ async function maybeGateOnActivation(gameBytes) {
 // and player.js can call into it without modification.
 window.WebPlayer = {
     gameId: null,
+    chromeStrings: null,
 
     initUI() { initPlayerUI(); },
 
@@ -555,6 +556,15 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
         throw new Error('Failed to initialise game');
     }
 
+    // Now that a WorldModel is live, resolve the game's own translated chrome
+    // strings (falls back to English for any key it doesn't define) and apply
+    // them to the dialog markup — this also keeps WebPlayer.chromeStrings
+    // current for the shared GameSaver in playercore.js (default save label,
+    // and the snapshot it stashes into the save record for next session's
+    // boot prompt — see startGame below).
+    WebPlayer.chromeStrings = JSON.parse(Bridge.GetChromeStringsJson());
+    applyChromeStrings(WebPlayer.chromeStrings);
+
     await maybeGateOnActivation(gameBytes);
 
     // Now that startup has actually succeeded, remove the start screen overlay
@@ -704,6 +714,15 @@ async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPr
         let saves = [];
         try { saves = await GameSaver.listSaves(gameId); } catch { saves = []; }
         if (saves.length > 0) {
+            // No WorldModel exists yet at this point (the WASM runtime isn't even
+            // booted), so the boot prompt can't resolve chrome strings live -
+            // instead, reuse whichever snapshot was captured the last time this
+            // game was saved (see GameSaver.save's chromeStrings field).
+            const snapshot = saves.find(s => s.chromeStrings)?.chromeStrings;
+            if (snapshot) {
+                WebPlayer.chromeStrings = snapshot;
+                applyChromeStrings(snapshot);
+            }
             const choice = await openSavesDialog('boot', gameId);
             if (choice.type === 'load') {
                 saveBytes = await GameSaver.load(choice.slotIndex, gameId);
@@ -729,6 +748,29 @@ function _esc(str) {
 
 let savesDialogWired = false;
 let bootChoiceResolve = null;
+
+// Applies a resolved chrome-strings dictionary (see ChromeStrings.Resolve in
+// PlayerCore/WasmPlayerBridge.GetChromeStringsJson, or a save's snapshot -
+// see GameSaver.save in playercore.js) to every #qv-saves element tagged
+// with a data-chrome-key* attribute. dict is always fully populated (every
+// key defaults to English), so a missing key here just means dict itself is
+// null/undefined (no game loaded, no snapshot available) - existing markup
+// is left untouched in that case.
+function applyChromeStrings(dict) {
+    if (!dict) return;
+    document.querySelectorAll('[data-chrome-key]').forEach(el => {
+        const value = dict[el.dataset.chromeKey];
+        if (value) el.textContent = value;
+    });
+    document.querySelectorAll('[data-chrome-key-placeholder]').forEach(el => {
+        const value = dict[el.dataset.chromeKeyPlaceholder];
+        if (value) el.placeholder = value;
+    });
+    document.querySelectorAll('[data-chrome-key-aria-label]').forEach(el => {
+        const value = dict[el.dataset.chromeKeyAriaLabel];
+        if (value) el.setAttribute('aria-label', value);
+    });
+}
 
 // Waits for the browser to actually paint the current frame. WasmPlayer's
 // WASM runtime is single-threaded and the engine's SaveAsync does its work
@@ -778,16 +820,18 @@ function renderSavesList(saves, mode) {
     const list = document.getElementById('qv-saves-list');
     if (!list) return;
     if (!saves.length) {
-        list.innerHTML = '<li class="text-sm text-surface-500">No saved games yet.</li>';
+        const noSavesText = WebPlayer.chromeStrings?.NoSavedGamesYet ?? 'No saved games yet.';
+        list.innerHTML = `<li class="text-sm text-surface-500">${_esc(noSavesText)}</li>`;
         return;
     }
     // s.name already carries a human-readable date/time when the user didn't
     // type a custom one (see GameSaver.save's default label) — don't also
     // render s.timestamp separately, or the same moment shows up twice in
     // two different formats.
+    const deleteLabel = _esc(WebPlayer.chromeStrings?.DeleteSave ?? 'Delete');
     list.innerHTML = saves.map(s => {
         const deleteBtn = mode === 'manage'
-            ? `<button type="button" class="btn-icon preset-tonal-error" data-delete-slot="${s.slotIndex}" aria-label="Delete">`
+            ? `<button type="button" class="btn-icon preset-tonal-error" data-delete-slot="${s.slotIndex}" aria-label="${deleteLabel}">`
                 + `<svg class="qv-icon" aria-hidden="true"><use href="#trash-2"></use></svg></button>`
             : '';
         return `<li class="flex items-center justify-between gap-2">`
@@ -850,7 +894,8 @@ async function loadSaveFromFile(file) {
     const uploadedIdentity = uploadedIfid || (originalAttr && computeGameId(originalAttr));
 
     if (!uploadedIdentity || currentIdentity.toLowerCase() !== uploadedIdentity.toLowerCase()) {
-        showSavesError('This save is for a different game — open that game first, then try again.');
+        showSavesError(WebPlayer.chromeStrings?.SaveWrongGame
+            ?? 'This save is for a different game — open that game first, then try again.');
         return;
     }
     hideSavesError();
@@ -886,7 +931,7 @@ function ensureSavesDialogWired() {
         // overlapping calls (see restartInProgress's doc comment), but
         // without this there was no visible feedback at all inviting
         // exactly the impatient re-click that guard exists for.
-        withBusyButton(e.currentTarget, 'Restarting…', () => restartGame(null));
+        withBusyButton(e.currentTarget, WebPlayer.chromeStrings?.RestartingBusy ?? 'Restarting…', () => restartGame(null));
     });
 
     document.getElementById('qv-saves-list').addEventListener('click', async (e) => {
@@ -906,8 +951,9 @@ function ensureSavesDialogWired() {
         }
         const delBtn = e.target.closest('[data-delete-slot]');
         if (delBtn) {
-            const name = delBtn.closest('li')?.querySelector('[data-slot]')?.textContent ?? 'this save';
-            if (!confirm(`Delete "${name}"? This can't be undone.`)) return;
+            const name = delBtn.closest('li')?.querySelector('[data-slot]')?.textContent ?? (WebPlayer.chromeStrings?.UnnamedSave ?? 'this save');
+            const confirmTemplate = WebPlayer.chromeStrings?.DeleteSaveConfirm ?? 'Delete "[name]"? This can\'t be undone.';
+            if (!confirm(confirmTemplate.replace('[name]', name))) return;
             await withBusyButton(delBtn, '', async () => {
                 await GameSaver.deleteSlot(Number(delBtn.dataset.deleteSlot), WebPlayer.gameId);
             });
@@ -917,7 +963,7 @@ function ensureSavesDialogWired() {
 
     document.getElementById('qv-saves-save-new').addEventListener('click', async (e) => {
         const input = document.getElementById('qv-saves-name-input');
-        await withBusyButton(e.currentTarget, 'Saving…', async () => {
+        await withBusyButton(e.currentTarget, WebPlayer.chromeStrings?.SavingBusy ?? 'Saving…', async () => {
             await GameSaver.save(input.value.trim() || undefined);
         });
         input.value = '';
@@ -925,7 +971,7 @@ function ensureSavesDialogWired() {
     });
 
     document.getElementById('qv-saves-download').addEventListener('click', (e) =>
-        withBusyButton(e.currentTarget, 'Saving…', downloadSaveToFile));
+        withBusyButton(e.currentTarget, WebPlayer.chromeStrings?.SavingBusy ?? 'Saving…', downloadSaveToFile));
 
     const uploadBtn = document.getElementById('qv-saves-upload-btn');
     const fileInput = document.getElementById('qv-saves-file-input');

--- a/src/WebPlayer/Components/Game.razor
+++ b/src/WebPlayer/Components/Game.razor
@@ -1,6 +1,7 @@
 @rendermode InteractiveServer
 @using System.Xml.Linq
 @using QuestViva.Common
+@using QuestViva.Engine
 @using QuestViva.PlayerCore
 @using QuestViva.WebPlayer.Components.Debugger
 @using QuestViva.WebPlayer.Models
@@ -47,7 +48,7 @@
        OnStart="() => StartGame(null)" OnLoad="@LoadGame"
        OnSaveNew="@SaveNew" OnDelete="@DeleteSlot"
        OnDownload="@DownloadSaveToFile" OnUploadFile="@LoadSaveFromFile"
-       OnClose="@CloseSaveManager"></Slots>
+       OnClose="@CloseSaveManager" ChromeStrings="@chromeStrings"></Slots>
 
 @code {
     private const long MaxSaveFileBytes = 50 * 1024 * 1024;
@@ -64,6 +65,7 @@
     private SaveSlot[] saves = [];
     private bool manageMode;
     private string? saveManagerError;
+    private Dictionary<string, string> chromeStrings = new(ChromeStrings.Defaults);
     private DotNetObjectReference<Game>? gameDotNetRef;
     private byte[]? originalGameBytes;
 
@@ -99,6 +101,14 @@
         if (saves.Length > 0)
         {
             manageMode = false;
+            // Nothing has been parsed into a WorldModel yet at this point, so the
+            // boot-time "Continue your game?" prompt can't read templates live -
+            // instead, pick up whichever chrome-strings snapshot was captured the
+            // last time this game was saved (see ChromeStrings.Resolve's call site
+            // below and GameSaver.save in playercore.js for where it's written).
+            var latestSnapshot = saves.OrderByDescending(s => s.Timestamp).FirstOrDefault()?.ChromeStrings;
+            if (latestSnapshot != null) chromeStrings = latestSnapshot;
+            await JS.InvokeVoidAsync("WebPlayer.setChromeStrings", chromeStrings);
             await JS.InvokeVoidAsync("WebPlayer.showSlots", false);
             StateHasChanged();
         }
@@ -127,8 +137,9 @@
 
     private async Task DeleteSlot(int slotIndex)
     {
-        var name = saves.FirstOrDefault(s => s.SlotIndex == slotIndex)?.Name ?? "this save";
-        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Delete \"{name}\"? This can't be undone.");
+        var name = saves.FirstOrDefault(s => s.SlotIndex == slotIndex)?.Name ?? chromeStrings["UnnamedSave"];
+        var confirmMessage = chromeStrings["DeleteSaveConfirm"].Replace("[name]", name);
+        var confirmed = await JS.InvokeAsync<bool>("confirm", confirmMessage);
         if (!confirmed) return;
 
         await JS.InvokeVoidAsync("WebPlayer.deleteSlot", slotIndex);
@@ -212,7 +223,7 @@
 
             if (uploadedIdentity == null || !string.Equals(currentIdentity, uploadedIdentity, StringComparison.OrdinalIgnoreCase))
             {
-                saveManagerError = "This save is for a different game — open that game first, then try again.";
+                saveManagerError = chromeStrings["SaveWrongGame"];
                 StateHasChanged();
                 return;
             }
@@ -294,6 +305,8 @@
         {
             gameDebug = game as IGameDebug;
             await JS.InvokeVoidAsync("WebPlayer.setCanDebug", EnableDebug && gameDebug != null);
+            chromeStrings = ChromeStrings.Resolve(game as WorldModel);
+            await JS.InvokeVoidAsync("WebPlayer.setChromeStrings", chromeStrings);
             StateHasChanged();
         }
     }

--- a/src/WebPlayer/Components/Slots.razor
+++ b/src/WebPlayer/Components/Slots.razor
@@ -1,4 +1,5 @@
 @using QuestViva.WebPlayer.Models
+@using QuestViva.PlayerCore
 <style scoped>
     dialog {
         border: none;
@@ -28,13 +29,13 @@
     @if (ManageMode)
     {
         <div class="d-flex justify-content-between align-items-center">
-            <h3 class="m-0">Save / Load</h3>
-            <button type="button" class="btn-close" aria-label="Close" @onclick="() => OnClose.InvokeAsync()"></button>
+            <h3 class="m-0">@ChromeStrings["SaveLoadTitle"]</h3>
+            <button type="button" class="btn-close" aria-label="@ChromeStrings["CloseDialog"]" @onclick="() => OnClose.InvokeAsync()"></button>
         </div>
     }
     else
     {
-        <h3>Continue your game?</h3>
+        <h3>@ChromeStrings["ContinueYourGamePrompt"]</h3>
     }
 
     @if (!string.IsNullOrEmpty(ErrorMessage))
@@ -42,11 +43,11 @@
         <div class="alert alert-danger mt-2">@ErrorMessage</div>
     }
 
-    <button class="btn btn-primary mt-2" @onclick="OnStart">Start from the beginning</button>
+    <button class="btn btn-primary mt-2" @onclick="OnStart">@ChromeStrings["StartFromBeginning"]</button>
 
     @if (Saves.Any())
     {
-        <h4 class="mt-3">Saved games</h4>
+        <h4 class="mt-3">@ChromeStrings["SavedGamesHeading"]</h4>
         @foreach (var save in Saves)
         {
             var slotIndex = save.SlotIndex;
@@ -54,7 +55,7 @@
                 <button class="btn btn-link p-0 text-start" @onclick="() => OnLoad.InvokeAsync(slotIndex)">@save.Name</button>
                 @if (ManageMode)
                 {
-                    <button class="btn btn-sm btn-outline-danger" @onclick="() => OnDelete.InvokeAsync(slotIndex)">Delete</button>
+                    <button class="btn btn-sm btn-outline-danger" @onclick="() => OnDelete.InvokeAsync(slotIndex)">@ChromeStrings["DeleteSave"]</button>
                 }
             </div>
         }
@@ -64,13 +65,13 @@
     {
         <hr/>
         <div class="input-group mt-2">
-            <input class="form-control" placeholder="Save name" @bind="newSaveName"/>
-            <button class="btn btn-primary" @onclick="SaveNew">Save new</button>
+            <input class="form-control" placeholder="@ChromeStrings["SaveNamePlaceholder"]" @bind="newSaveName"/>
+            <button class="btn btn-primary" @onclick="SaveNew">@ChromeStrings["SaveNew"]</button>
         </div>
         <div class="d-flex gap-2 mt-2">
-            <button class="btn btn-outline-secondary flex-fill" @onclick="() => OnDownload.InvokeAsync()">Save to file</button>
+            <button class="btn btn-outline-secondary flex-fill" @onclick="() => OnDownload.InvokeAsync()">@ChromeStrings["SaveToFile"]</button>
             <label class="btn btn-outline-secondary flex-fill mb-0">
-                Load from file
+                @ChromeStrings["LoadFromFile"]
                 <InputFile OnChange="OnFileSelected" class="d-none" accept=".quest-save"/>
             </label>
         </div>
@@ -88,6 +89,7 @@
     [Parameter] public required SaveSlot[] Saves { get; set; } = [];
     [Parameter] public bool ManageMode { get; set; }
     [Parameter] public string? ErrorMessage { get; set; }
+    [Parameter] public IReadOnlyDictionary<string, string> ChromeStrings { get; set; } = QuestViva.PlayerCore.ChromeStrings.Defaults;
 
     private string? newSaveName;
 

--- a/src/WebPlayer/Models/SaveSlot.cs
+++ b/src/WebPlayer/Models/SaveSlot.cs
@@ -5,4 +5,5 @@ public class SaveSlot
     public string? Name { get; set; }
     public int SlotIndex { get; set; }
     public DateTime Timestamp { get; set; }
+    public Dictionary<string, string>? ChromeStrings { get; set; }
 }

--- a/src/WebPlayer/wwwroot/playerweb.js
+++ b/src/WebPlayer/wwwroot/playerweb.js
@@ -3,6 +3,7 @@ class WebPlayer {
     static gameDotNetHelper;
     static gameId;
     static slotsDialogCanBeClosed = false;
+    static chromeStrings = null;
 
     // Fixed at class-definition time (not set conditionally later), so there's
     // no ordering/race concern with when initPlayerUI() binds #cmdSave's click
@@ -21,6 +22,10 @@ class WebPlayer {
 
     static setGameId(id) {
         WebPlayer.gameId = id;
+    }
+
+    static setChromeStrings(dict) {
+        WebPlayer.chromeStrings = dict;
     }
 
     static listSaves = async () => {

--- a/src/WebPlayer/wwwroot/playerweb.js
+++ b/src/WebPlayer/wwwroot/playerweb.js
@@ -26,6 +26,7 @@ class WebPlayer {
 
     static setChromeStrings(dict) {
         WebPlayer.chromeStrings = dict;
+        applyChromeStrings(dict);
     }
 
     static listSaves = async () => {


### PR DESCRIPTION
## Summary
- Sources WebPlayer/WasmPlayer's Save/Load dialog strings (and the `#cmdSave` trigger button, renamed from "Save" to "Save / Load" since it also handles Load and Start-from-beginning) from the game's own per-language Core library templates, instead of hardcoding English — a translation added to `Deutsch.aslx`/`Espanol.aslx` now lands in every game published from then on, matching how in-game narrative text already works.
- Snapshots the resolved chrome-strings dictionary into each save record at save-time (IndexedDB via `GameSaver.save`, and the Electron file-backed save manifest), so the boot-time "Continue your game?" prompt can show the right language *before* a `WorldModel` exists next session — there's nothing to read a template from at that point in either player, so this reuses whichever snapshot was captured the last time the game was saved.
- Adds English/German/Spanish translations for the new keys (the three `supported: true` languages in `tools/i18n/languages.json`, following the Du/tú register documented in `docs/i18n-style-guide.md`); the other 12 language files are untouched and fall back to English via `ChromeStrings.Resolve`, same as the audit tool's existing treatment of gaps in those files.
- Debugger dialog stays untouched (dev-only, never shipped to published games).

## Why
Part of an ongoing translations push. The Save/Load dialog was the last major hardcoded-English surface in the player chrome.

## Reviewer notes
- New shared helper: `src/PlayerCore/ChromeStrings.cs` — single source of English defaults + `Resolve(WorldModel)`, used by both players so the fallback table exists exactly once.
- New engine surface: `WorldModel.GetTemplateText(name)` (public wrapper around the previously `internal`-only `Template.GetText`, `throwException: false` so old already-published games / legacy V4 `.asl`/`.cas` games fall back cleanly).
- `applyChromeStrings` lives in the shared `playercore.js` (not per-player) since `playercore.htm`'s chrome, including the Save button, is common to both WebPlayer and WasmPlayer.
- Verified manually in-browser: full manage-mode dialog translation, default save label, save-time snapshot, and the boot-time prompt reading that snapshot pre-WorldModel — all confirmed working in German with no regression to the English baseline.
- `dotnet test` (EngineTests/PlayerCoreTests/WebPlayerTests) and `node tools/i18n/audit.mjs --strict` both pass.

## Test plan
- [x] `dotnet build --configuration Release` (full solution)
- [x] `dotnet test tests/EngineTests tests/PlayerCoreTests tests/WebPlayerTests`
- [x] `node tools/i18n/audit.mjs --strict` (en/de/es at 100% coverage for the player layer)
- [x] Manual verification via WasmPlayer dev server with a German test game: boot prompt, manage-mode dialog, Save button, default save label, delete confirm — all translated; English baseline unaffected