### PR TITLE
fix: repair three e2e tests broken by stale locators and a load race

### DIFF
--- a/tests/e2e/verify-appshell-drafts-rekey-backup.mjs
+++ b/tests/e2e/verify-appshell-drafts-rekey-backup.mjs
@@ -35,7 +35,9 @@ async function draftCount() {
     // refreshDrafts() is async (reads OPFS) — wait for it to actually settle
     // rather than counting immediately, or this races the render.
     await page.locator('text=Your local drafts').waitFor({ timeout: 5000 }).catch(() => {});
-    return page.locator('button:has-text("Delete")').count();
+    // Icon-only since #2020 — "Delete draft" only lives in its title/aria-label
+    // now, not as visible text content.
+    return page.locator('button[title="Delete draft"]').count();
 }
 
 try {
@@ -94,7 +96,7 @@ try {
     // directly, scoped to the dialog to avoid matching a different draft
     // row's own "Delete" button.
     await page.goto(`${baseUrl}/open`);
-    await page.click('button:has-text("Delete")');
+    await page.click('button[title="Delete draft"]');
     await page.locator('div[role="dialog"] button:has-text("Delete")').click();
     await page.waitForTimeout(500);
 

--- a/tests/e2e/verify-appshell-gamebook-mode.mjs
+++ b/tests/e2e/verify-appshell-gamebook-mode.mjs
@@ -70,14 +70,16 @@ try {
     }
     console.log('PASS: "Advanced" adders are limited to Function/Library/JavaScript in gamebook mode');
 
-    // Deleting the page that contains "player" (Page1, per the Gamebook
-    // template) must be a safe no-op, not a crash/corruption.
+    // The page that contains "player" (Page1, per the Gamebook template)
+    // must not be deletable — EditorController.CanDelete refuses it, so the
+    // toolbar Delete button is disabled rather than clickable (see
+    // Toolbar.svelte's canDelete derivation).
     await tree.getByText('Page1', { exact: true }).click();
-    await page.click('button:has-text("Delete")');
-    await page.waitForTimeout(300);
+    const deleteDisabled = await page.locator('button:has-text("Delete")').isDisabled();
+    if (!deleteDisabled) throw new Error('Delete button should be disabled for Page1 (containing player)');
     const page1StillThere = await tree.getByText('Page1', { exact: true }).isVisible().catch(() => false);
     if (!page1StillThere) throw new Error('Page1 (containing player) should NOT be deletable');
-    console.log('PASS: deleting the page containing "player" is a safe no-op');
+    console.log('PASS: deleting the page containing "player" is blocked (Delete button disabled)');
 
     console.log('PASS: all gamebook-mode checks passed');
 } catch (err) {

--- a/tests/e2e/verify-electron-recent-games.mjs
+++ b/tests/e2e/verify-electron-recent-games.mjs
@@ -93,6 +93,25 @@ try {
         await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
     }
 
+    // Waits for the toolbar's own filename readout (Toolbar.svelte's
+    // `{$gameFilename}` span) to show this specific file, not just for
+    // 'button[title="Manage assets"]' to be visible — that button is part of
+    // the *previous* game's still-mounted toolbar during a same-window
+    // edit-to-edit switch (Game A's editor -> Game B's editor), so it can
+    // resolve instantly, before the new game has actually finished loading.
+    // Racing ahead on that stale signal (e.g. firing another menu action
+    // while the real load is still in flight) lets the in-flight load's own
+    // goto('/edit') win later and silently clobber whatever navigation the
+    // next step expected.
+    async function waitForGameLoaded(filename) {
+        await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+        await win.waitForFunction(
+            (name) => document.querySelector('.font-mono.truncate')?.textContent?.trim() === name,
+            filename,
+            { timeout: 30000 },
+        );
+    }
+
     // 1. Fresh app, no recent games yet. Root lands on the Play tab by
     // default — the /open form lives behind the "Create" tab.
     await win.waitForSelector('a:has-text("Create")', { timeout: 30000 });
@@ -128,20 +147,22 @@ try {
     await clickMenuItem('File', 'New Game…');
     await win.waitForSelector('text=Game B.aslx', { timeout: 10000 });
     await win.click('button:has-text("Game A.aslx")');
-    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    await waitForGameLoaded('Game A.aslx');
     console.log('PASS: clicking Game A in Recent reopened it directly');
 
     // 5. Native "Open Recent" submenu click loads a game too (the nonce/query-
     // string path from +layout.svelte's onOpenRecent, not the /open page button).
     await clickMenuItem('File', 'Open Recent', 'Game B.aslx — Game B');
-    await win.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    await waitForGameLoaded('Game B.aslx');
     console.log('PASS: native "Open Recent" menu entry reopened Game B directly');
 
     // 6. Remove one entry from the /open page, confirm it's gone from both
     // the page and the native menu.
     await clickMenuItem('File', 'New Game…');
     await win.waitForSelector('text=Game A.aslx', { timeout: 20000 });
-    const gameARow = win.locator('div.flex.items-center.gap-2.w-full', { hasText: 'Game A.aslx' }).locator('button:has-text("Remove")');
+    // Icon-only button since #2020 — "Remove from Recent" only lives in its
+    // title/aria-label now, not as visible text content.
+    const gameARow = win.locator('div.flex.items-center.gap-2.w-full', { hasText: 'Game A.aslx' }).locator('button[title="Remove from Recent"]');
     await gameARow.click();
     await win.waitForSelector('text=Game A.aslx', { state: 'detached', timeout: 5000 }).catch(() => {});
     const gameAStillListed = await win.isVisible('text=Game A.aslx');


### PR DESCRIPTION
## Summary
Investigated the failures in [run 31602114418](https://github.com/textadventures/quest/actions/runs/31602114418) (`appshell_chromium`, `electron`, `appshell_opfs_firefox`). All three were test bugs, not product bugs — fixed by updating the test scripts, no application code touched.

- **`verify-appshell-gamebook-mode.mjs`**: the page containing "player" correctly has its Delete button *disabled* (`EditorController.CanDelete`) in Gamebook mode — the test assumed it would be clickable and a silent no-op. Now asserts the button is disabled instead of clicking it.
- **`verify-electron-recent-games.mjs`**: two bugs stacked on each other.
  - A real race: after reopening a game via the native "Open Recent" menu, the test's `button[title="Manage assets"]` wait could match a *stale* button still on screen from the previous game's still-mounted editor, resolving before the new game actually finished loading. A later action could then get silently overridden by the in-flight load's own navigation. Fixed by waiting for the toolbar's filename readout (`{$gameFilename}`) to show the specific expected file.
  - A stale locator: [#2020](https://github.com/textadventures/quest/pull/2020) turned the "Remove from Recent" button into an icon-only button (Aug 10) — `button:has-text("Remove")` had matched nothing since then, just masked until the race above was fixed and the test could actually reach that step. Switched to `button[title="Remove from Recent"]`.
- **`verify-appshell-drafts-rekey-backup.mjs`**: same icon-only-button drift from #2020 for the drafts list's "Delete draft" button — `button:has-text("Delete")` always counted 0 drafts. Switched to `button[title="Delete draft"]` in both places it's used.

## Test plan
- [x] `verify-appshell-gamebook-mode.mjs` — passing
- [x] `verify-electron-recent-games.mjs` — passing 4/4 consecutive local runs
- [x] `verify-appshell-drafts-rekey-backup.mjs` — passing 3/4 isolated local runs (the one failure was resource contention from running three Firefox instances back-to-back in my own test loop, not reproducible in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)