### PR TITLE
ci: run e2e workflow nightly, not just on manual dispatch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,15 +1,24 @@
 name: e2e
 
-# Manual only, not on every push/PR — these are Playwright browser/Electron-
-# driven verification scripts (tests/e2e/*.mjs), not the dotnet test suite.
-# They drive real dev servers / a packaged Electron app end-to-end rather than
-# mocking anything, so they're slower and younger than dotnet test. Good to
-# run before cutting a release, or after touching AppShell/WasmPlayer/
-# WebPlayer/ElectronApp. Each job below matches one of the distinct local
-# setups documented in the individual scripts' header comments — see those
-# for the "why" behind each one.
+# Nightly + manual, not on every push/PR — these are Playwright browser/
+# Electron-driven verification scripts (tests/e2e/*.mjs), not the dotnet test
+# suite. They drive real dev servers / a packaged Electron app end-to-end
+# rather than mocking anything, so they're slower and younger than dotnet
+# test — worth checking regularly, but too slow to put in every PR's critical
+# path. The nightly run is what catches drift between the scripts and the UI
+# (locator text/structure changes, timing assumptions) before it piles up
+# unnoticed; workflow_dispatch is still there for an on-demand run before
+# cutting a release, or after touching AppShell/WasmPlayer/WebPlayer/
+# ElectronApp. Each job below matches one of the distinct local setups
+# documented in the individual scripts' header comments — see those for the
+# "why" behind each one.
 on:
   workflow_dispatch:
+  schedule:
+    # 03:17 UTC — off the hour to avoid the top-of-hour pile-up GitHub warns
+    # about for scheduled workflows. Runs against whatever's on main at that
+    # time regardless of whether anything changed since the last run.
+    - cron: '17 3 * * *'
 
 jobs:
   # AppShell (Debug WasmEditor) + WasmPlayer (Debug), one Vite dev server and


### PR DESCRIPTION
## Summary
- Adds a `schedule: cron: '17 3 * * *'` trigger to `e2e.yml` alongside the existing `workflow_dispatch`, so the Playwright e2e suite runs nightly instead of only when manually remembered.
- `workflow_dispatch` is kept for on-demand runs (e.g. before cutting a release, or after touching AppShell/WasmPlayer/WebPlayer/ElectronApp).

## Why
Discussed in [#2051](https://github.com/textadventures/quest/pull/2051) — those three failures were all stale test locators that had drifted for days/weeks without anyone noticing, since the workflow only runs when manually triggered. It's too slow (~6-8 min across several parallel jobs) to gate every PR, but a nightly cadence catches this kind of drift within a day at zero cost to PR merge time.

Note: a scheduled run always fires regardless of whether anything changed on `main` since the last run — GitHub Actions doesn't diff commit activity for `schedule` triggers. That's a deliberate no-op-is-fine tradeoff here rather than adding extra logic to skip unchanged nights.

## Test plan
- [x] `.github/workflows/e2e.yml` YAML parses correctly (validated locally with PyYAML)
- [ ] First scheduled run at 03:17 UTC will confirm the trigger fires as expected — nothing else to test locally for a workflow-trigger-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)