### PR TITLE
feat(AppShell): add tree node icons, collapse s_-prefixed icon indirection

### DIFF
--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -1,10 +1,28 @@
 <script lang="ts">
-    import { untrack } from "svelte";
+    import { untrack, type Component } from "svelte";
     import { TreeView, createTreeViewCollection } from "@skeletonlabs/skeleton-svelte";
     import Search from "@lucide/svelte/icons/search";
     import X from "@lucide/svelte/icons/x";
     import SlidersHorizontal from "@lucide/svelte/icons/sliders-horizontal";
     import Check from "@lucide/svelte/icons/check";
+    import DoorOpen from "@lucide/svelte/icons/door-open";
+    import Package from "@lucide/svelte/icons/package";
+    import FileText from "@lucide/svelte/icons/file-text";
+    import Signpost from "@lucide/svelte/icons/signpost";
+    import MessageSquare from "@lucide/svelte/icons/message-square";
+    import Terminal from "@lucide/svelte/icons/terminal";
+    import RotateCw from "@lucide/svelte/icons/rotate-cw";
+    import SquareFunction from "@lucide/svelte/icons/square-function";
+    import Timer from "@lucide/svelte/icons/timer";
+    import Route from "@lucide/svelte/icons/route";
+    import Library from "@lucide/svelte/icons/library";
+    import LayoutTemplate from "@lucide/svelte/icons/layout-template";
+    import Braces from "@lucide/svelte/icons/braces";
+    import Shapes from "@lucide/svelte/icons/shapes";
+    import FileCode from "@lucide/svelte/icons/file-code";
+    import Gamepad2 from "@lucide/svelte/icons/gamepad-2";
+    import Puzzle from "@lucide/svelte/icons/puzzle";
+    import Folder from "@lucide/svelte/icons/folder";
     import DropdownMenu from "./DropdownMenu.svelte";
     import type { DropdownMenuItem } from "./DropdownMenu.svelte";
     import {
@@ -53,6 +71,50 @@
         if (node.key === "_objects") return $isGamebook ? t("treePanel.header.pages") : t("treePanel.header.objects");
         const key = HEADER_LABEL_KEYS[node.key];
         return key ? t(key) : node.text;
+    }
+
+    type IconComponent = Component<{ size?: number; class?: string }>;
+
+    // One icon per leaf nodeType (see EditorController.GetNodeType / WasmEditorBridge.TreeNodeData).
+    const NODE_TYPE_ICON: Record<string, IconComponent> = {
+        game: Gamepad2,
+        room: DoorOpen,
+        object: Package,
+        page: FileText,
+        exit: Signpost,
+        verb: MessageSquare,
+        command: Terminal,
+        turnscript: RotateCw,
+        function: SquareFunction,
+        timer: Timer,
+        walkthrough: Route,
+        include: Library,
+        template: LayoutTemplate,
+        dynamictemplate: Braces,
+        type: Shapes,
+        javascript: FileCode,
+    };
+
+    // Every header node's nodeType is the generic "header" (see WasmEditorBridge), so headers
+    // are iconified by their fixed key instead, echoing the category they contain.
+    const HEADER_ICON: Record<string, IconComponent> = {
+        _objects: Package,
+        _advanced: Folder,
+        _functions: SquareFunction,
+        _timers: Timer,
+        _walkthrough: Route,
+        _include: Library,
+        _template: LayoutTemplate,
+        _dynamictemplate: Braces,
+        _objecttype: Shapes,
+        _javascript: FileCode,
+        _gameVerbs: MessageSquare,
+        _gameCommands: Terminal,
+    };
+
+    function nodeIcon(node: HierNode): IconComponent {
+        if (node.nodeType === "header") return HEADER_ICON[node.id] ?? Folder;
+        return NODE_TYPE_ICON[node.nodeType] ?? Puzzle;
     }
 
     // Build HierNode tree from flat list
@@ -481,10 +543,11 @@
 {/snippet}
 
 {#snippet treeNode(node: HierNode, indexPath: number[])}
+    {@const Icon = nodeIcon(node)}
     <TreeView.NodeProvider value={{ node, indexPath }}>
         {#if node.children}
             <TreeView.Branch>
-                <TreeView.BranchControl class="group" ondblclick={() => toggleExpand(node.id)} onclick={() => activateIfAlreadySelected(node.id)}>
+                <TreeView.BranchControl class="group flex items-center gap-1.5" ondblclick={() => toggleExpand(node.id)} onclick={() => activateIfAlreadySelected(node.id)}>
                     <button
                         type="button"
                         tabindex="-1"
@@ -494,6 +557,7 @@
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="size-4"><polyline points="9 18 15 12 9 6" /></svg>
                     </button>
+                    <Icon class="flex-shrink-0 size-3.5 text-surface-500 {node.isLibrary ? "opacity-60" : ""}" />
                     <TreeView.BranchText class="flex-1 min-w-0 truncate {node.isLibrary ? "text-surface-600-400" : ""} {$cutElementKeys.has(node.id) ? "opacity-50 italic" : ""}">{node.text}</TreeView.BranchText>
                     <span class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100">
                         {@render nodeActions(node)}
@@ -507,7 +571,8 @@
                 </TreeView.BranchContent>
             </TreeView.Branch>
         {:else}
-            <TreeView.Item class="group flex items-center" onclick={() => activateIfAlreadySelected(node.id)}>
+            <TreeView.Item class="group flex items-center gap-1.5" onclick={() => activateIfAlreadySelected(node.id)}>
+                <Icon class="flex-shrink-0 size-3.5 text-surface-500 {node.isLibrary ? "opacity-60" : ""}" />
                 <span class="flex-1 min-w-0 truncate {node.isLibrary ? "text-surface-600-400" : ""} {$cutElementKeys.has(node.id) ? "opacity-50 italic" : ""}">{node.text}</span>
                 <span class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100">
                     {@render nodeActions(node)}

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -2,7 +2,6 @@ export interface TreeNode {
   key: string
   text: string
   parent: string | null
-  nodeIcon: string | null
   nodeType: string
   isLibrary: boolean
   // Authoritative — mirrors EditorController.CanDelete exactly (covers "game", the gamebook

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -447,7 +447,7 @@ public sealed class EditorController : IDisposable
             new AddedNodeEventArgs
             {
                 Key = key, Text = text, Parent = newParent, IsLibraryNode = false, Position = null,
-                NodeIcon = movedElement != null ? GetNodeIcon(movedElement) : null
+                NodeType = movedElement != null ? GetNodeType(movedElement) : null
             });
     }
 
@@ -548,7 +548,7 @@ public sealed class EditorController : IDisposable
                 new AddedNodeEventArgs
                 {
                     Key = key, Text = title, Parent = parent, IsLibraryNode = false, Position = null,
-                    NodeIcon = GetTreeHeaderIcon(type, key)
+                    NodeType = "header"
                 });
         }
     }
@@ -611,7 +611,7 @@ public sealed class EditorController : IDisposable
                 new AddedNodeEventArgs
                 {
                     Key = key, Text = text, Parent = parent, IsLibraryNode = isLibrary, Position = position,
-                    NodeIcon = GetNodeIcon(o)
+                    NodeType = GetNodeType(o)
                 });
 
             if (o.Name == "game" && !SimpleMode && EditorStyle == EditorStyle.TextAdventure)
@@ -620,13 +620,13 @@ public sealed class EditorController : IDisposable
                     new AddedNodeEventArgs
                     {
                         Key = k_verbs, Text = "Verbs", Parent = "game", IsLibraryNode = false, Position = null,
-                        NodeIcon = "s_verb"
+                        NodeType = "header"
                     });
                 AddedNode(this,
                     new AddedNodeEventArgs
                     {
                         Key = k_commands, Text = "Commands", Parent = "game", IsLibraryNode = false, Position = null,
-                        NodeIcon = "s_command"
+                        NodeType = "header"
                     });
             }
         }
@@ -762,63 +762,44 @@ public sealed class EditorController : IDisposable
         return GetDisplayName(WorldModel.Elements.Get(element));
     }
 
-    private string GetNodeIcon(Element o)
+    // The node-type string is consumed directly by the frontend (AppShell's TreePanel.svelte)
+    // both for behaviour (e.g. which "add" options a node offers) and for picking a tree icon —
+    // keep this as the single source of truth rather than adding another translation layer.
+    private string GetNodeType(Element o)
     {
         switch (o.ElemType)
         {
             case ElementType.Object:
                 switch (o.Type)
                 {
-                    case ObjectType.Game: return "s_game";
-                    case ObjectType.Exit: return "s_exit";
+                    case ObjectType.Game: return "game";
+                    case ObjectType.Exit: return "exit";
                     case ObjectType.Command:
-                        return o.Fields.GetAsType<bool>("isverb") ? "s_verb" : "s_command";
-                    case ObjectType.TurnScript: return "s_turn";
+                        return o.Fields.GetAsType<bool>("isverb") ? "verb" : "command";
+                    case ObjectType.TurnScript: return "turnscript";
                     case ObjectType.Object:
                         if (EditorStyle == EditorStyle.GameBook)
                         {
-                            return "s_add_page";
+                            return "page";
                         }
 
                         if (IsDialoguePage(o))
                         {
-                            return "s_add_page";
+                            return "page";
                         }
 
-                        return o.Fields.GetAsType<bool>("isroom") ? "s_room" : "s_object";
-                    default: return null;
+                        return o.Fields.GetAsType<bool>("isroom") ? "room" : "object";
+                    default: return "other";
                 }
-            case ElementType.Function: return "s_function";
-            case ElementType.Timer: return "s_timer";
-            case ElementType.Walkthrough: return "s_walk";
-            case ElementType.IncludedLibrary: return "s_library";
-            case ElementType.Template: return "s_template";
-            case ElementType.DynamicTemplate: return "s_dynamictemplate";
-            case ElementType.ObjectType: return "s_objecttype";
-            case ElementType.Javascript: return "s_javascript";
-            default: return null;
-        }
-    }
-
-    private string GetTreeHeaderIcon(ElementType? type, string key)
-    {
-        if (type == null)
-        {
-            return "s_folder";
-        }
-
-        switch (type.Value)
-        {
-            case ElementType.Object: return "s_object";
-            case ElementType.Function: return "s_function";
-            case ElementType.Timer: return "s_timer";
-            case ElementType.Walkthrough: return "s_walk";
-            case ElementType.IncludedLibrary: return "s_library";
-            case ElementType.Template: return "s_template";
-            case ElementType.DynamicTemplate: return "s_dynamictemplate";
-            case ElementType.ObjectType: return "s_objecttype";
-            case ElementType.Javascript: return "s_javascript";
-            default: return null;
+            case ElementType.Function: return "function";
+            case ElementType.Timer: return "timer";
+            case ElementType.Walkthrough: return "walkthrough";
+            case ElementType.IncludedLibrary: return "include";
+            case ElementType.Template: return "template";
+            case ElementType.DynamicTemplate: return "dynamictemplate";
+            case ElementType.ObjectType: return "type";
+            case ElementType.Javascript: return "javascript";
+            default: return "other";
         }
     }
 
@@ -2875,7 +2856,7 @@ public sealed class EditorController : IDisposable
         public string Parent { get; set; }
         public bool IsLibraryNode { get; set; }
         public int? Position { get; set; }
-        public string NodeIcon { get; set; }
+        public string NodeType { get; set; }
     }
 
     public class RemovedNodeEventArgs : EventArgs

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -17,7 +17,7 @@ using QuestViva.PlayerCore;
 
 namespace QuestViva.WasmEditor;
 
-internal record TreeNodeData(string Key, string Text, string? Parent, string? NodeIcon, string NodeType, bool IsLibrary, bool CanDelete);
+internal record TreeNodeData(string Key, string Text, string? Parent, string NodeType, bool IsLibrary, bool CanDelete);
 
 internal record ControlOption(string Value, string Label);
 
@@ -217,10 +217,7 @@ public partial class WasmEditorBridge
             {
                 if (TreeNodes[i].Key == e.OldName)
                 {
-                    TreeNodes[i] = TreeNodes[i] with
-                    {
-                        Key = e.NewName, Text = e.NewName, NodeType = GetNodeType(e.NewName, TreeNodes[i].NodeIcon)
-                    };
+                    TreeNodes[i] = TreeNodes[i] with { Key = e.NewName, Text = e.NewName };
                 }
                 else if (TreeNodes[i].Parent == e.OldName)
                 {
@@ -3639,32 +3636,6 @@ public partial class WasmEditorBridge
         );
     }
 
-    private static string GetNodeType(string key, string? nodeIcon)
-    {
-        return key.StartsWith("_")
-            ? "header"
-            : nodeIcon switch
-            {
-                "s_room" => "room",
-                "s_object" => "object",
-                "s_add_page" => "page",
-                "s_exit" => "exit",
-                "s_verb" => "verb",
-                "s_command" => "command",
-                "s_turn" => "turnscript",
-                "s_function" => "function",
-                "s_timer" => "timer",
-                "s_game" => "game",
-                "s_walk" => "walkthrough",
-                "s_library" => "include",
-                "s_template" => "template",
-                "s_dynamictemplate" => "dynamictemplate",
-                "s_objecttype" => "type",
-                "s_javascript" => "javascript",
-                _ => "other"
-            };
-    }
-
     private static void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e)
     {
         if (_suppressTreeEvents)
@@ -3674,7 +3645,7 @@ public partial class WasmEditorBridge
 
         // Authoritative — mirrors exactly what DeleteElement/DeleteElements will actually allow
         // (see EditorController.CanDelete), rather than the UI guessing from node type/text.
-        var node = new TreeNodeData(e.Key, e.Text, e.Parent, e.NodeIcon, GetNodeType(e.Key, e.NodeIcon),
+        var node = new TreeNodeData(e.Key, e.Text, e.Parent, e.NodeType,
             e.IsLibraryNode, _controller!.CanDelete(e.Key));
         if (_isRebuilding)
         {


### PR DESCRIPTION
## Summary

- The game-object tree in the AppShell editor has never rendered icons. `EditorController` produced `"s_room"`/`"s_exit"`/etc. strings (a leftover Quest 5 desktop-editor naming convention — unchanged since the project's first commit), `WasmEditorBridge` re-translated those into semantic node-type strings for the frontend, and `TreePanel.svelte` silently dropped the icon field before rendering.
- Collapses that two-hop translation into one: `EditorController.GetNodeType` now produces the semantic type string directly (no `"s_"` indirection), and `WasmEditorBridge` just passes it through.
- `TreePanel.svelte` now renders a [Lucide](https://lucide.dev) icon per node type (room, object, page, exit, verb, command, turn script, function, timer, walkthrough, included library, template, dynamic template, object type, javascript, game) and per header category, using the `@lucide/svelte` package already used elsewhere in AppShell — no new dependency.

## Test plan

- [x] `dotnet build --configuration Release` (full solution) — clean
- [x] `dotnet test --configuration Release` — 359/359 passing
- [x] `svelte-check` and `npm run lint` in `src/AppShell` — clean
- [x] Manually verified in the browser: created a draft game and added one of every element type (room, exit, command, verb, turn script, function, timer, template, object type, javascript, walkthrough, included libraries) — each renders its icon correctly, including through a page reload
- [ ] Dynamic Template was **not** exercised in this PR's manual pass beyond icon-code-path review — adding one currently throws an unrelated, pre-existing `NullReferenceException` on save (reproduces on `main`, unaffected by this change); tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)