### PR TITLE
fix(EditorCore): initialize Text field on new Dynamic Templates

### DIFF
--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -1703,7 +1703,8 @@ public sealed class EditorController : IDisposable
 
     public void CreateNewDynamicTemplate(string name)
     {
-        CreateNewElement(ElementType.DynamicTemplate, "dynamic template", name);
+        CreateNewElement(ElementType.DynamicTemplate, "dynamic template", name,
+            initialFields: new Dictionary<string, object> {{"text", ""}});
     }
 
     public void CreateNewType(string name)


### PR DESCRIPTION
## Summary

- Fixes a NullReferenceException that broke autosave immediately after adding a Dynamic Template in the editor (AppShell/WasmEditor), leaving the save-status pill stuck on "Save failed — Retry" with no recovery via Retry.
- Found incidentally while working on unrelated AppShell TreePanel changes; confirmed to reproduce on a clean checkout of `main`, so this is a pre-existing bug in the authoring/editor path, unrelated to that work.

## Root cause

`EditorController.CreateNewDynamicTemplate` created the new element via the generic `CreateNewElement` path with no `initialFields`, unlike `CreateNewTemplate` (which sets an initial empty `Text` field via `WorldModel.AddNewTemplate` → `Template.AddTemplate`). So a freshly created `DynamicTemplate` had no `Text` field set at all.

On autosave (`SaveMode.Editor`, where `WorldModel.EditMode` is `true` for the whole editor session), `DynamicTemplateSaver.Save` writes `e.Fields[FieldDefinitions.Text]` via `GameXmlWriter.WriteString`. Unlike plain `System.Xml.XmlWriter.WriteString` (a no-op on null), this project's `GameXmlWriter.WriteString` is a custom wrapper that unconditionally calls `text.Contains(Environment.NewLine)` before delegating — so a null `Text` threw a `NullReferenceException` there, immediately and unrecoverably breaking the pending save.

## Fix

`CreateNewDynamicTemplate` now passes an initial empty `text` field, mirroring the existing `CreateNewTemplate`/`Template.AddTemplate` convention.

## Test plan

- [x] `dotnet test tests/EditorCoreTests --configuration Release` — 24 passed
- [x] `dotnet test tests/EngineTests --configuration Release` — 306 passed
- [x] Manually reproduced in the AppShell dev server against a Debug WasmEditor build: created a new local draft (Text Adventure, English), expanded Advanced, clicked "+ Add Dynamic Template", entered a name, submitted — save status showed "Saved" (previously "Save failed — Retry")
- [x] Reloaded the page and confirmed the draft and the new Dynamic Template persisted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)