### PR TITLE
fix(AppShell): give the player object its own tree icon

### DIFF
--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -23,6 +23,7 @@
     import Gamepad2 from "@lucide/svelte/icons/gamepad-2";
     import Puzzle from "@lucide/svelte/icons/puzzle";
     import Folder from "@lucide/svelte/icons/folder";
+    import User from "@lucide/svelte/icons/user";
     import DropdownMenu from "./DropdownMenu.svelte";
     import type { DropdownMenuItem } from "./DropdownMenu.svelte";
     import {
@@ -114,6 +115,10 @@
 
     function nodeIcon(node: HierNode): IconComponent {
         if (node.nodeType === "header") return HEADER_ICON[node.id] ?? Folder;
+        // The player object is a plain Object element underneath (nodeType "object" in Text
+        // Adventure mode, "page" in Gamebook mode — see EditorController.GetNodeType), but it's
+        // always the single fixed "player" element key, so it gets its own icon regardless of mode.
+        if (node.id === "player") return User;
         return NODE_TYPE_ICON[node.nodeType] ?? Puzzle;
     }
 


### PR DESCRIPTION
## Summary
- In the tree panel, the `player` object was picking up whatever icon its underlying node type resolved to — the `page` icon in Gamebook mode, the generic `object`/`room` icon in Text Adventure mode — making it indistinguishable from a regular page/object.
- `player` is always the same fixed element key regardless of mode, so `nodeIcon` in `TreePanel.svelte` now special-cases it by `node.id === "player"` and gives it a dedicated `User` icon in both modes.
- Deliberately left `EditorController.GetNodeType` untouched — changing the backend `nodeType` for the player element would also have altered its context-menu behavior (adders, cut/copy/move gating), which wasn't asked for. This is a frontend-only, icon-only change.

## Test plan
- [x] `npm run lint` (AppShell) — clean
- [x] `npx svelte-check` — 0 errors, 0 warnings
- [x] Verified live in the AppShell dev server: created a fresh Gamebook draft, confirmed the `player` node now shows a person icon instead of the page icon, with no console errors and unchanged (pre-existing) context-menu behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)