### PR TITLE
feat(AppShell): add Page support to the Objects tab

### DIFF
--- a/src/AppShell/src/components/ElementsList.svelte
+++ b/src/AppShell/src/components/ElementsList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { SvelteSet } from "svelte/reactivity";
-    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createTurnScript, openAddLibraryModal, openAddJavascriptModal, swapElements } from "$lib/editor-store";
+    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createTurnScript, openAddLibraryModal, openAddJavascriptModal, swapElements, isGamebook } from "$lib/editor-store";
+    import { nodeIcon } from "$lib/node-icons";
     import { t } from "$lib/i18n";
 
     interface Props {
@@ -19,7 +20,7 @@
                 return ["command"];
             }
             if (ot === "turnscript") return ["turnscript"];
-            return ["room", "object"];
+            return ["room", "object", "page"];
         }
         return [et];
     }
@@ -51,7 +52,11 @@
     // ── Add actions ────────────────────────────────────────────────────────────
 
     let isObjectList = $derived(nodeTypes.includes("room") || nodeTypes.includes("object"));
-    let showRoomButton = $derived(isObjectList);
+    // Gamebook has no room/object distinction - everything is a page (see
+    // EditorController.GetNodeType) - so it gets a single "+ Add Page" button instead of
+    // separate Add Object / Add Room / Add Page buttons.
+    let showRoomButton = $derived(isObjectList && !$isGamebook);
+    let showPageButton = $derived(isObjectList && !$isGamebook);
 
     let addLabel = $derived(
         nodeTypes.includes("function") ? t("elementAdders.function") :
@@ -65,7 +70,7 @@
                 nodeTypes.includes("type") ? t("elementAdders.type") :
                 nodeTypes.includes("include") ? t("elementAdders.library") :
                 nodeTypes.includes("javascript") ? t("elementAdders.javascript") :
-                isObjectList ? t("elementAdders.object") :
+                isObjectList ? ($isGamebook ? t("elementAdders.page") : t("elementAdders.object")) :
                 null
     );
 
@@ -82,11 +87,15 @@
         else if (nodeTypes.includes("type")) openAddModal("type", null);
         else if (nodeTypes.includes("include")) openAddLibraryModal();
         else if (nodeTypes.includes("javascript")) openAddJavascriptModal();
-        else if (isObjectList) openAddModal("object", parent);
+        else if (isObjectList) openAddModal($isGamebook ? "page" : "object", parent);
     }
 
     function addRoom() {
         openAddModal("room", isHeaderNode ? null : elementKey);
+    }
+
+    function addPage() {
+        openAddModal("page", isHeaderNode ? null : elementKey);
     }
 
     // ── Move / delete ──────────────────────────────────────────────────────────
@@ -149,6 +158,13 @@
                 onclick={addRoom}
             >+ {t("elementAdders.room")}</button>
         {/if}
+        {#if showPageButton}
+            <button
+                type="button"
+                class="btn btn-sm preset-outlined-primary-500 text-xs py-0.5"
+                onclick={addPage}
+            >+ {t("elementAdders.page")}</button>
+        {/if}
     </div>
 
     <!-- Item rows -->
@@ -168,9 +184,15 @@
                 <!-- pr-20 keeps name clear of the hover buttons (≈3×24px) -->
                 <button
                     type="button"
-                    class="flex-1 text-left text-xs px-1.5 py-1 pr-20 text-primary-600-400 hover:underline truncate"
+                    class="flex-1 flex items-center gap-1.5 text-left text-xs px-1.5 py-1 pr-20 text-primary-600-400 hover:underline truncate"
                     onclick={() => selectNode(item.key)}
-                >{item.text}</button>
+                >
+                    {#if isObjectList}
+                        {@const Icon = nodeIcon(item.key, item.nodeType)}
+                        <Icon size={13} class="flex-shrink-0 opacity-70" />
+                    {/if}
+                    <span class="truncate">{item.text}</span>
+                </button>
                 <!-- pointer-events-none when invisible so clicks reach the name button -->
                 <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
                     <button

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -334,6 +334,15 @@
             ? "px-3 py-1.5 text-xs whitespace-nowrap transition-colors text-primary-600-400 border-b-2 border-primary-500 font-medium"
             : "px-3 py-1.5 text-xs whitespace-nowrap transition-colors text-surface-600-400 hover:text-surface-900-100";
     }
+
+    // The "_objects" header's single tab is captioned "Objects" server-side (see
+    // CoreEditorElements.aslx's EditorElementsObjects template), which has no game-type
+    // awareness. Override the displayed label in Gamebook mode, echoing TreePanel's
+    // headerText() override for the same node - the underlying caption stays the tab identity.
+    function tabLabel(caption: string | null): string {
+        if ($selectedKey === "_objects" && $isGamebook && caption) return t("treePanel.header.pages");
+        return caption ?? t("propertyEditor.tabFallback");
+    }
 </script>
 
 <div class="@container flex flex-col flex-1 bg-surface-50-950 overflow-hidden">
@@ -373,7 +382,7 @@
                         class={tabClass(tab.caption)}
                         onclick={() => { activeTab = tab.caption; }}
                     >
-                        {tab.caption ?? t("propertyEditor.tabFallback")}
+                        {tabLabel(tab.caption)}
                     </button>
                 {/each}
             </div>

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -1,29 +1,11 @@
 <script lang="ts">
-    import { untrack, type Component } from "svelte";
+    import { untrack } from "svelte";
     import { TreeView, createTreeViewCollection } from "@skeletonlabs/skeleton-svelte";
     import Search from "@lucide/svelte/icons/search";
     import X from "@lucide/svelte/icons/x";
     import SlidersHorizontal from "@lucide/svelte/icons/sliders-horizontal";
     import Check from "@lucide/svelte/icons/check";
-    import DoorOpen from "@lucide/svelte/icons/door-open";
-    import Package from "@lucide/svelte/icons/package";
-    import FileText from "@lucide/svelte/icons/file-text";
-    import Signpost from "@lucide/svelte/icons/signpost";
-    import MessageSquare from "@lucide/svelte/icons/message-square";
-    import Terminal from "@lucide/svelte/icons/terminal";
-    import RotateCw from "@lucide/svelte/icons/rotate-cw";
-    import SquareFunction from "@lucide/svelte/icons/square-function";
-    import Timer from "@lucide/svelte/icons/timer";
-    import Route from "@lucide/svelte/icons/route";
-    import Library from "@lucide/svelte/icons/library";
-    import LayoutTemplate from "@lucide/svelte/icons/layout-template";
-    import Braces from "@lucide/svelte/icons/braces";
-    import Shapes from "@lucide/svelte/icons/shapes";
-    import FileCode from "@lucide/svelte/icons/file-code";
-    import Gamepad2 from "@lucide/svelte/icons/gamepad-2";
-    import Puzzle from "@lucide/svelte/icons/puzzle";
-    import Folder from "@lucide/svelte/icons/folder";
-    import User from "@lucide/svelte/icons/user";
+    import { nodeIcon } from "$lib/node-icons";
     import DropdownMenu from "./DropdownMenu.svelte";
     import type { DropdownMenuItem } from "./DropdownMenu.svelte";
     import {
@@ -72,54 +54,6 @@
         if (node.key === "_objects") return $isGamebook ? t("treePanel.header.pages") : t("treePanel.header.objects");
         const key = HEADER_LABEL_KEYS[node.key];
         return key ? t(key) : node.text;
-    }
-
-    type IconComponent = Component<{ size?: number; class?: string }>;
-
-    // One icon per leaf nodeType (see EditorController.GetNodeType / WasmEditorBridge.TreeNodeData).
-    const NODE_TYPE_ICON: Record<string, IconComponent> = {
-        game: Gamepad2,
-        room: DoorOpen,
-        object: Package,
-        page: FileText,
-        exit: Signpost,
-        verb: MessageSquare,
-        command: Terminal,
-        turnscript: RotateCw,
-        function: SquareFunction,
-        timer: Timer,
-        walkthrough: Route,
-        include: Library,
-        template: LayoutTemplate,
-        dynamictemplate: Braces,
-        type: Shapes,
-        javascript: FileCode,
-    };
-
-    // Every header node's nodeType is the generic "header" (see WasmEditorBridge), so headers
-    // are iconified by their fixed key instead, echoing the category they contain.
-    const HEADER_ICON: Record<string, IconComponent> = {
-        _objects: Package,
-        _advanced: Folder,
-        _functions: SquareFunction,
-        _timers: Timer,
-        _walkthrough: Route,
-        _include: Library,
-        _template: LayoutTemplate,
-        _dynamictemplate: Braces,
-        _objecttype: Shapes,
-        _javascript: FileCode,
-        _gameVerbs: MessageSquare,
-        _gameCommands: Terminal,
-    };
-
-    function nodeIcon(node: HierNode): IconComponent {
-        if (node.nodeType === "header") return HEADER_ICON[node.id] ?? Folder;
-        // The player object is a plain Object element underneath (nodeType "object" in Text
-        // Adventure mode, "page" in Gamebook mode — see EditorController.GetNodeType), but it's
-        // always the single fixed "player" element key, so it gets its own icon regardless of mode.
-        if (node.id === "player") return User;
-        return NODE_TYPE_ICON[node.nodeType] ?? Puzzle;
     }
 
     // Build HierNode tree from flat list
@@ -548,7 +482,7 @@
 {/snippet}
 
 {#snippet treeNode(node: HierNode, indexPath: number[])}
-    {@const Icon = nodeIcon(node)}
+    {@const Icon = nodeIcon(node.id, node.nodeType)}
     <TreeView.NodeProvider value={{ node, indexPath }}>
         {#if node.children}
             <TreeView.Branch>

--- a/src/AppShell/src/lib/node-icons.ts
+++ b/src/AppShell/src/lib/node-icons.ts
@@ -1,0 +1,68 @@
+import type { Component } from "svelte";
+import DoorOpen from "@lucide/svelte/icons/door-open";
+import Package from "@lucide/svelte/icons/package";
+import FileText from "@lucide/svelte/icons/file-text";
+import Signpost from "@lucide/svelte/icons/signpost";
+import MessageSquare from "@lucide/svelte/icons/message-square";
+import Terminal from "@lucide/svelte/icons/terminal";
+import RotateCw from "@lucide/svelte/icons/rotate-cw";
+import SquareFunction from "@lucide/svelte/icons/square-function";
+import Timer from "@lucide/svelte/icons/timer";
+import Route from "@lucide/svelte/icons/route";
+import Library from "@lucide/svelte/icons/library";
+import LayoutTemplate from "@lucide/svelte/icons/layout-template";
+import Braces from "@lucide/svelte/icons/braces";
+import Shapes from "@lucide/svelte/icons/shapes";
+import FileCode from "@lucide/svelte/icons/file-code";
+import Gamepad2 from "@lucide/svelte/icons/gamepad-2";
+import Puzzle from "@lucide/svelte/icons/puzzle";
+import Folder from "@lucide/svelte/icons/folder";
+import User from "@lucide/svelte/icons/user";
+
+export type IconComponent = Component<{ size?: number; class?: string }>;
+
+// One icon per leaf nodeType (see EditorController.GetNodeType / WasmEditorBridge.TreeNodeData).
+export const NODE_TYPE_ICON: Record<string, IconComponent> = {
+    game: Gamepad2,
+    room: DoorOpen,
+    object: Package,
+    page: FileText,
+    exit: Signpost,
+    verb: MessageSquare,
+    command: Terminal,
+    turnscript: RotateCw,
+    function: SquareFunction,
+    timer: Timer,
+    walkthrough: Route,
+    include: Library,
+    template: LayoutTemplate,
+    dynamictemplate: Braces,
+    type: Shapes,
+    javascript: FileCode,
+};
+
+// Every header node's nodeType is the generic "header" (see WasmEditorBridge), so headers
+// are iconified by their fixed key instead, echoing the category they contain.
+export const HEADER_ICON: Record<string, IconComponent> = {
+    _objects: Package,
+    _advanced: Folder,
+    _functions: SquareFunction,
+    _timers: Timer,
+    _walkthrough: Route,
+    _include: Library,
+    _template: LayoutTemplate,
+    _dynamictemplate: Braces,
+    _objecttype: Shapes,
+    _javascript: FileCode,
+    _gameVerbs: MessageSquare,
+    _gameCommands: Terminal,
+};
+
+// The player object is a plain Object element underneath (nodeType "object" in Text
+// Adventure mode, "page" in Gamebook mode — see EditorController.GetNodeType), but it's
+// always the single fixed "player" element key, so it gets its own icon regardless of mode.
+export function nodeIcon(id: string, nodeType: string): IconComponent {
+    if (nodeType === "header") return HEADER_ICON[id] ?? Folder;
+    if (id === "player") return User;
+    return NODE_TYPE_ICON[nodeType] ?? Puzzle;
+}


### PR DESCRIPTION
## Summary
- Text Adventure mode's Objects tab now has an "+ Add Page" button alongside Add Object/Add Room, and Pages appear in the list below with a distinguishing icon (rooms/objects get one too).
- Gamebook mode - which has no room/object distinction, everything is a page - collapses this to a single "+ Add Page" button, and the tab is now labelled "Pages" instead of "Objects" to match the tree.
- Extracted the per-nodeType icon map out of `TreePanel.svelte` into a shared `lib/node-icons.ts` module so `ElementsList.svelte` can reuse it.

## Test plan
- [x] `npm run lint` and `svelte-check` pass with 0 errors/warnings
- [x] Manually verified in a Text Adventure draft: Objects tab shows Add Object/Add Room/Add Page, created a page via each entry point, icons render distinctly per row
- [x] Manually verified in a Gamebook draft: tab shows only "+ Add Page" and is labelled "Pages", created a page, icons render for existing pages/player

🤖 Generated with [Claude Code](https://claude.com/claude-code)