### PR TITLE
test: fix e2e Add-menu assertion and Electron temp-dir cleanup race

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["CLAUDE.md"]
+}

--- a/tests/e2e/verify-advanced-tree.mjs
+++ b/tests/e2e/verify-advanced-tree.mjs
@@ -1,9 +1,10 @@
 // Ad-hoc manual verification for the Advanced-tree progressive-disclosure
 // change: the toolbar's "Add element" dropdown should be trimmed down to
-// just "Add Room" (the advanced element types - functions, timers, etc. -
-// moved under the "Advanced" tree node instead of cluttering the toolbar),
-// and adding a function via that Advanced panel should actually produce a
-// real, selected tree node under Advanced > Functions, not just a
+// just "Add Room" and "Add Page" (the advanced element types - functions,
+// timers, etc. - moved under the "Advanced" tree node instead of cluttering
+// the toolbar, and text-adventure dialogue Pages get their own dropdown
+// entry), and adding a function via that Advanced panel should actually
+// produce a real, selected tree node under Advanced > Functions, not just a
 // silently-dropped click.
 import { chromium } from "playwright";
 
@@ -27,15 +28,17 @@ async function run() {
     // The dropdown is a sibling <div> rendered immediately after the toggle
     // button when open - scope the check to it, not the whole page, since
     // "Add Function" etc. legitimately appear elsewhere (the Advanced panel).
+    // A text adventure offers both "Add Room" and "Add Page" here; the
+    // advanced element types are what got trimmed out, not Pages.
     const addToolbarBtn = page.locator('button[title="Add element"]');
     await addToolbarBtn.click();
     await page.waitForTimeout(300);
     const addMenu = addToolbarBtn.locator("xpath=following-sibling::div[1]");
     const addMenuText = (await addMenu.innerText()).trim();
-    if (addMenuText !== "Add Room") {
-        throw new Error(`Expected toolbar Add menu to contain only "Add Room", got: ${JSON.stringify(addMenuText)}`);
+    if (addMenuText !== "Add Room\nAdd Page") {
+        throw new Error(`Expected toolbar Add menu to contain only "Add Room" and "Add Page", got: ${JSON.stringify(addMenuText)}`);
     }
-    console.log('PASS: toolbar Add dropdown is trimmed to just "Add Room"');
+    console.log('PASS: toolbar Add dropdown is trimmed to "Add Room" and "Add Page"');
     await page.keyboard.press("Escape");
 
     // Expand the Advanced tree node and confirm its panel offers the element

--- a/tests/e2e/verify-electron-open-game-no-window.mjs
+++ b/tests/e2e/verify-electron-open-game-no-window.mjs
@@ -89,8 +89,15 @@ try {
     console.error('FAIL:', err.message);
     process.exitCode = 1;
 } finally {
-    app?.process().kill('SIGKILL');
-    // SIGKILL doesn't wait for Chromium to finish its disk-cache writeback, so an immediate
-    // rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
+    const proc = app?.process();
+    if (proc && proc.exitCode === null) {
+        // kill() only sends the signal — it doesn't wait for the process to actually
+        // terminate, so without this the rmSync below could race a still-running process.
+        const exited = new Promise(resolve => proc.once('exit', resolve));
+        proc.kill('SIGKILL');
+        await exited;
+    }
+    // Even after exit, Chromium's disk-cache writeback can still be finishing up, so an
+    // immediate rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
     rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
 }


### PR DESCRIPTION
Fixes the two failures in the nightly e2e run ([31669273735](https://github.com/textadventures/quest/actions/runs/31669273735)).

## What changed

**`tests/e2e/verify-advanced-tree.mjs`** — deterministic failure on `appshell_chromium` (also failed the previous night): since #2058 added text-adventure dialogue Pages, the toolbar "Add element" dropdown always shows both "Add Room" and "Add Page" (`Toolbar.svelte`), but the test still expected only "Add Room". Updated the assertion to `"Add Room\nAdd Page"` and the header comment.

**`tests/e2e/verify-electron-open-game-no-window.mjs`** — flaky failure on `electron`: the test passed its assertions but the `finally` block sent `SIGKILL` without waiting for the process to exit, so `rmSync` raced Chromium's disk-cache writeback and threw `ENOTEMPTY`. Applied the same await-process-exit pattern already used in `verify-electron-unsaved-close-dialog.mjs` before removing the temp dir.

## Verification

Both scripts pass locally:
- `node verify-advanced-tree.mjs http://localhost:5174`
- `node verify-electron-open-game-no-window.mjs`