### PR TITLE
fix(WasmPlayer): surface game-load errors on the start screen instead of hanging

### DIFF
--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -21,6 +21,12 @@ public partial class WasmPlayerBridge
     private static PlayerHelper? _helper;
     private static WasmPlayerUi? _ui;
 
+    // Set when Initialise/InitialiseWithSave fails so JS can surface the same
+    // engine error text the Editor shows on load failure, instead of leaving the
+    // start-screen spinner up indefinitely with no feedback. Cleared on success
+    // (and never set when the failure happened before any load was attempted).
+    private static string[] _initialiseErrors = [];
+
     // ── JS → C# exports ─────────────────────────────────────────────────────
 
     [JSExport]
@@ -142,10 +148,16 @@ public partial class WasmPlayerBridge
         var (ok, errors) = await _helper.Initialise(_ui);
         if (!ok)
         {
+            // Stash the errors for JS to fetch (GetInitialiseErrorsJson) so it can
+            // display them on the start screen — outputting them to the game pane
+            // alone leaves them hidden under the #qv-start overlay while the JS side
+            // still thinks the game is loading.
+            _initialiseErrors = errors.ToArray();
             _ui.OutputText(string.Join("<br/>", errors) + "<br/>");
             await _ui.FlushBufferAndYieldAsync();
             return false;
         }
+        _initialiseErrors = [];
 
         var scripts = _game.GetExternalScripts();
         if (scripts != null)
@@ -166,6 +178,14 @@ public partial class WasmPlayerBridge
 
     [JSExport]
     public static string GetGameId() => _ui?.GameId ?? string.Empty;
+
+    // The engine's load/initialise errors from the most recent
+    // Initialise/InitialiseWithSave call, if it failed (empty otherwise). JS
+    // reads this when Initialise returns false to put the real reason on the
+    // start screen rather than leaving the loading spinner spinning forever.
+    [JSExport]
+    public static string GetInitialiseErrorsJson() =>
+        JsonSerializer.Serialize(_initialiseErrors, WasmJsonContext.Default.StringArray);
 
     // The game's own embedded identity (IFID, the <gameid> element in its
     // .aslx/save XML) — stable regardless of how/where the game was loaded

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -392,6 +392,19 @@ window.WebPlayer = {
 // Exported bridge reference — set once WASM is loaded.
 var Bridge;
 
+// The engine's load/initialise errors from the most recent Initialise call, if
+// it failed — reads the JSON exported by WasmPlayerBridge.GetInitialiseErrorsJson
+// (empty array when the last load succeeded). Used to put the real reason a game
+// failed to load on the start screen instead of a generic message.
+function getInitialiseErrors() {
+    try {
+        const parsed = JSON.parse(Bridge.GetInitialiseErrorsJson());
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
 function addPaperScript() {
     const canvas = document.getElementById('gridCanvas');
     const gridPanel = document.getElementById('gridPanel');
@@ -552,8 +565,20 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
         ? await Bridge.InitialiseWithSave(gameBytes, filename, saveBytes)
         : await Bridge.Initialise(gameBytes, filename);
     if (!ok) {
-        console.error('[Quest] Failed to initialise game');
-        throw new Error('Failed to initialise game');
+        // The game file itself was fine (downloaded/picked), but the engine
+        // rejected its contents — same errors the Editor shows on load.
+        // Previously this threw, which left #qv-start (with its spinner)
+        // covering the screen forever and, on the boot paths without a
+        // catch handler (embedded export, editor preview, ?id=, ?url=),
+        // never showed the reason at all. Surface the actual errors on the
+        // start screen instead and let the caller know the game didn't start.
+        const errors = getInitialiseErrors();
+        console.error('[Quest] Failed to initialise game', errors);
+        // A live app (Play tab / editor preview) handed this game over via bc —
+        // it owns the file-picking UI, so don't re-offer the start-screen
+        // pickers; just show the error, editor-style.
+        showGameLoadError(errors, !bc);
+        return false;
     }
 
     // Now that a WorldModel is live, resolve the game's own translated chrome
@@ -608,6 +633,8 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
     } else if (runWalkthrough) {
         await runWalkthroughStandalone(runWalkthrough);
     }
+
+    return true;
 }
 
 // Guards restartGame against overlapping calls — e.g. impatiently clicking
@@ -668,7 +695,14 @@ async function restartGameCore(saveBytes) {
             ? await Bridge.InitialiseWithSave(originalGameBytes, originalGameFilename, saveBytes)
             : await Bridge.Initialise(originalGameBytes, originalGameFilename);
         if (!ok) {
-            showSavesError('Failed to load that save.');
+            // The engine rejected the game's contents again (or the save didn't
+            // apply) — include the actual error rather than the old generic
+            // "Failed to load that save.", which is wrong for a "Start from the
+            // beginning" restart whose failure has nothing to do with a save.
+            const errors = getInitialiseErrors();
+            showSavesError(errors.length
+                ? `Failed to load. ${errors.join(' ')}`
+                : 'Failed to load that save.');
             return;
         }
 
@@ -730,7 +764,12 @@ async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPr
         }
     }
 
-    await initWasmPlayer(bytes, filename, bc, saveBytes, isPreview, recordWalkthrough, runWalkthrough, adjacentFiles);
+    // Returns true if the game started, false if it downloaded/picked fine but
+    // the engine rejected its contents (the error is shown on the start screen
+    // by initWasmPlayer in that case) — callers with post-success work (e.g.
+    // persisting the active URL) should key off this. Genuine setup failures
+    // (fetch, WASM boot) still throw as before.
+    return initWasmPlayer(bytes, filename, bc, saveBytes, isPreview, recordWalkthrough, runWalkthrough, adjacentFiles);
 }
 
 // ── Start screen helpers ──────────────────────────────────────────────────────
@@ -1857,6 +1896,44 @@ function showError(downloadUrl, isLocalFile, error) {
     wireStartScreen();
 }
 
+// The game file itself downloaded/picked fine but the engine rejected its
+// contents — a game-content error (parse failure, unknown function, etc.), the
+// same list the Editor surfaces on load, not a network/HTTP problem. Shows that
+// actual error text on the start screen and re-shows the pickers, so the player
+// doesn't sit on the loading spinner forever (what the old path did: it wrote
+// the errors to the output pane, which sits hidden under the #qv-start overlay,
+// then threw before the overlay was removed).
+//
+// showPickers=false is for sessions launched by the Quest Viva app itself — the
+// Play tab (source=local) and editor preview (source=editor) — where the app
+// owns the file-picking UI, so the start screen's "You can try a different file
+// below" pickers are irrelevant there. Just the error is shown, in the same
+// header+bullets format the Editor uses for a load-time error (see
+// EditorController.cs's "Failed to load game due to the following errors:"),
+// with a blank line between the header and the error message.
+function showGameLoadError(errors, showPickers = true) {
+    document.documentElement.classList.remove('qv-booting');
+    const pickers = document.getElementById('qv-pickers');
+    const msg = document.getElementById('qv-loading-msg');
+    const errorEl = document.getElementById('qv-error');
+    if (msg) msg.style.display = 'none';
+    if (pickers) pickers.style.display = showPickers ? 'block' : 'none';
+    if (!errorEl) return;
+    const list = errors.length ? errors : ['Unknown error'];
+    errorEl.style.whiteSpace = showPickers ? '' : 'pre-wrap';
+    if (showPickers) {
+        errorEl.innerHTML = '<strong>This game couldn\'t be started.</strong> '
+            + 'The game file loaded, but Quest Viva reported a problem with its contents:<br/>'
+            + list.map(_esc).join('<br/>')
+            + '<br/>You can try a different file below.';
+    } else {
+        errorEl.innerHTML = _esc('Failed to load game due to the following errors:\n\n'
+            + list.map(e => '* ' + e).join('\n'));
+    }
+    errorEl.style.display = 'block';
+    wireStartScreen();
+}
+
 // Keeps the address bar in sync with the game that's actually loaded (or being
 // attempted), so a refresh reproduces it. `name`/`value` set the active source
 // param; both `id` and `url` are cleared first since only one can be current.
@@ -1901,8 +1978,11 @@ function wireStartScreen() {
         showLoading();
         try {
             const { bytes, filename } = await fetchGameBytes(url);
-            await startGame(bytes, filename);
-            setLocationParam('url', url);
+            const ok = await startGame(bytes, filename);
+            // Don't persist the URL if the game itself failed to load — the
+            // engine error is already on screen, and keeping the URL would make
+            // a refresh re-run the same broken load.
+            if (ok) setLocationParam('url', url);
         } catch (err) {
             showError(url, false, err);
         }

--- a/tests/e2e/fixtures/load-error-test.aslx
+++ b/tests/e2e/fixtures/load-error-test.aslx
@@ -1,0 +1,23 @@
+<asl version="600">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="load-error-test">
+    <start type="script">
+      msg ("start")
+    </start>
+    <object name="room">
+      <inherit name="editor_room" />
+      <object name="player">
+        <inherit name="editor_object" />
+        <inherit name="editor_player" />
+      </object>
+      <object name="person">
+        <inherit name="editor_object" />
+        <inherit name="male" />
+        <speak type="script">
+          missing_function()
+        </speak>
+      </object>
+    </object>
+  </game>
+</asl>

--- a/tests/e2e/verify-game-load-error.mjs
+++ b/tests/e2e/verify-game-load-error.mjs
@@ -1,0 +1,142 @@
+// Ad-hoc manual verification: a game whose contents the engine rejects (e.g. an
+// unknown function in a script) must show the load error on the start screen
+// instead of hanging on the loading spinner forever. Previously initWasmPlayer
+// wrote the errors to the game output pane (hidden under the #qv-start overlay)
+// then threw before the overlay was removed, so every boot path without a catch
+// (embedded export, editor preview, ?id=, ?url=) sat on the spinner indefinitely.
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+async function expectStartScreenError(label) {
+    // #qv-error keeps its .hidden class; showGameLoadError shows it via an
+    // inline style.display override (same as showError), so wait on computed
+    // visibility, not the class.
+    await page.waitForSelector('#qv-error', { state: 'visible', timeout: 30000 });
+    const errorText = await page.$eval('#qv-error', el => el.textContent);
+    if (!errorText.includes("Function not found: 'missing_function'")) {
+        throw new Error(`${label}: expected the engine error text on the start screen, got: ${errorText}`);
+    }
+    console.log(`PASS: ${label}`);
+
+    const loadingVisible = await page.$eval('#qv-loading-msg', el => el.style.display !== 'none');
+    if (loadingVisible) {
+        throw new Error(`${label}: loading spinner must be hidden after a load failure`);
+    }
+    console.log('PASS: loading spinner is hidden after the failure');
+
+    const pickersVisible = await page.$eval('#qv-pickers', el => el.style.display !== 'none');
+    if (!pickersVisible) {
+        throw new Error(`${label}: file pickers must be shown again after a load failure`);
+    }
+    console.log('PASS: file pickers are shown again');
+}
+
+// A game launched by the Quest Viva app itself (Play tab, editor preview) was
+// handed over a BroadcastChannel — the app owns the file-picking UI, so the
+// player must show only the error, in the same format the editor uses for a
+// load-time error ("Failed to load game due to the following errors:" + "* "
+// bullets, with a blank line before the message), and must NOT show the
+// pickers or "You can try a different file below".
+async function expectAppLaunchedError(label, channelName) {
+    await page.goto(`${baseUrl}/?source=${channelName === 'quest-preview' ? 'editor' : 'local'}`);
+    await page.evaluate(async ({ fixtureUrl, channelName, filename }) => {
+        // Simulates the app side of the handoff: fetch the fixture and post it
+        // over the same channel the player window is listening on. The player
+        // page's own bc.onmessage is set synchronously during boot, so this
+        // lands after that handler is live.
+        const resp = await fetch(fixtureUrl);
+        const bytes = new Uint8Array(await resp.arrayBuffer());
+        const bc = new BroadcastChannel(channelName);
+        bc.postMessage({ type: 'game', bytes, filename, adjacentFiles: null });
+    }, { fixtureUrl: `${baseUrl}/e2e-fixtures/load-error-test.aslx`, channelName, filename: 'load-error-test.aslx' });
+
+    await page.waitForSelector('#qv-error', { state: 'visible', timeout: 30000 });
+    const errorText = await page.$eval('#qv-error', el => el.textContent);
+    if (!errorText.includes('Failed to load game due to the following errors:')) {
+        throw new Error(`${label}: expected the editor-style error header, got: ${JSON.stringify(errorText)}`);
+    }
+    if (!errorText.includes("* Error: Error adding script attribute 'speak' to element 'person': Function not found: 'missing_function'")) {
+        throw new Error(`${label}: expected the editor-style bulleted error, got: ${JSON.stringify(errorText)}`);
+    }
+    if (!errorText.includes('errors:\n\n')) {
+        throw new Error(`${label}: expected a blank line before the error message, got: ${JSON.stringify(errorText)}`);
+    }
+    console.log(`PASS: ${label} shows the editor-style error`);
+
+    const loadingVisible = await page.$eval('#qv-loading-msg', el => el.style.display !== 'none');
+    if (loadingVisible) {
+        throw new Error(`${label}: loading spinner must be hidden after a load failure`);
+    }
+    console.log('PASS: loading spinner is hidden after the failure');
+
+    const pickersVisible = await page.$eval('#qv-pickers', el => el.style.display !== 'none');
+    if (pickersVisible) {
+        throw new Error(`${label}: the file pickers must not be shown for an app-launched game`);
+    }
+    console.log('PASS: file pickers are hidden for an app-launched game');
+}
+
+async function run() {
+    // 1. Load the broken game by URL (?url= boot path — one of the ones that
+    //    previously hung forever). The engine error must appear on the start
+    //    screen and the spinner must be gone.
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/load-error-test.aslx`);
+    await expectStartScreenError('?url= boot shows the engine load error on the start screen');
+
+    // 2. Start-screen "Load from URL" input path: the error must surface and the
+    //    failed game's URL must not be persisted to the address bar (a refresh
+    //    would otherwise re-run the same broken load).
+    await page.goto(baseUrl);
+    await page.waitForSelector('#qv-url-input', { timeout: 30000 });
+    await page.fill('#qv-url-input', `${baseUrl}/e2e-fixtures/load-error-test.aslx`);
+    await page.click('#qv-url-btn');
+    await expectStartScreenError('start-screen URL input shows the engine load error');
+    if (page.url().includes('url=')) {
+        throw new Error(`failed game URL must not be persisted, got: ${page.url()}`);
+    }
+    console.log('PASS: failed game URL is not persisted');
+
+    // 3. File-picker boot path: the error must surface there too (previously it
+    //    called showError(null, true) → "It doesn't look like a Quest game file",
+    //    hiding the real reason).
+    await page.goto(baseUrl);
+    const response = await page.request.get(`${baseUrl}/e2e-fixtures/load-error-test.aslx`);
+    await page.locator('#qv-file-input').setInputFiles({
+        name: 'load-error-test.aslx',
+        mimeType: 'application/xml',
+        buffer: await response.body(),
+    });
+    await expectStartScreenError('file-picker boot shows the engine load error on the start screen');
+
+    // 4. Play-tab launch (source=local) and editor preview (source=editor) both
+    //    hand the game over over a BroadcastChannel — the Quest Viva app owns the
+    //    file-picking UI in those, so the error must show WITHOUT the pickers /
+    //    "try a different file" message, in the editor's load-error format.
+    await expectAppLaunchedError('source=local', 'quest-play-local');
+    await expectAppLaunchedError('source=editor', 'quest-preview');
+
+    // 5. Sanity check: a healthy game still boots to the player (no regression —
+    //    initWasmPlayer now returns true instead of throwing/nothing).
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/dialogue-pages-test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000 });
+    console.log('PASS: a healthy game still boots normally');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/verify-game-load-error-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## What

When a game file downloads/picks fine but the engine rejects its contents (parse failure, unknown function, etc.), the WasmPlayer previously sat on the start-screen loading spinner forever — `initWasmPlayer` wrote the errors to the game output pane (hidden under the `#qv-start` overlay) then threw before removing the overlay. Boot paths without a catch handler (embedded export, editor preview, `?id=`, `?url=`) never showed any reason, and the file-picker path showed a misleading generic "not a Quest game file" message.

## Changes

- **WasmPlayerBridge.cs**: stash engine load errors on failed `Initialise`/`InitialiseWithSave`, expose via new `GetInitialiseErrorsJson()` JSExport (cleared on success).
- **wasm-player.js**:
  - `initWasmPlayer` now surfaces the actual engine errors on the start screen and returns `false` instead of throwing.
  - Games launched by the app (Play tab `source=local`, editor preview `source=editor`) show just the error — same header+bullets format the editor uses ("Failed to load game due to the following errors:" + `* ` bullets, blank line before the message) — no file picker, since the app owns that UI.
  - Direct boots (`?url=`, file picker, embedded export) keep the existing picker behavior.
  - Failed game URLs are no longer persisted to the address bar.
  - Restart failures now include the actual error text instead of the misleading "Failed to load that save."
- **tests**: new `tests/e2e/fixtures/load-error-test.aslx` (minimal repro: unknown function in a `speak` script) and extended `verify-game-load-error.mjs` covering all boot paths (`?url=`, start-screen URL input, file picker, Play-tab and editor-preview handoffs, healthy-game regression).

## Verification

`node tests/e2e/verify-game-load-error.mjs` — 18 checks pass. WasmPlayer builds clean; full engine test suite (306) passes.

Manual check confirmed the editor's and player's *different* load errors for the German game from earlier are expected, not a regression: the editor deliberately tolerates unknown function calls in Edit mode (`FunctionCallScript.cs`), so each surfaces a different — but real — problem.