### PR TITLE
fix(Engine): restore exit grid offset X/Y editor controls

### DIFF
--- a/src/Engine/Core/CoreEditorExit.aslx
+++ b/src/Engine/Core/CoreEditorExit.aslx
@@ -144,7 +144,6 @@
         <caption>[EditorExitLength]</caption>
       </control>
 
-      <!--
       <control>
         <controltype>number</controltype>
         <attribute>grid_offset_x</attribute>
@@ -156,7 +155,6 @@
         <attribute>grid_offset_y</attribute>
         <caption>[EditorExitOffsetY]</caption>
       </control>
-      -->
 
     </tab>
 


### PR DESCRIPTION
## Summary
- Un-comments the Offset X / Offset Y editor controls for exits in `src/Engine/Core/CoreEditorExit.aslx` (Map tab), which have been dead since the very commit that introduced the `grid_offset_x`/`grid_offset_y` feature in 2012.
- The underlying attributes are fully functional: `CoreGrid.aslx` reads them in every direction branch to offset an exit's rendered position on a grid map, and `CoreTypes.aslx` gives them a default of `0`. Only the editor UI half of the feature was ever wired up as a stub and left commented out — not a later regression, and not a deliberate deprecation.
- The localized captions (`EditorExitOffsetX`/`EditorExitOffsetY`) already exist in the English, Spanish, and German language files, confirming the controls were meant to ship.

Per `CLAUDE.md`'s guidance on Core.aslx semantics: this only affects the authoring experience for games created/saved from now on (the Editor loads library functions live); it has no effect on already-published `.quest` files, since Core library code is inlined into a game at publish time.

## Test plan
- [x] `dotnet build --configuration Release` — succeeds, 0 warnings/errors
- [x] `dotnet test --configuration Release` — 361/361 tests pass across all projects