### PR TITLE
chore(Engine): link Core TODO comments to their tracking issues

### DIFF
--- a/src/Engine/Core/CoreCommands.aslx
+++ b/src/Engine/Core/CoreCommands.aslx
@@ -680,7 +680,7 @@
       }
       if (not handled) {
         if (HasScript(object2, "giveanything")) {
-          // TO DO: Would be better to use a delegate for giveanything, but need to implement Editor support first
+          // TO DO (#2068): Would be better to use a delegate for giveanything, but need to implement Editor support first
           parameters = NewObjectDictionary()
           dictionary add (parameters, "object", object1)
           do (object2, "giveanything", parameters)
@@ -704,7 +704,7 @@
         }
         else {
           if (HasScript(object1, "givetoanything")) {
-            // TO DO: Would be better to use a delegate for givetoanything, but need to implement Editor support first
+            // TO DO (#2068): Would be better to use a delegate for givetoanything, but need to implement Editor support first
             parameters = NewObjectDictionary()
             dictionary add (parameters, "object", object2)
             do (object1, "givetoanything", parameters)
@@ -739,7 +739,7 @@
       }
       else {
         if (HasScript(object2, "useanything")) {
-          // TO DO: Would be better to use a delegate for useanything, but need to implement Editor support first
+          // TO DO (#2068): Would be better to use a delegate for useanything, but need to implement Editor support first
           parameters = NewObjectDictionary()
           dictionary add (parameters, "object", object1)
           do (object2, "useanything", parameters)
@@ -763,7 +763,7 @@
         }
         else {
           if (HasScript(object1, "selfuseanything")) {
-            // TO DO: Would be better to use a delegate for selfuseanything, but need to implement Editor support first
+            // TO DO (#2068): Would be better to use a delegate for selfuseanything, but need to implement Editor support first
             parameters = NewObjectDictionary()
             dictionary add (parameters, "object", object2)
             do (object1, "selfuseanything", parameters)

--- a/src/Engine/Core/CoreEditorScriptsDarkness.aslx
+++ b/src/Engine/Core/CoreEditorScriptsDarkness.aslx
@@ -71,7 +71,7 @@
       <simple>brightness</simple>
       <simpleeditor>dropdown</simpleeditor>
       <attribute>1</attribute>
-      <!-- TO DO: Would be more user-friendly if we could use a dictionary type here (as in CoreEditorObjectSetup), but
+      <!-- TO DO (#2071): Would be more user-friendly if we could use a dictionary type here (as in CoreEditorObjectSetup), but
       this doesn't currently work in an expression control -->
       <validvalues type="simplestringlist">weak;strong;</validvalues>
     </control>
@@ -108,7 +108,7 @@
       <simple>brightness level</simple>
       <simpleeditor>dropdown</simpleeditor>
       <attribute>1</attribute>
-      <!-- TO DO: Would be more user-friendly if we could use a dictionary type here (as in CoreEditorObjectSetup), but
+      <!-- TO DO (#2071): Would be more user-friendly if we could use a dictionary type here (as in CoreEditorObjectSetup), but
        this doesn't currently work in an expression control -->
       <validvalues type="simplestringlist">weak;strong;</validvalues>
     </control>

--- a/src/Engine/Core/CoreEditorScriptsScripts.aslx
+++ b/src/Engine/Core/CoreEditorScriptsScripts.aslx
@@ -196,7 +196,7 @@
       <breakbefore/>
     </control>
 
-    <!-- TO DO: Popup needs to have ExpressionControl in it -->
+    <!-- TO DO (#2070): Popup needs to have ExpressionControl in it -->
 
     <control>
       <controltype>scriptdictionary</controltype>
@@ -268,7 +268,7 @@
       <caption>[EditorScriptsScriptsWithparameters]</caption>
     </control>
 
-    <!-- TO DO: Popup needs to have ExpressionControl in it -->
+    <!-- TO DO (#2070): Popup needs to have ExpressionControl in it -->
 
     <control>
       <controltype>list</controltype>
@@ -281,7 +281,7 @@
 
   <editor>
     <appliesto>do</appliesto>
-    <!-- TO DO: Don't display parameter #2 if it's null or empty -->
+    <!-- TO DO (#2070): Don't display parameter #2 if it's null or empty -->
     <display>Run #0's '#1' script with parameters from dictionary #2</display>
     <category>[EditorScriptsScriptsScripts]</category>
     <add>[EditorScriptsScriptsRunanobjects]</add>
@@ -326,7 +326,7 @@
 
   <editor>
     <appliesto>invoke</appliesto>
-    <!-- TO DO: Don't display parameter #1 if it's null or empty -->
+    <!-- TO DO (#2070): Don't display parameter #1 if it's null or empty -->
     <display>Run '#0' script with parameters from dictionary #1</display>
     <category>[EditorScriptsScriptsScripts]</category>
     <add>[EditorScriptsScriptsRunascript]</add>
@@ -429,7 +429,7 @@
       <breakbefore/>
     </control>
 
-    <!-- TO DO: Popup needs to have ExpressionControl in it -->
+    <!-- TO DO (#2070): Popup needs to have ExpressionControl in it -->
 
     <control>
       <controltype>list</controltype>

--- a/src/Engine/Core/CoreEditorScriptsTurnScripts.aslx
+++ b/src/Engine/Core/CoreEditorScriptsTurnScripts.aslx
@@ -16,7 +16,7 @@
       <controltype>expression</controltype>
       <attribute>0</attribute>
 
-      <!-- TO DO: simpleeditor needs to be a dropdown turnscript list -->
+      <!-- TO DO (#2069): simpleeditor needs to be a dropdown turnscript list -->
     </control>
   </editor>
 
@@ -37,7 +37,7 @@
       <controltype>expression</controltype>
       <attribute>0</attribute>
 
-      <!-- TO DO: simpleeditor needs to be a dropdown turnscript list -->
+      <!-- TO DO (#2069): simpleeditor needs to be a dropdown turnscript list -->
     </control>
   </editor>
 
@@ -58,7 +58,7 @@
       <controltype>expression</controltype>
       <attribute>0</attribute>
 
-      <!-- TO DO: simpleeditor needs to be a dropdown turnscript list -->
+      <!-- TO DO (#2069): simpleeditor needs to be a dropdown turnscript list -->
     </control>
 
     <control>

--- a/src/Engine/Core/CoreParser.aslx
+++ b/src/Engine/Core/CoreParser.aslx
@@ -351,7 +351,7 @@
       }
       if (resolvedall) {
         // All the objects have been resolved, so now we can actually do the command
-        // TO DO: game.lastobjects should be game.pov.lastobjects
+        // TO DO (#2073): game.lastobjects should be game.pov.lastobjects
         game.lastobjects = game.pov.currentcommandresolvedobjects
         if (not DictionaryContains(game.pov.currentcommandresolvedelements, "multiple")) {
           dictionary add (game.pov.currentcommandresolvedelements, "multiple", false)
@@ -362,7 +362,7 @@
           }
         }
         if (not GetBoolean(game.pov.currentcommandpattern, "isoops")) {
-          // TO DO: game.unresolved* should be game.pov.unresolved*
+          // TO DO (#2073): game.unresolved* should be game.pov.unresolved*
           game.unresolvedcommand = null
           game.unresolvedcommandvarlist = null
           game.unresolvedcommandkey = null
@@ -457,7 +457,7 @@
           return (result)
         }
         else {
-          // TO DO: Check this behaviour. We only want to try ignoring prefixes if we have definitely got an unresolved name.
+          // TO DO (#2074): Check this behaviour. We only want to try ignoring prefixes if we have definitely got an unresolved name.
           foreach (prefix, game.parserignoreprefixes) {
             if (StartsWith(value, prefix + " ")) {
               result = ResolveNameInternal(variable, Mid(value, LengthOf(prefix) + 1), objtype)

--- a/src/Engine/Core/Languages/Francais.aslx
+++ b/src/Engine/Core/Languages/Francais.aslx
@@ -293,7 +293,7 @@
   </function>
 
   <function name="Conjugate" type="string" parameters="obj, verb">
-    // TO DO: This should be implemented for any verbs passed to WriteVerb in templates above
+    // TO DO (#2072): This should be implemented for any verbs passed to WriteVerb in templates above
     return (verb)
   </function>
 


### PR DESCRIPTION
## Summary
All 18 remaining inline `TODO` comments in `src/Engine/Core` now reference the GitHub issue tracking that work (#2068-#2074), filed in the previous cleanup round. Comment text is otherwise unchanged - just `// TO DO:` → `// TO DO (#NNNN):`.

Mapping:
- `CoreParser.aslx` ×2 (`game.lastobjects`/`game.unresolvedcommand*`) → #2073
- `CoreParser.aslx` ×1 (prefix-ignoring behaviour) → #2074
- `CoreCommands.aslx` ×4 (delegate for `*anything` handlers) → #2068
- `CoreEditorScriptsTurnScripts.aslx` ×3 (dropdown turnscript list) → #2069
- `CoreEditorScriptsScripts.aslx` ×5 (ExpressionControl in popup ×3, hide empty parameter ×2) → #2070
- `CoreEditorScriptsDarkness.aslx` ×2 (dictionary type for brightness picker) → #2071
- `Languages/Francais.aslx` ×1 (Conjugate stub) → #2072

## Test plan
- [x] `dotnet build --configuration Release` — clean, 0 warnings/errors
- [x] `dotnet test --configuration Release` — 361/361 passing
- [x] All touched files re-verified as well-formed XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)