### PR TITLE
feat(AppShell): add collapsible code sections and autocompletion to CodeMirror editors

### DIFF
--- a/src/AppShell/src/components/CodeEditor.svelte
+++ b/src/AppShell/src/components/CodeEditor.svelte
@@ -4,7 +4,7 @@
     import { EditorView, keymap, lineNumbers, highlightActiveLine } from "@codemirror/view";
     import { history, defaultKeymap, historyKeymap, indentWithTab } from "@codemirror/commands";
     import { bracketMatching, indentOnInput, codeFolding, foldGutter, foldKeymap } from "@codemirror/language";
-    import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+    import { closeBrackets, closeBracketsKeymap, autocompletion, completionKeymap, acceptCompletion } from "@codemirror/autocomplete";
     import { searchKeymap } from "@codemirror/search";
     import { javascript } from "@codemirror/lang-javascript";
     import { questScript } from "$lib/quest-script-lang";
@@ -62,13 +62,19 @@
                 bracketMatching(),
                 closeBrackets(),
                 indentOnInput(),
+                autocompletion(),
                 EditorView.lineWrapping,
                 keymap.of([
                     ...closeBracketsKeymap,
                     ...defaultKeymap,
                     ...historyKeymap,
                     ...searchKeymap,
+                    ...completionKeymap,
                     ...foldKeymap,
+                    // Tab also accepts a completion (VS Code-style) — acceptCompletion only
+                    // returns true while a suggestion is open, so otherwise this falls through
+                    // to indentWithTab below.
+                    { key: "Tab", run: acceptCompletion },
                     indentWithTab,
                     {
                         key: "Mod-s",

--- a/src/AppShell/src/components/CodeEditor.svelte
+++ b/src/AppShell/src/components/CodeEditor.svelte
@@ -3,7 +3,7 @@
     import { EditorState, Compartment, Transaction } from "@codemirror/state";
     import { EditorView, keymap, lineNumbers, highlightActiveLine } from "@codemirror/view";
     import { history, defaultKeymap, historyKeymap, indentWithTab } from "@codemirror/commands";
-    import { bracketMatching, indentOnInput } from "@codemirror/language";
+    import { bracketMatching, indentOnInput, codeFolding, foldGutter, foldKeymap } from "@codemirror/language";
     import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
     import { searchKeymap } from "@codemirror/search";
     import { javascript } from "@codemirror/lang-javascript";
@@ -55,6 +55,8 @@
             parent: editorEl,
             extensions: [
                 lineNumbers(),
+                foldGutter(),
+                codeFolding(),
                 highlightActiveLine(),
                 history(),
                 bracketMatching(),
@@ -66,6 +68,7 @@
                     ...defaultKeymap,
                     ...historyKeymap,
                     ...searchKeymap,
+                    ...foldKeymap,
                     indentWithTab,
                     {
                         key: "Mod-s",

--- a/src/AppShell/src/lib/quest-script-lang.ts
+++ b/src/AppShell/src/lib/quest-script-lang.ts
@@ -1,5 +1,6 @@
 import { StreamLanguage, LanguageSupport, foldService } from "@codemirror/language";
 import type { StreamParser, StringStream } from "@codemirror/language";
+import { completeAnyWord } from "@codemirror/autocomplete";
 import type { EditorState } from "@codemirror/state";
 
 // Approximate, non-validating highlighter for Quest's own line-oriented script
@@ -99,5 +100,8 @@ export const questScriptFoldService = foldService.of((state: EditorState, lineSt
 export const questScriptLanguage = StreamLanguage.define(questScriptParser);
 
 export function questScript(): LanguageSupport {
-    return new LanguageSupport(questScriptLanguage, [questScriptFoldService]);
+    return new LanguageSupport(questScriptLanguage, [
+        questScriptFoldService,
+        questScriptLanguage.data.of({ autocomplete: completeAnyWord }),
+    ]);
 }

--- a/src/AppShell/src/lib/quest-script-lang.ts
+++ b/src/AppShell/src/lib/quest-script-lang.ts
@@ -1,5 +1,6 @@
-import { StreamLanguage, LanguageSupport } from "@codemirror/language";
+import { StreamLanguage, LanguageSupport, foldService } from "@codemirror/language";
 import type { StreamParser, StringStream } from "@codemirror/language";
+import type { EditorState } from "@codemirror/state";
 
 // Approximate, non-validating highlighter for Quest's own line-oriented script
 // DSL (e.g. `msg ("Hello")`, `if (x = 1) { ... }`) — distinct from the ASLX XML
@@ -54,10 +55,49 @@ const questScriptParser: StreamParser<null> = {
     },
 };
 
+// Quest's script DSL is line-oriented and its StreamParser produces no brace-delimited syntax tree,
+// so CodeMirror's foldNodeProp can't discover block boundaries. Provide them via foldService
+// instead: a line whose trimmed content ends with `{` opens a block, and we scan forward (honoring
+// strings and `//` comments, mirroring the tokenizer above) for the matching `}`. The returned
+// range spans just the body — keeping the opening `{` and closing `}` visible, in the same spirit
+// as CodeMirror's built-in foldInside for delimited nodes. The scan is line-count-capped so a stray
+// `{` elsewhere (e.g. in XML prose, where this service is also registered) can't trigger a long
+// pathological scan.
+export const questScriptFoldService = foldService.of((state: EditorState, lineStart: number) => {
+    const openLine = state.doc.lineAt(lineStart);
+    const trimmed = openLine.text.replace(/\s+$/, "");
+    if (!trimmed.endsWith("{")) return null;
+    const from = openLine.from + trimmed.length;
+    let depth = 1;
+    let line = openLine;
+    let linesScanned = 0;
+    while (line.to < state.doc.length && linesScanned++ < 1000) {
+        line = state.doc.lineAt(line.to + 1);
+        let inString = false;
+        for (let j = 0; j < line.text.length; j++) {
+            const ch = line.text[j];
+            if (inString) {
+                if (ch === "\\") j++;
+                else if (ch === '"') inString = false;
+            } else if (ch === '"') {
+                inString = true;
+            } else if (ch === "/" && line.text[j + 1] === "/") {
+                break;
+            } else if (ch === "{") {
+                depth++;
+            } else if (ch === "}") {
+                depth--;
+                if (depth === 0) return { from, to: line.from + j };
+            }
+        }
+    }
+    return null;
+});
+
 // Exported (not just wrapped in questScript()'s LanguageSupport) so xml-with-script.ts can embed
 // this language's .parser directly as a Lezer nested parser inside <element type="script"> content.
 export const questScriptLanguage = StreamLanguage.define(questScriptParser);
 
 export function questScript(): LanguageSupport {
-    return new LanguageSupport(questScriptLanguage);
+    return new LanguageSupport(questScriptLanguage, [questScriptFoldService]);
 }

--- a/src/AppShell/src/lib/xml-with-script-lang.ts
+++ b/src/AppShell/src/lib/xml-with-script-lang.ts
@@ -2,6 +2,7 @@ import { parseMixed } from "@lezer/common";
 import type { SyntaxNodeRef, Input } from "@lezer/common";
 import { xmlLanguage, autoCloseTags } from "@codemirror/lang-xml";
 import { LanguageSupport } from "@codemirror/language";
+import { completeAnyWord } from "@codemirror/autocomplete";
 import { questScriptLanguage, questScriptFoldService } from "./quest-script-lang";
 
 // ASLX marks every script-bearing attribute the same way regardless of the wrapping element's own
@@ -36,6 +37,13 @@ export function xmlWithScript(): LanguageSupport {
     // questScriptFoldService is registered for the whole document rather than just the embedded
     // script regions — it only ever fires on `{`-terminated lines (a very Quest-script-y signal that
     // won't occur in XML markup or prose), which is what lets the raw XML view fold script blocks
-    // that the base xmlLanguage's foldNodeProp can't see into.
-    return new LanguageSupport(xmlWithScriptLanguage, [autoCloseTags, questScriptFoldService]);
+    // that the base xmlLanguage's foldNodeProp can't see into. completeAnyWord is similarly
+    // document-wide: lang-xml's own schema completion is near-useless without a schema, so suggest
+    // words already in the file (tag/attribute names) instead — it combines with (and never
+    // replaces) the XML language's built-in source.
+    return new LanguageSupport(xmlWithScriptLanguage, [
+        autoCloseTags,
+        questScriptFoldService,
+        xmlWithScriptLanguage.data.of({ autocomplete: completeAnyWord }),
+    ]);
 }

--- a/src/AppShell/src/lib/xml-with-script-lang.ts
+++ b/src/AppShell/src/lib/xml-with-script-lang.ts
@@ -2,7 +2,7 @@ import { parseMixed } from "@lezer/common";
 import type { SyntaxNodeRef, Input } from "@lezer/common";
 import { xmlLanguage, autoCloseTags } from "@codemirror/lang-xml";
 import { LanguageSupport } from "@codemirror/language";
-import { questScriptLanguage } from "./quest-script-lang";
+import { questScriptLanguage, questScriptFoldService } from "./quest-script-lang";
 
 // ASLX marks every script-bearing attribute the same way regardless of the wrapping element's own
 // name — e.g. <start type="script">, <script type="script">, <take type="script">, <lock
@@ -33,5 +33,9 @@ const xmlWithScriptLanguage = xmlLanguage.configure({
 });
 
 export function xmlWithScript(): LanguageSupport {
-    return new LanguageSupport(xmlWithScriptLanguage, [autoCloseTags]);
+    // questScriptFoldService is registered for the whole document rather than just the embedded
+    // script regions — it only ever fires on `{`-terminated lines (a very Quest-script-y signal that
+    // won't occur in XML markup or prose), which is what lets the raw XML view fold script blocks
+    // that the base xmlLanguage's foldNodeProp can't see into.
+    return new LanguageSupport(xmlWithScriptLanguage, [autoCloseTags, questScriptFoldService]);
 }


### PR DESCRIPTION
## Summary

Adds collapsible code sections and autocompletion to the CodeMirror-based editor views in AppShell:

### Folding

- **Raw XML code view** (`CodeViewPanel`) and **Safe Mode** (`SafeModeEditor`) — fold XML elements via `@codemirror/lang-xml`'s built-in `foldNodeProp`, plus `<script type="script">` regions via a new custom fold service.
- **In-line script Code view** (`ScriptEditor`) — Quest-script blocks fold via the new `foldService`.
- **JS / .aslx texteditors** (`PropertyEditor`) — fold via `@codemirror/lang-javascript` / XML node props.

All wiring is in the shared `CodeEditor.svelte` (`codeFolding()`, `foldGutter()`, `foldKeymap`), so every editor gets a fold gutter and `Ctrl-Shift-[`/`]` etc. for free.

`quest-script-lang.ts` exports `questScriptFoldService`: any `{`-terminated line opens a block that folds to its matching `}`, scanning forward while respecting `"..."` strings, `\\` escapes, `//` comments, and nesting — keeping the opening `{` and closing `}` visible. The scan is capped at 1000 lines so a stray `{` can't trigger a pathological scan. Registered in both `questScript()` and `xmlWithScript()` (the raw XML view), since it only ever fires on `{`-terminated lines it can't interfere with XML element folding.

### Autocompletion

- `autocompletion()` + `completionKeymap` enabled in the shared editor, so suggestions appear while typing (or via Ctrl-Space) and are accepted with **Enter or Tab** (Tab falls through to normal indent when no suggestion is open).
- **JS** keeps its built-in keyword/snippet/local-name completions from `@codemirror/lang-javascript`.
- **XML and quest-script** views get `completeAnyWord` — suggestions of words already in the document (tag/attribute names, variables, function names). It combines with (never replaces) the XML language's own schema-based source.

## Verification

- `npm run check` — 0 errors/warnings
- `eslint` — clean
- Fold logic unit-tested against strings, comments, nesting, empty and unclosed blocks