### PR TITLE
fix: stop e2e unsaved-close test failing on temp-dir cleanup race

### DIFF
--- a/tests/e2e/verify-electron-unsaved-close-dialog.mjs
+++ b/tests/e2e/verify-electron-unsaved-close-dialog.mjs
@@ -56,8 +56,14 @@ async function withFreshApp(fn) {
             await exited;
         }
         // Even after exit, Chromium's disk-cache writeback can still be finishing up, so an
-        // immediate rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out that race.
-        rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+        // immediate rmSync can hit ENOTEMPTY on Cache_Data — maxRetries/retryDelay ride out
+        // that race, and if it still can't win, that's just leftover junk in the OS temp dir,
+        // not a test failure: log it and move on rather than failing the whole verification.
+        try {
+            rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+        } catch (err) {
+            console.warn(`WARN: could not remove temp userData dir ${userDataDir}: ${err.message}`);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The scheduled e2e run [31863118254](https://github.com/textadventures/quest/actions/runs/31863118254) failed in the `electron` job during `verify-electron-unsaved-close-dialog.mjs`. All three test scenarios actually **passed** — the failure came from the `withFreshApp` helper's temp-dir cleanup:

```
FAIL: ENOTEMPTY: directory not empty, rmdir '.../quest-electron-userdata-...'
```

The `rmSync` already had `maxRetries: 5`/`retryDelay: 200` to ride out Chromium's disk-cache writeback race (added in #2013), but this time it still hit `ENOTEMPTY` on `Cache_Data`, threw out of the `finally` block, and failed the entire job.

## Change

Leftover files in the OS temp dir are harmless, so cleanup is now genuinely best-effort: catch the error and log a warning instead of failing the whole verification. The test assertions themselves remain strict — this only softens the housekeeping.

## Testing

`node --check tests/e2e/verify-electron-unsaved-close-dialog.mjs` passes.