### PR TITLE
fix(ElectronApp): wire transcript preload into editor Preview popup

### DIFF
--- a/src/ElectronApp/src/ipc/player.ts
+++ b/src/ElectronApp/src/ipc/player.ts
@@ -9,6 +9,64 @@ export interface PlayerWindowRequest {
     id?: string;
 }
 
+// Games can't open further windows of their own — same-origin player
+// navigation isn't a thing a game needs, and anything else (a game script's
+// window.open to some external URL) goes to the OS browser instead of
+// spawning another in-app window. The one exception is the "view transcript"
+// link JS.showTranscript() prints (playercore.js's transcriptUrl, a
+// same-origin relative link to TranscriptViewer/index.html): that page reads
+// the transcript data straight out of this session's localStorage, so it has
+// to open as an in-app window on this same origin — sending it to the OS
+// browser would land on a *different* browser's storage jar (or, if that
+// browser happens to be Chromium-based and somehow shared, still the wrong
+// origin, since static-server.ts binds a fresh random port every launch) and
+// always show "no transcripts".
+//
+// Shared by every surface that can host a player window — ipc/player.ts's
+// own "Play" flow below, and main.ts's editor Preview popup — so both give
+// the TranscriptViewer child window the same transcript-viewer-preload.ts
+// bridge. A window that gets this call but never has it applied to the
+// window a game's transcript link actually opens in (e.g. a popup created
+// through some other path with its own setWindowOpenHandler) will still show
+// the TranscriptViewer page, just with window.electronTranscripts left
+// undefined — it loads over plain HTTP same as any other static asset.
+export function attachTranscriptWindowHandling(win: BrowserWindow, origin: string): void {
+    win.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
+        if (targetUrl.startsWith(`${origin}/player/TranscriptViewer/`)) {
+            return {
+                action: "allow",
+                overrideBrowserWindowOptions: {
+                    width: 640,
+                    height: 480,
+                    webPreferences: {
+                        contextIsolation: true,
+                        nodeIntegration: false,
+                        // First-party content (not game-supplied) — gets the
+                        // fuller list/read/delete transcript bridge, not the
+                        // player window's append-only one. See
+                        // transcript-viewer-preload.ts.
+                        preload: path.join(__dirname, "..", "transcript-viewer-preload.js"),
+                    },
+                },
+            };
+        }
+        void shell.openExternal(targetUrl);
+        return { action: "deny" };
+    });
+    // TranscriptViewer/index.html's own OPEN button does
+    // window.open("about:blank", ...) + document.write(...) to display a
+    // transcript's contents — that's a *second* window.open, from the
+    // TranscriptViewer window's webContents rather than this one, so it
+    // needs its own handler. Trusted first-party content (shipped by us, not
+    // game- or web-supplied), so allow it unconditionally rather than
+    // pattern-matching about:blank.
+    win.webContents.on("did-create-window", (childWindow, details) => {
+        if (details.url.startsWith(`${origin}/player/TranscriptViewer/`)) {
+            childWindow.webContents.setWindowOpenHandler(() => ({ action: "allow" }));
+        }
+    });
+}
+
 // Backs window.electronApp.player in preload.ts. Takes a request *shape*, not
 // a URL — the renderer never gets to hand main.ts an arbitrary string to
 // navigate a new window to, only the two known player boot modes.
@@ -49,53 +107,7 @@ export function registerPlayerHandlers(getOrigin: () => string | null): void {
                 preload: path.join(__dirname, "..", "player-preload.js"),
             },
         });
-        // Games can't open further windows of their own — same-origin
-        // player navigation isn't a thing a game needs, and anything else
-        // (a game script's window.open to some external URL) goes to the OS
-        // browser instead of spawning another in-app window. The one
-        // exception is the "view transcript" link JS.showTranscript() prints
-        // (playercore.js's transcriptUrl, a same-origin relative link to
-        // TranscriptViewer/index.html): that page reads the transcript data
-        // straight out of this session's localStorage, so it has to open as
-        // an in-app window on this same origin — sending it to the OS
-        // browser would land on a *different* browser's storage jar (or, if
-        // that browser happens to be Chromium-based and somehow shared,
-        // still the wrong origin, since static-server.ts binds a fresh
-        // random port every launch) and always show "no transcripts".
-        win.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
-            if (targetUrl.startsWith(`${origin}/player/TranscriptViewer/`)) {
-                return {
-                    action: "allow",
-                    overrideBrowserWindowOptions: {
-                        width: 640,
-                        height: 480,
-                        webPreferences: {
-                            contextIsolation: true,
-                            nodeIntegration: false,
-                            // First-party content (not game-supplied) — gets
-                            // the fuller list/read/delete transcript bridge,
-                            // not the player window's append-only one. See
-                            // transcript-viewer-preload.ts.
-                            preload: path.join(__dirname, "..", "transcript-viewer-preload.js"),
-                        },
-                    },
-                };
-            }
-            void shell.openExternal(targetUrl);
-            return { action: "deny" };
-        });
-        // TranscriptViewer/index.html's own OPEN button does
-        // window.open("about:blank", ...) + document.write(...) to display a
-        // transcript's contents — that's a *second* window.open, from the
-        // TranscriptViewer window's webContents rather than this one, so it
-        // needs its own handler. Trusted first-party content (shipped by us,
-        // not game- or web-supplied), so allow it unconditionally rather
-        // than pattern-matching about:blank.
-        win.webContents.on("did-create-window", (childWindow, details) => {
-            if (details.url.startsWith(`${origin}/player/TranscriptViewer/`)) {
-                childWindow.webContents.setWindowOpenHandler(() => ({ action: "allow" }));
-            }
-        });
+        attachTranscriptWindowHandling(win, origin);
         // playercore.js's beforeunload handler calls e.preventDefault() once
         // hasUnsavedProgress is set (i.e. after a turn) — a real browser
         // would show its native "Leave site?" dialog for that, but Electron

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -6,7 +6,7 @@ import { registerDialogHandlers } from "./ipc/dialog";
 import { registerShellHandlers } from "./ipc/shell";
 import { registerPathsHandlers } from "./ipc/paths";
 import { registerRecentHandlers } from "./ipc/recent";
-import { registerPlayerHandlers } from "./ipc/player";
+import { registerPlayerHandlers, attachTranscriptWindowHandling } from "./ipc/player";
 import { registerTranscriptHandlers } from "./ipc/transcript";
 import { registerGameSaveHandlers } from "./ipc/gamesave";
 import { registerCatalogPlaysHandlers } from "./ipc/catalog-plays";
@@ -543,6 +543,19 @@ function createEditorWindow(port: number, initialPath?: string | null, initialRo
         }
         void shell.openExternal(url);
         return { action: "deny" };
+    });
+    // The preview player window above is itself an opener: its game content
+    // can print the same "view transcript" link ipc/player.ts's Play-flow
+    // windows do (playercore.js's transcriptUrl), which needs the
+    // TranscriptViewer child window wired up the same way — see
+    // attachTranscriptWindowHandling's comment. Without this, that popup
+    // opens with no preload at all (Electron's default for an
+    // unhandled/unconfigured window.open) and window.electronTranscripts is
+    // left undefined.
+    editorWindow.webContents.on("did-create-window", (childWindow, details) => {
+        if (details.url.startsWith(`http://127.0.0.1:${port}/player/`)) {
+            attachTranscriptWindowHandling(childWindow, `http://127.0.0.1:${port}`);
+        }
     });
 
     // initialRoute is a pre-built route (used by sendMenuAction below to land


### PR DESCRIPTION
## Summary
- Editor's Preview button opens the player in its own popup (`main.ts`), separate from the Play flow's player window (`ipc/player.ts`) — only the latter attached the `setWindowOpenHandler`/`did-create-window` pair that gives the TranscriptViewer child window its `transcript-viewer-preload.js` bridge.
- A transcript opened from a *previewed* game therefore got a popup with no preload at all, leaving `window.electronTranscripts` undefined and throwing `Cannot read properties of undefined (reading 'list')` in `TranscriptViewer/index.html`'s `loadTable()`.
- Extracted the wiring into `attachTranscriptWindowHandling()` in `ipc/player.ts` and reused it for the Preview popup in `main.ts`.

## Test plan
- [x] `npm run build:ts` (ElectronApp) compiles clean
- [x] User confirmed fix works in the packaged app: Preview a game, start/stop a transcript, "show script" → transcript window now loads correctly instead of getting stuck on "Loading..."

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>