### PR TITLE
feat(AppShell): collapsed-by-default game tree with per-game expansion state, expand/collapse-all and move up/down

### DIFF
--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { untrack } from "svelte";
+    import { untrack, onDestroy } from "svelte";
     import { TreeView, createTreeViewCollection } from "@skeletonlabs/skeleton-svelte";
     import Search from "@lucide/svelte/icons/search";
     import X from "@lucide/svelte/icons/x";
@@ -170,6 +170,9 @@
     // fully-collapsed tree.
     let loadedStateFor = $state<string | null>(null);
     let saveTimer: ReturnType<typeof setTimeout> | undefined;
+    // Latest (gameId, ids) not yet written out — flushed from onDestroy when
+    // the panel unmounts (navigating Home etc.) before the debounce could fire.
+    let pendingTreeState: { gameId: string; ids: string[] } | null = null;
 
     // On game load, default to a collapsed tree — only the top-level structural
     // header (the "_objects"/"_pages" one) starts open, so rooms, objects, turn
@@ -251,15 +254,25 @@
 
     // Debounced persistence of the expansion state, keyed by the game's stable
     // <gameid>. Skipped for legacy games without one (they keep the collapsed
-    // default on every load). The teardown clears any pending write — fine to
-    // drop, the next load just re-applies the default for those few seconds.
+    // default on every load). The timer itself is cleared on teardown — a
+    // change made within the debounce window of navigating away (Home, opening
+    // another game, …) would otherwise be lost — so the latest pending state is
+    // flushed from onDestroy instead.
     $effect(() => {
         const ids = expandedIds;
         const gameId = getCurrentGameId();
         if (!loadedStateFor || !gameId) return;
+        pendingTreeState = { gameId, ids };
         clearTimeout(saveTimer);
-        saveTimer = setTimeout(() => saveTreeState(gameId, ids), 300);
+        saveTimer = setTimeout(() => {
+            pendingTreeState = null;
+            saveTreeState(gameId, ids);
+        }, 300);
         return () => clearTimeout(saveTimer);
+    });
+
+    onDestroy(() => {
+        if (pendingTreeState) saveTreeState(pendingTreeState.gameId, pendingTreeState.ids);
     });
 
     // Auto-expand the ancestor chain whenever the selected node changes

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -206,9 +206,13 @@
 
     // The player object conventionally lives inside the starting room, possibly
     // nested in other objects. Return every ancestor of the player node so the
-    // whole chain (room → … → player) is expanded by default.
+    // whole chain (room → … → player) is expanded by default. Match the player
+    // by name, not nodeType: it's "object" in a text adventure but "page" in
+    // gamebook mode (any object in GameBook style is typed "page"), so only
+    // structural/library rows (headers, include files, library-origin nodes)
+    // are excluded.
     function startingRoomPath(nodes: TreeNode[]): string[] {
-        const player = nodes.find(n => n.key === "player" && n.nodeType === "object");
+        const player = nodes.find(n => n.key === "player" && n.nodeType !== "header" && n.nodeType !== "include" && !n.isLibrary);
         if (!player) return [];
         const nodeMap = new Map(nodes.map(n => [n.key, n]));
         const ids: string[] = [];

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -16,9 +16,11 @@
         canMoveElement, openMoveModal, copyElements, cutElements, canPasteElements, pasteElements,
         clipboardVersion, cutElementKeys,
         showLibraryElements, toggleShowLibraryElements,
+        swapElements, getCurrentGameId,
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
     import { t } from "$lib/i18n";
+    import { loadTreeState, saveTreeState } from "$lib/tree-state";
 
     let { width, onactivate }: { width?: number; onactivate?: () => void } = $props();
 
@@ -159,17 +161,64 @@
     // ── Expansion state ────────────────────────────────────────────────────────
 
     let expandedIds = $state<string[]>([]);
-    let loadedGameKey = $state<string | null>(null);
+    // "State loaded for" marker — the `${gameKey}|${gameId}` of the tree the
+    // current expandedIds came from. Guards both directions: a fresh game (new
+    // key or id) re-applies the default + stored state, while a mid-session
+    // refreshTree (element added/renamed, etc.) leaves the user's expansion
+    // alone, and a TreePanel remount (navigating back into the editor) sees
+    // its previously-null marker and re-applies instead of showing a blank,
+    // fully-collapsed tree.
+    let loadedStateFor = $state<string | null>(null);
+    let saveTimer: ReturnType<typeof setTimeout> | undefined;
 
-    // On game load, expand all nodes except _advanced
+    // On game load, default to a collapsed tree — only the top-level structural
+    // header (the "_objects"/"_pages" one) starts open, so rooms, objects, turn
+    // scripts, functions etc. are all collapsed (#827). The "game" node starts
+    // collapsed too, hiding its Verbs/Commands headers until opened, and the
+    // "_advanced" header stays collapsed like everything else — its subtree
+    // (Included Libraries, Functions, ...) is the biggest source of default
+    // clutter. The one exception: the room the player starts in is expanded all
+    // the way down to the player object, so the game's opening scene is visible
+    // at a glance. Any per-game state saved for this game (see the persistence
+    // effect below) then overrides the default, so a returning author finds the
+    // tree exactly as they left it.
     $effect(() => {
         const nodes = $treeNodes;
-        if (nodes.length === 0) { loadedGameKey = null; return; }
+        if (nodes.length === 0) { loadedStateFor = null; return; }
         const gameKey = nodes.find(n => n.nodeType === "game")?.key ?? null;
-        if (gameKey === loadedGameKey) return;
-        loadedGameKey = gameKey;
-        expandedIds = nodes.filter(n => n.key !== "_advanced").map(n => n.key);
+        if (!gameKey) return;
+        const gameId = getCurrentGameId();
+        const stateKey = `${gameKey}|${gameId ?? ""}`;
+        if (stateKey === loadedStateFor) return;
+        loadedStateFor = stateKey;
+        const defaultIds = nodes
+            .filter(n => n.nodeType === "header" && !n.parent && n.key !== "_advanced")
+            .map(n => n.key);
+        const playerPath = startingRoomPath(nodes);
+        expandedIds = [...new Set([...defaultIds, ...playerPath])];
+        if (!gameId) return;
+        void loadTreeState(gameId).then((stored) => {
+            if (stored && stored.length > 0 && loadedStateFor === stateKey) {
+                expandedIds = stored;
+            }
+        });
     });
+
+    // The player object conventionally lives inside the starting room, possibly
+    // nested in other objects. Return every ancestor of the player node so the
+    // whole chain (room → … → player) is expanded by default.
+    function startingRoomPath(nodes: TreeNode[]): string[] {
+        const player = nodes.find(n => n.key === "player" && n.nodeType === "object");
+        if (!player) return [];
+        const nodeMap = new Map(nodes.map(n => [n.key, n]));
+        const ids: string[] = [];
+        let cur: TreeNode | undefined = player;
+        while (cur?.parent) {
+            ids.push(cur.parent);
+            cur = nodeMap.get(cur.parent);
+        }
+        return ids;
+    }
 
     function toggleExpand(id: string) {
         // While filtering, all matching branches are force-expanded so results stay
@@ -177,17 +226,37 @@
         if (isFiltering) return;
         if (expandedIds.includes(id)) {
             // If the selected node is inside this branch, select the branch itself first
-            const nodeMap = new Map($treeNodes.map(n => [n.key, n]));
-            let cur = nodeMap.get($selectedKey ?? "");
-            while (cur?.parent) {
-                if (cur.parent === id) { selectNode(id); break; }
-                cur = nodeMap.get(cur.parent);
-            }
+            selectBranchIfSelectedInside(id);
             expandedIds = expandedIds.filter(x => x !== id);
         } else {
             expandedIds = [...expandedIds, id];
         }
     }
+
+    // If the currently-selected node sits inside the branch being collapsed,
+    // select the branch node itself so the tree doesn't end up with its
+    // selection hidden inside a closed branch.
+    function selectBranchIfSelectedInside(id: string) {
+        const nodeMap = new Map($treeNodes.map(n => [n.key, n]));
+        let cur = nodeMap.get($selectedKey ?? "");
+        while (cur?.parent) {
+            if (cur.parent === id) { selectNode(id); break; }
+            cur = nodeMap.get(cur.parent);
+        }
+    }
+
+    // Debounced persistence of the expansion state, keyed by the game's stable
+    // <gameid>. Skipped for legacy games without one (they keep the collapsed
+    // default on every load). The teardown clears any pending write — fine to
+    // drop, the next load just re-applies the default for those few seconds.
+    $effect(() => {
+        const ids = expandedIds;
+        const gameId = getCurrentGameId();
+        if (!loadedStateFor || !gameId) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => saveTreeState(gameId, ids), 300);
+        return () => clearTimeout(saveTimer);
+    });
 
     // Auto-expand the ancestor chain whenever the selected node changes
     $effect(() => {
@@ -298,6 +367,33 @@
         return nt !== "header" && nt !== "other" && node.canDelete;
     }
 
+    // Move up/down reorder the node among its same-parent siblings — the tree's
+    // synthetic parent grouping always maps to a single world-model parent (e.g.
+    // everything under "_objects" is a top-level element on the game), so
+    // swapping the two SortIndex meta-fields is always well-defined (see
+    // EditorController.SwapElements). Mirrors ElementsList's up/down buttons.
+    // The array order of $treeNodes is the tree's display order, so the
+    // adjacent flat-list entry is the swap target.
+    function reorderOptions(node: HierNode): Array<{ label: string; action: () => void }> {
+        const opts: Array<{ label: string; action: () => void }> = [];
+        // Headers, the game node, and included-library file nodes are structural
+        // or read-only — nothing is reorderable among them. (Library rows in
+        // particular are meant to have no context menu at all, mirroring the
+        // isLibrary guard in nodeMenuOptions.)
+        if (node.nodeType === "header" || node.nodeType === "game" || node.nodeType === "include") return opts;
+        const flat = $treeNodes.find(n => n.key === node.id);
+        if (!flat) return opts;
+        // The game node itself appears under "_objects" alongside the game's
+        // top-level elements — it's not a real sibling (nothing can be
+        // reordered above or below it), so exclude it from the sibling list.
+        const siblings = $treeNodes.filter(n => n.parent === flat.parent && n.nodeType !== "game");
+        const index = siblings.findIndex(n => n.key === flat.key);
+        if (index < 0) return opts;
+        if (index > 0) opts.push({ label: t("common.moveUp"), action: () => swapElements(flat.key, siblings[index - 1].key) });
+        if (index < siblings.length - 1) opts.push({ label: t("common.moveDown"), action: () => swapElements(flat.key, siblings[index + 1].key) });
+        return opts;
+    }
+
     function nodeMenuOptions(node: HierNode): Array<{ label: string; action: () => void }> {
         // Library-origin nodes (from Core.aslx or another included library) are read-only —
         // the only way to act on one is the "Copy into your game" banner in the properties
@@ -377,6 +473,20 @@
             if (canPasteElements(id)) {
                 opts.push({ label: t("common.paste"), action: () => pasteElements(id) });
             }
+        }
+
+        // Reordering + expand/collapse-all are available on any node with
+        // same-parent siblings or children (headers and the game node included)
+        // — both operate on the tree's synthetic grouping, not the world model.
+        opts.push(...reorderOptions(node));
+
+        if (node.children?.length && !isFiltering) {
+            // While filtering, every matching branch is force-expanded anyway
+            // (see effectiveExpandedIds), so both actions would be no-ops.
+            opts.push(
+                { label: t("treePanel.expandAllBelow"), action: () => { expandedIds = [...new Set([...expandedIds, ...collectBranchIds([node])])]; } },
+                { label: t("treePanel.collapseAllBelow"), action: () => { selectBranchIfSelectedInside(node.id); const toClose = new Set(collectBranchIds([node])); expandedIds = expandedIds.filter(id => !toClose.has(id)); } },
+            );
         }
 
         if (isDeletable(node)) {

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -18,6 +18,14 @@ let _bridge: WasmBridge | null = null;
 let _adapter: FileAdapter | null = null;
 let _loadedGameId: string | null = null;
 
+// The <gameid> of the currently-loaded game (stable per game, unlike element
+// names — the root element is always called "game"), or null for legacy games
+// that predate the field. Set on openGame() / rekeyIfGameIdChanged(). Used to
+// key per-game UI state such as the tree's expansion state (tree-state.ts).
+export function getCurrentGameId(): string | null {
+    return _loadedGameId;
+}
+
 export const isLoaded = writable(false);
 export const loadingStatus = writable<string | null>(null);
 export const addElementModal = writable<AddElementModalState>(null);

--- a/src/AppShell/src/lib/electron-types.d.ts
+++ b/src/AppShell/src/lib/electron-types.d.ts
@@ -127,6 +127,14 @@ interface ElectronUpdateDismissApi {
     set(version: string): Promise<void>;
 }
 
+// Per-game editor UI state (currently the tree's expanded-node ids), keyed by
+// the game's <gameid> element — persisted to a userData file (ElectronApp's
+// ui-state-store.ts), not localStorage — see tree-state.ts for why.
+interface ElectronUiStateApi {
+    get(): Promise<Record<string, string[]>>;
+    set(gameId: string, state: string[]): Promise<void>;
+}
+
 // id: catalog game (textadventures.co.uk id); omitted: a locally-picked
 // file, whose bytes/resources the caller hands over separately via the
 // 'quest-play-local' BroadcastChannel — see ipc/player.ts and
@@ -152,6 +160,7 @@ interface ElectronApi {
     recent: ElectronRecentApi;
     catalogPlays: ElectronCatalogPlaysApi;
     updateDismiss: ElectronUpdateDismissApi;
+    uiState: ElectronUiStateApi;
     fileWatch: ElectronFileWatchApi;
     menu: ElectronMenuApi;
     player: ElectronPlayerApi;

--- a/src/AppShell/src/lib/tree-state.ts
+++ b/src/AppShell/src/lib/tree-state.ts
@@ -1,0 +1,49 @@
+import { isElectron } from "./runtime";
+
+// Per-game game-tree expansion state (which node ids are expanded), keyed by
+// the game's <gameid> element so each game remembers its own tree layout
+// across sessions. localStorage is fine in the browser; Electron persists to a
+// userData file via IPC instead (ui-state-store.ts) — static-server.ts's
+// ephemeral port makes the page origin different every launch, so localStorage
+// never survives a restart there (same rationale as theme-store.ts).
+const STORAGE_KEY_PREFIX = "questviva-tree-state-";
+
+export async function loadTreeState(gameId: string): Promise<string[] | null> {
+    if (isElectron()) {
+        try {
+            const all = await window.electronApp!.uiState.get();
+            const state = all[gameId];
+            return Array.isArray(state) ? state : null;
+        } catch {
+            // Losing the tree state just means the default (collapsed) is used, not fatal.
+            return null;
+        }
+    }
+    if (typeof localStorage === "undefined") return null;
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY_PREFIX + gameId);
+        if (!raw) return null;
+        const parsed: unknown = JSON.parse(raw);
+        return Array.isArray(parsed) ? (parsed as string[]) : null;
+    } catch {
+        return null;
+    }
+}
+
+export function saveTreeState(gameId: string, expandedIds: string[]): void {
+    if (isElectron()) {
+        try {
+            void window.electronApp!.uiState.set(gameId, expandedIds);
+        } catch {
+            // Same degradation as the read path — nothing to recover, not fatal.
+        }
+        return;
+    }
+    if (typeof localStorage === "undefined") return;
+    try {
+        localStorage.setItem(STORAGE_KEY_PREFIX + gameId, JSON.stringify(expandedIds));
+    } catch {
+        // Storage can be unavailable (private browsing, quota) — losing the
+        // tree state just means the default is used next load, not fatal.
+    }
+}

--- a/src/AppShell/src/lib/tree-state.ts
+++ b/src/AppShell/src/lib/tree-state.ts
@@ -33,7 +33,12 @@ export async function loadTreeState(gameId: string): Promise<string[] | null> {
 export function saveTreeState(gameId: string, expandedIds: string[]): void {
     if (isElectron()) {
         try {
-            void window.electronApp!.uiState.set(gameId, expandedIds);
+            // expandedIds can be a Svelte $state array (a Proxy). IPC's
+            // structured clone can't clone proxies, so pass a plain copy —
+            // localStorage tolerates the proxy because JSON.stringify does.
+            void window.electronApp!.uiState.set(gameId, [...expandedIds]).catch(() => {
+                // Same degradation as the read path — nothing to recover, not fatal.
+            });
         } catch {
             // Same degradation as the read path — nothing to recover, not fatal.
         }

--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -132,6 +132,8 @@
     "treePanel.nodeOptions": "Optionen",
     "treePanel.expand": "Aufklappen",
     "treePanel.collapse": "Zuklappen",
+    "treePanel.expandAllBelow": "Alles darunter aufklappen",
+    "treePanel.collapseAllBelow": "Alles darunter zuklappen",
     "treePanel.header.objects": "Objekte",
     "treePanel.header.pages": "Seiten",
     "treePanel.header.functions": "Funktionen",

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -132,6 +132,8 @@
     "treePanel.nodeOptions": "Options",
     "treePanel.expand": "Expand",
     "treePanel.collapse": "Collapse",
+    "treePanel.expandAllBelow": "Expand all below",
+    "treePanel.collapseAllBelow": "Collapse all below",
     "treePanel.header.objects": "Objects",
     "treePanel.header.pages": "Pages",
     "treePanel.header.functions": "Functions",

--- a/src/AppShell/static/locales/es.json
+++ b/src/AppShell/static/locales/es.json
@@ -132,6 +132,8 @@
     "treePanel.nodeOptions": "Opciones",
     "treePanel.expand": "Expandir",
     "treePanel.collapse": "Contraer",
+    "treePanel.expandAllBelow": "Expandir todo debajo",
+    "treePanel.collapseAllBelow": "Contraer todo debajo",
     "treePanel.header.objects": "Objetos",
     "treePanel.header.pages": "Páginas",
     "treePanel.header.functions": "Funciones",

--- a/src/AppShell/static/locales/xx.json
+++ b/src/AppShell/static/locales/xx.json
@@ -119,6 +119,8 @@
     "treePanel.nodeOptions": "[Óptíóns]",
     "treePanel.expand": "[Éxpánd]",
     "treePanel.collapse": "[Cóllápsé]",
+    "treePanel.expandAllBelow": "[Éxpánd áll bélów]",
+    "treePanel.collapseAllBelow": "[Cóllápsé áll bélów]",
     "elementsList.noItems": "[Nó ítéms.]",
     "elementsList.cannotDelete": "[Thís cán't bé délétéd]",
     "elementsList.selectedCount": "[{count} séléctéd]",

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -2574,9 +2574,13 @@ public sealed class EditorController : IDisposable
         var a = WorldModel.Elements.Get(key1);
         var b = WorldModel.Elements.Get(key2);
 
+        // Wrap in a transaction so the swap is undoable/redoable — MetaFields
+        // mutations only register with the UndoLogger while one is open.
+        WorldModel.UndoLogger.StartTransaction(string.Format("Move '{0}' and '{1}'", a.Name, b.Name));
         var index = a.MetaFields[MetaFieldDefinitions.SortIndex];
         a.MetaFields[MetaFieldDefinitions.SortIndex] = b.MetaFields[MetaFieldDefinitions.SortIndex];
         b.MetaFields[MetaFieldDefinitions.SortIndex] = index;
+        WorldModel.UndoLogger.EndTransaction();
     }
 
     public void BeginWalkthrough(string name, bool record)

--- a/src/ElectronApp/src/ipc/ui-state.ts
+++ b/src/ElectronApp/src/ipc/ui-state.ts
@@ -1,0 +1,11 @@
+import { ipcMain } from "electron";
+import { readUiState, setUiState } from "../ui-state-store";
+
+// Backs window.electronApp.uiState in preload.ts — per-game editor UI state
+// (currently the game tree's expanded-node ids) persisted to a userData file,
+// since static-server.ts's ephemeral port makes localStorage unreliable in
+// Electron. See ui-state-store.ts.
+export function registerUiStateHandlers(): void {
+    ipcMain.handle("uiState:get", async () => readUiState());
+    ipcMain.handle("uiState:set", async (_event, gameId: string, state: string[]) => setUiState(gameId, state));
+}

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -14,6 +14,7 @@ import { registerUpdateDismissHandlers } from "./ipc/update-dismiss";
 import { registerFileWatchHandlers } from "./ipc/file-watch";
 import { registerLocaleHandlers } from "./ipc/locale";
 import { registerThemeHandlers } from "./ipc/theme";
+import { registerUiStateHandlers } from "./ipc/ui-state";
 import { listRecentGames, clearRecentGames, type RecentGame, type RecentKind } from "./recent-games";
 
 let editorWindow: BrowserWindow | null = null;
@@ -593,6 +594,7 @@ if (!gotLock) {
         registerPathsHandlers();
         registerLocaleHandlers();
         registerThemeHandlers();
+        registerUiStateHandlers();
         // Edit-kind changes rebuild the native "Open Recent" submenu; both kinds
         // also get broadcast to the renderer (see broadcastRecentChanged).
         registerRecentHandlers((kind) => {

--- a/src/ElectronApp/src/preload.ts
+++ b/src/ElectronApp/src/preload.ts
@@ -169,6 +169,13 @@ contextBridge.exposeInMainWorld("electronApp", {
         get: (): Promise<string | null> => ipcRenderer.invoke("updateDismiss:get"),
         set: (version: string): Promise<void> => ipcRenderer.invoke("updateDismiss:set", version),
     },
+    uiState: {
+        // Per-game editor UI state (currently the tree's expanded-node ids),
+        // keyed by the game's <gameid> — see ElectronApp's ui-state-store.ts
+        // for why this can't be localStorage.
+        get: (): Promise<Record<string, string[]>> => ipcRenderer.invoke("uiState:get"),
+        set: (gameId: string, state: string[]): Promise<void> => ipcRenderer.invoke("uiState:set", gameId, state),
+    },
     player: {
         // Opens a dedicated player BrowserWindow (see ipc/player.ts) rather
         // than a renderer-driven window.open() — sidesteps the browser's

--- a/src/ElectronApp/src/ui-state-store.ts
+++ b/src/ElectronApp/src/ui-state-store.ts
@@ -1,0 +1,45 @@
+import { app } from "electron";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+// Per-game editor UI state (currently the game tree's expanded-node ids),
+// keyed by the game's <gameid> element so each game remembers its own tree
+// layout across sessions. Persisted to a userData file rather than
+// localStorage — same rationale as theme-store.ts: static-server.ts binds to
+// an OS-assigned ephemeral port (listen(0, ...)) that changes every launch,
+// so the page origin is never the same twice and localStorage never survives
+// a restart in Electron.
+export type UiState = Record<string, string[]>;
+
+function storePath(): string {
+    return path.join(app.getPath("userData"), "ui-state.json");
+}
+
+// Whole-map read: the renderer loads it once per game open. Missing file
+// (first run) or corrupt JSON is an empty map, never an error.
+export async function readUiState(): Promise<UiState> {
+    try {
+        const text = await fs.readFile(storePath(), "utf-8");
+        const parsed = JSON.parse(text) as unknown;
+        if (typeof parsed !== "object" || parsed === null) return {};
+        const result: UiState = {};
+        for (const [gameId, state] of Object.entries(parsed)) {
+            if (Array.isArray(state)) result[gameId] = state as string[];
+        }
+        return result;
+    } catch {
+        return {};
+    }
+}
+
+// Writes to a temp file and renames over the real one — same atomicity
+// rationale as theme-store.ts's writeTheme. Debounced on the renderer side,
+// so this is called at most a couple of times a second.
+export async function setUiState(gameId: string, state: string[]): Promise<void> {
+    const all = await readUiState();
+    all[gameId] = state;
+    const finalPath = storePath();
+    const tmpPath = `${finalPath}.tmp-${process.pid}-${Date.now()}`;
+    await fs.writeFile(tmpPath, JSON.stringify(all));
+    await fs.rename(tmpPath, finalPath);
+}

--- a/src/ElectronApp/src/ui-state-store.ts
+++ b/src/ElectronApp/src/ui-state-store.ts
@@ -32,14 +32,22 @@ export async function readUiState(): Promise<UiState> {
     }
 }
 
+// Serializes writes — each set is a read-modify-write of the whole map, and
+// two overlapping ones (a debounced save landing while a flush-on-unmount is in
+// flight) could otherwise interleave and lose a game's state.
+let writeQueue: Promise<void> = Promise.resolve();
+
 // Writes to a temp file and renames over the real one — same atomicity
 // rationale as theme-store.ts's writeTheme. Debounced on the renderer side,
 // so this is called at most a couple of times a second.
-export async function setUiState(gameId: string, state: string[]): Promise<void> {
-    const all = await readUiState();
-    all[gameId] = state;
-    const finalPath = storePath();
-    const tmpPath = `${finalPath}.tmp-${process.pid}-${Date.now()}`;
-    await fs.writeFile(tmpPath, JSON.stringify(all));
-    await fs.rename(tmpPath, finalPath);
+export function setUiState(gameId: string, state: string[]): Promise<void> {
+    writeQueue = writeQueue.then(async () => {
+        const all = await readUiState();
+        all[gameId] = state;
+        const finalPath = storePath();
+        const tmpPath = `${finalPath}.tmp-${process.pid}-${Date.now()}`;
+        await fs.writeFile(tmpPath, JSON.stringify(all));
+        await fs.rename(tmpPath, finalPath);
+    });
+    return writeQueue;
 }

--- a/tests/e2e/verify-advanced-tree.mjs
+++ b/tests/e2e/verify-advanced-tree.mjs
@@ -41,9 +41,13 @@ async function run() {
     console.log('PASS: toolbar Add dropdown is trimmed to "Add Room" and "Add Page"');
     await page.keyboard.press("Escape");
 
-    // Expand the Advanced tree node and confirm its panel offers the element
-    // types that used to live directly in the toolbar dropdown.
-    await page.getByRole("button", { name: "Expand Advanced" }).click();
+    // Select the Advanced tree node and confirm its panel offers the element
+    // types that used to live directly in the toolbar dropdown. (The node no
+    // longer needs expanding — branch expansion now starts collapsed-by-default
+    // per #827, but the Advanced header itself stays open on load).
+    // Exact match + .first() so the tree node's label wins over the game-name
+    // header ("Advanced Tree Test.aslx" contains but isn't equal to "Advanced").
+    await page.getByText("Advanced", { exact: true }).first().click();
     await page.waitForTimeout(500);
     const addFunctionBtn = page.getByRole("button", { name: "+ Add Function" });
     if (!(await addFunctionBtn.isVisible())) {

--- a/tests/e2e/verify-appshell-attributes-stack-scroll.mjs
+++ b/tests/e2e/verify-appshell-attributes-stack-scroll.mjs
@@ -62,6 +62,8 @@ try {
     // Same close affordance on VerbsEditor's Behaviour panel.
     await page.getByRole('button', { name: 'room', exact: true }).click(); // back to tree pane
     await page.waitForSelector('text=GAME OBJECTS', { timeout: 5000 });
+    const roomCaret = page.locator('[data-part="branch-control"]:has-text("room") >> button[aria-label="Expand"]');
+    if (await roomCaret.count()) { await roomCaret.first().click(); } // room already expanded by default (#827)
     await page.click('text=player');
     await page.getByRole('button', { name: /^Verbs$/ }).click();
     await page.waitForSelector('text=No verbs added yet', { timeout: 5000 });

--- a/tests/e2e/verify-appshell-empty-advanced-categories.mjs
+++ b/tests/e2e/verify-appshell-empty-advanced-categories.mjs
@@ -53,7 +53,11 @@ try {
     // while "Included Libraries" is not.
     const advancedSummary = tree.getByText('Advanced', { exact: true });
     await advancedSummary.waitFor({ state: 'visible', timeout: 5000 });
-    await tree.locator('button[aria-label="Expand"]').last().click();
+    // "_advanced" starts collapsed like every other branch now (#827), so
+    // expand it via its own caret (there are several collapsed branches — room
+    // and Included Libraries too — so target the Advanced row specifically).
+    await advancedSummary.locator('xpath=ancestor::*[@data-part="branch-control"]').locator('button[aria-label="Expand"]').click();
+    await page.waitForTimeout(300);
 
     await tree.getByText('Included Libraries', { exact: true }).waitFor({ state: 'visible', timeout: 5000 });
     console.log('PASS: "Advanced" is visible and shows "Included Libraries" (non-empty by default)');

--- a/tests/e2e/verify-appshell-gamebook-mode.mjs
+++ b/tests/e2e/verify-appshell-gamebook-mode.mjs
@@ -70,6 +70,14 @@ try {
     }
     console.log('PASS: "Advanced" adders are limited to Function/Library/JavaScript in gamebook mode');
 
+    // The tree starts collapsed (#827), but the page containing "player" —
+    // Page1 per the Gamebook template — is expanded all the way down to the
+    // player (whose nodeType is "page" in gamebook mode, not "object").
+    const page1Row = tree.locator('[data-part="branch-control"]', { hasText: 'Page1' });
+    await page1Row.locator('button[aria-label="Collapse"]').waitFor({ state: 'visible', timeout: 5000 });
+    await tree.getByText('player', { exact: true }).waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: starting page is expanded down to the player (nodeType "page")');
+
     // The page that contains "player" (Page1, per the Gamebook template)
     // must not be deletable — EditorController.CanDelete refuses it, so the
     // toolbar Delete button is disabled rather than clickable (see

--- a/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
+++ b/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
@@ -232,7 +232,9 @@ async function run() {
 
     // --- TreePanel context menu (via "room", the only movable node in a
     // fresh draft) — exercises elementAdders.* reuse + treePanel.deleteNamed
-    // interpolation + common.moveTo/cut/copy, then opens MoveElementModal. ---
+    // interpolation + common.moveTo/cut/copy, then opens MoveElementModal.
+    // 13 items: the 11 at HEAD plus the two new expand/collapse-all-below
+    // entries; "Move to…" is index 7. ---
     await page.evaluate(() => {
         const roomText = Array.from(document.querySelectorAll('span')).find(el => el.textContent.trim() === 'room');
         const control = roomText.closest('[data-part="branch-control"]') ?? roomText.parentElement;
@@ -240,9 +242,9 @@ async function run() {
     });
     await page.waitForSelector('.tree-dropdown', { timeout: 10000 });
     const treeMenuItems = await page.$$eval('.tree-dropdown button', els => els.map(el => el.textContent ?? ''));
-    if (treeMenuItems.length !== 10) throw new Error(`TreePanel context menu: expected 10 items (room, movable), found ${treeMenuItems.length}`);
+    if (treeMenuItems.length !== 13) throw new Error(`TreePanel context menu: expected 13 items (room, movable), found ${treeMenuItems.length}`);
     for (const text of treeMenuItems) assertPseudo('TreePanel context menu item', text);
-    await page.click('.tree-dropdown button >> nth=6'); // "Move to…" — 7th item, see the 10-item assertion above
+    await page.click('.tree-dropdown button >> nth=7'); // "Move to…" — 8th item, see the 13-item assertion above
     await page.waitForSelector('div[role="dialog"]', { timeout: 10000 });
     assertPseudo('MoveElementModal heading', await page.textContent('div[role="dialog"] h2'));
     assertPseudo('MoveElementModal "New parent" label', await page.textContent('div[role="dialog"] span >> nth=0'));
@@ -250,8 +252,12 @@ async function run() {
     for (const text of moveModalButtons) assertPseudo('MoveElementModal button', text);
     await closeDialog();
 
-    // --- ElementsList — via the always-present "Verbs" header node ---
-    await page.click('text="Verbs"');
+    // --- ElementsList — via the "Commands" header node (chosen over "Verbs":
+    // verbsEditor.header IS in xx.json so it renders "[Vérbs]", while
+    // treePanel.header.commands isn't and falls back to English). The "game"
+    // node starts collapsed (#827), so expand it first. ---
+    await page.locator('[data-part="branch-control"]:has-text("game") >> button').first().click();
+    await page.click('text="Commands"');
     await page.waitForSelector('.flex.items-center.gap-1.mb-2 button', { timeout: 10000 });
     assertPseudoWithPrefix('ElementsList add button', await page.textContent('.flex.items-center.gap-1.mb-2 button'), '+ ');
     assertPseudo('ElementsList "No items" copy', await page.textContent('p.italic'));
@@ -259,8 +265,12 @@ async function run() {
     // --- Advanced adders (PropertyEditor.ALL_ADVANCED_ADDERS, shared
     // elementAdders.* keys, fixed order: Function/Timer/Walkthrough/Library/
     // Template/DynamicTemplate/Type/JavaScript) — also opens
-    // AddLibraryModal/AddJavascriptModal (indices 3 and 7). ---
-    await page.click('text="Advanced" >> nth=0');
+    // AddLibraryModal/AddJavascriptModal (indices 3 and 7). Select the
+    // "_advanced" header: its label is common.advanced ("[Ádváncéd]" under xx),
+    // so pick it as the only tree branch whose text starts with "[" rather
+    // than clicking English text that can't match under the pseudo-locale. ---
+    const advancedBranch = page.locator('[data-part="branch-control"]').filter({ hasText: /^\s*\[/ });
+    await advancedBranch.click();
     const advancedAddersScope = '.flex.flex-col.items-start.gap-1\\.5.px-3.py-3';
     await page.waitForSelector(`${advancedAddersScope} button`, { timeout: 10000 });
     const advancedAdders = await page.$$eval(`${advancedAddersScope} button`, els => els.map(el => el.textContent ?? ''));
@@ -391,7 +401,9 @@ async function run() {
     assertPseudo('ScriptEditor "N selected" copy', await scriptToolbar.locator('span').last().textContent());
 
     // --- VerbsEditor — via "player" (only "object" elements get a Verbs tab;
-    // rooms don't) — static labels only, no Combobox interaction. ---
+    // rooms don't) — static labels only, no Combobox interaction. "player"
+    // lives under the "room" branch, which now starts expanded all the way
+    // down to the player (#827), so it's already visible. ---
     await page.click('span:text-is("player")');
     await page.click('button:has-text("Verbs")');
     await page.waitForSelector('table', { timeout: 10000 });
@@ -410,6 +422,14 @@ async function run() {
     // (TreePanel's view-options menu — the same one checked earlier). ---
     await page.locator('button[aria-label]').first().click();
     await page.click('.absolute button');
+    // With libraries shown, the Verbs header has children (drink & co.); it
+    // starts collapsed like everything else (#827), so expand it before the
+    // click below. (A fresh game's empty Verbs header renders as a leaf item,
+    // which is why this can't happen earlier.)
+    const verbsRow = page.locator('[data-part="branch-control"]:has-text("[Vérbs]")');
+    if (await verbsRow.count()) {
+        await verbsRow.locator('button').first().click();
+    }
     await page.click('text="drink"');
     await page.waitForSelector('.bg-warning-100-900', { timeout: 10000 });
     assertPseudo('LibraryElementBanner message', await page.textContent('.bg-warning-100-900 span'));

--- a/tests/e2e/verify-appshell-mobile-master-detail.mjs
+++ b/tests/e2e/verify-appshell-mobile-master-detail.mjs
@@ -52,8 +52,18 @@ try {
     console.log('PASS: tapping a tree node pushes the properties pane with a back header showing its name');
     await mobilePage.screenshot({ path: '/tmp/mobile-props-pane.png' });
 
-    // Back button returns to tree, with expansion state intact (game/room still expanded).
+    // Back button returns to tree. The "room" branch now starts expanded all
+    // the way down to the player (#827), so it should already be open; make
+    // sure of that (in case state left it collapsed), then verify the
+    // expansion survives the pane switch (the original intent of this check).
     await mobilePage.click('button:has-text("room")');
+    await mobilePage.waitForSelector('text=GAME OBJECTS', { timeout: 5000 });
+    const roomCaret = mobilePage.locator('[data-part="branch-control"]:has-text("room") >> button[aria-label="Expand"]');
+    if (await roomCaret.count()) { await roomCaret.first().click(); }
+    await mobilePage.waitForSelector('text=player', { timeout: 5000 });
+    await mobilePage.click('text=player');
+    await mobilePage.waitForSelector('button:has-text("player")', { timeout: 5000 });
+    await mobilePage.click('button:has-text("player")'); // back to tree
     await mobilePage.waitForSelector('text=GAME OBJECTS', { timeout: 5000 });
     const playerVisibleAfterBack = await mobilePage.locator('text=player').first().isVisible();
     if (!playerVisibleAfterBack) throw new Error('Tree expansion state should survive switching panes');

--- a/tests/e2e/verify-appshell-tap-same-tree-node.mjs
+++ b/tests/e2e/verify-appshell-tap-same-tree-node.mjs
@@ -43,6 +43,11 @@ try {
     // Same check on a leaf node (no children, different TreeView.Item path).
     await page.click('button:has-text("room")'); // back to tree
     await page.waitForSelector('text=GAME OBJECTS', { timeout: 5000 });
+    // "player" lives inside the "room" branch, which now starts expanded all
+    // the way down to the player (#827) — just make sure it's open (if a prior
+    // state left it collapsed) before the leaf-node checks below.
+    const roomCaret = page.locator('[data-part="branch-control"]:has-text("room") >> button[aria-label="Expand"]');
+    if (await roomCaret.count()) { await roomCaret.first().click(); }
     await page.click('text=player');
     await page.waitForSelector('button:has-text("player")', { timeout: 5000 });
     await page.click('button:has-text("player")'); // back to tree

--- a/tests/e2e/verify-default-tree-state.mjs
+++ b/tests/e2e/verify-default-tree-state.mjs
@@ -1,0 +1,117 @@
+// Manual verification for three TreePanel default-state tweaks:
+//   1. game node starts collapsed
+//   2. starting room is expanded all the way down to the player object
+//   3. Move up/down (swapElements) is undoable/redoable
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5180';
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+const tree = page.locator('div.border-r.border-surface-200-800.bg-surface-50-950').first();
+const branch = (name) => tree.locator('[data-part="branch-control"]', { hasText: name });
+
+async function addViaToolbar(menuLabel, name) {
+    await page.click('button[title="Add element"]');
+    await page.locator('button', { hasText: menuLabel }).click();
+    await page.fill('#element-name', name);
+    await page.keyboard.press('Enter');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+async function rowOrder() {
+    const texts = await tree.evaluateAll(
+        els => els.map(e => e.textContent.replace('⋯', '').trim()),
+        '[data-part="branch-control"], [data-part="item"]'
+    );
+    return texts;
+}
+
+async function openNodeMenu(name) {
+    const row = tree.locator('[data-part="branch-control"], [data-part="item"]', { hasText: name }).last();
+    await row.hover();
+    const opts = row.locator('button[title="Options"]');
+    await opts.waitFor({ state: 'visible', timeout: 5000 });
+    await opts.click();
+    await page.waitForSelector('.tree-dropdown', { timeout: 5000 });
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Default Tree State ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Manage assets"]', { timeout: 30000 });
+    await page.waitForTimeout(600);
+    console.log('PASS: local draft created and opened in the editor');
+
+    // 1. game node collapsed by default → Verbs/Commands hidden
+    const gameRow = branch('game');
+    await gameRow.waitFor({ timeout: 10000 });
+    await gameRow.locator('button[aria-label="Expand"]').waitFor({ timeout: 5000 });
+    const treeText = await tree.innerText();
+    if (treeText.includes('Verbs') || treeText.includes('Commands')) {
+        throw new Error('Expected "Verbs"/"Commands" (under game) to be hidden when game starts collapsed');
+    }
+    console.log('PASS: game node starts collapsed (Verbs/Commands hidden)');
+
+    // 2. starting room expanded all the way down to player
+    const roomRow = branch('room');
+    await roomRow.waitFor({ timeout: 10000 });
+    await roomRow.locator('button[aria-label="Collapse"]').waitFor({ timeout: 5000 });
+    const playerRow = tree.locator('[data-part="item"]', { hasText: 'player' });
+    await playerRow.waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: starting room is expanded down to the player object');
+
+    // 3. Move down is undoable
+    await addViaToolbar('Add Room', 'Kitchen');
+    await addViaToolbar('Add Room', 'Garden');
+    let order = await rowOrder();
+    const kIdx = order.findIndex(t => t.includes('Kitchen'));
+    const gIdx = order.findIndex(t => t.includes('Garden'));
+    if (kIdx < 0 || gIdx < 0 || kIdx > gIdx) throw new Error('Expected Kitchen before Garden before the move');
+
+    await openNodeMenu('Kitchen');
+    await page.locator('.tree-dropdown button', { hasText: 'Move down' }).click();
+    await page.waitForTimeout(400);
+    order = await rowOrder();
+    if (order.findIndex(t => t.includes('Kitchen')) < order.findIndex(t => t.includes('Garden'))) {
+        throw new Error('Expected Kitchen to have moved after Garden');
+    }
+    console.log('PASS: Move down reordered Kitchen after Garden');
+
+    const undoBtn = page.locator('button[title="Undo"]');
+    await undoBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await undoBtn.click();
+    await page.waitForTimeout(400);
+    order = await rowOrder();
+    if (order.findIndex(t => t.includes('Kitchen')) > order.findIndex(t => t.includes('Garden'))) {
+        throw new Error('Expected undo to restore Kitchen before Garden');
+    }
+    console.log('PASS: Undo restored the original order');
+
+    const redoBtn = page.locator('button[title="Redo"]');
+    await redoBtn.click();
+    await page.waitForTimeout(400);
+    order = await rowOrder();
+    if (order.findIndex(t => t.includes('Kitchen')) < order.findIndex(t => t.includes('Garden'))) {
+        throw new Error('Expected redo to re-apply the move (Kitchen after Garden)');
+    }
+    console.log('PASS: Redo re-applied the move');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-default-tree-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary

Closes the tree-clutter half of #827. The editor's element tree used to start fully expanded on every game load; it now starts collapsed, with the author's expansion state remembered per game.

## Changes

- **Collapsed-by-default tree**: only the top-level header (`_objects`/`_pages`) and the branch containing the player's starting room (expanded all the way down to the player object) open on load. The `game` node, rooms, `_advanced` and everything under it start collapsed.
- **Per-game persistence**: expanded ids are keyed by the game's `<gameid>` — localStorage in the browser, an Electron `uiState` IPC channel backed by a userData JSON file in the desktop app. Legacy games without a `gameid` keep the default on every load.
- **Context-menu additions** (`TreePanel.svelte`):
  - `Expand all below` / `Collapse all below` on any branch.
  - `Move up` / `Move down` to reorder same-parent siblings (mirrors ElementsList's up/down buttons).
- **Undoable moves**: `EditorController.SwapElements` now wraps its SortIndex swap in an undo transaction, so Move up/down can be undone/redone (previously the meta-field change was silently dropped from the undo log).
- **Regression fix**: included-library file rows (English.aslx/Core.aslx) no longer get spurious Move up/down entries — they're meant to have no context menu at all.

## Tests

- New `tests/e2e/verify-default-tree-state.mjs` covering the default state (game collapsed, starting room expanded to player) and the Move down → Undo → Redo round-trip.
- Updated existing e2e tests for the new defaults (pseudoloc expands `game`/Verbs before interacting with Commands and library verbs; room-expand steps in tap-same-tree-node, mobile-master-detail, attributes-stack-scroll are now conditional).
- Full verification: all e2e tests, svelte-check 0 errors/warnings, eslint clean, AppShell build, ElectronApp `build:ts`, `dotnet build` 0 warnings, full .NET test suite passes.