### PR TITLE
fix(AppShell): render Command Pattern and Use/Give per-object controls

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, setSelectedFilter, addDictItem, removeDictItem, updateDictItem, getObjectNames, getExitNames, getPageNames, selectNode, createPageSilent, openAddModal, openAddLibraryModal, openAddJavascriptModal, getAssetText, putAssetText, putLibraryAssetText, isBuiltInLibrary, getLibraryXml } from "$lib/editor-store";
+    import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, setSelectedFilter, addDictItem, removeDictItem, updateDictItem, getObjectNames, getExitNames, getPageNames, selectNode, createPageSilent, openAddModal, openAddLibraryModal, openAddJavascriptModal, getAssetText, putAssetText, putLibraryAssetText, isBuiltInLibrary, getLibraryXml, setPatternAttribute } from "$lib/editor-store";
     import { showToast } from "$lib/toast";
     import { t } from "$lib/i18n";
     import type { ControlInfo, ControlOption, TextProcessorCommand } from "$lib/types";
@@ -139,6 +139,18 @@
 
     function onTextChange(attribute: string, controlType: string, value: string) {
         if ($selectedKey) recordResult(attribute, setAttribute($selectedKey, attribute, controlType, value));
+    }
+
+    // Routed through setPatternAttribute (not the generic setAttribute/textbox path) so an
+    // in-place edit updates the existing IEditableCommandPattern's text rather than replacing
+    // it with a raw string - overwriting it would silently reclassify the attribute as the
+    // "string" (regex) mode on next render, breaking "#text#"-style simple-pattern placeholders.
+    function onPatternTextChange(attribute: string, value: string) {
+        if ($selectedKey) recordResult(attribute, setPatternAttribute($selectedKey, attribute, value));
+    }
+
+    function onMultiTypeChange(subAttribute: string, newType: string) {
+        if ($selectedKey) recordResult(subAttribute, setMultiType($selectedKey, subAttribute, newType));
     }
 
     function onCheckboxChange(attribute: string, checked: boolean) {
@@ -742,7 +754,7 @@
             <select
                 class="select text-xs py-0.5 px-1.5 w-auto self-start"
                 value={selectedType}
-                onchange={(e) => $selectedKey && setMultiType($selectedKey, ctrl.subAttribute!, (e.target as HTMLSelectElement).value)}
+                onchange={(e) => onMultiTypeChange(ctrl.subAttribute!, (e.target as HTMLSelectElement).value)}
             >
                 {#each ctrl.options as opt (opt.value)}
                     <option value={opt.value}>{opt.label}</option>
@@ -768,13 +780,25 @@
                         onchange={(e) => onTextChange(ctrl.subAttribute!, "richtext", (e.target as HTMLTextAreaElement).value)}
                     ></textarea>
                 {/if}
-            {:else if subEditorType === "textbox" && ctrl.subAttribute !== null}
+            {:else if (subEditorType === "textbox" || subEditorType === "string") && ctrl.subAttribute !== null}
+                <!-- "string" (with no <editors> override) falls through to a plain textbox by
+                     default - e.g. Command's "Regular expression" pattern mode and Use/Give's
+                     "Print a message" mode. A control that wants richtext instead (e.g. object
+                     descriptions) opts in via <editors>string=richtext</editors>. -->
                 <input
                     type="text"
                     autocapitalize="off"
                     class="input text-xs py-0.5 px-1.5 w-full"
                     value={attrValue(ctrl.subAttribute) ?? ""}
                     onchange={(e) => onTextChange(ctrl.subAttribute!, "textbox", (e.target as HTMLInputElement).value)}
+                />
+            {:else if subEditorType === "simplepattern" && ctrl.subAttribute !== null}
+                <input
+                    type="text"
+                    autocapitalize="off"
+                    class="input text-xs py-0.5 px-1.5 w-full"
+                    value={attrValue(ctrl.subAttribute) ?? ""}
+                    onchange={(e) => onPatternTextChange(ctrl.subAttribute!, (e.target as HTMLInputElement).value)}
                 />
             {:else if subEditorType === "script" && ctrl.subAttribute !== null && $selectedKey !== null}
                 <ScriptEditor elementKey={$selectedKey} attribute={ctrl.subAttribute} />
@@ -788,6 +812,13 @@
                     />
                     <span class="text-xs text-surface-600-400">{ctrl.checkboxCaption ?? ctrl.subAttribute}</span>
                 </label>
+            {:else if subEditorType === "scriptdictionary" && ctrl.subAttribute !== null && $selectedKey !== null}
+                <ScriptDictionaryEditor
+                    elementKey={$selectedKey}
+                    attribute={ctrl.subAttribute}
+                    value={attrValue(ctrl.subAttribute)}
+                    keySource={ctrl.source === "object" ? "object" : "text"}
+                />
             {/if}
         </div>
     {:else if ctrl.controlType === "script" && ctrl.attribute !== null && $selectedKey !== null}
@@ -928,7 +959,7 @@
                     <select
                         class="select text-xs py-0.5 px-1.5 w-auto"
                         value={selectedType}
-                        onchange={(e) => $selectedKey && setMultiType($selectedKey, ctrl.subAttribute!, (e.target as HTMLSelectElement).value)}
+                        onchange={(e) => onMultiTypeChange(ctrl.subAttribute!, (e.target as HTMLSelectElement).value)}
                     >
                         {#each ctrl.options as opt (opt.value)}
                             <option value={opt.value}>{opt.label}</option>
@@ -955,13 +986,21 @@
                             onchange={(e) => onTextChange(ctrl.subAttribute!, "richtext", (e.target as HTMLTextAreaElement).value)}
                         ></textarea>
                     {/if}
-                {:else if subEditorType === "textbox" && ctrl.subAttribute !== null}
+                {:else if (subEditorType === "textbox" || subEditorType === "string") && ctrl.subAttribute !== null}
                     <input
                         type="text"
                         autocapitalize="off"
                         class="input text-xs py-0.5 px-1.5 w-full"
                         value={attrValue(ctrl.subAttribute) ?? ""}
                         onchange={(e) => onTextChange(ctrl.subAttribute!, "textbox", (e.target as HTMLInputElement).value)}
+                    />
+                {:else if subEditorType === "simplepattern" && ctrl.subAttribute !== null}
+                    <input
+                        type="text"
+                        autocapitalize="off"
+                        class="input text-xs py-0.5 px-1.5 w-full"
+                        value={attrValue(ctrl.subAttribute) ?? ""}
+                        onchange={(e) => onPatternTextChange(ctrl.subAttribute!, (e.target as HTMLInputElement).value)}
                     />
                 {:else if subEditorType === "script" && ctrl.subAttribute !== null && $selectedKey !== null}
                     <ScriptEditor elementKey={$selectedKey} attribute={ctrl.subAttribute} />
@@ -975,6 +1014,13 @@
                         />
                         <span class="text-xs text-surface-600-400">{ctrl.checkboxCaption ?? ctrl.subAttribute}</span>
                     </label>
+                {:else if subEditorType === "scriptdictionary" && ctrl.subAttribute !== null && $selectedKey !== null}
+                    <ScriptDictionaryEditor
+                        elementKey={$selectedKey}
+                        attribute={ctrl.subAttribute}
+                        value={attrValue(ctrl.subAttribute)}
+                        keySource={ctrl.source === "object" ? "object" : "text"}
+                    />
                 {/if}
             </div>
         {:else}

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -648,6 +648,12 @@ public partial class WasmEditorBridge
                 case "script":
                     _controller.CreateNewEditableScripts(elementKey, attribute, null!, false);
                     break;
+                case "scriptdictionary":
+                    _controller.CreateNewEditableScriptDictionary(elementKey, attribute, null!, null!, false);
+                    break;
+                case "simplepattern":
+                    data.SetAttribute(attribute, new EditorCommandPattern(""));
+                    break;
                 default:
                     return $"Unknown type: {newType}";
             }
@@ -1299,6 +1305,7 @@ public partial class WasmEditorBridge
                 IEditableScripts => "script",
                 IEditableObjectReference => "object",
                 IEditableCommandPattern => "simplepattern",
+                IEditableDictionary<IEditableScripts> => "scriptdictionary",
                 _ => "null"
             };
         }
@@ -3880,7 +3887,7 @@ public partial class WasmEditorBridge
 
             var caption = ctrl.Caption ?? ctrl.GetString("selfcaption");
             return new ControlInfo(ctrl.Id, ctrl.ControlType, caption, options, subEditors, ctrl.Attribute,
-                multiTpCommands, Advanced: !ctrl.IsControlVisibleInSimpleMode, CheckboxCaption: ctrl.GetString("checkbox"));
+                multiTpCommands, Source: ctrl.GetString("source"), Advanced: !ctrl.IsControlVisibleInSimpleMode, CheckboxCaption: ctrl.GetString("checkbox"));
         }
         else if (ctrl.ControlType == "elementslist")
         {

--- a/tests/e2e/verify-appshell-multi-control-editors.mjs
+++ b/tests/e2e/verify-appshell-multi-control-editors.mjs
@@ -1,0 +1,174 @@
+// Verifies two "multi" attribute-editor controls in PropertyEditor.svelte that used to
+// render nothing at all because their subEditorType had no matching branch in the
+// controlRow/controlOnly if/else chains - see CoreEditorCommand.aslx's Command "Pattern"
+// control (subEditorType "simplepattern") and CoreEditorObjectUseGive.aslx's "Handle objects
+// individually" controls (subEditorType "scriptdictionary"). Both are handled by matching the
+// raw type-key directly (no aslx <editors> override needed) - the old WPF/ASP.NET editors had
+// a hardcoded default type->widget map covering these standard types (see
+// EditorControls/MultiControl.xaml.cs / WebEditor's ControlHelpers.cs on the v5 tags) that
+// PropertyEditor.svelte has no equivalent of; it only recognises a fixed set of literal
+// subEditorType strings. Fixing the missing render branches alone wasn't enough: the actual
+// mode-switch handler, WasmEditorBridge.SetMultiType, also had no case for either
+// "scriptdictionary" or "simplepattern" (silently no-opped via its `default` branch), and
+// AddDropdownTypeValues' typeof-resolution switch had no case mapping
+// IEditableDictionary<IEditableScripts> back to the "scriptdictionary" label - so even
+// after SetMultiType created the underlying value, the mode dropdown kept reporting "None"
+// and the newly-rendered branch never engaged. This script exercises the full round trip
+// for both controls so a regression in any one of those three layers fails here.
+//
+// Requires the AppShell dev server running locally (WasmEditor Debug build first):
+//   cd src/AppShell && npm run dev
+// Run: node tests/e2e/verify-appshell-multi-control-editors.mjs [baseUrl]
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+// A leaf's row is [data-part="item"], a branch's own row is [data-part="branch-control"]
+// (same disambiguation as verify-appshell-exits-editor.mjs's selectTreeNode).
+async function selectTreeNode(page, name) {
+    await page.locator(`[data-value="${name}"][data-part="item"], [data-value="${name}"][data-part="branch-control"]`).first().click();
+}
+
+async function addViaMenu(page, buttonText, name) {
+    await page.click('button[title="Add element"]');
+    await page.click(`button:has-text("${buttonText}")`, { timeout: 5000 });
+    await page.waitForSelector('#element-name');
+    await page.fill('#element-name', name);
+    await page.click('[role="dialog"] button:has-text("Add")');
+    await page.waitForSelector(`text=${name}`, { timeout: 10000 });
+}
+
+async function readRawXml(page) {
+    await page.click('button[title="Raw XML code view"]');
+    const text = await page.locator('.cm-content').first().innerText();
+    await page.click('button:has-text("Cancel")');
+    await page.waitForSelector('button[title="Raw XML code view"]', { timeout: 5000 });
+    return text;
+}
+
+try {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Multi Control Editors Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Add element"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    // ── Command "Pattern" control (simplepattern / string) ──────────────────────────
+    // Unlike "Add Object", "Add Command" creates the element immediately with no name modal.
+    await selectTreeNode(page, 'room');
+    await page.click('button[title="Add element"]');
+    await page.click('button:has-text("Add Command to")', { timeout: 5000 });
+    await page.waitForSelector('text=Command:', { timeout: 10000 });
+
+    // Scoped tightly to the Pattern row's own wrapper (two levels up from the "Pattern:" label:
+    // span -> label/select row -> flex-col wrapper) and to its *direct* children only - a plain
+    // input[type=text].first() would instead match the sidebar's "Filter game objects" textbox,
+    // and an unscoped descendant search would also catch the "Unresolved object text" control
+    // that shares the same outer flex-col ancestor.
+    const patternRow = page.getByText('Pattern:', { exact: true }).locator('xpath=../..');
+    const patternModeSelect = patternRow.locator(':scope > select, :scope > div > select').first();
+    await patternModeSelect.waitFor({ state: 'visible', timeout: 5000 });
+    const patternInput = patternRow.locator(':scope > input[type=text]');
+    await patternInput.waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: Pattern textbox renders in "Command pattern" (simplepattern) mode');
+
+    await patternInput.fill('say #text#');
+    await patternInput.blur();
+    await page.waitForTimeout(300);
+
+    const modeAfterTyping = await patternModeSelect.inputValue();
+    if (modeAfterTyping !== 'simplepattern') {
+        throw new Error(`Typing into the Pattern field must not change its mode - got "${modeAfterTyping}", expected "simplepattern"`);
+    }
+    console.log('PASS: typing a simple pattern does not reclassify it as a regex');
+
+    let xml = await readRawXml(page);
+    if (!xml.includes('<pattern>say #text#</pattern>')) {
+        throw new Error(`Expected a plain <pattern>say #text#</pattern> element in saved XML, got: ${xml.slice(0, 800)}`);
+    }
+    console.log('PASS: simple pattern round-trips as a plain <pattern> element (not type="string")');
+
+    // Switch to "Regular expression" mode and back, exercising SetMultiType's
+    // "string" and "simplepattern" cases both ways.
+    await patternModeSelect.selectOption('string');
+    await page.waitForTimeout(200);
+    await patternInput.fill('^say (.*)$');
+    await patternInput.blur();
+    await page.waitForTimeout(300);
+    const modeAfterRegex = await patternModeSelect.inputValue();
+    if (modeAfterRegex !== 'string') throw new Error('Switching to "Regular expression" did not stick');
+    console.log('PASS: "Regular expression" mode works and persists');
+
+    await patternModeSelect.selectOption('simplepattern');
+    await page.waitForTimeout(200);
+    const modeAfterSwitchBack = await patternModeSelect.inputValue();
+    if (modeAfterSwitchBack !== 'simplepattern') {
+        throw new Error('Switching back to "Command pattern" from "Regular expression" did not stick (SetMultiType missing "simplepattern" case)');
+    }
+    console.log('PASS: switching back to "Command pattern" mode works');
+
+    // ── Use/Give "Handle objects individually" control (scriptdictionary) ───────────
+    await selectTreeNode(page, 'room');
+    await addViaMenu(page, 'Add Object in', 'defibrillator');
+    await selectTreeNode(page, 'room');
+    await addViaMenu(page, 'Add Object in', 'patient');
+
+    await selectTreeNode(page, 'patient');
+    await page.getByRole('button', { name: 'Features', exact: true }).click();
+    await page.getByText(/Use\/Give:/).click();
+    await page.getByRole('button', { name: 'Use/Give', exact: true }).click();
+
+    const useonSelect = page.locator('select').filter({ hasText: 'None' }).first();
+    await useonSelect.waitFor({ state: 'visible', timeout: 5000 });
+    await useonSelect.selectOption('scriptdictionary');
+    await page.waitForTimeout(300);
+
+    const modeAfterScriptDict = await useonSelect.inputValue();
+    if (modeAfterScriptDict !== 'scriptdictionary') {
+        throw new Error('Selecting "Handle objects individually" did not stick (SetMultiType missing "scriptdictionary" case, or AddDropdownTypeValues missing its typeof mapping)');
+    }
+    console.log('PASS: "Handle objects individually" mode is selected and persists');
+
+    // Scoped to the useon control's own wrapper - an unscoped 'button:has-text("Add")' would
+    // instead hit the toolbar's "+ Add" (element) button, which precedes this in the DOM, and an
+    // unscoped 'defibrillator' text match would hit the tree sidebar's own "defibrillator" node.
+    const useonSection = useonSelect.locator('xpath=../..');
+    const objectPicker = useonSection.locator('select').filter({ hasText: /Select object/ }).first();
+    await objectPicker.waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: the per-object list (ScriptDictionaryEditor) renders once scriptdictionary mode is active');
+
+    await objectPicker.selectOption({ label: 'defibrillator' });
+    await useonSection.locator('button:has-text("Add")').click();
+    await page.waitForTimeout(300);
+
+    // The key renders as a plain text node inside the expand/collapse <button>, not its own span.
+    const entry = useonSection.locator('button', { hasText: 'defibrillator' });
+    await entry.waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: "defibrillator" entry added to the per-object list');
+
+    xml = await readRawXml(page);
+    if (!xml.includes('<useon type="scriptdictionary">') || !xml.includes('key="defibrillator"')) {
+        throw new Error(`Expected <useon type="scriptdictionary"> with a defibrillator item in saved XML, got: ${xml.slice(0, 1000)}`);
+    }
+    console.log('PASS: scriptdictionary entry round-trips into saved XML');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+    try {
+        const pages = browser.contexts().flatMap(c => c.pages());
+        if (pages[0]) await pages[0].screenshot({ path: '/tmp/multi-control-editors-failure.png' });
+    } catch { /* best-effort */ }
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary

Two "multi" attribute-editor controls in the AppShell editor rendered nothing at all:

- **Command's Pattern field** ("Command pattern" mode) — no text input appeared, so a Command's pattern (e.g. `say #text#`) couldn't be typed through the UI.
- **Use/Give's per-object list** ("Handle objects individually" mode, and the related "Print a message" mode found while investigating) — selecting the mode showed no follow-up UI at all.

Root cause was three separate gaps stacked on top of each other:

1. `PropertyEditor.svelte`'s `multi`-control render chain had no branch for `subEditorType` `"simplepattern"` or `"scriptdictionary"` (and `"string"` only matched an explicit `<editors>` override, not the raw type-key), so it silently rendered nothing.
2. `WasmEditorBridge.SetMultiType` — the function that runs when the mode dropdown actually changes — had no `case` for `"scriptdictionary"` or `"simplepattern"`, falling into its `default: return "Unknown type"`. That error was never surfaced to the UI (the mode `<select>`'s `onchange` didn't route through `recordResult`), so the mode silently failed to switch at all, independent of (1).
3. `AddDropdownTypeValues`' typeof-resolution switch had no case mapping `IEditableDictionary<IEditableScripts>` back to `"scriptdictionary"`, so even after (2) is fixed the mode dropdown kept reporting "None".

I initially also added an `<editors>` mapping to `CoreEditorCommand.aslx` to route `"simplepattern"` to a widget name, but that wasn't necessary — checked against the v5 tags and confirmed the old WPF/ASP.NET editors had a hardcoded default type→widget map covering these standard types (`EditorControls/MultiControl.xaml.cs`, `WebEditor/WebEditor/Views/Edit/ControlHelpers.cs`) that never needed an aslx-level override for `simplepattern`/`scriptdictionary`/`string`. `PropertyEditor.svelte` has no equivalent default, so the fix is to match the raw type-key directly in Svelte instead — no aslx change needed, and `CoreEditorCommand.aslx` is untouched.

Also fixed a related correctness bug found while wiring up the Pattern control: editing simplepattern text through the generic textbox path would have replaced the attribute with a raw string, silently reclassifying it as regex mode on the next render and breaking `#text#`-style placeholders. Routed through the existing (previously unused by the UI) `setPatternAttribute` bridge call instead, which edits the wrapped `IEditableCommandPattern` in place.

## What a reviewer should know

- `Source` is now propagated for `multi` controls in `WasmEditorBridge.cs` (was previously always `null`) — needed so Use/Give's per-object list renders an object-name dropdown (`<source>object</source>` in the aslx) instead of a free-text key field.
- The mode `<select>`'s `onchange` now routes through `recordResult`, so a future `SetMultiType` "Unknown type" error would show as a toast instead of silently no-opping.
- Widening the `"string"` fallback to a plain textbox also fixed Use/Give's "Print a message" mode (`useon`/`selfuseon`/`give`/`giveto`), which had the identical bug but wasn't in the original report.

## Test plan

- [x] `dotnet build --configuration Release` — full solution builds clean
- [x] `dotnet test --configuration Release` — 355 tests pass
- [x] `npm run lint` / `npm run check` in `src/AppShell` — clean
- [x] New `tests/e2e/verify-appshell-multi-control-editors.mjs` Playwright script — covers both controls end-to-end (mode switching both ways, XML round-trip) — passes
- [x] Manually verified in the running AppShell dev server: Command pattern typing/mode-switching, Use/Give "Handle objects individually" + per-object script, and Use/Give "Print a message" mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)