### PR TITLE
fix: expand collapsed game tree nodes in e2e verbs-editor test

### DIFF
--- a/tests/e2e/verify-appshell-verbs-editor.mjs
+++ b/tests/e2e/verify-appshell-verbs-editor.mjs
@@ -157,7 +157,15 @@ async function run() {
 
     // The new verb command element lands under the game's synthetic "Verbs" tree node (key
     // "_gameVerbs" — see EditorController's k_verbs), alongside any library-defined verbs.
+    // The game node starts collapsed by default (#827), so expand it first to make its
+    // Verbs/Commands/Advanced headers visible.
+    await page.locator('[data-scope="tree-view"][data-value="game"][data-part="branch-control"] button[aria-label="Expand"]').click();
     await selectTreeNode('_gameVerbs');
+    // "_gameVerbs" itself starts collapsed too, so expand it to make its new
+    // "Verb: juggle" command child visible in the tree (the bare "juggle" text
+    // also matches the Verbs editor table cell, but the tree node is first in
+    // the DOM and hidden, so Playwright would otherwise wait on it forever).
+    await page.locator('[data-scope="tree-view"][data-value="_gameVerbs"][data-part="branch-control"] button[aria-label="Expand"]').click();
     await page.waitForSelector('text=juggle', { timeout: 10000 });
     console.log('PASS: the novel verb also created a new command element under the Verbs tree node');
 


### PR DESCRIPTION
## What

The nightly e2e run failed in `appshell_chromium` on `verify-appshell-verbs-editor.mjs`.

## Why

PR #2085 made the game tree collapsed-by-default (`#827`), so every branch except `_objects`/starting-room starts closed. This test wasn't updated like the others: its final step clicked the `_gameVerbs` header, which sits under the now-collapsed `game` node — Playwright timed out waiting for it to become visible. A second latent failure followed: `text=juggle` matched the hidden `Verb: juggle` tree node (first in DOM) instead of the visible table cell.

## Fix

Expand the `game` node before selecting `_gameVerbs`, and expand `_gameVerbs` before the `juggle` visibility check — same pattern PR #2085 already established in `verify-appshell-i18n-pseudoloc.mjs`.

## Verification

Built WasmEditor/WasmPlayer (Debug), ran AppShell + WasmPlayer dev servers, and ran the script twice — all 18 checks pass both times.