### PR TITLE
test: expect three Gamebook template options in language-picker test

### DIFF
--- a/tests/e2e/verify-appshell-gamebook-language-picker.mjs
+++ b/tests/e2e/verify-appshell-gamebook-language-picker.mjs
@@ -63,8 +63,8 @@ async function run() {
     await page.click('input[name="gametype"] >> nth=1');
     await page.waitForSelector('select', { timeout: 10000 });
     const options = await page.$$eval('select option', els => els.map(el => el.textContent ?? ''));
-    assertEqual('Gamebook template option count', options.length, 2);
-    if (!options.includes('English') || !options.includes('Deutsch')) {
+    assertEqual('Gamebook template option count', options.length, 3);
+    if (!options.includes('English') || !options.includes('Deutsch') || !options.includes('Español')) {
         throw new Error(`Gamebook template options missing expected labels: ${JSON.stringify(options)}`);
     }
     console.log(`PASS: [Gamebook template options] ${JSON.stringify(options)}`);


### PR DESCRIPTION
The nightly e2e run (first run since #2088 wired all scripts into CI) failed on `verify-appshell-gamebook-language-picker.mjs`: it expected exactly 2 Gamebook template options but #2035 added `Gamebook-Espanol.template`, so the picker now offers English/Deutsch/Español.

Verified locally against the AppShell dev server — the test passes end to end.