### PR TITLE
fix(AppShell): add rename support to ScriptDictionaryEditor

### DIFF
--- a/src/AppShell/src/components/ScriptDictionaryEditor.svelte
+++ b/src/AppShell/src/components/ScriptDictionaryEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { SvelteSet } from "svelte/reactivity";
-    import { addScriptDictItem, removeScriptDictItem, makeScriptDictEditable, getObjectNames } from "$lib/editor-store";
+    import { addScriptDictItem, removeScriptDictItem, renameScriptDictItem, makeScriptDictEditable, getObjectNames } from "$lib/editor-store";
     import ScriptEditor from "./ScriptEditor.svelte";
     import { t } from "$lib/i18n";
 
@@ -30,6 +30,11 @@
     const expandedKeys = new SvelteSet<string>();
     let newKey = $state("");
 
+    let editingKey = $state<string | null>(null);
+    let editingKeyValue = $state("");
+    let editingKeyInputEl = $state<HTMLInputElement>();
+    $effect(() => { if (editingKey !== null) editingKeyInputEl?.focus(); });
+
     let allObjectNames = $state<string[]>([]);
     $effect(() => {
         if (keySource === "object") allObjectNames = getObjectNames() ?? [];
@@ -52,6 +57,32 @@
     function toggleExpanded(key: string) {
         if (expandedKeys.has(key)) expandedKeys.delete(key); else expandedKeys.add(key);
     }
+
+    function startRename(key: string) {
+        editingKey = key;
+        editingKeyValue = key;
+    }
+
+    function cancelRename() {
+        editingKey = null;
+        editingKeyValue = "";
+    }
+
+    function commitRename() {
+        if (!editingKey) return;
+        const oldKey = editingKey;
+        const newKeyValue = editingKeyValue.trim();
+        if (!newKeyValue || newKeyValue === oldKey) {
+            cancelRename();
+            return;
+        }
+        const result = renameScriptDictItem(elementKey, attribute, oldKey, newKeyValue);
+        if (result === "ok" && expandedKeys.has(oldKey)) {
+            expandedKeys.delete(oldKey);
+            expandedKeys.add(newKeyValue);
+        }
+        cancelRename();
+    }
 </script>
 
 <div class="flex flex-col gap-1 w-full">
@@ -73,18 +104,39 @@
         {#each keys as key (key)}
             <div class="border border-surface-200-800 rounded">
                 <div class="flex items-center gap-1 px-2 py-1">
-                    <button
-                        type="button"
-                        class="flex-1 text-left text-xs font-medium hover:text-primary-600-400"
-                        onclick={() => toggleExpanded(key)}
-                    >
-                        <span class="mr-1 text-surface-600-400">{expandedKeys.has(key) ? "▼" : "▶"}</span>{key}
-                    </button>
-                    <button
-                        type="button"
-                        class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5 flex-shrink-0"
-                        onclick={() => removeScriptDictItem(elementKey, attribute, key)}
-                    >✕</button>
+                    {#if editingKey === key}
+                        <input
+                            type="text"
+                            autocapitalize="off"
+                            class="input text-xs py-0.5 px-1.5 flex-1"
+                            aria-label={t("scriptDictionaryEditor.editKeyInputAriaLabel")}
+                            bind:this={editingKeyInputEl}
+                            bind:value={editingKeyValue}
+                            onkeydown={(e) => {
+                                if (e.key === "Enter") commitRename();
+                                else if (e.key === "Escape") cancelRename();
+                            }}
+                            onblur={commitRename}
+                        />
+                    {:else}
+                        <button
+                            type="button"
+                            class="flex-1 text-left text-xs font-medium hover:text-primary-600-400"
+                            onclick={() => toggleExpanded(key)}
+                        >
+                            <span class="mr-1 text-surface-600-400">{expandedKeys.has(key) ? "▼" : "▶"}</span>{key}
+                        </button>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined-primary-500 text-xs px-1.5 py-0.5 flex-shrink-0"
+                            onclick={() => startRename(key)}
+                        >{t("scriptDictionaryEditor.editKey")}</button>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5 flex-shrink-0"
+                            onclick={() => removeScriptDictItem(elementKey, attribute, key)}
+                        >✕</button>
+                    {/if}
                 </div>
                 {#if expandedKeys.has(key)}
                     <div class="px-2 pb-2 border-t border-surface-100-900">

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -1173,6 +1173,14 @@ export function removeScriptDictItem(elementKey: string, attribute: string, key:
     return result;
 }
 
+export function renameScriptDictItem(elementKey: string, attribute: string, oldKey: string, newKey: string): string {
+    if (!_bridge) return "error";
+    const result = _bridge.RenameScriptDictionaryItem(elementKey, attribute, oldKey, newKey);
+    if (result === "ok") { refreshSelectedData(); bumpScriptVersion(); }
+    refreshUndoRedo();
+    return result;
+}
+
 export function changeAttributeType(elementKey: string, attribute: string, newType: string): string {
     if (!_bridge) return "error";
     const result = _bridge.ChangeAttributeType(elementKey, attribute, newType);

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -71,6 +71,7 @@ export interface WasmBridge {
   MakeScriptDictEditable(elementKey: string, attribute: string): string
   AddScriptDictionaryItem(elementKey: string, attribute: string, key: string): string
   RemoveScriptDictionaryItem(elementKey: string, attribute: string, key: string): string
+  RenameScriptDictionaryItem(elementKey: string, attribute: string, oldKey: string, newKey: string): string
   ChangeAttributeType(elementKey: string, attribute: string, newType: string): string
   SetPatternAttribute(elementKey: string, attribute: string, pattern: string): string
   // Element creation / deletion

--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -262,6 +262,8 @@
     "scriptDictionaryEditor.selectObjectOption": "Objekt auswählen…",
     "scriptDictionaryEditor.addEntryKeyPlaceholder": "Schlüssel hinzufügen…",
     "scriptDictionaryEditor.addEntryKeyAriaLabel": "Schlüssel hinzufügen",
+    "scriptDictionaryEditor.editKey": "Schlüssel bearbeiten",
+    "scriptDictionaryEditor.editKeyInputAriaLabel": "Schlüssel bearbeiten",
 
     "scriptEditor.inheritedReadOnly": "Dieses Skript ist geerbt — nur lesbar.",
     "scriptEditor.visualView": "Visuelle Ansicht",

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -262,6 +262,8 @@
     "scriptDictionaryEditor.selectObjectOption": "Select object…",
     "scriptDictionaryEditor.addEntryKeyPlaceholder": "Add entry key…",
     "scriptDictionaryEditor.addEntryKeyAriaLabel": "Add entry key",
+    "scriptDictionaryEditor.editKey": "Edit Key",
+    "scriptDictionaryEditor.editKeyInputAriaLabel": "Edit key",
 
     "scriptEditor.inheritedReadOnly": "This script is inherited — read-only.",
     "scriptEditor.visualView": "Visual view",

--- a/src/AppShell/static/locales/es.json
+++ b/src/AppShell/static/locales/es.json
@@ -262,6 +262,8 @@
     "scriptDictionaryEditor.selectObjectOption": "Selecciona objeto…",
     "scriptDictionaryEditor.addEntryKeyPlaceholder": "Añadir clave de entrada…",
     "scriptDictionaryEditor.addEntryKeyAriaLabel": "Añadir clave de entrada",
+    "scriptDictionaryEditor.editKey": "Editar clave",
+    "scriptDictionaryEditor.editKeyInputAriaLabel": "Editar clave",
 
     "scriptEditor.inheritedReadOnly": "Este programa es heredado — solo lectura.",
     "scriptEditor.visualView": "Vista visual",

--- a/src/AppShell/static/locales/xx.json
+++ b/src/AppShell/static/locales/xx.json
@@ -225,6 +225,8 @@
     "scriptDictionaryEditor.selectObjectOption": "[Séléct óbjéct…]",
     "scriptDictionaryEditor.addEntryKeyPlaceholder": "[Ádd éntry kéy…]",
     "scriptDictionaryEditor.addEntryKeyAriaLabel": "[Ádd éntry kéy]",
+    "scriptDictionaryEditor.editKey": "[Édít Kéy]",
+    "scriptDictionaryEditor.editKeyInputAriaLabel": "[Édít kéy]",
     "scriptEditor.inheritedReadOnly": "[Thís scrípt ís ínhérítéd — réád-ónly.]",
     "scriptEditor.visualView": "[Vísúál víéw]",
     "scriptEditor.visualEditor": "[Vísúál édítór]",

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -3401,6 +3401,48 @@ public partial class WasmEditorBridge
         }
     }
 
+    [JSExport]
+    public static string RenameScriptDictionaryItem(string elementKey, string attribute, string oldKey, string newKey)
+    {
+        if (_controller == null)
+        {
+            return "error";
+        }
+
+        var data = _controller.GetEditorData(elementKey);
+        if (data == null)
+        {
+            return "error";
+        }
+
+        var dict = data.GetAttribute(attribute) as IEditableDictionary<IEditableScripts>;
+        if (dict == null)
+        {
+            return "error";
+        }
+
+        if (oldKey == newKey)
+        {
+            return "ok";
+        }
+
+        try
+        {
+            var validation = dict.CanAdd(newKey);
+            if (!validation.Valid)
+            {
+                return validation.Message.ToString();
+            }
+
+            dict.ChangeKey(oldKey, newKey);
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     private static string? SerializeAttributeValue(object? val)

--- a/tests/e2e/verify-appshell-multi-control-editors.mjs
+++ b/tests/e2e/verify-appshell-multi-control-editors.mjs
@@ -16,6 +16,11 @@
 // and the newly-rendered branch never engaged. This script exercises the full round trip
 // for both controls so a regression in any one of those three layers fails here.
 //
+// Also covers ScriptDictionaryEditor's "Edit Key" rename affordance (WasmEditorBridge.
+// RenameScriptDictionaryItem, backed by IEditableDictionary<T>.ChangeKey) - renaming an
+// entry's key must preserve its script content and expanded state, round-trip under the new
+// key in saved XML, and reject a rename that collides with an existing key.
+//
 // Requires the AppShell dev server running locally (WasmEditor Debug build first):
 //   cd src/AppShell && npm run dev
 // Run: node tests/e2e/verify-appshell-multi-control-editors.mjs [baseUrl]
@@ -160,6 +165,89 @@ try {
         throw new Error(`Expected <useon type="scriptdictionary"> with a defibrillator item in saved XML, got: ${xml.slice(0, 1000)}`);
     }
     console.log('PASS: scriptdictionary entry round-trips into saved XML');
+
+    // ── ScriptDictionaryEditor "Edit Key" rename ─────────────────────────────────
+    // readRawXml() switches the properties panel back to its default "Setup" tab on Cancel,
+    // so the Use/Give tab (and useonSection/entry within it) needs re-selecting first - which
+    // remounts ScriptDictionaryEditor, resetting its local expand/collapse state, so the entry
+    // needs re-expanding too before "+ Add script" is present.
+    await page.getByRole('button', { name: 'Use/Give', exact: true }).click();
+    await entry.waitFor({ state: 'visible', timeout: 10000 });
+    if ((await entry.textContent()).startsWith('▶')) await entry.click();
+
+    // Reference the entry's bordered wrapper by position, not by a locator derived from its
+    // key text/button - "Edit Key" replaces that button with an input, which would make any
+    // text- or button-based locator (including one chained from `entry` itself) stop matching
+    // anything the moment editing starts, since Playwright locators re-run their full selector
+    // chain on every action. There's only one entry at this point, hence .nth(0).
+    const defibrillatorEntry = useonSection.locator('div.border.border-surface-200-800.rounded').nth(0);
+    await defibrillatorEntry.locator('button:has-text("+ Add script")').click();
+    const scriptDialog = page.locator('[role="dialog"]').filter({ hasText: 'Add Script Command' });
+    await scriptDialog.waitFor({ timeout: 10000 });
+    await scriptDialog.getByRole('button', { name: 'OK' }).click();
+    await scriptDialog.waitFor({ state: 'hidden', timeout: 5000 });
+    console.log('PASS: added a "Print a message" script to the defibrillator entry');
+
+    const messageInput = defibrillatorEntry.locator('input[type="text"]').last();
+    await messageInput.fill('It beeps helpfully.');
+    await messageInput.blur();
+    await page.waitForTimeout(300);
+    console.log('PASS: filled in the script message');
+
+    await defibrillatorEntry.getByRole('button', { name: 'Edit Key' }).click();
+    const keyInput = defibrillatorEntry.locator('input[type="text"]').first();
+    await keyInput.waitFor({ state: 'visible', timeout: 10000 });
+    await keyInput.fill('medkit');
+    await keyInput.press('Enter');
+    await page.waitForTimeout(300);
+
+    const renamedEntry = useonSection.locator('button', { hasText: 'medkit' });
+    await renamedEntry.waitFor({ state: 'visible', timeout: 10000 });
+    if (await useonSection.locator('button', { hasText: 'defibrillator' }).count() !== 0) {
+        throw new Error('Expected the old key "defibrillator" to be gone after renaming to "medkit"');
+    }
+    console.log('PASS: "Edit Key" renames the entry from "defibrillator" to "medkit"');
+
+    const messageInputAfterRename = defibrillatorEntry.locator('input[type="text"]').last();
+    if (await messageInputAfterRename.inputValue() !== 'It beeps helpfully.') {
+        throw new Error('Expected the script content to be preserved and still visible (entry still expanded) after renaming the key');
+    }
+    console.log('PASS: script content is preserved and the entry stays expanded across the rename');
+
+    xml = await readRawXml(page);
+    if (!xml.includes('key="medkit"') || !xml.includes('It beeps helpfully.')) {
+        throw new Error(`Expected the renamed key "medkit" with its script content in saved XML, got: ${xml.slice(0, 1200)}`);
+    }
+    if (xml.includes('key="defibrillator"')) {
+        throw new Error('Expected the old key "defibrillator" to be gone from saved XML after rename');
+    }
+    console.log('PASS: renamed scriptdictionary entry round-trips into saved XML under the new key, old key removed');
+
+    // Renaming to an already-used key must be rejected (CanAdd validation), leaving the
+    // original entry untouched rather than silently overwriting or crashing.
+    // readRawXml() reset the tab to "Setup" again - re-select "Use/Give" as above.
+    await page.getByRole('button', { name: 'Use/Give', exact: true }).click();
+    await objectPicker.waitFor({ state: 'visible', timeout: 10000 });
+    await objectPicker.selectOption({ label: 'defibrillator' });
+    await useonSection.locator('button:has-text("Add")').click();
+    await page.waitForTimeout(300);
+    const secondEntry = useonSection.locator('button', { hasText: 'defibrillator' });
+    await secondEntry.waitFor({ state: 'visible', timeout: 10000 });
+    // Same positional approach as defibrillatorEntry above - the newly-added entry is appended
+    // after "medkit", making it index 1.
+    const secondEntryContainer = useonSection.locator('div.border.border-surface-200-800.rounded').nth(1);
+    await secondEntryContainer.getByRole('button', { name: 'Edit Key' }).click();
+    const secondKeyInput = secondEntryContainer.locator('input[type="text"]').first();
+    await secondKeyInput.fill('medkit');
+    await secondKeyInput.press('Enter');
+    await page.waitForTimeout(300);
+    if (await useonSection.locator('button', { hasText: 'defibrillator' }).count() === 0) {
+        throw new Error('Expected renaming to an already-used key ("medkit") to be rejected, but the entry key changed anyway');
+    }
+    if (await useonSection.locator('button', { hasText: 'medkit' }).count() !== 1) {
+        throw new Error('Expected exactly one "medkit" entry to remain after the rejected duplicate-key rename');
+    }
+    console.log('PASS: renaming to an already-used key is rejected, leaving the original key unchanged');
 
     console.log('PASS: all checks passed');
 } catch (err) {


### PR DESCRIPTION
## Summary

- Adds an "Edit Key" rename affordance to `ScriptDictionaryEditor.svelte` — the component backing both a character's Ask/Tell topic list and the Use/Give per-object script list. Previously entries could only be added or removed, not renamed (Quest 5's old editor supported this via its own "Edit Key" button).
- Backed by a new `RenameScriptDictionaryItem` bridge method (`WasmEditorBridge.cs`), which reuses `IEditableDictionary<T>.ChangeKey` — already used internally when renaming an object cascades into its referencing dictionaries — so no new EditorCore plumbing was needed.
- Clicking "Edit Key" swaps the entry's header into an inline text input (Enter commits, Escape cancels, blur commits). A rename that collides with an existing key is rejected via the dictionary's existing `CanAdd` validation, leaving the original key untouched. Renaming preserves the entry's script content and expanded/collapsed state.
- Locale strings added for en/de/es/xx.

This unblocks regenerating `ask_about.md`'s `Asktell3.png` doc screenshot, whose instructions ("...click on 'Edit Key'. Replace 'dr black' with 'dr doctor black'.") describe exactly this operation — that screenshot regeneration itself is a separate follow-up.

## Test plan

- [x] `dotnet build` (Debug and Release/AOT) for `src/WasmEditor` succeeds
- [x] `npm run check` (svelte-check) and `npm run lint` (eslint) pass in `src/AppShell`
- [x] Extended `tests/e2e/verify-appshell-multi-control-editors.mjs` with coverage for: renaming a Use/Give entry's key via "Edit Key", confirming the script content and expanded state survive the rename, confirming the saved XML round-trips under the new key with the old key gone, and confirming a rename to an already-used key is rejected — all passing
- [x] Manually verified in-browser against the exact `ask_about.md` scenario (Mary's Ask/Tell topic "dr black" → "dr doctor black"), confirmed via raw XML inspection that the script content and key rename round-trip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)