### PR TITLE
feat(Engine): add "require all keys" toggle for lockable containers

### DIFF
--- a/src/Engine/Core/CoreEditorObjectContainer.aslx
+++ b/src/Engine/Core/CoreEditorObjectContainer.aslx
@@ -251,6 +251,14 @@
 
     <control>
       <controltype>checkbox</controltype>
+      <caption>[EditorObjectContainerRequireAllKeys]</caption>
+      <attribute>requireallkeys</attribute>
+      <mustinherit>container_lockable</mustinherit>
+      <onlydisplayif>GetInt(this, "keycount") > 1</onlydisplayif>
+    </control>
+
+    <control>
+      <controltype>checkbox</controltype>
       <caption>[EditorObjectContainerLocked]</caption>
       <attribute>locked</attribute>
       <mustinherit>container_lockable</mustinherit>

--- a/src/Engine/Core/CoreFunctions.aslx
+++ b/src/Engine/Core/CoreFunctions.aslx
@@ -406,6 +406,39 @@
     return (true)
   </function>
 
+  <function name="AnyKeyAvailable" parameters="object" type="boolean">
+    if (HasObject(object, "key")) {
+      if (not HasInt(object,"keycount")) {
+        object.keycount = 1
+        object.key1 = object.key
+      }
+      if (not HasObject(object, "key1")) {
+        object.key1 = object.key
+      }
+    }
+    if (GetInt(object, "keycount") = 0) {
+      return (true)
+    }
+    for (x, 1, object.keycount) {
+      keyname = "key" + ToString(x)
+      if (HasObject(object, keyname)) {
+        if (ListContains(ScopeInventory(), GetAttribute(object, keyname))) {
+          return (true)
+        }
+      }
+    }
+    return (false)
+  </function>
+
+  <function name="KeysAvailable" parameters="object" type="boolean">
+    if (object.requireallkeys) {
+      return (AllKeysAvailable(object))
+    }
+    else {
+      return (AnyKeyAvailable(object))
+    }
+  </function>
+
   <function name="CreateBiExits" parameters="dir, from, to">
     create exit (dir, from, to)
     create exit (ReverseDirection(dir), to, from)

--- a/src/Engine/Core/CoreTypes.aslx
+++ b/src/Engine/Core/CoreTypes.aslx
@@ -701,7 +701,7 @@
   <type name="container_lockable">
     <openscript type="script">
       if (this.locked) {
-        if (this.autounlock and AllKeysAvailable(this)) {
+        if (this.autounlock and KeysAvailable(this)) {
           do (this, "unlock")
           if (not this.isopen) {
             OpenObject (this)
@@ -731,7 +731,7 @@
         msg (DynamicTemplate("CannotLockOpen", this))
       }
       else {
-        if (AllKeysAvailable(this)) {
+        if (KeysAvailable(this)) {
           msg (this.lockmessage)
           this.locked = true
         }
@@ -745,7 +745,7 @@
         msg (DynamicTemplate("AlreadyUnlocked", this))
       }
       else {
-        if (AllKeysAvailable(this)) {
+        if (KeysAvailable(this)) {
           msg (this.unlockmessage)
           this.locked = false
           if (this.autoopen and not this.isopen) {
@@ -764,6 +764,7 @@
     <canlockopen type="boolean">false</canlockopen>
     <autoopen/>
     <autounlock/>
+    <requireallkeys type="boolean">true</requireallkeys>
   </type>
 
   <type name="defaultplayer">

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -319,6 +319,7 @@
   <template name="EditorObjectContainerLocking">Verriegeln</template>
   <template name="EditorObjectContainerLocktype">Schlosstyp</template>
   <template name="EditorObjectContainerKey">Schlüssel</template>
+  <template name="EditorObjectContainerRequireAllKeys">Alle Schlüssel erforderlich</template>
   <template name="EditorObjectContainerLocked">Objekt ist verschlossen</template>
   <template name="EditorObjectContainerAutomatically">Objekt automatisch aufschliessen, wenn der Spieler den oder die Schlüssel besitzt</template>
   <template name="EditorObjectContainerAutomatically2">Objekt automatisch öffnen, wenn aufgeschlossen wurde</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -319,6 +319,7 @@
   <template name="EditorObjectContainerLocking">Locking</template>
   <template name="EditorObjectContainerLocktype">Lock type</template>
   <template name="EditorObjectContainerKey">Key</template>
+  <template name="EditorObjectContainerRequireAllKeys">Require all keys</template>
   <template name="EditorObjectContainerLocked">Locked</template>
   <template name="EditorObjectContainerAutomatically">Automatically unlock if player has the key(s)</template>
   <template name="EditorObjectContainerAutomatically2">Automatically open when unlocked</template>

--- a/src/Engine/Core/Languages/EditorEspanol.aslx
+++ b/src/Engine/Core/Languages/EditorEspanol.aslx
@@ -321,6 +321,7 @@
   <template name="EditorObjectContainerLocking">Cerradura</template>
   <template name="EditorObjectContainerLocktype">Tipo de cerradura</template>
   <template name="EditorObjectContainerKey">Llave</template>
+  <template name="EditorObjectContainerRequireAllKeys">Requerir todas las llaves</template>
   <template name="EditorObjectContainerLocked">Bloqueado</template>
   <template name="EditorObjectContainerAutomatically">Desbloquear automáticamente si el jugador tiene la llave</template>
   <template name="EditorObjectContainerAutomatically2">Abrir automáticamente cuando se desbloquea</template>

--- a/tests/EngineTests/ContainerLockableTests.cs
+++ b/tests/EngineTests/ContainerLockableTests.cs
@@ -1,0 +1,41 @@
+using Moq;
+using QuestViva.Common;
+
+namespace QuestViva.EngineTests;
+
+// Regression coverage for the "Require all keys" toggle on lockable containers: by default
+// (requireallkeys unset/true) a container needs every configured key present, matching the
+// pre-existing AllKeysAvailable behaviour; with requireallkeys=false, any one of the configured
+// keys is enough (AnyKeyAvailable), matching the old Quest 5.8 "Require all keys" checkbox.
+[TestClass]
+public class ContainerLockableTests
+{
+    [TestMethod]
+    public async Task RunWalkthrough()
+    {
+        var gameDataProvider = new FileGameDataProvider("containerlockabletest.aslx");
+        var gameData = await gameDataProvider.GetData();
+        var worldModel = Helpers.CreateWorldModel(gameData);
+
+        worldModel.LogError += ex => throw ex;
+
+        var player = new Mock<IPlayer>();
+        var success = await worldModel.Initialise(player.Object);
+        Assert.IsTrue(success, "Initialisation failed");
+
+        await worldModel.Begin();
+
+        foreach (var cmd in worldModel.Walkthroughs.Walkthroughs["verify"].Steps)
+        {
+            if (cmd.StartsWith("assert:"))
+            {
+                var expr = cmd.Substring(7);
+                Assert.IsTrue(await worldModel.AssertAsync(expr), expr);
+            }
+            else
+            {
+                await worldModel.SendCommand(cmd);
+            }
+        }
+    }
+}

--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -52,6 +52,9 @@
         <None Update="dialoguepagetest.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="containerlockabletest.aslx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="savetest.aslx">
             <SubType>Designer</SubType>
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/tests/EngineTests/containerlockabletest.aslx
+++ b/tests/EngineTests/containerlockabletest.aslx
@@ -1,0 +1,70 @@
+<asl version="600">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="containerlockabletest"/>
+  <object name="room">
+    <object name="player">
+      <inherit name="defaultplayer" />
+      <object name="keya">
+        <inherit name="editor_object"/>
+      </object>
+    </object>
+    <object name="keyb">
+      <inherit name="editor_object"/>
+    </object>
+    <object name="chestall">
+      <inherit name="container"/>
+      <inherit name="container_lockable"/>
+      <keycount type="int">2</keycount>
+      <key1 type="object">keya</key1>
+      <key2 type="object">keyb</key2>
+      <locked type="boolean">true</locked>
+    </object>
+    <object name="chestany">
+      <inherit name="container"/>
+      <inherit name="container_lockable"/>
+      <requireallkeys type="boolean">false</requireallkeys>
+      <keycount type="int">2</keycount>
+      <key1 type="object">keya</key1>
+      <key2 type="object">keyb</key2>
+      <locked type="boolean">true</locked>
+    </object>
+  </object>
+
+  <command name="cmd_unlockall">
+    <pattern>unlockall</pattern>
+    <script>
+      do (chestall, "unlock")
+    </script>
+  </command>
+
+  <command name="cmd_unlockany">
+    <pattern>unlockany</pattern>
+    <script>
+      do (chestany, "unlock")
+    </script>
+  </command>
+
+  <command name="cmd_takekeyb">
+    <pattern>takekeyb</pattern>
+    <script>
+      keyb.parent = player
+    </script>
+  </command>
+
+  <walkthrough name="verify">
+    <steps>
+      <![CDATA[
+      assert:chestall.locked
+      assert:chestany.locked
+      unlockall
+      assert:chestall.locked
+      unlockany
+      assert:not chestany.locked
+      takekeyb
+      unlockall
+      assert:not chestall.locked
+      ]]>
+    </steps>
+  </walkthrough>
+</asl>


### PR DESCRIPTION
## Summary
- `docs/containers.md` has described a "Require all keys" checkbox on lockable containers since a 2018 docs commit, claiming it shipped in Quest 5.8 — but it was never actually implemented. Checked with `git log --all -S` for `requireallkeys`/`AnyKeyAvailable`/`anykey` across the whole repo history (which goes back to the 2010 Quest 5 CodePlex import): zero hits outside the docs. The 2014 commit that introduced multi-key locking (`AllKeysAvailable`) never had an "any key" branch.
- This PR builds the feature for real, so the long-standing docs finally match reality:
  - `requireallkeys` boolean attribute on `container_lockable` (default `true`, so existing games/objects are unaffected).
  - New `AnyKeyAvailable(object)` function in `CoreFunctions.aslx`, and a `KeysAvailable(object)` wrapper that branches on `requireallkeys` — used by `container_lockable`'s `openscript`/`lock`/`unlock` instead of calling `AllKeysAvailable` directly.
  - New "Require all keys" checkbox on the Container tab (`CoreEditorObjectContainer.aslx`), shown only when 2+ keys are configured, wired up for English/German/Spanish editor languages. Renders automatically in AppShell via the existing generic checkbox-control path — no AppShell code changes needed.

## Test plan
- [x] `dotnet test --configuration Release` — full suite passes (352 tests), including a new `ContainerLockableTests` walkthrough covering: default (unset) still requires all keys; `requireallkeys=false` unlocks with just one of two configured keys.
- [x] `dotnet build --configuration Release` — full solution builds clean.
- [x] Confirmed the checkbox control follows the same declarative pattern as sibling checkboxes (`Locked`, `autounlock`, `canlockopen`) which AppShell already renders correctly with no per-attribute code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)