### PR TITLE
test: fix flaky autosave test by dispatching change events explicitly

### DIFF
--- a/tests/e2e/verify-appshell-autosave.mjs
+++ b/tests/e2e/verify-appshell-autosave.mjs
@@ -41,17 +41,30 @@ async function run() {
     await descBox.waitFor({ timeout: 10000 });
     const marker = `Autosave marker ${Date.now()}`;
     await descBox.fill(marker);
+
+    // Explicitly dispatch input+change events to guarantee the PropertyEditor's
+    // onchange handler fires. page.fill() sets the DOM value and dispatches
+    // input events, but the native change event (which triggers the bridge's
+    // setAttribute → isDirty flip) doesn't always fire on blur in headless
+    // Chromium on CI — making the subsequent pill check time out.
+    await descBox.dispatchEvent('input');
+    await descBox.dispatchEvent('change');
     await page.click('.toolbar-divider'); // blur onto something inert
 
-    // The debounce-to-save-start latency (not the pill's own visible window,
-    // which editor-store.ts's MIN_SAVING_VISIBLE_MS already holds open ~300ms)
-    // is the part that varies — measured ~700-900ms locally, but a loaded CI
-    // runner can occasionally push it past a tighter budget. 3000ms measurably
-    // flaked here (confirmed on main too, not something this branch caused).
-    await page.waitForSelector('text=Saving…', { timeout: 8000 });
-    console.log('PASS: "Saving…" pill appeared after edit, without clicking any Save button');
+    // Wait for the "Unsaved" pill (class save-chip-unsaved) — it appears the
+    // instant isDirty flips to true, confirming the bridge was actually
+    // updated. Then wait for "Unsaved" to disappear (save completed, pill
+    // transitioned to "Saving…" then "Saved"), and finally confirm "Saved"
+    // is visible.  Checking "Saving…" directly via text= flaked on CI because
+    // MIN_SAVING_VISIBLE_MS's 300ms window could elapse between frames, and
+    // "Unsaved" contains the substring "Saved" which gave false positives.
+    await page.locator('.save-chip-unsaved').waitFor({ state: 'visible', timeout: 5000 });
+    console.log('PASS: "Unsaved" pill appeared — bridge isDirty confirmed');
 
-    await page.waitForSelector('text=Saved', { timeout: 10000 });
+    await page.locator('.save-chip-unsaved').waitFor({ state: 'hidden', timeout: 10000 });
+    console.log('PASS: "Unsaved" pill gone — save cycle started');
+
+    await page.locator('.save-chip-saved').waitFor({ state: 'visible', timeout: 10000 });
     console.log('PASS: pill returned to "Saved" after the autosave debounce fired');
 
     // Reopen via /open (a bare reload of "/" just redirects to /open anyway,


### PR DESCRIPTION
Fixes the flaky `verify-appshell-autosave.mjs` e2e test that was failing on CI.

**Root cause:** `page.fill()` doesn't reliably trigger the native `change` event in headless Chromium on CI. Without the `change` event, the PropertyEditor's `onchange` handler never fires, the WASM bridge's `isDirty` flag never flips, and the "Saving…" pill never appears — causing the test to time out.

**Fix:**
1. Explicitly dispatch `input` + `change` events after `fill()` to guarantee the bridge is updated
2. Wait for the "Unsaved" pill (CSS class `.save-chip-unsaved`) as a proxy for `isDirty`, confirming the bridge was actually marked dirty
3. Wait for the pill to transition to "Saved" (via `.save-chip-saved` class) instead of checking for the transient "Saving…" text — which was unreliable because `MIN_SAVING_VISIBLE_MS` (300ms) could elapse between frames, and text matching "Saved" against "Unsaved" gave false positives