### PR TITLE
feat(Engine): AddPageLink/RemovePageLink for Text Adventure games

### DIFF
--- a/src/Engine/Core/CoreEditorScriptsPages.aslx
+++ b/src/Engine/Core/CoreEditorScriptsPages.aslx
@@ -52,4 +52,85 @@
     </control>
   </editor>
 
+  <editor>
+    <appliesto>(function)AddPageLink</appliesto>
+    <display>[EditorScriptsPagesAddLinkFromXToY]</display>
+    <category>[EditorScriptsPagesCategory]</category>
+    <create>AddPageLink (,,"")</create>
+    <add>[EditorScriptsPagesAddPageLink]</add>
+
+    <control>
+      <controltype>label</controltype>
+      <caption>[EditorScriptsPagesAddPageLinkFrom]</caption>
+    </control>
+
+    <control>
+      <controltype>expression</controltype>
+      <attribute>0</attribute>
+      <simple>page</simple>
+      <simpleeditor>objects</simpleeditor>
+      <objecttype>page</objecttype>
+    </control>
+
+    <control>
+      <controltype>label</controltype>
+      <caption>[EditorScriptsPagesAddPageLinkTo]</caption>
+    </control>
+
+    <control>
+      <controltype>expression</controltype>
+      <attribute>1</attribute>
+      <simple>page</simple>
+      <simpleeditor>objects</simpleeditor>
+      <objecttype>page</objecttype>
+    </control>
+
+    <control>
+      <controltype>label</controltype>
+      <caption>[EditorScriptsPagesAddLinkText]</caption>
+      <breakbefore/>
+    </control>
+
+    <control>
+      <controltype>expression</controltype>
+      <attribute>2</attribute>
+      <simple>text</simple>
+      <expand/>
+    </control>
+  </editor>
+
+  <editor>
+    <appliesto>(function)RemovePageLink</appliesto>
+    <display>[EditorScriptsPagesRemoveLinkFromXToY]</display>
+    <category>[EditorScriptsPagesCategory]</category>
+    <create>RemovePageLink (,)</create>
+    <add>[EditorScriptsPagesRemovePageLink]</add>
+
+    <control>
+      <controltype>label</controltype>
+      <caption>[EditorScriptsPagesRemovePageLinkFrom]</caption>
+    </control>
+
+    <control>
+      <controltype>expression</controltype>
+      <attribute>0</attribute>
+      <simple>page</simple>
+      <simpleeditor>objects</simpleeditor>
+      <objecttype>page</objecttype>
+    </control>
+
+    <control>
+      <controltype>label</controltype>
+      <caption>[EditorScriptsPagesAddPageLinkTo]</caption>
+    </control>
+
+    <control>
+      <controltype>expression</controltype>
+      <attribute>1</attribute>
+      <simple>page</simple>
+      <simpleeditor>objects</simpleeditor>
+      <objecttype>page</objecttype>
+    </control>
+  </editor>
+
 </library>

--- a/src/Engine/Core/CorePages.aslx
+++ b/src/Engine/Core/CorePages.aslx
@@ -205,4 +205,23 @@
     return (GetBoolean(page, "visited"))
   </function>
 
+  <!--
+  Same mechanism as GamebookCore.aslx's functions of the same name (both operate on
+  a plain "options" stringdictionary keyed by destination.name), reimplemented here
+  since GamebookCore.aslx isn't included in a Text Adventure game's library chain.
+  -->
+  <function name="AddPageLink" parameters="source, destination, text">
+    RemovePageLink (source, destination)
+    dictionary add (source.options, destination.name, text)
+  </function>
+
+  <function name="RemovePageLink" parameters="source, destination">
+    if (source.options = null) {
+      source.options = NewStringDictionary()
+    }
+    if (DictionaryContains(source.options, destination.name)) {
+      dictionary remove (source.options, destination.name)
+    }
+  </function>
+
 </library>

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -25,6 +25,14 @@
   <template name="EditorScriptsPagesShowPage">Seite anzeigen</template>
   <template name="EditorScriptsPagesAllowCancel">Erlaube dem Spieler, den Dialog zu verlassen (jeder andere Befehl beendet ihn)</template>
   <template name="EditorScriptsPagesRunTurnScripts">Turn-Skripte während des Dialogs ausführen</template>
+  <template name="EditorScriptsPagesAddLinkFromXToY">Link von #0 auf #1 "#2" hinzufügen</template>
+  <template name="EditorScriptsPagesAddPageLink">Seitenlink hinzufügen</template>
+  <template name="EditorScriptsPagesAddPageLinkFrom">Seitenlink von</template>
+  <template name="EditorScriptsPagesAddPageLinkTo">zu</template>
+  <template name="EditorScriptsPagesAddLinkText">Link-Text:</template>
+  <template name="EditorScriptsPagesRemoveLinkFromXToY">Link von #0 bis #1 entfernen</template>
+  <template name="EditorScriptsPagesRemovePageLink">Seitenlink entfernen</template>
+  <template name="EditorScriptsPagesRemovePageLinkFrom">Seitenlink entfernen von</template>
   <template name="EditorGBAction">Aktion</template>
   <template name="EditorGBPlaySoundWhenEnterPage">Sound beim Betreten der Seite abspielen</template>
   <template name="EditorGBPlaySoundFilterName">Sound-Dateien</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -24,6 +24,14 @@
   <template name="EditorScriptsPagesShowPage">Show page</template>
   <template name="EditorScriptsPagesAllowCancel">Allow the player to leave the dialogue (any other command ends it)</template>
   <template name="EditorScriptsPagesRunTurnScripts">Run turn scripts during the dialogue</template>
+  <template name="EditorScriptsPagesAddLinkFromXToY">Add link from #0 to #1 "#2"</template>
+  <template name="EditorScriptsPagesAddPageLink">Add page link</template>
+  <template name="EditorScriptsPagesAddPageLinkFrom">Add page link from</template>
+  <template name="EditorScriptsPagesAddPageLinkTo">to</template>
+  <template name="EditorScriptsPagesAddLinkText">Link text:</template>
+  <template name="EditorScriptsPagesRemoveLinkFromXToY">Remove link from #0 to #1</template>
+  <template name="EditorScriptsPagesRemovePageLink">Remove page link</template>
+  <template name="EditorScriptsPagesRemovePageLinkFrom">Remove page link from</template>
   <template name="EditorGBAction">Action</template>
   <template name="EditorGBPlaySoundWhenEnterPage">Play sound when entering page</template>
   <template name="EditorGBPlaySoundFilterName">Sound Files</template>

--- a/src/Engine/Core/Languages/EditorEspanol.aslx
+++ b/src/Engine/Core/Languages/EditorEspanol.aslx
@@ -31,6 +31,14 @@
   <template name="EditorScriptsPagesShowPage">Mostrar página</template>
   <template name="EditorScriptsPagesAllowCancel">Permitir que el jugador abandone el diálogo (cualquier otro comando lo termina)</template>
   <template name="EditorScriptsPagesRunTurnScripts">Ejecutar los scripts de turno durante el diálogo</template>
+  <template name="EditorScriptsPagesAddLinkFromXToY">Añadir enlace de #0 a #1 "#2"</template>
+  <template name="EditorScriptsPagesAddPageLink">Añadir enlace de página</template>
+  <template name="EditorScriptsPagesAddPageLinkFrom">Añadir enlace de página desde</template>
+  <template name="EditorScriptsPagesAddPageLinkTo">a</template>
+  <template name="EditorScriptsPagesAddLinkText">Texto del enlace:</template>
+  <template name="EditorScriptsPagesRemoveLinkFromXToY">Quitar enlace de #0 a #1</template>
+  <template name="EditorScriptsPagesRemovePageLink">Quitar enlace de página</template>
+  <template name="EditorScriptsPagesRemovePageLinkFrom">Quitar enlace de página desde</template>
   <template name="EditorGBAction">Acción</template>
   <template name="EditorGBPlaySoundWhenEnterPage">Reproducir sonido al entrar a la página</template>
   <template name="EditorGBPlaySoundFilterName">Archivos de sonido</template>

--- a/tests/EngineTests/DialoguePageTests.cs
+++ b/tests/EngineTests/DialoguePageTests.cs
@@ -214,6 +214,47 @@ public class DialoguePageTests
     }
 
     [TestMethod]
+    public async Task AddPageLink_AddsAnOptionToAPageThatHadNone()
+    {
+        var driver = await LoadGameAsync();
+
+        await driver.SendCommandAsync("addlink");
+        await driver.SendCommandAsync("talk");
+        var output = string.Join("\n", await driver.SendCommandAsync("2")); // castle - previously terminal
+
+        output.ShouldContain("The castle is closed.");
+        output.ShouldContain("1: Ask about the weather instead");
+        await AssertTrueAsync(driver, "game.currentpage = guard_castle");
+    }
+
+    [TestMethod]
+    public async Task AddPageLink_ReplacesAnExistingLinkToTheSameDestination()
+    {
+        var driver = await LoadGameAsync();
+
+        await driver.SendCommandAsync("updatelink");
+        var output = string.Join("\n", await driver.SendCommandAsync("talk"));
+
+        output.ShouldContain("Ask about the weather (updated)");
+        output.ShouldNotContain(": Ask about the weather\n");
+    }
+
+    [TestMethod]
+    public async Task RemovePageLink_RemovesAnOption()
+    {
+        var driver = await LoadGameAsync();
+
+        await driver.SendCommandAsync("removelink");
+        var output = string.Join("\n", await driver.SendCommandAsync("talk"));
+
+        output.ShouldNotContain("Ask about the castle");
+
+        // and the option number is no longer accepted
+        output = string.Join("\n", await driver.SendCommandAsync("2"));
+        output.ShouldContain("Please choose one of the options above.");
+    }
+
+    [TestMethod]
     public async Task SaveAndLoadMidDialogue_PreservesDialogueStateAndOptions()
     {
         var driver = await LoadGameAsync();

--- a/tests/EngineTests/dialoguepagetest.aslx
+++ b/tests/EngineTests/dialoguepagetest.aslx
@@ -117,6 +117,27 @@
     </script>
   </command>
 
+  <command name="cmd_addlink">
+    <pattern>addlink</pattern>
+    <script>
+      AddPageLink (guard_castle, guard_weather, "Ask about the weather instead")
+    </script>
+  </command>
+
+  <command name="cmd_updatelink">
+    <pattern>updatelink</pattern>
+    <script>
+      AddPageLink (guard_intro, guard_weather, "Ask about the weather (updated)")
+    </script>
+  </command>
+
+  <command name="cmd_removelink">
+    <pattern>removelink</pattern>
+    <script>
+      RemovePageLink (guard_intro, guard_castle)
+    </script>
+  </command>
+
   <turnscript name="ticker">
     <enabled type="boolean">true</enabled>
     <script>


### PR DESCRIPTION
## Summary
- Adds `AddPageLink`/`RemovePageLink` implementations to `CorePages.aslx` so they're usable in Text Adventure games (previously only available in Gamebook mode via `GamebookCore.aslx`, which isn't in a Text Adventure game's library chain)
- Adds matching Script Adder entries (English/German/Spanish)

## Test plan
- [x] `dotnet test tests/EngineTests --filter "FullyQualifiedName~DialoguePageTests"` — 15/15 pass
- [x] Full solution build succeeds

Split out of the long-running `v5-docs-migrate` branch so it can be reviewed and merged independently of the docs migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)