### PR TITLE
fix(Engine): remove Vimeo support entirely, keep runtime playback for existing games

### DIFF
--- a/examples/blank.aslx
+++ b/examples/blank.aslx
@@ -3842,9 +3842,6 @@
   <function name="ShowYouTube" parameters="id">
     JS.AddYouTube (id)
   </function>
-  <function name="ShowVimeo" parameters="id">
-    JS.AddVimeo (id)
-  </function>
   <function name="WaitForKeyPress">
     request (Wait, "")
   </function>

--- a/examples/gamebook.aslx
+++ b/examples/gamebook.aslx
@@ -657,9 +657,6 @@
   <function name="ShowYouTube" parameters="id">
     JS.AddYouTube (id)
   </function>
-  <function name="ShowVimeo" parameters="id">
-    JS.AddVimeo (id)
-  </function>
   <function name="WaitForKeyPress">
     request (Wait, "")
   </function>

--- a/src/Engine/Core/CoreEditorScriptsOutput.aslx
+++ b/src/Engine/Core/CoreEditorScriptsOutput.aslx
@@ -371,23 +371,6 @@
     </control>
   </editor>
 
-  <!-- removed the ability to add this as it doesn't work on desktop -->
-  <editor>
-    <appliesto>(function)ShowVimeo</appliesto>
-    <display>Play Vimeo video #0</display>
-
-    <control>
-      <controltype>label</controltype>
-      <caption>[EditorScriptsOutputPlayVimeovideo]</caption>
-    </control>
-
-    <control>
-      <controltype>expression</controltype>
-      <attribute>0</attribute>
-      <simple>id</simple>
-    </control>
-  </editor>
-
   <editor>
     <appliesto>(function)DisplayHttpLink</appliesto>
     <display>Display link '#0' to http(s)://#1</display>

--- a/src/Engine/Core/CoreOutput.aslx
+++ b/src/Engine/Core/CoreOutput.aslx
@@ -829,10 +829,6 @@
     JS.AddYouTube(id)
   </function>
 
-  <function name="ShowVimeo" parameters="id">
-    JS.AddVimeo(id)
-  </function>
-
   <function name="WaitForKeyPress">
     request (Wait, "")
   </function>

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -608,7 +608,6 @@
   <template name="EditorScriptsOutputLoop">Den Sound in einer Schleife abspielen?</template>
   <template name="EditorScriptsOutputStopsound">Sound stoppen</template>
   <template name="EditorScriptsOutputPlayYouTube">Youtube-Video abspielen</template>
-  <template name="EditorScriptsOutputPlayVimeovideo">Vimeo-Video abspielen</template>
   <template name="EditorScriptsOutputPrintweblink">Einen Weblink anzeigen</template>
   <template name="EditorScriptsOutputDisplaylink">Folgenden Link anzeigen</template>
   <template name="EditorScriptsOutputhttp//">http://</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -607,7 +607,6 @@
   <template name="EditorScriptsOutputLoop">Loop:</template>
   <template name="EditorScriptsOutputStopsound">Stop sound</template>
   <template name="EditorScriptsOutputPlayYouTube">Play YouTube video</template>
-  <template name="EditorScriptsOutputPlayVimeovideo">Play Vimeo video</template>
   <template name="EditorScriptsOutputPrintweblink">Print web link</template>
   <template name="EditorScriptsOutputDisplaylink">Display link</template>
   <template name="EditorScriptsOutputhttp//">http://</template>

--- a/src/Engine/Core/Languages/EditorEspanol.aslx
+++ b/src/Engine/Core/Languages/EditorEspanol.aslx
@@ -610,7 +610,6 @@
   <template name="EditorScriptsOutputLoop">Bucle:</template>
   <template name="EditorScriptsOutputStopsound">Detener sonido</template>
   <template name="EditorScriptsOutputPlayYouTube">Reproducir vídeo de Youtube</template>
-  <template name="EditorScriptsOutputPlayVimeovideo">Reproducir vídeo de Vimeo</template>
   <template name="EditorScriptsOutputPrintweblink">Imprimir un vínculo de internet</template>
   <template name="EditorScriptsOutputDisplaylink">Mostrar vínculo</template>
   <template name="EditorScriptsOutputhttp//">http://</template>

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -1206,12 +1206,6 @@ function AddYouTube(id) {
     addText(embedHTML);
 }
 
-function AddVimeo(id) {
-    var url = "https://player.vimeo.com/video/" + id + "?autoplay=1";
-    var embedHTML = "<iframe sandbox=\"allow-same-origin allow-scripts allow-popups\" src=\"" + url + "\" width=\"500\" height=\"281\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>";
-    addText(embedHTML);
-}
-
 function SetMenuBackground(color) {
     var css = getCSSRule("div.jj_menu_item");
     css.style.backgroundColor = color;

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -1206,6 +1206,16 @@ function AddYouTube(id) {
     addText(embedHTML);
 }
 
+// ShowVimeo itself was removed from Core.aslx (no longer offered to newly-authored/saved
+// games), but this is the shared runtime, not something frozen per-game - an already-published
+// game's own inlined ShowVimeo function still calls JS.AddVimeo directly, so this has to keep
+// working regardless of what Core.aslx currently offers. See Core Library Semantics in CLAUDE.md.
+function AddVimeo(id) {
+    var url = "https://player.vimeo.com/video/" + id + "?autoplay=1";
+    var embedHTML = "<iframe sandbox=\"allow-same-origin allow-scripts allow-popups\" src=\"" + url + "\" width=\"500\" height=\"281\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>";
+    addText(embedHTML);
+}
+
 function SetMenuBackground(color) {
     var css = getCSSRule("div.jj_menu_item");
     css.style.backgroundColor = color;


### PR DESCRIPTION
## Summary
- Drops `ShowVimeo` from `Core.aslx`/`CoreOutput.aslx`, its Script Adder entry, and language templates, so newly-authored/saved games can no longer add it (Vimeo as a platform is largely dead)
- Cleans the inlined `ShowVimeo` copy out of the two example game templates so new example content doesn't carry it forward
- Restores `JS.AddVimeo` in `playercore.js` in a follow-up commit: that file is shared runtime served to every player, not frozen per-game like `Core.aslx`, so an already-published game's own inlined `ShowVimeo` still needs it to keep working

## Test plan
- [x] Full solution build succeeds

Split out of the long-running `v5-docs-migrate` branch so it can be reviewed and merged independently of the docs migration. The corresponding docs changes (removing the ShowVimeo docs page, etc.) stay on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)