### PR TITLE
fix(PlayerCore): restore WriteToLog as a no-op

### DIFF
--- a/src/PlayerCore/Resources/player.js
+++ b/src/PlayerCore/Resources/player.js
@@ -223,6 +223,15 @@ function addExternalScript(url) {
     });
 }
 
+// The "write log to file" feature itself was removed from Core.aslx (#1924) - a game authored
+// since then has no way to call this. But an already-published game's own inlined Log function
+// may still call JS.WriteToLog(text) when its game.writelogtofile flag is set, and that has to
+// keep working regardless of what Core.aslx currently offers. See Core Library Semantics in
+// CLAUDE.md.
+function WriteToLog(data) {
+    // Do nothing.
+}
+
 function WriteToTranscript(data) {
     if (noTranscript) {
         // Do nothing.


### PR DESCRIPTION
## Summary
- Restores `WriteToLog` in `player.js` as a no-op, so games that call it don't error out

## Test plan
- [x] Full solution build succeeds

Split out of the long-running `v5-docs-migrate` branch so it can be reviewed and merged independently of the docs migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)