### PR TITLE
fix(Engine): make the 'in' operator work on dictionaries

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using NCalc;
@@ -290,6 +291,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     private async Task EvaluateBinaryAsync(BinaryEventArgs args)
     {
         var isEquality = args.BinaryExpression.Type is BinaryExpressionType.Equal or BinaryExpressionType.NotEqual;
+        var isInOperator = args.BinaryExpression.Type is BinaryExpressionType.In or BinaryExpressionType.NotIn;
 
         var operatorName = args.BinaryExpression.Type switch
         {
@@ -301,10 +303,25 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             _ => null
         };
 
-        if (operatorName == null && !isEquality) return;
+        if (operatorName == null && !isEquality && !isInOperator) return;
 
         var left = await args.LeftValueAsync();
         var right = await args.RightValueAsync();
+
+        // NCalc's built-in 'in' operator does a plain foreach over the right-hand IEnumerable,
+        // which for IDictionary yields boxed KeyValuePairs rather than keys, so it can never
+        // match a key on the left. Route dictionaries through IDictionary.Contains(key) instead,
+        // matching DictionaryContains()'s behaviour.
+        if (isInOperator)
+        {
+            if (right is IDictionary dictionary)
+            {
+                var contains = dictionary.Contains(left);
+                args.Result = args.BinaryExpression.Type == BinaryExpressionType.In ? contains : !contains;
+            }
+
+            return;
+        }
 
         HandleBinaryResult(args, isEquality, operatorName, left, right);
     }

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -420,6 +420,18 @@ public class ExpressionTests
     }
 
     [TestMethod]
+    public async Task TestInOperatorOnDictionary()
+    {
+        var dict = new QuestDictionary<string> { { "foo", "bar" }, { "baz", "qux" } };
+        var c = new Context { Parameters = new Parameters { { "mydict", dict } } };
+
+        (await new Expression<bool>("\"foo\" in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(true);
+        (await new Expression<bool>("\"missing\" in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(false);
+        (await new Expression<bool>("\"foo\" not in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(false);
+        (await new Expression<bool>("\"missing\" not in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(true);
+    }
+
+    [TestMethod]
     public async Task TestMethodCallSyntax()
     {
         (await RunExpressionGeneric("\"hello world\".StartsWith(\"hello\")")).ShouldBe(true);


### PR DESCRIPTION
## Summary
- The `in`/`not in` operators always returned `False` for dictionaries in Quest Viva, even though `DictionaryContains()` worked correctly (#2094).
- This was a regression from the FLEE→NCalc migration: NCalc's built-in `in` handler does a plain `foreach` over the right-hand `IEnumerable`, which for `IDictionary` yields boxed `KeyValuePair`s rather than keys — so a string key could never match an entry, always returning `false`.
- `EvaluateBinaryAsync` in [`NcalcExpressionEvaluator.cs`](src/Engine/Expressions/NcalcExpressionEvaluator.cs) now intercepts `BinaryExpressionType.In`/`NotIn` and, when the right-hand value is an `IDictionary`, routes it through `IDictionary.Contains(key)` — the same key-check `DictionaryContains()` already uses. Lists/arrays/strings are untouched and continue to fall through to NCalc's default `in` handling.

## Test plan
- [x] Added `TestInOperatorOnDictionary` in [`ExpressionTests.cs`](tests/EngineTests/ExpressionTests.cs) covering `in` and `not in`, both hit and miss.
- [x] `dotnet test --configuration Release` — full solution, 366/366 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)