### PR TITLE
fix(AppShell): refresh code view when switching commands in editor

### DIFF
--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -153,6 +153,16 @@
         }
     });
 
+    // Code view has its own separately-fetched buffer (scriptCode), so it needs its own
+    // reactive refresh when the selected element/attribute changes (e.g. picking a different
+    // command in the tree while code view is already open) - the scriptData effect above only
+    // covers the visual editor's data.
+    $effect(() => {
+        if (isRoot && codeViewMode) {
+            scriptCode = getScriptCode(elementKey, attribute);
+        }
+    });
+
     function scripts(): ScriptNodeData[] {
         if (!isRoot && initialData !== null) return initialData;
         return scriptData?.scripts ?? [];


### PR DESCRIPTION
## Summary
- The code-view editor for a Command's script only fetched its `scriptCode` buffer when toggling into code view, not when the selected command changed while code view was already open — so switching to a different command in the left-hand tree left the code editor showing the previous command's script.
- Added a reactive effect in `ScriptEditor.svelte` that keeps `scriptCode` in sync with the selected `elementKey`/`attribute` whenever code view is active, mirroring the existing pattern already used for the visual editor's `scriptData`.

## Test plan
- [x] `svelte-check` clean
- [x] `eslint` clean
- [x] Manually verified in the browser: created two Command objects with distinct scripts, opened code view on one, clicked the other in the tree — code view now updates immediately without needing to bounce through the visual editor first