### PR TITLE
feat(AppShell): default-to-code-view setting, taller attribute value box

### DIFF
--- a/src/AppShell/src/components/AttributesEditor.svelte
+++ b/src/AppShell/src/components/AttributesEditor.svelte
@@ -473,7 +473,7 @@
             </div>
             {#if selectedAttr}
                 {@const attr = selectedAttr}
-                <div class="p-3 flex flex-col gap-2 overflow-y-auto">
+                <div class="p-3 flex flex-col gap-2 overflow-y-auto flex-1 min-h-0">
                     <div class="font-medium text-surface-700-300 truncate flex-shrink-0" title={attr.name}>{attr.name}</div>
 
                     {#if attr.isInherited || attr.isDefaultType}
@@ -510,7 +510,11 @@
                     {/if}
 
                     <!-- Value editor -->
-                    <div class="flex flex-col gap-1">
+                    <div
+                        class="flex flex-col gap-1"
+                        class:flex-1={attr.type === "string" || attr.type === "simplepattern"}
+                        class:min-h-0={attr.type === "string" || attr.type === "simplepattern"}
+                    >
                         <span class="text-surface-600-400 uppercase tracking-wide text-xs flex-shrink-0">{t("propertyEditor.valueFallback")}</span>
                         {#if attr.type === "null"}
                             <p class="text-surface-600-400 italic">{t("attributesEditor.noValueParenthetical")}</p>
@@ -568,8 +572,7 @@
                             <!-- string, simplepattern -->
                             <textarea
                                 autocapitalize="off"
-                                class="input text-xs py-1 px-1.5 w-full resize-none"
-                                rows="4"
+                                class="input text-xs py-1 px-1.5 w-full flex-1 min-h-24 resize-y"
                                 value={editingValue}
                                 disabled={isValueLocked(attr)}
                                 oninput={(e) => { editingValue = (e.target as HTMLTextAreaElement).value; }}

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -43,6 +43,7 @@
         removeScriptDictCase,
         renameScriptDictCase,
     } from "$lib/editor-store";
+    import { defaultCodeView } from "$lib/code-view-store";
     import type {
         ScriptBlockData,
         ScriptNodeData,
@@ -109,6 +110,16 @@
     function templatesFor(expressionType: string | null | undefined): ExpressionTemplate[] {
         return (expressionType && templatesByType[expressionType]) || [];
     }
+
+    // Only root instances show the code-view toggle (nested if/for/case
+    // sub-editors share the root's `attribute` script, so their own
+    // codeViewMode is never read — see the isRoot guards below and on the
+    // scriptCode effect). The setting is a standing preference, not a
+    // per-panel choice: changing it flips every root ScriptEditor currently
+    // on screen, overriding whatever any of them was individually showing.
+    $effect(() => {
+        if (isRoot) codeViewMode = $defaultCodeView;
+    });
 
     // Load on mount and whenever scriptVersion bumps (undo/redo)
     $effect(() => {

--- a/src/AppShell/src/components/SettingsModal.svelte
+++ b/src/AppShell/src/components/SettingsModal.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+    import { Switch } from "@skeletonlabs/skeleton-svelte";
     import { settingsModalOpen } from "$lib/settings-store";
     import { locale, setLocale, SUPPORTED_LOCALES, t } from "$lib/i18n";
     import { theme, setTheme, type ThemePreference } from "$lib/theme-store";
+    import { defaultCodeView, setDefaultCodeView } from "$lib/code-view-store";
 
     function displayName(code: string): string {
         let name: string;
@@ -85,6 +87,17 @@
                     <option value="dark">{t("settingsModal.themeDark")}</option>
                     <option value="system">{t("settingsModal.themeSystem")}</option>
                 </select>
+            </div>
+
+            <div class="flex flex-col gap-1">
+                <Switch
+                    checked={$defaultCodeView}
+                    onCheckedChange={(e) => setDefaultCodeView(e.checked)}
+                >
+                    <Switch.Control><Switch.Thumb /></Switch.Control>
+                    <Switch.HiddenInput />
+                    <Switch.Label class="text-xs text-surface-600-400">{t("settingsModal.defaultCodeView")}</Switch.Label>
+                </Switch>
             </div>
         </div>
     </div>

--- a/src/AppShell/src/lib/code-view-store.ts
+++ b/src/AppShell/src/lib/code-view-store.ts
@@ -1,0 +1,59 @@
+import { writable } from "svelte/store";
+import { isElectron } from "./runtime";
+
+// Whether ScriptEditor instances default to raw code view instead of the
+// visual block editor. Changing it also flips every ScriptEditor currently
+// mounted (see ScriptEditor.svelte's effect on this store) — a setting the
+// user opts into as a standing preference, not a per-panel toggle.
+export const defaultCodeView = writable<boolean>(false);
+
+const STORAGE_KEY = "questviva-default-code-view";
+
+// Electron's static server binds to a random port every launch (see
+// theme-store.ts), so localStorage (origin-scoped) never survives that —
+// persist to a userData file via IPC instead there.
+async function readStoredDefaultCodeView(): Promise<boolean | null> {
+    if (isElectron()) {
+        try {
+            return await window.electronApp!.defaultCodeView.get();
+        } catch {
+            return null;
+        }
+    }
+    if (typeof localStorage === "undefined") return null;
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        return stored === null ? null : stored === "true";
+    } catch {
+        return null;
+    }
+}
+
+async function writeStoredDefaultCodeView(value: boolean): Promise<void> {
+    if (isElectron()) {
+        try {
+            await window.electronApp!.defaultCodeView.set(value);
+        } catch {
+            // Losing the preference just means it's re-detected next load, not fatal.
+        }
+        return;
+    }
+    if (typeof localStorage === "undefined") return;
+    try {
+        localStorage.setItem(STORAGE_KEY, String(value));
+    } catch {
+        // Storage can be unavailable (private browsing, quota) — losing the
+        // preference just means it's re-detected next load, not fatal.
+    }
+}
+
+// Called once from +layout.svelte's onMount, alongside initTheme/initI18n.
+export async function initDefaultCodeView(): Promise<void> {
+    const stored = await readStoredDefaultCodeView();
+    if (stored !== null) defaultCodeView.set(stored);
+}
+
+export function setDefaultCodeView(value: boolean): void {
+    defaultCodeView.set(value);
+    void writeStoredDefaultCodeView(value);
+}

--- a/src/AppShell/src/lib/electron-types.d.ts
+++ b/src/AppShell/src/lib/electron-types.d.ts
@@ -135,6 +135,14 @@ interface ElectronUiStateApi {
     set(gameId: string, state: string[]): Promise<void>;
 }
 
+// Whether ScriptEditor instances default to raw code view — persisted to a
+// userData file (ElectronApp's default-code-view-store.ts), not localStorage
+// — see code-view-store.ts for why.
+interface ElectronDefaultCodeViewApi {
+    get(): Promise<boolean | null>;
+    set(enabled: boolean): Promise<void>;
+}
+
 // id: catalog game (textadventures.co.uk id); omitted: a locally-picked
 // file, whose bytes/resources the caller hands over separately via the
 // 'quest-play-local' BroadcastChannel — see ipc/player.ts and
@@ -161,6 +169,7 @@ interface ElectronApi {
     catalogPlays: ElectronCatalogPlaysApi;
     updateDismiss: ElectronUpdateDismissApi;
     uiState: ElectronUiStateApi;
+    defaultCodeView: ElectronDefaultCodeViewApi;
     fileWatch: ElectronFileWatchApi;
     menu: ElectronMenuApi;
     player: ElectronPlayerApi;

--- a/src/AppShell/src/routes/+layout.svelte
+++ b/src/AppShell/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
     import { isElectron } from "$lib/runtime";
     import { initI18n, localeReady } from "$lib/i18n";
     import { initTheme } from "$lib/theme-store";
+    import { initDefaultCodeView } from "$lib/code-view-store";
     import HomeHeader from "$components/HomeHeader.svelte";
     import HomeTabs from "$components/HomeTabs.svelte";
     import ConfirmDialog from "$components/ConfirmDialog.svelte";
@@ -68,6 +69,10 @@
 
     onMount(() => {
         void initTheme();
+    });
+
+    onMount(() => {
+        void initDefaultCodeView();
     });
 
     onMount(() => {

--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -89,6 +89,7 @@
     "settingsModal.themeLight": "Hell",
     "settingsModal.themeDark": "Dunkel",
     "settingsModal.themeSystem": "Systemeinstellung",
+    "settingsModal.defaultCodeView": "Skripte standardmäßig in Code-Ansicht anzeigen",
 
     "common.moveTo": "Verschieben nach…",
     "common.cut": "Ausschneiden",

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -89,6 +89,7 @@
     "settingsModal.themeLight": "Light",
     "settingsModal.themeDark": "Dark",
     "settingsModal.themeSystem": "Match system",
+    "settingsModal.defaultCodeView": "Default scripts to code view",
 
     "common.moveTo": "Move to…",
     "common.cut": "Cut",

--- a/src/AppShell/static/locales/es.json
+++ b/src/AppShell/static/locales/es.json
@@ -89,6 +89,7 @@
     "settingsModal.themeLight": "Claro",
     "settingsModal.themeDark": "Oscuro",
     "settingsModal.themeSystem": "Seguir sistema",
+    "settingsModal.defaultCodeView": "Mostrar guiones en vista de código de forma predeterminada",
 
     "common.moveTo": "Mover a…",
     "common.cut": "Cortar",

--- a/src/AppShell/static/locales/xx.json
+++ b/src/AppShell/static/locales/xx.json
@@ -79,6 +79,7 @@
     "settingsModal.themeLight": "[Líght]",
     "settingsModal.themeDark": "[Dárk]",
     "settingsModal.themeSystem": "[Mátch systém]",
+    "settingsModal.defaultCodeView": "[Défáúlt scrípts tó códé víéw]",
     "common.moveTo": "[Móvé tó…]",
     "common.cut": "[Cút]",
     "common.copy": "[Cópy]",

--- a/src/ElectronApp/src/default-code-view-store.ts
+++ b/src/ElectronApp/src/default-code-view-store.ts
@@ -1,0 +1,32 @@
+import { app } from "electron";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+// Whether ScriptEditor instances default to raw code view, persisted
+// separately from AppShell's own localStorage-based store
+// (src/AppShell/src/lib/code-view-store.ts) — same rationale as
+// theme-store.ts: static-server.ts's ephemeral port means localStorage set
+// in one session is invisible in the next.
+function storePath(): string {
+    return path.join(app.getPath("userData"), "default-code-view.json");
+}
+
+export async function readDefaultCodeView(): Promise<boolean | null> {
+    try {
+        const text = await fs.readFile(storePath(), "utf-8");
+        const parsed = JSON.parse(text) as unknown;
+        return typeof parsed === "object" && parsed !== null && typeof (parsed as { enabled?: unknown }).enabled === "boolean"
+            ? (parsed as { enabled: boolean }).enabled
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+// Same atomic tmp-file + rename as theme-store.ts's writeTheme.
+export async function writeDefaultCodeView(enabled: boolean): Promise<void> {
+    const finalPath = storePath();
+    const tmpPath = `${finalPath}.tmp-${process.pid}-${Date.now()}`;
+    await fs.writeFile(tmpPath, JSON.stringify({ enabled }));
+    await fs.rename(tmpPath, finalPath);
+}

--- a/src/ElectronApp/src/ipc/default-code-view.ts
+++ b/src/ElectronApp/src/ipc/default-code-view.ts
@@ -1,0 +1,10 @@
+import { ipcMain } from "electron";
+import { readDefaultCodeView, writeDefaultCodeView } from "../default-code-view-store";
+
+// Backs window.electronApp.defaultCodeView in preload.ts — see
+// default-code-view-store.ts for why this can't just be AppShell's own
+// localStorage-based persistence.
+export function registerDefaultCodeViewHandlers(): void {
+    ipcMain.handle("defaultCodeView:get", async () => readDefaultCodeView());
+    ipcMain.handle("defaultCodeView:set", async (_event, enabled: boolean) => writeDefaultCodeView(enabled));
+}

--- a/src/ElectronApp/src/main.ts
+++ b/src/ElectronApp/src/main.ts
@@ -11,6 +11,7 @@ import { registerTranscriptHandlers } from "./ipc/transcript";
 import { registerGameSaveHandlers } from "./ipc/gamesave";
 import { registerCatalogPlaysHandlers } from "./ipc/catalog-plays";
 import { registerUpdateDismissHandlers } from "./ipc/update-dismiss";
+import { registerDefaultCodeViewHandlers } from "./ipc/default-code-view";
 import { registerFileWatchHandlers } from "./ipc/file-watch";
 import { registerLocaleHandlers } from "./ipc/locale";
 import { registerThemeHandlers } from "./ipc/theme";
@@ -606,6 +607,7 @@ if (!gotLock) {
         registerGameSaveHandlers();
         registerCatalogPlaysHandlers();
         registerUpdateDismissHandlers();
+        registerDefaultCodeViewHandlers();
         // Renderer-armed (see electron-adapter.ts's arm calls) — this only ever
         // notifies about whatever file(s) the renderer last asked to watch.
         registerFileWatchHandlers((filenames) => {

--- a/src/ElectronApp/src/preload.ts
+++ b/src/ElectronApp/src/preload.ts
@@ -169,6 +169,12 @@ contextBridge.exposeInMainWorld("electronApp", {
         get: (): Promise<string | null> => ipcRenderer.invoke("updateDismiss:get"),
         set: (version: string): Promise<void> => ipcRenderer.invoke("updateDismiss:set", version),
     },
+    defaultCodeView: {
+        // Whether ScriptEditor instances default to raw code view — see
+        // ElectronApp's default-code-view-store.ts for why this can't be localStorage.
+        get: (): Promise<boolean | null> => ipcRenderer.invoke("defaultCodeView:get"),
+        set: (enabled: boolean): Promise<void> => ipcRenderer.invoke("defaultCodeView:set", enabled),
+    },
     uiState: {
         // Per-game editor UI state (currently the tree's expanded-node ids),
         // keyed by the game's <gameid> — see ElectronApp's ui-state-store.ts


### PR DESCRIPTION
## Summary
- Add a "Default scripts to code view" toggle to Settings, persisted like theme/locale (`localStorage` in the browser, a dedicated Electron IPC store on desktop). Flipping it live-updates every `ScriptEditor` currently on screen — the global setting always wins over whatever a panel was individually showing — and new panels pick it up on mount.
- Manual per-instance "Code view"/"Visual editor" toggling still works between global changes, so one script can be viewed as code while another stays visual.
- Fix the Attributes editor's string/simplepattern "Value" textarea, which was hardcoded to `rows="4"` and couldn't grow — it now flexes to fill the available panel height.

Prompted by user feedback that per-section Code View buttons get cumbersome across a panel with many scripts, and that the attribute value box only showed 4 lines, making it hard to view larger text blocks.

## Test plan
- [x] `npm run check` (svelte-check) clean in `src/AppShell`
- [x] `npm run lint` (eslint) clean in `src/AppShell`
- [x] `npm run build:ts` (tsc) clean in `src/ElectronApp`
- [x] Manually verified in a running AppShell dev server: attribute value box now fills available height; toggling the new Settings switch live-flips both a "Start script" and a "Script when entering a room" panel between code/visual view in both directions; per-instance override still works; the preference persists across a full page reload
- [ ] Manual verification of Electron persistence (userData JSON file) not done — code follows the existing theme/updateDismiss pattern exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)