### PR TITLE
feat(AppShell): group library-origin elements by source file in editor tree

### DIFF
--- a/src/AppShell/src/components/ElementsList.svelte
+++ b/src/AppShell/src/components/ElementsList.svelte
@@ -36,6 +36,27 @@
         )
     );
 
+    // ── Library grouping ──────────────────────────────────────────────────────
+    // Purely a display grouping over the existing flat, SortIndex-ordered `items` — no
+    // reordering. A group header is inserted before each new contiguous run of library items
+    // sharing a filename, so move up/down (which swaps SortIndex on the underlying list)
+    // stays untouched and headers simply track wherever the runs currently fall.
+    type Row = { kind: "header"; key: string; label: string } | { kind: "item"; index: number; item: typeof items[number] };
+
+    let rows = $derived.by(() => {
+        const out: Row[] = [];
+        let lastGroup: string | null = null;
+        items.forEach((item, index) => {
+            const group = item.isLibrary && item.filename ? item.filename : null;
+            if (group !== null && group !== lastGroup) {
+                out.push({ kind: "header", key: `__group_${item.key}`, label: group });
+            }
+            lastGroup = group;
+            out.push({ kind: "item", index, item });
+        });
+        return out;
+    });
+
     // ── Selection ──────────────────────────────────────────────────────────────
 
     const selectedKeys = new SvelteSet<string>();
@@ -171,53 +192,59 @@
     {#if items.length === 0}
         <p class="text-xs text-surface-600-400 italic">{t("elementsList.noItems")}</p>
     {:else}
-        {#each items as item, i (item.key)}
-            <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-center">
-                <label class="flex items-center pt-1 pb-1 pl-1.5 pr-0.5 cursor-pointer flex-shrink-0">
-                    <input
-                        type="checkbox"
-                        class="checkbox size-3.5"
-                        checked={selectedKeys.has(item.key)}
-                        onchange={(e) => toggleSelect(item.key, (e.target as HTMLInputElement).checked)}
-                    />
-                </label>
-                <!-- pr-20 keeps name clear of the hover buttons (≈3×24px) -->
-                <button
-                    type="button"
-                    class="flex-1 flex items-center gap-1.5 text-left text-xs px-1.5 py-1 pr-20 text-primary-600-400 hover:underline truncate"
-                    onclick={() => selectNode(item.key)}
-                >
-                    {#if isObjectList}
-                        {@const Icon = nodeIcon(item.key, item.nodeType)}
-                        <Icon size={13} class="flex-shrink-0 opacity-70" />
-                    {/if}
-                    <span class="truncate">{item.text}</span>
-                </button>
-                <!-- pointer-events-none when invisible so clicks reach the name button -->
-                <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
+        {#each rows as row (row.kind === "header" ? row.key : row.item.key)}
+            {#if row.kind === "header"}
+                <div class="text-[11px] font-semibold text-surface-600-400 uppercase tracking-wide mt-2 mb-1 px-1 truncate" title={row.label}>{row.label}</div>
+            {:else}
+                {@const item = row.item}
+                {@const i = row.index}
+                <div class="group relative border border-surface-200-800 rounded mb-1 bg-surface-50-950 flex items-center">
+                    <label class="flex items-center pt-1 pb-1 pl-1.5 pr-0.5 cursor-pointer flex-shrink-0">
+                        <input
+                            type="checkbox"
+                            class="checkbox size-3.5"
+                            checked={selectedKeys.has(item.key)}
+                            onchange={(e) => toggleSelect(item.key, (e.target as HTMLInputElement).checked)}
+                        />
+                    </label>
+                    <!-- pr-20 keeps name clear of the hover buttons (≈3×24px) -->
                     <button
                         type="button"
-                        class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
-                        title={t("common.moveUp")}
-                        disabled={i === 0}
-                        onclick={() => moveUp(i)}
-                    >↑</button>
-                    <button
-                        type="button"
-                        class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
-                        title={t("common.moveDown")}
-                        disabled={i === items.length - 1}
-                        onclick={() => moveDown(i)}
-                    >↓</button>
-                    <button
-                        type="button"
-                        class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
-                        title={item.canDelete ? t("common.delete") : t("elementsList.cannotDelete")}
-                        disabled={!item.canDelete}
-                        onclick={() => onDeleteItem(item.key)}
-                    >×</button>
+                        class="flex-1 flex items-center gap-1.5 text-left text-xs px-1.5 py-1 pr-20 text-primary-600-400 hover:underline truncate"
+                        onclick={() => selectNode(item.key)}
+                    >
+                        {#if isObjectList}
+                            {@const Icon = nodeIcon(item.key, item.nodeType)}
+                            <Icon size={13} class="flex-shrink-0 opacity-70" />
+                        {/if}
+                        <span class="truncate">{item.text}</span>
+                    </button>
+                    <!-- pointer-events-none when invisible so clicks reach the name button -->
+                    <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                            title={t("common.moveUp")}
+                            disabled={i === 0}
+                            onclick={() => moveUp(i)}
+                        >↑</button>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                            title={t("common.moveDown")}
+                            disabled={i === items.length - 1}
+                            onclick={() => moveDown(i)}
+                        >↓</button>
+                        <button
+                            type="button"
+                            class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
+                            title={item.canDelete ? t("common.delete") : t("elementsList.cannotDelete")}
+                            disabled={!item.canDelete}
+                            onclick={() => onDeleteItem(item.key)}
+                        >×</button>
+                    </div>
                 </div>
-            </div>
+            {/if}
         {/each}
     {/if}
 

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -30,6 +30,8 @@
         nodeType: string
         isLibrary: boolean
         canDelete: boolean
+        // Only meaningful on isLibrary nodes — see groupLibraryChildren.
+        filename?: string | null
         children?: HierNode[]
     }
 
@@ -58,6 +60,46 @@
         return key ? t(key) : node.text;
     }
 
+    // Folds a run of 2+ consecutive same-filename library children (e.g. every function from
+    // Core.aslx) into a single synthetic, expand-on-demand "folder" node — a big library's worth
+    // of functions/timers/etc. otherwise floods this tree flat. Purely a display grouping over the
+    // existing SortIndex order (mirrors ElementsList's grouping); a lone run of 1 isn't worth the
+    // extra click to expand, so it's left inline. The synthetic node's isLibrary:true makes it
+    // fall out of nodeMenuOptions/reorderOptions for free (same guard real library rows use), and
+    // its id is deterministic so expand-state persistence (tree-state.ts) still works across reloads.
+    function groupLibraryChildren(children: HierNode[], parentId: string): HierNode[] {
+        const out: HierNode[] = [];
+        let i = 0;
+        while (i < children.length) {
+            const node = children[i];
+            if (node.isLibrary && node.filename) {
+                let j = i + 1;
+                while (j < children.length && children[j].isLibrary && children[j].filename === node.filename) j++;
+                if (j - i > 1) {
+                    // Suffixed with the run's first child id (globally unique, since it's a real
+                    // element key) rather than just filename — the same file can produce more than
+                    // one non-adjacent run under one parent (SortIndex order isn't guaranteed to
+                    // keep same-file items contiguous), and two runs would otherwise collide on id.
+                    out.push({
+                        id: `${parentId}::lib::${node.filename}::${node.id}`,
+                        text: node.filename,
+                        nodeType: "librarygroup",
+                        isLibrary: true,
+                        canDelete: false,
+                        children: children.slice(i, j),
+                    });
+                } else {
+                    out.push(node);
+                }
+                i = j;
+            } else {
+                out.push(node);
+                i++;
+            }
+        }
+        return out;
+    }
+
     // Build HierNode tree from flat list
     function buildHierTree(nodes: TreeNode[]): HierNode[] {
         // Deduplicate by key (last write wins, matching C# upsert behaviour in OnAddedNode)
@@ -73,14 +115,25 @@
             byParent.get(p)!.push(n);
         }
         const build = (node: TreeNode): HierNode => {
-            const children = byParent.get(node.key);
+            const children = byParent.get(node.key)?.map(build);
+            // "Included Libraries" lists the library *files* themselves (nodeType "include") —
+            // each one's own name is already a filename, so grouping them by which file declared
+            // the <include> just wraps a filename in an identically-named folder, and the same
+            // library can be pulled in from more than one place, producing several duplicate-
+            // labeled groups. Skip grouping at this level only; libraries defined *inside* a
+            // browsed included library (its functions, objects, its own nested includes, ...)
+            // still group normally, same as everywhere else.
+            const grouped = children && children[0]?.nodeType !== "include"
+                ? groupLibraryChildren(children, node.key)
+                : children;
             return {
                 id: node.key,
                 text: node.nodeType === "header" ? headerText(node) : node.text,
                 nodeType: node.nodeType,
                 isLibrary: node.isLibrary,
                 canDelete: node.canDelete,
-                ...(children ? { children: children.map(build) } : {}),
+                filename: node.filename,
+                ...(grouped ? { children: grouped } : {}),
             };
         };
         return (byParent.get(null) ?? []).map(build);

--- a/src/AppShell/src/lib/node-icons.ts
+++ b/src/AppShell/src/lib/node-icons.ts
@@ -39,6 +39,8 @@ export const NODE_TYPE_ICON: Record<string, IconComponent> = {
     dynamictemplate: Braces,
     type: Shapes,
     javascript: FileCode,
+    // Synthetic "grouped by source library file" folder node — see TreePanel's groupLibraryChildren.
+    librarygroup: Folder,
 };
 
 // Every header node's nodeType is the generic "header" (see WasmEditorBridge), so headers

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -8,6 +8,9 @@ export interface TreeNode {
   // player object, and any built-in library such as Core.aslx or a language file), so the UI
   // never needs its own guess at what's deletable.
   canDelete: boolean
+  // The .aslx file this element was loaded from (e.g. "Core.aslx", "CoreTimers.aslx", or the
+  // game's own file). Only meaningful for grouping when isLibrary is true.
+  filename: string | null
 }
 
 export interface ControlOption {

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -610,7 +610,8 @@ public sealed class EditorController : IDisposable
             AddedNode(this,
                 new AddedNodeEventArgs
                 {
-                    Key = key, Text = text, Parent = parent, IsLibraryNode = isLibrary, Position = position,
+                    Key = key, Text = text, Parent = parent, IsLibraryNode = isLibrary,
+                    Filename = o.MetaFields[MetaFieldDefinitions.Filename], Position = position,
                     NodeType = GetNodeType(o)
                 });
 
@@ -2871,6 +2872,7 @@ public sealed class EditorController : IDisposable
         public string Text { get; set; }
         public string Parent { get; set; }
         public bool IsLibraryNode { get; set; }
+        public string Filename { get; set; }
         public int? Position { get; set; }
         public string NodeType { get; set; }
     }

--- a/src/Engine/GameLoader/ElementLoaders.cs
+++ b/src/Engine/GameLoader/ElementLoaders.cs
@@ -338,7 +338,10 @@ internal partial class GameLoader
             }
 
             var stream = WorldModel.GetLibraryStream(filename);
-            var newReader = new XmlTextReader(stream);
+            // BaseURI (via this url overload) is what LoadXml/GameLoader.AddedElement records as
+            // MetaFieldDefinitions.Filename for every element loaded from this stream — used by the
+            // editor to group library elements by their source library file.
+            var newReader = new XmlTextReader(filename, stream);
             while (newReader.NodeType != XmlNodeType.Element && !newReader.EOF)
             {
                 newReader.Read();

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -17,7 +17,7 @@ using QuestViva.PlayerCore;
 
 namespace QuestViva.WasmEditor;
 
-internal record TreeNodeData(string Key, string Text, string? Parent, string NodeType, bool IsLibrary, bool CanDelete);
+internal record TreeNodeData(string Key, string Text, string? Parent, string NodeType, bool IsLibrary, bool CanDelete, string? Filename);
 
 internal record ControlOption(string Value, string Label);
 
@@ -3956,7 +3956,7 @@ public partial class WasmEditorBridge
         // Authoritative — mirrors exactly what DeleteElement/DeleteElements will actually allow
         // (see EditorController.CanDelete), rather than the UI guessing from node type/text.
         var node = new TreeNodeData(e.Key, e.Text, e.Parent, e.NodeType,
-            e.IsLibraryNode, _controller!.CanDelete(e.Key));
+            e.IsLibraryNode, _controller!.CanDelete(e.Key), e.Filename);
         if (_isRebuilding)
         {
             // ClearTree already emptied the list; all keys are unique in a fresh rebuild.


### PR DESCRIPTION
## Summary

Closes #2103.

- The Functions list (and equivalent lists elsewhere) plus the sidebar tree now group library-origin elements by their source `.aslx` file (`Core.aslx`, `CoreTimers.aslx`, `English.aslx`, ...) once "Show Library Elements" is on, instead of one long flat list.
- Grouping is purely a display transform over the existing per-element `SortIndex` order — no new persisted concept, no `.aslx` schema change.
- Fixed a real pre-existing bug the feature exposed: `IncludeLoaderBase` built its `XmlTextReader` from a bare `Stream`, so `reader.BaseURI` (and therefore `MetaFieldDefinitions.Filename` on every loaded element) was always empty. This also means the "This element comes from a library (Core.aslx)" banner has never shown a filename for anyone, on any game, until this fix.
- The sidebar tree deliberately does *not* group the "Included Libraries" branch itself — grouping library-reference nodes by which file included them just wraps an already-filename-labeled row in an identically-labeled folder, and duplicate labels appear when the same library is pulled in from more than one place.

## Test plan

- [x] `dotnet build` clean on EditorCore/WasmEditor
- [x] `svelte-check` and `eslint` clean on AppShell
- [x] Full `dotnet test`: 366/366 passing (Engine, EditorCore, PlayerCore, Legacy, WebPlayer)
- [x] Manual verification in a live browser session: grouped headers render correctly in both the Functions list panel and the sidebar tree; move up/down/delete still work per-item within a group; a user-authored function stays flat with no header; "Included Libraries" stays flat/ungrouped; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)