### PR TITLE
fix(AppShell): honor multiline/expand script control hints, auto-size code view

### DIFF
--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -231,6 +231,30 @@
         return isSimpleValue(ctrl);
     }
 
+    // Grows a multiline textbox to exactly fit its content (one line when empty/single-line,
+    // taller as more lines are typed) instead of a fixed row count that leaves blank space.
+    function autoResizeTextarea(node: HTMLTextAreaElement, value: string) {
+        void value; // only needed so Svelte calls `update` below when it changes externally
+        function resize() {
+            node.style.height = "auto";
+            node.style.height = `${node.scrollHeight}px`;
+        }
+        resize();
+        node.addEventListener("input", resize);
+        return {
+            update(newValue: string) {
+                // Skip when this fires for the field's own keystrokes (already resized live by
+                // the "input" listener) and only re-measure for genuinely external changes.
+                if (newValue !== node.value) {
+                    resize();
+                }
+            },
+            destroy() {
+                node.removeEventListener("input", resize);
+            },
+        };
+    }
+
     function toSimpleDisplay(ctrl: ScriptControlData): string {
         const v = ctrl.value ?? "";
         switch (ctrl.simpleEditor) {
@@ -549,7 +573,7 @@
             language="quest-script"
             readonly={isLocked}
             onChange={onCodeViewSave}
-            minHeight="10rem"
+            minHeight="auto"
         />
     {:else}
         <div role="region" inert={isLocked || undefined} class={isLocked ? "opacity-60" : ""}>
@@ -803,24 +827,39 @@
                         onchange={(v) => onSimpleValueChange(scriptIndex, ctrl, v)}
                         class="input text-xs py-0 px-1 min-w-16 max-w-48"
                     />
+                {:else if ctrl.multiline}
+                    <!-- multiline textbox (e.g. Print's message) - keeps embedded newlines,
+                         auto-sized to the height of its content rather than a fixed row count -->
+                    <textarea
+                        autocapitalize="off"
+                        rows="1"
+                        class="input text-xs py-0.5 px-1 min-w-16 w-full resize-none overflow-hidden"
+                        value={toSimpleDisplay(ctrl)}
+                        use:autoResizeTextarea={toSimpleDisplay(ctrl)}
+                        onchange={(e) => onSimpleValueChange(scriptIndex, ctrl, (e.target as HTMLTextAreaElement).value)}
+                    ></textarea>
                 {:else}
                     <!-- textbox (default for message, text, colour, etc.) -->
                     <input
                         type="text"
                         autocapitalize="off"
-                        class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+                        class={"input text-xs py-0 px-1 min-w-16 flex-1" + (ctrl.expand ? " w-full" : " max-w-48")}
                         value={toSimpleDisplay(ctrl)}
                         onchange={(e) => onSimpleValueChange(scriptIndex, ctrl, (e.target as HTMLInputElement).value)}
                     />
                 {/if}
             {:else}
-                <!-- Expression mode: raw expression text input -->
-                <ExpressionInput
-                    value={ctrl.value ?? ""}
-                    onchange={(v) => onSetParam(scriptIndex, ctrl.attribute!, v)}
-                    {objectNames}
-                    class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
-                />
+                <!-- Expression mode: raw expression text input. ExpressionInput's own root
+                     element isn't a flex item that grows on its own, so it needs a growing
+                     wrapper here to actually fill the row when expand is set. -->
+                <div class={ctrl.expand ? "flex-1 min-w-0" : "flex-none"}>
+                    <ExpressionInput
+                        value={ctrl.value ?? ""}
+                        onchange={(v) => onSetParam(scriptIndex, ctrl.attribute!, v)}
+                        {objectNames}
+                        class={"input text-xs py-0 px-1 min-w-16" + (ctrl.expand ? " w-full" : " max-w-48")}
+                    />
+                </div>
             {/if}
         {/if}
     {:else if ctrl.controlType === "expression"}

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -128,6 +128,12 @@ export interface ScriptControlData {
   // one per dictionary key - lets the case-list editor render each case's script from initial
   // data without a further round trip, mirroring how "scripts" does this for a "script" control.
   cases?: CaseScriptData[] | null
+  // <multiline/> - the "textbox" simple editor should render as a resizable textarea that
+  // keeps embedded newlines instead of a single-line input.
+  multiline?: boolean
+  // <expand/> - this control should grow to fill the remaining width of its row instead of
+  // being capped to a fixed max-width.
+  expand?: boolean
 }
 
 export interface ElseIfClauseData {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -87,7 +87,13 @@ internal record ScriptControlData(
     // Pre-fetched nested script trees for a "scriptdictionary" control (e.g. switch's "cases"),
     // one per dictionary key - mirrors how the "script" controltype's own Scripts field lets a
     // nested ScriptEditor render from initialData without a further round trip.
-    List<CaseScriptData>? Cases = null
+    List<CaseScriptData>? Cases = null,
+    // <multiline/> - the "textbox" simple editor should render as a resizable textarea that
+    // keeps embedded newlines (e.g. msg's message text) instead of a single-line input.
+    bool Multiline = false,
+    // <expand/> - this control should grow to fill the remaining width of its row instead of
+    // being capped to a fixed max-width.
+    bool Expand = false
 );
 
 internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
@@ -3923,6 +3929,8 @@ public partial class WasmEditorBridge
         // generic +/- item list.
         var isFunctionParams = ctrl.GetBool("functionparams");
         var breakBefore = ctrl.GetBool("breakbefore");
+        var multiline = ctrl.GetBool("multiline");
+        var expand = ctrl.Expand;
 
         string? useTemplates = null;
 
@@ -3985,7 +3993,9 @@ public partial class WasmEditorBridge
             isFunctionParams,
             breakBefore,
             useTemplates,
-            cases
+            cases,
+            multiline,
+            expand
         );
     }
 


### PR DESCRIPTION
## Summary
- The script editor now honors the `<multiline/>` and `<expand/>` aslx control hints (previously parsed but unused for `expand`, and not parsed at all for `multiline`). Print's message box (and any other control declaring both) now renders as a full-width, auto-growing textarea that preserves embedded newlines (round-tripped to/from `<br/>` in the saved expression), instead of a narrow single-line input capped at `max-w-48`.
- Switching that same field to "expression" mode is now also full width — `ExpressionInput`'s own root element wasn't a growing flex item, so it needed a wrapping `div` to actually claim the row.
- The multiline textarea auto-sizes to its content (one line when empty/short, grows live as more lines are typed) instead of a fixed `rows="3"`.
- The per-script Code view editor's `minHeight` changed from a fixed `10rem` (~10 blank lines) to `auto`, so an empty or short script no longer shows a tall mostly-empty box.

## Changes
- `src/WasmEditor/WasmEditorBridge.cs`: parse `<multiline/>` and thread the existing (previously unused) `Expand` control property through to `ScriptControlData`.
- `src/AppShell/src/lib/types.ts`: add `multiline`/`expand` to `ScriptControlData`.
- `src/AppShell/src/components/ScriptEditor.svelte`: render a full-width auto-resizing `<textarea>` when `multiline` is set; fill row width when `expand` is set (both simple and expression mode); drop the Code view editor's minimum height to `auto`.

## Test plan
- [x] `dotnet build --configuration Release` (full solution)
- [x] `dotnet test tests/EditorCoreTests --configuration Release`
- [x] `npx svelte-check` / `npm run lint` in `src/AppShell`
- [x] Manually verified in the AppShell dev server: Print's message box is full width and multi-line (Enter inserts real newlines, persists as `msg ("line1<br/>line2")`); switching to expression mode is full width; an unrelated non-expand control (Move object) is unaffected; the Code view editor sizes to 1/2/4 lines of actual content instead of always showing ~10 blank lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)