### PR TITLE
fix(AppShell): match textarea in code-view e2e round-trip check

### DIFF
--- a/tests/e2e/verify-appshell-code-view.mjs
+++ b/tests/e2e/verify-appshell-code-view.mjs
@@ -29,11 +29,12 @@ async function setCmContent(page, text) {
     return cm;
 }
 
-// The Print script's message renders as an <input>'s value, not visible text content, so this
-// checks inputValue() rather than a text= selector (which only matches rendered text nodes).
+// The Print script's message renders as an <input>'s or <textarea>'s value (multiline as of
+// #2115), not visible text content, so this checks .value rather than a text= selector (which
+// only matches rendered text nodes).
 async function waitForInputValue(page, value) {
     await page.waitForFunction(
-        v => [...document.querySelectorAll('input[type="text"]')].some(i => i.value === v),
+        v => [...document.querySelectorAll('input[type="text"], textarea')].some(i => i.value === v),
         value,
         { timeout: 5000 }
     );


### PR DESCRIPTION
## Summary
- The nightly `e2e` workflow's `appshell_chromium` / `verify-appshell-code-view.mjs` job started failing after [#2115](https://github.com/textadventures/quest/pull/2115), which intentionally changed Print's "message" control to render as a `<textarea>` (multiline) instead of a single-line `<input type="text">`.
- `waitForInputValue()` in the test only ever queried `input[type="text"]` elements, so it timed out (`page.waitForFunction: Timeout 5000ms exceeded`) waiting for the round-tripped value that was now sitting in a `<textarea>`.
- Updated the selector to match both `input[type="text"]` and `textarea`.

This is a test-only fix for a gap exposed by an intentional product change — not a regression in the app.

## Test plan
- [x] Built `WasmEditor` (Debug) and started the AppShell dev server locally (`PUBLIC_SHOW_HOME=true npx vite dev --port 5174`)
- [x] Ran `node verify-appshell-code-view.mjs http://localhost:5174` directly — all 18 checks pass