### PR TITLE
ci: allow "e2e" scope in PR title lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -23,6 +23,9 @@ jobs:
           # match a project name exactly, so it clusters and capitalizes
           # consistently in the release-please changelog. "main" is included
           # because release-please's own PR titles are "chore(main): release X.Y.Z".
+          # "e2e" is included because tests/e2e/*.mjs scripts (see e2e.yml) span
+          # multiple projects (AppShell, WebPlayer, WasmPlayer, ElectronApp), so
+          # a test-only fix often doesn't belong to any single project scope.
           scopes: |
             Common
             Engine
@@ -35,4 +38,5 @@ jobs:
             WasmEditor
             ElectronApp
             Site
+            e2e
             main


### PR DESCRIPTION
## Summary
- `tests/e2e/*.mjs` scripts (see `e2e.yml`) span multiple projects — AppShell, WebPlayer, WasmPlayer, ElectronApp — so a fix scoped purely to the e2e test suite doesn't map cleanly onto any single project name in `pr-title-lint.yml`'s scope allowlist.
- This just came up on [#2117](https://github.com/textadventures/quest/pull/2117), which had to be retitled to `fix(AppShell): ...` even though the change was really e2e-test-only.
- Adds `e2e` as an allowed scope so future e2e-only PRs can use `fix(e2e): ...` / `feat(e2e): ...` directly.

## Test plan
- [x] N/A — workflow config change only, no code path to exercise locally