### PR TITLE
fix(Engine): make transcript viewer message translatable

### DIFF
--- a/src/Engine/Core/CoreCommands.aslx
+++ b/src/Engine/Core/CoreCommands.aslx
@@ -949,7 +949,7 @@
   <command name="view_transcript_cmd" pattern="[view_transcript_cmd]">
     <script>
       if (not GetBoolean(game, "notranscript")){
-        JS.showTranscript ()
+        JS.showTranscript (Template("TranscriptViewerMessage"), Template("TranscriptViewerLinkText"))
       }
       else {
         msg (Template("NoTranscriptFeature"))

--- a/src/Engine/Core/Languages/Deutsch.aslx
+++ b/src/Engine/Core/Languages/Deutsch.aslx
@@ -558,6 +558,8 @@
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Gib </i>" + Template("TranscriptOffAllCaps") + "<i> ein um das Transkript zu beenden.  ]</i></b>"]]></dynamictemplate>
   <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start des Transkripts:<br/><b>TITEL: </b>" + game.gamename + "<br/><b>AUTOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSKRIPT AUS</template>
+  <template name="TranscriptViewerMessage">Deine Transkripte werden im localStorage deines Browsers gespeichert. Du kannst sie hier ansehen, herunterladen oder löschen:</template>
+  <template name="TranscriptViewerLinkText">Deine Transkripte</template>
   <template name="Noted">Vermerkt.</template>
   <template name="ShowMenuResponsePrompt">>> </template>
   <template name="PageDialogueChooseOption">Bitte wähle eine der oben genannten Optionen.</template>

--- a/src/Engine/Core/Languages/English.aslx
+++ b/src/Engine/Core/Languages/English.aslx
@@ -502,6 +502,8 @@
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
   <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start of a transcript of:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSCRIPT OFF</template>
+  <template name="TranscriptViewerMessage">Your transcripts are saved to the localStorage in your browser. You can view, download, or delete them here:</template>
+  <template name="TranscriptViewerLinkText">Your Transcripts</template>
   <template name="Noted">Noted.</template>
   <template name="ShowMenuResponsePrompt">>> </template>
   <template name="PageDialogueChooseOption">Please choose one of the options above.</template>

--- a/src/Engine/Core/Languages/Espanol.aslx
+++ b/src/Engine/Core/Languages/Espanol.aslx
@@ -713,6 +713,8 @@
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Escribe </i>" + Template("TranscriptOffAllCaps") + "<i> para desactivar la transcripción.  ]</i></b>"]]></dynamictemplate>
   <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Inicio de la transcripción de:<br/><b>TÍTULO: </b>" + game.gamename + "<br/><b>AUTOR: </b>" + game.author + "<br/><b>VERSIÓN: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSCRIPCIÓN APAGADA</template>
+  <template name="TranscriptViewerMessage">Tus transcripciones se guardan en el localStorage de tu navegador. Puedes verlas, descargarlas o eliminarlas aquí:</template>
+  <template name="TranscriptViewerLinkText">Tus transcripciones</template>
   <template name="Noted">Anotado.</template>
   <template name="ShowMenuResponsePrompt">>> </template>
   <template name="PageDialogueChooseOption">Por favor, elige una de las opciones anteriores.</template>

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -1873,8 +1873,15 @@ function SaveTranscript(text) {
 var transcriptUrl = 'TranscriptViewer/index.html';
 
 // Another fallback to avoid errors
-function showTranscript() {
-    addTextAndScroll('Your transcripts are saved to the localStorage in your browser. You can view, download, or delete them here: <a href="' + transcriptUrl + '" target="_blank">Your Transcripts</a><br/>');
+// message/linkText are passed in by CoreCommands.aslx via translated templates
+// (Core/Languages/*.aslx). Games published before this was added have the old
+// zero-arg "JS.showTranscript ()" call baked into their package (Core library
+// scripts are inlined at publish time, but this JS file isn't), so fall back
+// to the original hardcoded English text when called without arguments.
+function showTranscript(message, linkText) {
+    if (message == null) message = 'Your transcripts are saved to the localStorage in your browser. You can view, download, or delete them here:';
+    if (linkText == null) linkText = 'Your Transcripts';
+    addTextAndScroll(message + ' <a href="' + transcriptUrl + '" target="_blank">' + linkText + '</a><br/>');
 }
 
 function replaceTranscriptString(data) {


### PR DESCRIPTION
## Summary
- The "show transcript" command's response (`Your transcripts are saved to the localStorage in your browser...`) was hardcoded English directly in `playercore.js`, bypassing the per-language Core template system that every sibling transcript message (`NoTranscriptFeature`, `TranscriptDisabled`, etc.) already uses.
- Added `TranscriptViewerMessage` and `TranscriptViewerLinkText` templates to `English.aslx`, and translated them into `Deutsch.aslx` (informal "Du") and `Espanol.aslx` (informal "tú"), per `docs/i18n-style-guide.md`. `tools/i18n/audit.mjs --strict` requires 100% Player (.aslx) layer coverage for `en`/`de`/`es`, so both were needed for CI's `i18n_audit` job to pass.
- `view_transcript_cmd` in `CoreCommands.aslx` now passes the resolved templates into `JS.showTranscript(...)`.
- `showTranscript()` in `playercore.js` falls back to the original hardcoded English text when called with no arguments — `playercore.js` isn't inlined per-game the way `Core.aslx` is, so already-published games (which have the old zero-arg `JS.showTranscript ()` call baked into their package) keep working unchanged.

## Test plan
- [x] `dotnet test tests/EngineTests --configuration Release` — 311/311 passing
- [x] `node tools/i18n/audit.mjs --strict` — exits 0 (was exiting 1 with just the English template added)
- [x] Verified live in WasmPlayer: typed `show transcript`, confirmed the message renders identically to before, with the "Your Transcripts" link pointing at `TranscriptViewer/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)