### PR TITLE
feat(WasmPlayer): show Debug options for .aslx played from the Play tab

### DIFF
--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -474,8 +474,14 @@ function swapInPlayerUi() {
 // beginning"/Load in an editor-preview session.
 let currentIsPreview = false;
 
-async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null) {
+// Same idea as currentIsPreview, but for the source=local .aslx case (see
+// setCanDebug's call sites below) — kept separate from isPreview because it
+// must NOT also disable Save or add the Restart button the way isPreview does.
+let currentAllowDebug = false;
+
+async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null, allowDebug = false) {
     currentIsPreview = isPreview;
+    currentAllowDebug = allowDebug;
     const dotnetJsUrl = wasmPlayerScriptUrl
         ? new URL('_framework/dotnet.js', wasmPlayerScriptUrl).href
         : './_framework/dotnet.js';
@@ -611,10 +617,12 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
     // BroadcastChannel (to hand off the picked file's bytes and answer
     // resource requests) but is a real play session and should offer saving.
     WebPlayer.setCanSave(!isPreview);
-    // Only ever shown in editor-preview sessions (see the module doc comment
-    // above the Debugger section) — never for a normal play session, even
+    // Shown in editor-preview sessions, and also in a source=local play
+    // session for a raw .aslx file specifically (allowDebug — see the
+    // source=local boot branch below, which is the only caller that ever
+    // passes it true) — never for any other normal play session, even
     // though the loaded game itself might have DebugEnabled true.
-    WebPlayer.setCanDebug(isPreview && Bridge.IsDebugEnabled());
+    WebPlayer.setCanDebug((isPreview || allowDebug) && Bridge.IsDebugEnabled());
 
     await Bridge.Begin();
 
@@ -719,7 +727,7 @@ async function restartGameCore(saveBytes) {
         // restartGame reachable *from* a preview session too, hardcoding true
         // here would wrongly re-enable Save after a preview restart.
         WebPlayer.setCanSave(!currentIsPreview);
-        WebPlayer.setCanDebug(currentIsPreview && Bridge.IsDebugEnabled());
+        WebPlayer.setCanDebug((currentIsPreview || currentAllowDebug) && Bridge.IsDebugEnabled());
         await Bridge.Begin();
     } finally {
         restartingEl?.classList.add('hidden');
@@ -729,7 +737,7 @@ async function restartGameCore(saveBytes) {
 // Wraps initWasmPlayer with the boot-time "Continue / New Game" prompt: if
 // saves already exist for this game, ask before committing to either the
 // fresh game or a chosen save. Used by all boot entry points below.
-async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null) {
+async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null, allowDebug = false) {
     originalGameBytes = bytes;
     originalGameFilename = filename;
     originalAdjacentFiles = adjacentFiles;
@@ -769,7 +777,7 @@ async function startGame(bytes, filename, bc = null, gameIdOverride = null, isPr
     // by initWasmPlayer in that case) — callers with post-success work (e.g.
     // persisting the active URL) should key off this. Genuine setup failures
     // (fetch, WASM boot) still throw as before.
-    return initWasmPlayer(bytes, filename, bc, saveBytes, isPreview, recordWalkthrough, runWalkthrough, adjacentFiles);
+    return initWasmPlayer(bytes, filename, bc, saveBytes, isPreview, recordWalkthrough, runWalkthrough, adjacentFiles, allowDebug);
 }
 
 // ── Start screen helpers ──────────────────────────────────────────────────────
@@ -1022,10 +1030,11 @@ async function openSavesDialog(mode, gameId = WebPlayer.gameId) {
 }
 
 // ── Debugger (#questVivaDebugger) ─────────────────────────────────────────────
-// Only ever opened in editor-preview sessions (see WebPlayer.setCanDebug's
-// call site in initWasmPlayer/restartGame) — element browser, per-tab
-// attribute inspector with a "hack your own game" override, and a walkthrough
-// runner. Mirrors WebPlayer's Debugger/Attributes/Walkthrough.razor, which
+// Only ever opened in editor-preview sessions, or a source=local play session
+// for a raw .aslx file (see WebPlayer.setCanDebug's call sites in
+// initWasmPlayer/restartGame) — element browser, per-tab attribute inspector
+// with a "hack your own game" override, and a walkthrough runner. Mirrors
+// WebPlayer's Debugger/Attributes/Walkthrough.razor, which
 // drive IGameDebug directly as Blazor components; here the same data comes
 // over the bridge as JSON (Bridge.Get*Json — see WasmPlayerBridge.cs) for
 // plain-DOM rendering instead.
@@ -2084,7 +2093,15 @@ async function fetchGameBytes(url) {
                 // reassigns bc.onmessage itself to keep answering
                 // 'resource-response' messages for the rest of the session.
                 bc.onmessage = null;
-                await startGame(data.bytes, data.filename, bc, null, false, null, null, data.adjacentFiles ?? null);
+                // A raw .aslx picked straight from the Play tab is an
+                // author's own in-progress source file (unlike a packaged
+                // .quest/.asl/.cas), so treat it like an editor preview for
+                // Debug purposes — but only that, via the separate
+                // allowDebug flag: Save/Restart still behave as a normal
+                // play session (isPreview stays false) since a real save is
+                // still wanted here.
+                const allowDebug = /\.aslx$/i.test(data.filename ?? '');
+                await startGame(data.bytes, data.filename, bc, null, false, null, null, data.adjacentFiles ?? null, allowDebug);
             }
         };
         return;

--- a/tests/e2e/verify-appshell-play-open-file.mjs
+++ b/tests/e2e/verify-appshell-play-open-file.mjs
@@ -51,6 +51,13 @@ async function run() {
     await popup.waitForFunction(() => document.title === 'Simple', null, { timeout: 15000 });
     console.log('[player] game booted, document.title:', await popup.title());
 
+    // A raw .aslx played straight from the Play tab (unlike a packaged .quest)
+    // should offer the same Debug options as the editor's own preview — see
+    // wasm-player.js's source=local boot branch.
+    const debugDisplay = await popup.$eval('#cmdDebug', el => getComputedStyle(el).display);
+    console.log('[player] Debug button display for .aslx file:', debugDisplay);
+    if (debugDisplay === 'none') throw new Error('Debug button should be visible when playing a .aslx file directly from the Play tab');
+
     // Back on the AppShell tab, the picked-file UI should have reset to the plain button.
     await page.waitForSelector('button:has-text("Open a game file…")', { timeout: 5000 });
     console.log('[appshell] picked-file UI reset after handoff');


### PR DESCRIPTION
## Summary
- When an author runs their game from the Editor, we show Debug options. This extends the same behavior to AppShell's Play tab: running a raw `.aslx` file directly from there (the `source=local` file-picker flow) now shows the Debug button/dialog too — but **only** for `.aslx` files, not `.quest` packages (or `.asl`/`.cas`).
- Implemented as a new `allowDebug` flag threaded separately from `isPreview` through `startGame`/`initWasmPlayer`, computed from the filename extension in the `source=local` boot branch. Kept separate from `isPreview` deliberately: reusing `isPreview` would also have disabled Save and added the Restart button, neither of which should change for a real Play-tab session — this only affects Debug visibility.
- This lines up naturally with `IGameDebug.DebugEnabled`, which is already true for any raw `.aslx`/`.asl` source and false for a packaged `.quest` file — so the extension check on the Play tab side matches exactly.

## Test plan
- [x] Manually verified via BroadcastChannel simulation against the WasmPlayer dev server: `.aslx` → Debug button visible (`cmdDebug` display `initial`), Save still enabled, Debugger dialog opens and works; `.quest` package → Debug hidden, Save enabled.
- [x] Extended `tests/e2e/verify-appshell-play-open-file.mjs` (the existing Play-tab "pick a file → Start" e2e test) with an assertion that Debug is visible after the real file-picker flow — ran it against live AppShell + WasmPlayer dev servers: **PASS**.
- [x] Reran `tests/e2e/verify-wasmplayer-debugger.mjs` (editor-preview path, unaffected by this change) — all checks **PASS**.
- [x] Reran `tests/e2e/verify-appshell-play-refresh.mjs` (local-play refresh/reconnect) — **PASS**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)