### PR TITLE
fix(AppShell): script editor controls reclaim width on touch

### DIFF
--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -704,7 +704,7 @@
 </div>
 
 {#snippet normalBlock(script: ScriptNodeData, i: number)}
-    <div class="px-2 py-1 pr-16 flex flex-wrap items-center gap-x-1 gap-y-0.5 text-xs">
+    <div class="px-2 py-1 pr-16 pointer-coarse:pr-2 flex flex-wrap items-center gap-x-1 gap-y-0.5 text-xs">
         {#each script.controls ?? [] as ctrl, ci (ci)}
             {@render inlineControl(ctrl, i, script.controls ?? [], ci)}
         {/each}
@@ -1094,7 +1094,7 @@
 {/snippet}
 
 {#snippet ifBlock(script: ScriptNodeData, i: number)}
-    <div class="px-2 py-1 pr-16 text-xs">
+    <div class="px-2 py-1 pr-16 pointer-coarse:pr-2 text-xs">
         <!-- If condition -->
         <div class="flex items-center gap-1 flex-wrap">
             <span class="text-surface-600-400 font-medium select-none">{t("scriptEditor.ifKeyword")}</span>


### PR DESCRIPTION
## Summary
- Script rows in the visual script editor reserved `pr-16` (64px) of right padding for the move-up/move-down/delete buttons, but those buttons are hover-only (`opacity-0 group-hover:opacity-100`) with no touch fallback — on touch, reordering/deleting is handled instead by the checkbox + selection toolbar. That left 64px of dead space on mobile, squeezing the row content.
- Added `pointer-coarse:pr-2` to both script-row snippets (`normalBlock` and `ifBlock`) so the reserved padding drops to match the row's own left padding on touch devices, while desktop/mouse keeps the full 64px reserved for the hover buttons. Same pattern already used in `TreePanel.svelte`.

## Test plan
- [x] Verified in-browser with mobile/touch emulation (375x812, `pointer: coarse`): computed `padding-right` on the script row goes from 64px → 8px.
- [x] Verified desktop/mouse mode (`pointer: fine`) still reserves the full 64px.
- [x] `npx eslint src/components/ScriptEditor.svelte` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)