### PR TITLE
fix(AppShell): accept .xml extension for included libraries

### DIFF
--- a/src/AppShell/src/components/AddLibraryModal.svelte
+++ b/src/AppShell/src/components/AddLibraryModal.svelte
@@ -85,7 +85,7 @@
                     onclick={() => inputEl.click()}
                     disabled={uploading}
                 >{uploading ? t("assetManager.uploading") : filename ? t("addLibraryModal.change") : t("assetManager.upload")}</button>
-                <input bind:this={inputEl} type="file" accept=".aslx" class="hidden" onchange={handleUpload} />
+                <input bind:this={inputEl} type="file" accept=".aslx,.xml" class="hidden" onchange={handleUpload} />
             </div>
             {#if error}<p class="text-xs text-error-500">{error}</p>{/if}
         </div>

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { selectedKey, selectedData, treeNodes, isGamebook, setAttribute, setDropdownType, setMultiType, setObjectReference, setSelectedFilter, addDictItem, removeDictItem, updateDictItem, getObjectNames, getExitNames, getPageNames, selectNode, createPageSilent, openAddModal, openAddLibraryModal, openAddJavascriptModal, getAssetText, putAssetText, putLibraryAssetText, isBuiltInLibrary, getLibraryXml, setPatternAttribute } from "$lib/editor-store";
     import { showToast } from "$lib/toast";
+    import { isLibraryFilename } from "$lib/filesystem/types";
     import { t } from "$lib/i18n";
     import type { ControlInfo, ControlOption, TextProcessorCommand } from "$lib/types";
     import type { TreeNode } from "$lib/types";
@@ -85,7 +86,7 @@
         const onDisk = lastTexteditorWrite?.filename === filename ? lastTexteditorWrite.text : loadedContent;
         if (value === onDisk) return;
         lastTexteditorWrite = { filename, text: value };
-        if (filename.toLowerCase().endsWith(".aslx")) {
+        if (isLibraryFilename(filename)) {
             void putLibraryAssetText(filename, value).then(result => {
                 // A malformed library edit is rejected before it's written (putLibraryAssetText
                 // validates against a throwaway controller first), so the game can't be reloaded
@@ -828,12 +829,13 @@
     {:else if ctrl.controlType === "texteditor" && ctrl.attribute !== null}
         {@const filename = attrValue(ctrl.attribute)}
         <!-- The same control type drives both file kinds: a Javascript element's src (.js — the
-             original use, editable in place) and an Included Library's filename (.aslx — see
-             CoreEditorIncludedLibrary.aslx). Library content is handled differently because it's
+             original use, editable in place) and an Included Library's filename (.aslx, or .xml
+             for compatibility with libraries authored in Quest 5's desktop editor — see
+             CoreEditorIncludedLibrary.aslx and isLibraryFilename). Library content is handled differently because it's
              consumed at load time, not at play time: custom libraries are written via
              putLibraryAssetText (which flags that a reload is needed), and the engine-shipped
              built-in libraries are shown read-only since they don't belong to the game at all. -->
-        {@const isLibraryFile = !!filename && filename.toLowerCase().endsWith(".aslx")}
+        {@const isLibraryFile = !!filename && isLibraryFilename(filename)}
         {@const builtInLibrary = isLibraryFile && !!filename && isBuiltInLibrary(filename)}
         {@const language = isLibraryFile ? "xml" : "javascript"}
         <div class="w-full min-h-64">

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -3,7 +3,7 @@ import { zipSync } from "fflate";
 import { PUBLIC_WASM_PLAYER_URL, PUBLIC_APPSHELL_VERSION } from "$env/static/public";
 import { loadWasm } from "./wasm";
 import type { WasmBridge } from "./wasm";
-import type { AssetInfo, FileAdapter } from "./filesystem/types";
+import { isLibraryFilename, type AssetInfo, type FileAdapter } from "./filesystem/types";
 import { LocalDraftAdapter, shouldShowBackupBanner, markBackupBannerResolved } from "./filesystem/local-adapter";
 import { ServerFileAdapter } from "./filesystem/server-adapter";
 import { triggerDownload } from "./filesystem/download";
@@ -199,7 +199,7 @@ export const lastFailedGameFilename = writable<string | null>(null);
 async function listLibraryCandidateFilenames(adapter: FileAdapter): Promise<string[]> {
     return adapter.listLibraryCandidates
         ? await adapter.listLibraryCandidates()
-        : (await adapter.listAssets()).map(a => a.key).filter(key => key.toLowerCase().endsWith(".aslx"));
+        : (await adapter.listAssets()).map(a => a.key).filter(key => isLibraryFilename(key));
 }
 
 async function resolveLibraryCandidateFiles(adapter: FileAdapter): Promise<Record<string, Uint8Array>> {

--- a/src/AppShell/src/lib/filesystem/browser-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/browser-adapter.ts
@@ -1,4 +1,4 @@
-import { isJunkAssetName, isLibraryAslxContent, type AssetInfo, type FileAdapter, type LoadedFile } from "./types";
+import { isJunkAssetName, isLibraryAslxContent, isLibraryFilename, type AssetInfo, type FileAdapter, type LoadedFile } from "./types";
 import { toBlob, triggerDownload } from "./download";
 
 // FSA globals — not in the TS DOM lib at this target version
@@ -149,7 +149,7 @@ export class BrowserFileAdapter implements FileAdapter {
         try {
             const assets: AssetInfo[] = [];
             for await (const [name, handle] of this._dir) {
-                if (handle.kind === "file" && !name.toLowerCase().endsWith(".aslx") && !isJunkAssetName(name)) {
+                if (handle.kind === "file" && !isLibraryFilename(name) && !isJunkAssetName(name)) {
                     assets.push({ key: name, url: "" });
                 }
             }
@@ -168,7 +168,7 @@ export class BrowserFileAdapter implements FileAdapter {
         try {
             const libraries: string[] = [];
             for await (const [name, handle] of this._dir) {
-                if (handle.kind === "file" && name.toLowerCase().endsWith(".aslx") && name !== this._filename) {
+                if (handle.kind === "file" && isLibraryFilename(name) && name !== this._filename) {
                     libraries.push(name);
                 }
             }

--- a/src/AppShell/src/lib/filesystem/electron-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/electron-adapter.ts
@@ -1,4 +1,4 @@
-import { isJunkAssetName, type AssetInfo, type FileAdapter } from "./types";
+import { isJunkAssetName, isLibraryFilename, type AssetInfo, type FileAdapter } from "./types";
 
 const ASLX_FILTER = [{ name: "Quest game files", extensions: ["aslx"] }];
 
@@ -95,7 +95,7 @@ async function trackRecent(dirPath: string, filename: string, kind: RecentKind =
 async function computeWatchList(dirPath: string, mainFilename: string): Promise<string[]> {
     const entries = await electronApp().fs.readDir(dirPath);
     const libraries = entries
-        .filter((e) => e.isFile && e.name.toLowerCase().endsWith(".aslx") && e.name !== mainFilename)
+        .filter((e) => e.isFile && isLibraryFilename(e.name) && e.name !== mainFilename)
         .map((e) => e.name);
     return [mainFilename, ...libraries];
 }
@@ -190,7 +190,7 @@ export class ElectronFileAdapter implements FileAdapter {
     async listAssets(): Promise<AssetInfo[]> {
         const entries = await electronApp().fs.readDir(this.dirPath);
         return entries
-            .filter((e) => e.isFile && !e.name.toLowerCase().endsWith(".aslx") && !isJunkAssetName(e.name))
+            .filter((e) => e.isFile && !isLibraryFilename(e.name) && !isJunkAssetName(e.name))
             .map((e) => ({ key: e.name, url: "" }));
     }
 
@@ -201,7 +201,7 @@ export class ElectronFileAdapter implements FileAdapter {
     async listLibraryCandidates(): Promise<string[]> {
         const entries = await electronApp().fs.readDir(this.dirPath);
         return entries
-            .filter((e) => e.isFile && e.name.toLowerCase().endsWith(".aslx") && e.name !== this._filename)
+            .filter((e) => e.isFile && isLibraryFilename(e.name) && e.name !== this._filename)
             .map((e) => e.name);
     }
 

--- a/src/AppShell/src/lib/filesystem/types.ts
+++ b/src/AppShell/src/lib/filesystem/types.ts
@@ -58,3 +58,12 @@ export function isJunkAssetName(name: string): boolean {
 export function isLibraryAslxContent(text: string): boolean {
     return text.match(/<([a-zA-Z][\w:-]*)/)?.[1] === "library";
 }
+
+// Included Library filenames are normally .aslx, but Quest 5's desktop editor also accepted
+// .xml for them (its docs mentioned it too) — kept here so libraries authored back then still
+// upload/import/watch/edit correctly. Never applies to a game's own main file, which is always
+// .aslx regardless.
+export function isLibraryFilename(name: string): boolean {
+    const lower = name.toLowerCase();
+    return lower.endsWith(".aslx") || lower.endsWith(".xml");
+}

--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -155,7 +155,7 @@
     "addJavascriptModal.helpText": "Wähle eine vorhandene .js-Datei aus, gebe einen Dateinamen ein, um eine neue Datei zu erstellen, oder lade eine Datei hoch.",
 
     "addLibraryModal.title": "Eingebundene Bibliothek hinzufügen",
-    "addLibraryModal.helpText": "Lade eine .aslx Bibliotheksdatei hoch.",
+    "addLibraryModal.helpText": "Lade eine .aslx- oder .xml-Bibliotheksdatei hoch.",
     "addLibraryModal.noFileChosen": "Keine Datei ausgewählt",
     "addLibraryModal.change": "Ändern…",
     "addLibraryModal.alreadyUsedError": "\"{name}\" wird bereits von einer anderen eingebundenen Bibliothek verwendet.",

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -155,7 +155,7 @@
     "addJavascriptModal.helpText": "Pick an existing .js file, type a filename to create a new one, or upload a file.",
 
     "addLibraryModal.title": "Add Included Library",
-    "addLibraryModal.helpText": "Upload a .aslx library file.",
+    "addLibraryModal.helpText": "Upload a .aslx or .xml library file.",
     "addLibraryModal.noFileChosen": "No file chosen",
     "addLibraryModal.change": "Change…",
     "addLibraryModal.alreadyUsedError": "\"{name}\" is already used by another Included Library.",

--- a/src/AppShell/static/locales/es.json
+++ b/src/AppShell/static/locales/es.json
@@ -155,7 +155,7 @@
     "addJavascriptModal.helpText": "Elige un archivo .js existente, escribe un nombre de archivo para crear uno nuevo, o sube un archivo.",
 
     "addLibraryModal.title": "Añadir Biblioteca Incluida",
-    "addLibraryModal.helpText": "Sube un archivo de biblioteca .aslx.",
+    "addLibraryModal.helpText": "Sube un archivo de biblioteca .aslx o .xml.",
     "addLibraryModal.noFileChosen": "Ningún archivo seleccionado",
     "addLibraryModal.change": "Cambiar…",
     "addLibraryModal.alreadyUsedError": "\"{name}\" ya está siendo usado por otra Biblioteca Incluida.",

--- a/src/AppShell/static/locales/xx.json
+++ b/src/AppShell/static/locales/xx.json
@@ -128,7 +128,7 @@
     "elementsList.selectedCount": "[{count} séléctéd]",
     "addJavascriptModal.helpText": "[Píck án éxístíng .js fílé, typé á fílénámé tó créáté á néw óné, ór úplóád á fílé.]",
     "addLibraryModal.title": "[Ádd Ínclúdéd Líbráry]",
-    "addLibraryModal.helpText": "[Úplóád á .áslx líbráry fílé.]",
+    "addLibraryModal.helpText": "[Úplóád á .áslx ór .xml líbráry fílé.]",
     "addLibraryModal.noFileChosen": "[Nó fílé chósén]",
     "addLibraryModal.change": "[Chángé…]",
     "addLibraryModal.alreadyUsedError": "[\"{name}\" ís álréády úséd by ánóthér Ínclúdéd Líbráry.]",

--- a/tests/e2e/fixtures/custom-library-test.xml
+++ b/tests/e2e/fixtures/custom-library-test.xml
@@ -1,0 +1,5 @@
+<library>
+  <function name="MyXmlLibraryGreeting">
+    <![CDATA[<msg>Hello from my .xml library</msg>]]>
+  </function>
+</library>

--- a/tests/e2e/verify-appshell-library-xml-extension.mjs
+++ b/tests/e2e/verify-appshell-library-xml-extension.mjs
@@ -1,0 +1,124 @@
+// Verifies that Included Libraries can also be uploaded with a .xml extension, not just .aslx.
+// Quest 5's desktop editor accepted .xml for included libraries too (its docs mentioned it), so
+// this checks the AppShell editor keeps that alternate extension working end-to-end: the Add
+// Library file picker accepts it, the uploaded file is treated as a library (editable XML editor,
+// not shown in Manage assets as a deletable asset), and the game reloads cleanly afterwards —
+// proving <include ref="custom-library-test.xml"/> actually resolves via the adapter's library
+// candidate discovery, not just that the upload itself succeeded.
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+const fixture = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'custom-library-test.xml');
+
+const browser = await chromium.launch();
+
+// Same paste-based content replacement as the library-editor test (see its header comment for
+// why: CodeMirror's own typing/auto-indent behavior isn't reliable to drive via keyboard.type).
+const selectAllKey = process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
+const pasteKey = process.platform === 'darwin' ? 'Meta+V' : 'Control+V';
+
+async function setCmContent(page, text) {
+    const cm = page.locator('.cm-editor .cm-content').first();
+    await cm.click();
+    await page.keyboard.press(selectAllKey);
+    await page.evaluate(t => navigator.clipboard.writeText(t), text);
+    await page.keyboard.press(pasteKey);
+    return cm;
+}
+
+function treeItem(page, name) {
+    return page.locator('[data-scope="tree-view"] [data-part="item"]').filter({ hasText: name });
+}
+
+// Included Libraries live under the "Advanced" header, which is collapsed by default. The expand
+// toggle is the chevron button inside the branch-control (not the control itself), so click that.
+async function expandBranch(page, value) {
+    const content = page.locator(`[data-value="${value}"][data-part="branch-content"]`);
+    for (let i = 0; i < 4; i++) {
+        if (await content.isVisible()) return;
+        await page
+            .locator(`[data-value="${value}"][data-part="branch-control"] button[aria-label="Expand"], [data-value="${value}"][data-part="branch-control"] button[aria-label="Collapse"]`)
+            .first()
+            .click();
+        await page.waitForTimeout(200);
+    }
+    throw new Error(`Failed to expand tree branch "${value}"`);
+}
+
+async function revealLibraries(page) {
+    await expandBranch(page, '_advanced');
+    await expandBranch(page, '_include');
+}
+
+const CUSTOM_LIBRARY = 'custom-library-test.xml';
+
+try {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    await ctx.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Library Xml Extension Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+    await revealLibraries(page);
+
+    // --- The Add Library file picker accepts .xml, not just .aslx ---
+    await page.locator('[data-value="_include"] .node-actions button').click();
+    await page.waitForSelector('.tree-dropdown button:has-text("Add library")', { timeout: 5000 });
+    await page.click('.tree-dropdown button:has-text("Add library")');
+    await page.waitForSelector('[role="dialog"]', { timeout: 5000 });
+    const accept = await page.locator('[role="dialog"] input[type="file"]').getAttribute('accept');
+    if (!accept || !accept.split(',').map(s => s.trim()).includes('.xml')) {
+        throw new Error(`Expected the Add Library file input's accept attribute to include ".xml", got "${accept}"`);
+    }
+    console.log('PASS: the Add Library file picker accepts .xml');
+
+    await page.setInputFiles('[role="dialog"] input[type="file"]', fixture);
+    await page.waitForFunction(() => document.querySelector('[role="dialog"] button') !== null, { timeout: 5000 });
+    await page.click('[role="dialog"] button:has-text("Add library")');
+    await page.waitForSelector('[role="dialog"]', { state: 'hidden', timeout: 5000 }).catch(() => {});
+    await treeItem(page, CUSTOM_LIBRARY).first().waitFor({ state: 'visible', timeout: 10000 });
+    console.log('PASS: custom .xml library uploaded and added via the Included Libraries header menu');
+    await page.click('button:has-text("Dismiss")');
+    await page.waitForSelector('text=Reload the editor to apply your library changes', { state: 'hidden', timeout: 5000 });
+
+    // --- It's treated as a library, not a plain asset: editable XML editor with its content ---
+    await treeItem(page, CUSTOM_LIBRARY).first().click();
+    await page.waitForSelector('.cm-editor', { timeout: 10000 });
+    const customEditable = await page.locator('.cm-content').first().getAttribute('contenteditable');
+    if (customEditable !== 'true') throw new Error(`Expected the custom .xml library editor to be editable (contenteditable=true), got "${customEditable}"`);
+    const customContent = await page.locator('.cm-content').first().innerText();
+    if (!customContent.includes('MyXmlLibraryGreeting')) throw new Error('Expected the custom library editor to show the uploaded .xml content');
+    console.log('PASS: selecting the .xml library shows its uploaded content in an editable editor');
+
+    // --- Reload (the app's own in-editor reload, which re-runs WASM Initialise) proves
+    //     <include ref="custom-library-test.xml"/> actually resolves via the adapter's library
+    //     candidate discovery, not just that the upload succeeded ---
+    await setCmContent(page, '<library>\n  <function name="MyXmlLibraryGreeting">\n    <![CDATA[<msg>Edited xml library</msg>]]>\n  </function>\n</library>');
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+    await page.waitForSelector('text=Reload the editor to apply your library changes', { timeout: 5000 });
+    await page.click('button:has-text("Reload")');
+    await page.waitForSelector('button[title="More"]', { timeout: 90000 });
+    await revealLibraries(page);
+    await treeItem(page, CUSTOM_LIBRARY).first().waitFor({ state: 'visible', timeout: 10000 });
+    await treeItem(page, CUSTOM_LIBRARY).first().click();
+    await page.waitForSelector('.cm-editor', { timeout: 10000 });
+    const reloadedContent = await page.locator('.cm-content').first().innerText();
+    if (!reloadedContent.includes('Edited xml library')) throw new Error('Expected the .xml library edit to survive the editor reload (proving it resolves via listLibraryCandidates on load, not just on upload)');
+    console.log('PASS: after reload, the game still loads and the .xml library is still resolved with its edited content');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary

- Quest 5's desktop editor allowed `.xml` as a filename extension for Included Library files (its own docs mentioned it), but Quest Viva's editor only recognized `.aslx`, breaking upload/import of libraries authored with that extension.
- Library detection has always been content-based (the file's root element is `<library>`) with no extension gating on the engine/server side, so this was purely an AppShell (SvelteKit) restriction — the Add Library file picker, asset-list exclusion, library-candidate discovery, and file-watch lists all hardcoded `.aslx`.
- Added a shared `isLibraryFilename()` helper (accepting both `.aslx` and `.xml`) and applied it consistently everywhere a library filename was checked: `AddLibraryModal.svelte`, `PropertyEditor.svelte`, `browser-adapter.ts`, `electron-adapter.ts`, and the fallback candidate discovery in `editor-store.ts`. Locale strings (en/es/de/xx) updated to mention the new extension too.

## Test plan

- [x] `npm run lint` and `npm run check` (svelte-check) pass clean in `src/AppShell`
- [x] Existing e2e test `tests/e2e/verify-appshell-library-editor.mjs` still passes (no regression for `.aslx` libraries)
- [x] New e2e test `tests/e2e/verify-appshell-library-xml-extension.mjs` added and passing: uploads a `.xml` library via the Add Library dialog, confirms the file picker accepts `.xml`, confirms it's editable with its content, edits it, and confirms the edit survives an editor reload (proving the library resolves via candidate discovery, not just at upload time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)