### PR TITLE
fix(AppShell): dialogs move focus on open so Escape closes them

### DIFF
--- a/src/AppShell/src/components/AddJavascriptModal.svelte
+++ b/src/AppShell/src/components/AddJavascriptModal.svelte
@@ -21,6 +21,9 @@
     // exactly its src (EditorController.GetDisplayName), so this needs no extra bridge call.
     let alreadyUsed = $derived($treeNodes.filter(n => n.nodeType === "javascript").map(n => n.text));
 
+    let dialogEl = $state<HTMLDivElement>();
+    $effect(() => { dialogEl?.focus(); });
+
     function handleKeydown(e: KeyboardEvent) {
         if (e.key === "Escape") oncancel();
     }
@@ -47,6 +50,7 @@
 </script>
 
 <div
+    bind:this={dialogEl}
     role="dialog"
     aria-modal="true"
     tabindex="-1"

--- a/src/AppShell/src/components/AddLibraryModal.svelte
+++ b/src/AppShell/src/components/AddLibraryModal.svelte
@@ -22,6 +22,9 @@
     // filename (EditorController.GetDisplayName), so this needs no extra bridge call.
     let alreadyUsed = $derived(new Set($treeNodes.filter(n => n.nodeType === "include").map(n => n.text)));
 
+    let dialogEl = $state<HTMLDivElement>();
+    $effect(() => { dialogEl?.focus(); });
+
     async function handleUpload(e: Event) {
         const target = e.target as HTMLInputElement;
         const file = target.files?.[0];
@@ -58,6 +61,7 @@
 </script>
 
 <div
+    bind:this={dialogEl}
     role="dialog"
     aria-modal="true"
     tabindex="-1"

--- a/src/AppShell/src/components/AssetManagerModal.svelte
+++ b/src/AppShell/src/components/AssetManagerModal.svelte
@@ -30,6 +30,8 @@
     let inputEl: HTMLInputElement;
     let uploading = $state(false);
     let error = $state("");
+    let dialogEl = $state<HTMLDivElement>();
+    $effect(() => { dialogEl?.focus(); });
 
     async function handleUpload(e: Event) {
         const target = e.target as HTMLInputElement;
@@ -76,6 +78,7 @@
 </script>
 
 <div
+    bind:this={dialogEl}
     role="dialog"
     aria-modal="true"
     tabindex="-1"

--- a/src/AppShell/src/components/MoveElementModal.svelte
+++ b/src/AppShell/src/components/MoveElementModal.svelte
@@ -25,6 +25,8 @@
     ]);
 
     let target = $state("");
+    let dialogEl = $state<HTMLDivElement>();
+    $effect(() => { dialogEl?.focus(); });
 
     function handleKeydown(e: KeyboardEvent) {
         if (e.key === "Enter" && target) confirm();
@@ -42,6 +44,7 @@
 </script>
 
 <div
+    bind:this={dialogEl}
     role="dialog"
     aria-modal="true"
     tabindex="-1"

--- a/src/AppShell/src/components/MoveToFolderModal.svelte
+++ b/src/AppShell/src/components/MoveToFolderModal.svelte
@@ -22,6 +22,8 @@
 
     let target = $state("");
     let hasChosen = $state(false);
+    let dialogEl = $state<HTMLDivElement>();
+    $effect(() => { dialogEl?.focus(); });
 
     function handleKeydown(e: KeyboardEvent) {
         if (e.key === "Enter" && hasChosen) confirm();
@@ -38,6 +40,7 @@
 </script>
 
 <div
+    bind:this={dialogEl}
     role="dialog"
     aria-modal="true"
     tabindex="-1"

--- a/src/AppShell/src/components/PublishModal.svelte
+++ b/src/AppShell/src/components/PublishModal.svelte
@@ -10,6 +10,8 @@
     let includeWalkthrough = $state(false);
     let publishing = $state(false);
     let error = $state("");
+    let dialogEl = $state<HTMLDivElement>();
+    $effect(() => { dialogEl?.focus(); });
 
     async function handlePublish() {
         publishing = true;
@@ -34,6 +36,7 @@
 </script>
 
 <div
+    bind:this={dialogEl}
     role="dialog"
     aria-modal="true"
     tabindex="-1"

--- a/src/AppShell/src/components/SettingsModal.svelte
+++ b/src/AppShell/src/components/SettingsModal.svelte
@@ -5,6 +5,9 @@
     import { theme, setTheme, type ThemePreference } from "$lib/theme-store";
     import { defaultCodeView, setDefaultCodeView } from "$lib/code-view-store";
 
+    let dialogEl = $state<HTMLDivElement>();
+    $effect(() => { if ($settingsModalOpen) dialogEl?.focus(); });
+
     function displayName(code: string): string {
         let name: string;
         try {
@@ -48,6 +51,7 @@
 
 {#if $settingsModalOpen}
     <div
+        bind:this={dialogEl}
         role="dialog"
         aria-modal="true"
         tabindex="-1"


### PR DESCRIPTION
## Summary
- Several editor modals (Settings, Move to, Move to folder, Add Javascript, Add Library, Asset Manager, Publish) wire an Escape `onkeydown` handler onto their outer `role="dialog"` div, but never move DOM focus into that div when it opens.
- Since a keydown event only bubbles up from whatever element currently holds focus, Escape silently did nothing unless focus already happened to land inside the dialog (e.g. a textbox the user had clicked into) — the button that opened the dialog kept focus otherwise.
- `ConfirmDialog.svelte` already got this right (`bind:this` + `$effect` calling `.focus()` on open); this PR applies the same pattern to the seven modals that were missing it.

## Test plan
- [x] `npx svelte-check` in `src/AppShell` — 0 errors/warnings
- [x] `npm run lint` in `src/AppShell` — clean
- [x] Verified live in the browser (AppShell dev server): opened Settings, Move to (from a tree item's context menu), and Publish without touching any inner control, pressed Escape, confirmed each closes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)