### PR TITLE
feat(WasmPlayer): sort the debugger's object list by Name

### DIFF
--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -187,7 +187,10 @@
         <div id="qv-debugger-tabs" class="flex flex-wrap gap-2 mb-4"></div>
 
         <div class="flex flex-1" id="qv-debugger-panes" style="min-height:0">
-            <ul id="qv-debugger-list" class="space-y-1 shrink-0 overflow-y-auto"></ul>
+            <div id="qv-debugger-list" class="shrink-0">
+                <button type="button" id="qv-debugger-list-sort"><span class="qv-debugger-sort-label">Name</span></button>
+                <ul id="qv-debugger-list-items" class="space-y-1"></ul>
+            </div>
             <div id="qv-debugger-splitter" role="separator" aria-orientation="vertical" aria-label="Resize object list"></div>
             <div id="qv-debugger-detail" class="flex-1 overflow-y-auto text-sm">
                 <p class="text-surface-500">Select an item to view details.</p>

--- a/src/WasmPlayer/styles/chrome.css
+++ b/src/WasmPlayer/styles/chrome.css
@@ -260,6 +260,43 @@
 }
 
 #qv-debugger-list {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+/* Column header for the object/walkthrough list — a single "Name" column,
+   so unlike the attribute table's per-column [data-sort-col] headers this
+   just toggles ascending/descending on click (see renderDebuggerList's
+   debuggerListSortAscending). Styled to match .qv-debugger-table thead th
+   below even though it isn't a <table> — the list is a plain <ul> (see
+   .qv-debugger-list-item's doc comment), and adding a real single-column
+   table just for the header would be more markup for no benefit. */
+#qv-debugger-list-sort {
+    display: block;
+    width: 100%;
+    flex-shrink: 0;
+    text-align: left;
+    cursor: pointer;
+    user-select: none;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-surface-500);
+    border: none;
+    border-bottom: 1px solid var(--color-surface-300-700);
+    background: none;
+    padding: 0.25rem 0.5rem 0.5rem;
+    margin-bottom: 0.25rem;
+}
+
+#qv-debugger-list-sort:hover {
+    color: var(--color-surface-900-100);
+}
+
+#qv-debugger-list-items {
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-y: auto;
 }
 

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -1042,6 +1042,13 @@ async function openSavesDialog(mode, gameId = WebPlayer.gameId) {
 let debuggerWired = false;
 let debuggerActiveTab = 'Walkthrough';
 let debuggerSelectedItem = null;
+// Sort direction for the left-hand object/walkthrough list's single "Name"
+// column — clicking #qv-debugger-list-sort toggles this (see
+// ensureDebuggerWired). Deliberately not reset when switching tabs/objects
+// (unlike debuggerAttrSort below): it's a display preference for the list
+// itself, not per-object state, so it should stay put as the user browses
+// around, the same way a real file manager's sort column does.
+let debuggerListSortAscending = true;
 // Name of the walkthrough currently running, or null — the source of truth
 // for the Run/Cancel/status UI, *not* the DOM elements themselves. Closing
 // and reopening the dialog (or switching tabs/objects) rebuilds
@@ -1316,12 +1323,20 @@ function renderDebuggerTabs(types) {
 // when a turn has made the currently-selected item (an object that got
 // destroyed, a timer that finished, ...) disappear from its own list.
 function renderDebuggerList() {
-    const list = document.getElementById('qv-debugger-list');
+    const list = document.getElementById('qv-debugger-list-items');
+    const sortLabel = document.querySelector('#qv-debugger-list-sort .qv-debugger-sort-label');
+    if (sortLabel) sortLabel.textContent = 'Name' + (debuggerListSortAscending ? ' ▲' : ' ▼');
+
     const items = debuggerActiveTab === 'Walkthrough'
         ? JSON.parse(Bridge.GetWalkthroughNamesJson())
         : JSON.parse(Bridge.GetDebugObjectsJson(debuggerActiveTab));
+    // .slice() first — GetObjects/GetWalkthroughNamesJson return declaration
+    // order, and refreshDebuggerAfterTurn's `items.includes(...)` check below
+    // (in its own caller) has no need to see that order disturbed.
+    const sorted = items.slice().sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+    if (!debuggerListSortAscending) sorted.reverse();
 
-    if (!items.length) {
+    if (!sorted.length) {
         list.innerHTML = '<li class="text-sm text-surface-500 px-2 py-1">Nothing here.</li>';
         return items;
     }
@@ -1329,7 +1344,7 @@ function renderDebuggerList() {
     // A plain selectable list, not hyperlinks — .qv-debugger-list-item is a
     // block row with its own hover/selected background (shares
     // .qv-debugger-row-selected with the attribute table below).
-    list.innerHTML = items.map(item => {
+    list.innerHTML = sorted.map(item => {
         const selected = item === debuggerSelectedItem;
         return `<li><button type="button" class="qv-debugger-list-item${selected ? ' qv-debugger-row-selected' : ''}" data-item="${_esc(item)}" aria-selected="${selected}">${_esc(item)}</button></li>`;
     }).join('');
@@ -1629,10 +1644,10 @@ function ensureDebuggerWired() {
     });
 
     // Only needs setting once — #qv-debugger-list itself is never rebuilt
-    // (only its innerHTML, by renderDebuggerList), so this inline width
-    // survives every re-render and even a game restart (the dialog is on
-    // swapInPlayerUi's preserve-list). Subsequent changes come from dragging
-    // the splitter (wireDebuggerSplitter).
+    // (only #qv-debugger-list-items' innerHTML, by renderDebuggerList), so
+    // this inline width survives every re-render and even a game restart
+    // (the dialog is on swapInPlayerUi's preserve-list). Subsequent changes
+    // come from dragging the splitter (wireDebuggerSplitter).
     document.getElementById('qv-debugger-list').style.width = `${debuggerListWidth}px`;
 
     wireDebuggerMoveResize();
@@ -1654,6 +1669,12 @@ function ensureDebuggerWired() {
     });
 
     document.getElementById('qv-debugger-list').addEventListener('click', (e) => {
+        if (e.target.closest('#qv-debugger-list-sort')) {
+            debuggerListSortAscending = !debuggerListSortAscending;
+            renderDebuggerList();
+            return;
+        }
+
         const btn = e.target.closest('[data-item]');
         if (!btn) return;
         debuggerSelectedItem = btn.dataset.item;


### PR DESCRIPTION
## Summary
- The WasmPlayer debugger's object/walkthrough list (`#qv-debugger-list`) never had a sortable "Name" column — confirmed via full git history on both WebPlayer's and WasmPlayer's debugger implementations, it's always been a plain unordered list since their first commits.
- The user remembered this working in the Quest 5 desktop editor's debugger (a different, older app), and wanted the same UX added to the current WasmPlayer debugger.
- Adds a clickable "Name" header above the object list that sorts ascending by default and toggles ascending/descending on click, mirroring the existing sort UX already used by the debugger's attribute detail table (Attribute/Value/Source columns).

## Changes
- `src/WasmPlayer/index.html` — wraps the list in a container with a header button (`#qv-debugger-list-sort`) above a scrollable `<ul id="qv-debugger-list-items">`.
- `src/WasmPlayer/wasm-player.js` — new `debuggerListSortAscending` state (persists across tab/object switches, like a file manager's sort column), sorting in `renderDebuggerList`, and a click handler to toggle it.
- `src/WasmPlayer/styles/chrome.css` — styles the header to match the attribute table's header look, and restructures the list's flex layout so it scrolls independently under the fixed header (including the narrow-width stacked layout).

## Test plan
- [x] Verified in-browser (WasmPlayer dev build, editor-preview debugger): clicking "Name" toggles ▲/▼ and sorts the Objects tab alphabetically.
- [x] Verified item selection and the attribute detail panel still work after selecting a sorted row.
- [x] Verified the narrow-width (`@container` stacked) layout still renders correctly with the new header.
- [x] `dotnet build src/WasmPlayer/WasmPlayer.csproj` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)