### PR TITLE
feat(AppShell): move function folders and add objects/functions in-place

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -218,6 +218,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-preview-custom-library.mjs http://localhost:5174
         working-directory: tests/e2e
+      - run: node verify-appshell-folder-move-and-add-here.mjs http://localhost:5174
+        working-directory: tests/e2e
 
   # OPFS local-drafts behavior on non-FSA browsers, against a Release
   # WasmEditor build — createSyncAccessHandle (Safari's write path) needs the

--- a/src/AppShell/src/components/AddElementModal.svelte
+++ b/src/AppShell/src/components/AddElementModal.svelte
@@ -1,18 +1,44 @@
 <script lang="ts">
-    import { validateName } from "$lib/editor-store";
+    import { untrack } from "svelte";
+    import { validateName, getFunctionFolders, getPossibleNewObjectParents } from "$lib/editor-store";
     import { t } from "$lib/i18n";
+    import Combobox from "$components/Combobox.svelte";
+    import type { ControlOption } from "$lib/types";
 
     interface Props {
         elementType: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type";
         parent?: string | null;
-        onconfirm: (name: string) => void;
+        folder?: string | null;
+        onconfirm: (name: string, target: string | null) => void;
         oncancel: () => void;
     }
 
-    const { elementType, parent = null, onconfirm, oncancel }: Props = $props();
+    const { elementType, parent = null, folder = null, onconfirm, oncancel }: Props = $props();
 
     let label = $derived(t(`addElementModal.labels.${elementType}`));
     let heading = $derived(parent ? t("addElementModal.addHeadingIn", { label, parent }) : t("addElementModal.addHeading", { label }));
+
+    // Folder picker (Functions only) — lets a function be created straight into an existing or
+    // brand-new folder, defaulting to the folder whose "..." menu was used (if any). Mirrors
+    // MoveToFolderModal's own options/Combobox.
+    let folderOptions: ControlOption[] = $derived([
+        { value: "", label: t("moveToFolderModal.topLevel") },
+        ...getFunctionFolders().map(name => ({ value: name, label: name })),
+    ]);
+    // Deliberately only the initial value — this modal is freshly mounted per open, so there's
+    // nothing later to stay in sync with (mirrors CodeEditor's own initial-value-only props).
+    let folderTarget = $state(untrack(() => folder ?? ""));
+
+    // Parent picker (Objects only, and only when created under another Object rather than a Room
+    // or at the top level) — scoped to just the clicked object's own ancestor chain, not every
+    // object in the game (that's MoveElementModal's job for an existing object). Mirrors
+    // MoveElementModal's own options/Combobox.
+    let objectParentOptions: ControlOption[] = $derived(
+        elementType === "object" && parent
+            ? getPossibleNewObjectParents(parent).map(name => ({ value: name, label: name }))
+            : []
+    );
+    let objectParentTarget = $state(untrack(() => parent ?? ""));
 
     let dialogEl: HTMLDivElement;
     let inputEl: HTMLInputElement;
@@ -40,7 +66,10 @@
         if (!name || error) return;
         const result = validateName(name);
         if (result !== "ok") { error = result; return; }
-        onconfirm(name);
+        const target = elementType === "function" ? folderTarget
+            : elementType === "object" && objectParentOptions.length > 0 ? objectParentTarget
+            : null;
+        onconfirm(name, target);
     }
 </script>
 
@@ -73,6 +102,28 @@
                 <p class="text-xs text-error-500">{error}</p>
             {/if}
         </div>
+
+        {#if elementType === "function"}
+            <div class="flex flex-col gap-1">
+                <span class="text-xs text-surface-600-400">{t("moveToFolderModal.folderLabel")}</span>
+                <Combobox
+                    options={folderOptions}
+                    value={folderTarget}
+                    onchange={(v) => { folderTarget = v; }}
+                    class="input bg-surface-50-950 px-2 py-1 text-sm w-full"
+                />
+            </div>
+        {:else if elementType === "object" && objectParentOptions.length > 0}
+            <div class="flex flex-col gap-1">
+                <span class="text-xs text-surface-600-400">{t("addElementModal.parentLabel")}</span>
+                <Combobox
+                    options={objectParentOptions}
+                    value={objectParentTarget}
+                    onchange={(v) => { objectParentTarget = v; }}
+                    class="input bg-surface-50-950 px-2 py-1 text-sm w-full"
+                />
+            </div>
+        {/if}
 
         <div class="flex justify-end gap-2">
             <button class="btn btn-sm preset-tonal" onclick={oncancel}>{t("common.cancel")}</button>

--- a/src/AppShell/src/components/ElementsList.svelte
+++ b/src/AppShell/src/components/ElementsList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { SvelteSet } from "svelte/reactivity";
-    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createTurnScript, openAddLibraryModal, openAddJavascriptModal, swapElements, isGamebook, openMoveToFolderModal, canMoveFunctionUp, canMoveFunctionDown } from "$lib/editor-store";
+    import { treeNodes, selectedKey, selectNode, deleteElement, openAddModal, createVerb, createCommand, createTurnScript, openAddLibraryModal, openAddJavascriptModal, swapElements, isGamebook, openMoveToFolderModal, canMoveFunctionUp, canMoveFunctionDown, canMoveFunctionFolderUp, canMoveFunctionFolderDown, moveFunctionFolderUp, moveFunctionFolderDown } from "$lib/editor-store";
     import { nodeIcon } from "$lib/node-icons";
     import Folder from "@lucide/svelte/icons/folder";
     import { t } from "$lib/i18n";
@@ -48,15 +48,16 @@
     // merely comes right after — without it, an ungrouped item immediately following a group (no
     // header of its own in between) rendered identically to a grouped one, making it look like
     // part of the folder above when it wasn't.
-    type Row = { kind: "header"; key: string; label: string } | { kind: "item"; index: number; item: typeof items[number]; grouped: boolean };
+    type Row = { kind: "header"; key: string; label: string; isLibraryGroup: boolean } | { kind: "item"; index: number; item: typeof items[number]; grouped: boolean };
 
     let rows = $derived.by(() => {
         const out: Row[] = [];
         let lastGroup: string | null = null;
         items.forEach((item, index) => {
-            const group = item.isLibrary && item.filename ? item.filename : (item.folder || null);
+            const isLibraryGroup = !!(item.isLibrary && item.filename);
+            const group = isLibraryGroup ? item.filename! : (item.folder || null);
             if (group !== null && group !== lastGroup) {
-                out.push({ kind: "header", key: `__group_${item.key}`, label: group });
+                out.push({ kind: "header", key: `__group_${item.key}`, label: group, isLibraryGroup });
             }
             lastGroup = group;
             out.push({ kind: "item", index, item, grouped: group !== null });
@@ -218,7 +219,36 @@
     {:else}
         {#each rows as row (row.kind === "header" ? row.key : row.item.key)}
             {#if row.kind === "header"}
-                <div class="text-[11px] font-semibold text-surface-600-400 uppercase tracking-wide mt-2 mb-1 px-1 truncate" title={row.label}>{row.label}</div>
+                <div class="group relative flex items-center mt-2 mb-1">
+                    <div
+                        class="text-[11px] font-semibold text-surface-600-400 uppercase tracking-wide px-1 truncate flex-1 {supportsFolders && !row.isLibraryGroup ? "pr-16" : ""}"
+                        title={row.label}
+                    >{row.label}</div>
+                    {#if supportsFolders && !row.isLibraryGroup}
+                        <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                                title={t("elementAdders.functionHere")}
+                                onclick={() => openAddModal("function", null, row.label)}
+                            >+</button>
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                                title={t("common.moveUp")}
+                                disabled={!canMoveFunctionFolderUp(row.label)}
+                                onclick={() => moveFunctionFolderUp(row.label)}
+                            >↑</button>
+                            <button
+                                type="button"
+                                class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
+                                title={t("common.moveDown")}
+                                disabled={!canMoveFunctionFolderDown(row.label)}
+                                onclick={() => moveFunctionFolderDown(row.label)}
+                            >↓</button>
+                        </div>
+                    {/if}
+                </div>
             {:else}
                 {@const item = row.item}
                 {@const i = row.index}

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -356,18 +356,29 @@
         if (pendingTreeState) saveTreeState(pendingTreeState.gameId, pendingTreeState.ids);
     });
 
-    // Auto-expand the ancestor chain whenever the selected node changes
+    // Ancestor ids of targetId within the *hierarchical* (post-grouping) tree, root-first -
+    // unlike a flat-tree parent-chain walk, this also passes through any synthetic folder/library
+    // group node the target got folded into (see buildHierTree/groupLibraryChildren), since those
+    // exist only as HierNode wrappers, never as a real element's own `parent` field.
+    function findAncestorIds(nodes: HierNode[], targetId: string, path: string[] = []): string[] | null {
+        for (const node of nodes) {
+            if (node.id === targetId) return path;
+            if (node.children) {
+                const found = findAncestorIds(node.children, targetId, [...path, node.id]);
+                if (found) return found;
+            }
+        }
+        return null;
+    }
+
+    // Auto-expand the ancestor chain (including any folder/library group it's folded into)
+    // whenever the selected node changes - e.g. a function just created inside a folder via "Add
+    // Function here" should have that folder visibly open, not collapsed around it.
     $effect(() => {
         const key = $selectedKey;
-        const nodes = $treeNodes;
-        if (!key || !nodes.length) return;
-        const nodeMap = new Map(nodes.map(n => [n.key, n]));
-        const toExpand: string[] = [];
-        let cur: TreeNode | undefined = nodeMap.get(key);
-        while (cur?.parent) {
-            toExpand.push(cur.parent);
-            cur = nodeMap.get(cur.parent);
-        }
+        const tree = rawHierTree;
+        if (!key || !tree.length) return;
+        const toExpand = findAncestorIds(tree, key) ?? [];
         // Use untrack so reading expandedIds doesn't make this effect re-run when
         // the user manually collapses a branch (which would immediately re-expand it).
         const current = untrack(() => expandedIds);

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -18,6 +18,7 @@
         showLibraryElements, toggleShowLibraryElements,
         swapElements, getCurrentGameId,
         canMoveFunctionUp, canMoveFunctionDown,
+        canMoveFunctionFolderUp, canMoveFunctionFolderDown, moveFunctionFolderUp, moveFunctionFolderDown,
     } from "$lib/editor-store";
     import type { TreeNode } from "$lib/types";
     import { t } from "$lib/i18n";
@@ -478,6 +479,19 @@
         // particular are meant to have no context menu at all, mirroring the
         // isLibrary guard in nodeMenuOptions.)
         if (node.nodeType === "header" || node.nodeType === "game" || node.nodeType === "include") return opts;
+        if (node.nodeType === "usergroup") {
+            // A folder's synthetic id has no single flat-tree entry to look up (see buildHierTree/
+            // groupLibraryChildren) - node.text is the folder name itself, and moving the whole
+            // block is handled server-side by name rather than by swapping two flat siblings.
+            const folderName = node.text;
+            if (canMoveFunctionFolderUp(folderName)) {
+                opts.push({ label: t("common.moveUp"), action: () => moveFunctionFolderUp(folderName) });
+            }
+            if (canMoveFunctionFolderDown(folderName)) {
+                opts.push({ label: t("common.moveDown"), action: () => moveFunctionFolderDown(folderName) });
+            }
+            return opts;
+        }
         const flat = $treeNodes.find(n => n.key === node.id);
         if (!flat) return opts;
         // The game node itself appears under "_objects" alongside the game's
@@ -547,11 +561,14 @@
             );
         } else if (nt === "object") {
             opts.push(
+                { label: t("elementAdders.objectHere"), action: () => openAddModal("object", id) },
                 { label: t("elementAdders.command"), action: () => createCommand(id) },
                 { label: t("elementAdders.verb"), action: () => createVerb(id) },
                 { label: t("elementAdders.turnScript"), action: () => createTurnScript(id) },
                 { label: t("elementAdders.pageHere"), action: () => openAddModal("page", id) },
             );
+        } else if (nt === "usergroup") {
+            opts.push({ label: t("elementAdders.functionHere"), action: () => openAddModal("function", null, text) });
         } else if (nt === "page" && !$isGamebook) {
             // Text Adventure dialogue pages can nest sub-pages; gamebook pages are
             // always flat, so this adder is TA-only.

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -12,7 +12,7 @@ import { showToast } from "./toast";
 import { t } from "./i18n";
 import type { TreeNode, EditorDataResponse, ScriptBlockData, ScriptCommandCategoriesData, ExpressionTemplateData, ExpressionTemplate, FullAttributeData, ExitsData, VerbInfo, ExpressionFunctionInfo } from "./types";
 
-export type AddElementModalState = { type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null } | null;
+export type AddElementModalState = { type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type"; parent: string | null; folder: string | null } | null;
 
 let _bridge: WasmBridge | null = null;
 let _adapter: FileAdapter | null = null;
@@ -34,8 +34,8 @@ export const addElementModal = writable<AddElementModalState>(null);
 // wording/affordances in the tree, toolbar and advanced-adders panel.
 export const isGamebook = writable(false);
 
-export function openAddModal(type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type", parent: string | null) {
-    addElementModal.set({ type, parent });
+export function openAddModal(type: "room" | "object" | "page" | "function" | "timer" | "walkthrough" | "template" | "dynamictemplate" | "type", parent: string | null, folder: string | null = null) {
+    addElementModal.set({ type, parent, folder });
 }
 // A Javascript element's src (the file it points to) can't be changed after creation — see
 // PropertyEditor's "lockedAfterCreate" handling — so unlike the other adders above, creating one
@@ -1716,6 +1716,44 @@ export function canMoveFunctionUp(key: string): boolean {
 
 export function canMoveFunctionDown(key: string): boolean {
     return _bridge?.CanMoveFunctionDown(key) ?? false;
+}
+
+// A folder is always a contiguous run of same-folder functions, so unlike a single function's
+// move up/down, moving the whole block past its neighbour can never split anything — these are
+// gated only on "is there something on that side at all" (see EditorController's own
+// CanMoveFunctionFolderUp/Down).
+export function canMoveFunctionFolderUp(folder: string): boolean {
+    return _bridge?.CanMoveFunctionFolderUp(folder) ?? false;
+}
+
+export function canMoveFunctionFolderDown(folder: string): boolean {
+    return _bridge?.CanMoveFunctionFolderDown(folder) ?? false;
+}
+
+export function moveFunctionFolderUp(folder: string): void {
+    if (!_bridge) return;
+    if (_bridge.MoveFunctionFolderUp(folder) === "ok") {
+        refreshTree();
+        refreshUndoRedo();
+    }
+}
+
+export function moveFunctionFolderDown(folder: string): void {
+    if (!_bridge) return;
+    if (_bridge.MoveFunctionFolderDown(folder) === "ok") {
+        refreshTree();
+        refreshUndoRedo();
+    }
+}
+
+// Ancestor chain (root-first, ending with elementKey itself) for scoping the "Add Object here"
+// create modal's parent picker to just the clicked object's own lineage, rather than every object
+// in the game (that's getMovePossibleParents, used by "Move to" instead). Returns [] for anything
+// that isn't itself an Object (e.g. a Room, which can't be nested) — see
+// EditorController.GetPossibleNewParentsForCurrentSelection.
+export function getPossibleNewObjectParents(key: string): string[] {
+    if (!_bridge) return [];
+    return JSON.parse(_bridge.GetPossibleNewObjectParentsForCurrentSelection(key));
 }
 
 // Bumped by copyElements/cutElements so TreePanel's per-node "⋯" menus (computed

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -116,6 +116,11 @@ export interface WasmBridge {
   SetFunctionFolder(elementKey: string, folder: string): string
   CanMoveFunctionUp(elementKey: string): boolean
   CanMoveFunctionDown(elementKey: string): boolean
+  CanMoveFunctionFolderUp(folder: string): boolean
+  CanMoveFunctionFolderDown(folder: string): boolean
+  MoveFunctionFolderUp(folder: string): string
+  MoveFunctionFolderDown(folder: string): string
+  GetPossibleNewObjectParentsForCurrentSelection(elementKey: string): string
   CopyElements(keysJson: string): void
   CutElements(keysJson: string): void
   CanPasteElements(parentKey: string): boolean

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -144,15 +144,18 @@
         }
     }
 
-    async function handleAddConfirm(name: string) {
+    async function handleAddConfirm(name: string, target: string | null) {
         const mode = get(addElementModal);
         addElementModal.set(null);
         await tick();
         if (!mode) return;
         if (mode.type === "room") createRoom(name, mode.parent);
-        else if (mode.type === "object") createObject(name, mode.parent);
+        else if (mode.type === "object") createObject(name, target ?? mode.parent);
         else if (mode.type === "page") createPage(name, mode.parent);
-        else if (mode.type === "function") createFunction(name);
+        else if (mode.type === "function") {
+            const key = createFunction(name);
+            if (!key.startsWith("error:") && target) setFunctionFolder(key, target);
+        }
         else if (mode.type === "timer") createTimer(name);
         else if (mode.type === "walkthrough") createWalkthrough(name, mode.parent);
         else if (mode.type === "template") createTemplate(name);
@@ -213,6 +216,7 @@
         <AddElementModal
             elementType={$addElementModal.type}
             parent={$addElementModal.parent}
+            folder={$addElementModal.folder}
             onconfirm={handleAddConfirm}
             oncancel={() => addElementModal.set(null)}
         />

--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -58,6 +58,7 @@
     "addElementModal.addHeadingIn": "Neu: {label} unter \"{parent}\"",
     "addElementModal.nameLabel": "Name",
     "addElementModal.namePlaceholder": "Gib einen Namen ein...",
+    "addElementModal.parentLabel": "Übergeordnete Ebene",
 
     "assetManager.title": "Ressourcen",
     "assetManager.uploading": "Hochladen…",
@@ -110,6 +111,7 @@
     "elementAdders.pageHere": "Seite hier hinzufügen",
     "elementAdders.page": "Neue Seite",
     "elementAdders.function": "Neue Funktion",
+    "elementAdders.functionHere": "Neue Funktion hier",
     "elementAdders.timer": "Neuer Timer",
     "elementAdders.verb": "Neues Verb",
     "elementAdders.command": "Neues Kommando",

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -58,6 +58,7 @@
     "addElementModal.addHeadingIn": "Add {label} in \"{parent}\"",
     "addElementModal.nameLabel": "Name",
     "addElementModal.namePlaceholder": "Enter a name...",
+    "addElementModal.parentLabel": "Parent",
 
     "assetManager.title": "Assets",
     "assetManager.uploading": "Uploading…",
@@ -110,6 +111,7 @@
     "elementAdders.pageHere": "Add Page here",
     "elementAdders.page": "Add Page",
     "elementAdders.function": "Add Function",
+    "elementAdders.functionHere": "Add Function here",
     "elementAdders.timer": "Add Timer",
     "elementAdders.verb": "Add Verb",
     "elementAdders.command": "Add Command",

--- a/src/AppShell/static/locales/es.json
+++ b/src/AppShell/static/locales/es.json
@@ -58,6 +58,7 @@
     "addElementModal.addHeadingIn": "Añadir {label} en \"{parent}\"",
     "addElementModal.nameLabel": "Nombre",
     "addElementModal.namePlaceholder": "Ingresa un nombre...",
+    "addElementModal.parentLabel": "Padre",
 
     "assetManager.title": "Recursos",
     "assetManager.uploading": "Subiendo…",
@@ -110,6 +111,7 @@
     "elementAdders.pageHere": "Añadir página aquí",
     "elementAdders.page": "Añadir Página",
     "elementAdders.function": "Añadir Función",
+    "elementAdders.functionHere": "Añadir Función aquí",
     "elementAdders.timer": "Añadir Temporizador",
     "elementAdders.verb": "Añadir Verbo",
     "elementAdders.command": "Añadir Comando",

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -574,7 +574,16 @@ public sealed class EditorController : IDisposable
 
         foreach (ElementType type in Enum.GetValues<ElementType>())
         {
-            foreach (var o in WorldModel.Elements.GetElements(type).Where(e => e.Parent == null))
+            // GetElements returns elements in raw creation/storage order, not SortIndex order -
+            // fine normally (the two coincide until something reorders SortIndex without also
+            // touching storage order, e.g. SwapElements or SetFunctionFolder's slice
+            // redistribution), but a full rebuild like this one must sort explicitly or a
+            // reordered element's new tree position silently reverts to its old, pre-reorder spot
+            // the next time anything triggers a full UpdateTree() rather than an incremental
+            // single-element reposition (see m_worldModel_ElementMetaFieldUpdated's own
+            // GetElementPosition, which already gets this right for that path).
+            foreach (var o in WorldModel.Elements.GetElements(type).Where(e => e.Parent == null)
+                         .OrderBy(e => e.MetaFields[MetaFieldDefinitions.SortIndex]))
             {
                 AddElementAndChildrenToTree(o);
             }
@@ -586,7 +595,10 @@ public sealed class EditorController : IDisposable
     private void AddElementAndChildrenToTree(Element o)
     {
         AddElementToTree(o);
-        foreach (var child in WorldModel.Elements.GetDirectChildren(o))
+        // Same SortIndex-ordering requirement as the top-level loop in UpdateTree() above -
+        // GetDirectChildren is also raw storage order, not SortIndex order.
+        foreach (var child in WorldModel.Elements.GetDirectChildren(o)
+                     .OrderBy(e => e.MetaFields[MetaFieldDefinitions.SortIndex]))
         {
             AddElementAndChildrenToTree(child);
         }
@@ -2701,6 +2713,135 @@ public sealed class EditorController : IDisposable
         return WorldModel.Elements.GetElements(ElementType.Function)
             .OrderBy(e => e.MetaFields[MetaFieldDefinitions.SortIndex])
             .ToList();
+    }
+
+    public bool CanMoveFunctionFolderUp(string folder) => CanMoveFunctionFolderAdjacent(folder, up: true);
+
+    public bool CanMoveFunctionFolderDown(string folder) => CanMoveFunctionFolderAdjacent(folder, up: false);
+
+    private bool CanMoveFunctionFolderAdjacent(string folder, bool up)
+    {
+        var all = GetFunctionsOrderedBySortIndex();
+        var (start, end) = GetFolderRange(all, folder);
+        if (start < 0)
+        {
+            return false;
+        }
+
+        return up ? start > 0 : end < all.Count - 1;
+    }
+
+    // A folder is always a contiguous run of same-folder functions in SortIndex order (an
+    // invariant SetFunctionFolder maintains), so unlike a single function's move up/down, moving
+    // the whole block can never split anything - there's nothing to guard beyond "is there
+    // something on that side at all" (see CanMoveFunctionFolderAdjacent above).
+    public void MoveFunctionFolderUp(string folder) => MoveFunctionFolder(folder, up: true);
+
+    public void MoveFunctionFolderDown(string folder) => MoveFunctionFolder(folder, up: false);
+
+    private void MoveFunctionFolder(string folder, bool up)
+    {
+        var all = GetFunctionsOrderedBySortIndex();
+        var (start, end) = GetFolderRange(all, folder);
+        if (start < 0)
+        {
+            return;
+        }
+
+        int neighborStart, neighborEnd;
+        if (up)
+        {
+            if (start == 0)
+            {
+                return;
+            }
+
+            (neighborStart, neighborEnd) = GetAdjacentBlock(all, start - 1, towardsStart: true);
+        }
+        else
+        {
+            if (end == all.Count - 1)
+            {
+                return;
+            }
+
+            (neighborStart, neighborEnd) = GetAdjacentBlock(all, end + 1, towardsStart: false);
+        }
+
+        var lo = Math.Min(start, neighborStart);
+        var hi = Math.Max(end, neighborEnd);
+
+        var folderBlock = all.Skip(start).Take(end - start + 1).ToList();
+        var neighborBlock = all.Skip(neighborStart).Take(neighborEnd - neighborStart + 1).ToList();
+        // Moving up puts the folder before its neighbour; moving down puts it after.
+        var newOrder = up ? folderBlock.Concat(neighborBlock) : neighborBlock.Concat(folderBlock);
+
+        // Same technique as SetFunctionFolder: redistribute the touched slice's own original
+        // SortIndex values among its new order, leaving every untouched element (on either side
+        // of the slice) numerically unaffected.
+        var originalValues = all.Skip(lo).Take(hi - lo + 1)
+            .Select(e => e.MetaFields[MetaFieldDefinitions.SortIndex])
+            .OrderBy(i => i)
+            .ToList();
+
+        WorldModel.UndoLogger.StartTransaction(string.Format("Move folder '{0}'", folder));
+        var i = 0;
+        foreach (var element in newOrder)
+        {
+            element.MetaFields[MetaFieldDefinitions.SortIndex] = originalValues[i];
+            i++;
+        }
+        WorldModel.UndoLogger.EndTransaction();
+    }
+
+    // The folder's own contiguous member run - assumed contiguous (SetFunctionFolder's own
+    // invariant), so the first and last matching indexes fully bound it.
+    private static (int start, int end) GetFolderRange(List<Element> all, string folder)
+    {
+        var start = all.FindIndex(e => e.Fields[FieldDefinitions.EditorFolder] == folder);
+        if (start < 0)
+        {
+            return (-1, -1);
+        }
+
+        var end = start;
+        while (end + 1 < all.Count && all[end + 1].Fields[FieldDefinitions.EditorFolder] == folder)
+        {
+            end++;
+        }
+
+        return (start, end);
+    }
+
+    // The block immediately beside the folder on the given side: if that neighbour itself belongs
+    // to a (different) non-empty folder, extends across that folder's whole contiguous run;
+    // otherwise it's just the one lone non-foldered function at fromIndex.
+    private static (int start, int end) GetAdjacentBlock(List<Element> all, int fromIndex, bool towardsStart)
+    {
+        var neighborFolder = all[fromIndex].Fields[FieldDefinitions.EditorFolder];
+        if (string.IsNullOrEmpty(neighborFolder))
+        {
+            return (fromIndex, fromIndex);
+        }
+
+        var start = fromIndex;
+        var end = fromIndex;
+        if (towardsStart)
+        {
+            while (start > 0 && all[start - 1].Fields[FieldDefinitions.EditorFolder] == neighborFolder)
+            {
+                start--;
+            }
+        }
+        else
+        {
+            while (end + 1 < all.Count && all[end + 1].Fields[FieldDefinitions.EditorFolder] == neighborFolder)
+            {
+                end++;
+            }
+        }
+
+        return (start, end);
     }
 
     public void BeginWalkthrough(string name, bool record)

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -2919,6 +2919,53 @@ public partial class WasmEditorBridge
     }
 
     [JSExport]
+    public static bool CanMoveFunctionFolderUp(string folder)
+    {
+        return _controller?.CanMoveFunctionFolderUp(folder) ?? false;
+    }
+
+    [JSExport]
+    public static bool CanMoveFunctionFolderDown(string folder)
+    {
+        return _controller?.CanMoveFunctionFolderDown(folder) ?? false;
+    }
+
+    [JSExport]
+    public static string MoveFunctionFolderUp(string folder)
+    {
+        if (_controller == null)
+        {
+            return "error";
+        }
+
+        _controller.MoveFunctionFolderUp(folder);
+        // Full rebuild, not an incremental patch - same reasoning as SetFunctionFolder's wrapper
+        // above: this can reposition an arbitrary-sized slice of functions at once.
+        _controller.UpdateTree();
+        return "ok";
+    }
+
+    [JSExport]
+    public static string MoveFunctionFolderDown(string folder)
+    {
+        if (_controller == null)
+        {
+            return "error";
+        }
+
+        _controller.MoveFunctionFolderDown(folder);
+        _controller.UpdateTree();
+        return "ok";
+    }
+
+    [JSExport]
+    public static string GetPossibleNewObjectParentsForCurrentSelection(string elementKey)
+    {
+        var parents = _controller?.GetPossibleNewObjectParentsForCurrentSelection(elementKey)?.ToList() ?? [];
+        return JsonSerializer.Serialize(parents, WasmEditorJsonContext.Default.ListString);
+    }
+
+    [JSExport]
     public static void CopyElements(string keysJson)
     {
         if (_controller == null)

--- a/tests/EditorCoreTests/EditorControllerRoomsAndPagesTests.cs
+++ b/tests/EditorCoreTests/EditorControllerRoomsAndPagesTests.cs
@@ -43,6 +43,44 @@ public class EditorControllerRoomsAndPagesTests
         controller.Uninitialise();
     }
 
+    // Coverage for the ported-but-previously-unexposed v5 desktop editor method that scopes the
+    // "Add Object here" create modal's parent picker to just the target object's own ancestor
+    // chain (root-first), rather than every object in the game (that's GetMovePossibleParents,
+    // used by "Move to" instead).
+    [TestMethod]
+    public async Task TestGetPossibleNewObjectParentsForCurrentSelection_NestedObject_ReturnsAncestorChainRootFirst()
+    {
+        var controller = await LoadTemplateController("English");
+
+        controller.CreateNewObject("box", "game", "A Box");
+        controller.CreateNewObject("innerThing", "box", "Inner Thing");
+
+        var parents = controller.GetPossibleNewObjectParentsForCurrentSelection("innerThing").ToArray();
+
+        CollectionAssert.AreEqual(new[] { "game", "box", "innerThing" }, parents);
+
+        controller.Uninitialise();
+    }
+
+    [TestMethod]
+    public async Task TestGetPossibleNewObjectParentsForCurrentSelection_Room_ReturnsAncestorChainToo()
+    {
+        // A Room is ObjectType.Object underneath (see the ObjectType enum - Room/Object/Page are
+        // all just inherited-type distinctions layered over the same core Object type, IsRoom's
+        // own comment above says as much), so the ancestor-chain method returns a real chain for
+        // a Room just as it does for a plain Object - "Add Object here" from a Room can offer a
+        // parent picker too (e.g. to create the new object as a top-level sibling instead).
+        var controller = await LoadTemplateController("English");
+
+        controller.CreateNewRoom("aRoom", "game", "A Room");
+
+        var parents = controller.GetPossibleNewObjectParentsForCurrentSelection("aRoom").ToArray();
+
+        CollectionAssert.AreEqual(new[] { "game", "aRoom" }, parents);
+
+        controller.Uninitialise();
+    }
+
     private static async Task<EditorController> LoadTemplateController(string templateName)
     {
         var templates = EditorController.GetAvailableTemplates();

--- a/tests/EditorCoreTests/FunctionFolderTests.cs
+++ b/tests/EditorCoreTests/FunctionFolderTests.cs
@@ -214,6 +214,151 @@ public class FunctionFolderTests
         controller.Uninitialise();
     }
 
+    [TestMethod]
+    public async Task CanMoveFunctionFolderUpDown_FalseAtBoundaries_TrueOtherwise()
+    {
+        var controller = await LoadTemplateController("English");
+        controller.CreateNewFunction("f1");
+        controller.CreateNewFunction("f2");
+        controller.CreateNewFunction("f3");
+        controller.SetFunctionFolder("f2", "Group");
+        // Final order: f1(none), f2(Group), f3(none) - Group is the very last thing in the list.
+
+        Assert.IsTrue(controller.CanMoveFunctionFolderUp("Group"), "f1 sits before the folder");
+        Assert.IsFalse(controller.CanMoveFunctionFolderDown("Group"), "nothing follows the folder");
+
+        controller.Uninitialise();
+    }
+
+    [TestMethod]
+    public async Task MoveFunctionFolderUp_SwapsWholeBlockPastLoneFunction_PreservingMemberOrder()
+    {
+        var controller = await LoadTemplateController("English");
+        controller.CreateNewFunction("f1");
+        controller.CreateNewFunction("f2");
+        controller.CreateNewFunction("f3");
+        controller.SetFunctionFolder("f2", "Group");
+        controller.SetFunctionFolder("f3", "Group");
+        // Final order: f1(none), f2(Group), f3(Group).
+
+        controller.MoveFunctionFolderUp("Group");
+
+        var order = new[] { "f1", "f2", "f3" }
+            .Select(name => GetSortIndex(controller, name))
+            .ToArray();
+        Assert.IsTrue(order[1] < order[0], "the Group block should now precede f1");
+        Assert.IsTrue(order[1] < order[2], "f2 should stay before f3 within the Group block");
+        Assert.AreEqual("Group", GetFolder(controller, "f2"));
+        Assert.AreEqual("Group", GetFolder(controller, "f3"));
+
+        controller.Uninitialise();
+    }
+
+    [TestMethod]
+    public async Task MoveFunctionFolderDown_SwapsWholeBlockPastAnotherFolder_PreservingBothBlocksOrder()
+    {
+        var controller = await LoadTemplateController("English");
+        controller.CreateNewFunction("a1");
+        controller.CreateNewFunction("a2");
+        controller.CreateNewFunction("b1");
+        controller.CreateNewFunction("b2");
+        controller.SetFunctionFolder("a1", "Alpha");
+        controller.SetFunctionFolder("a2", "Alpha");
+        controller.SetFunctionFolder("b1", "Beta");
+        controller.SetFunctionFolder("b2", "Beta");
+        // Final order: a1(Alpha), a2(Alpha), b1(Beta), b2(Beta).
+
+        controller.MoveFunctionFolderDown("Alpha");
+
+        var order = new[] { "a1", "a2", "b1", "b2" }
+            .Select(name => GetSortIndex(controller, name))
+            .ToArray();
+        Assert.IsTrue(order[2] < order[0], "Beta block should now precede Alpha block");
+        Assert.IsTrue(order[2] < order[3], "b1 should stay before b2 within Beta");
+        Assert.IsTrue(order[0] < order[1], "a1 should stay before a2 within Alpha");
+
+        controller.Uninitialise();
+    }
+
+    [TestMethod]
+    public async Task MoveFunctionFolder_DoesNotTouchLibraryFunctionSortIndexes()
+    {
+        var controller = await LoadTemplateController("English");
+        controller.CreateNewFunction("f1");
+        controller.CreateNewFunction("f2");
+        controller.CreateNewFunction("f3");
+        controller.SetFunctionFolder("f2", "Group");
+        controller.SetFunctionFolder("f3", "Group");
+
+        var libraryFunctions = controller.WorldModel.Elements.GetElements(ElementType.Function)
+            .Where(e => e.MetaFields[MetaFieldDefinitions.Library])
+            .ToList();
+        var beforeSortIndexes = libraryFunctions.ToDictionary(e => e.Name, e => e.MetaFields[MetaFieldDefinitions.SortIndex]);
+
+        controller.MoveFunctionFolderUp("Group");
+
+        foreach (var function in libraryFunctions)
+        {
+            Assert.AreEqual(beforeSortIndexes[function.Name], function.MetaFields[MetaFieldDefinitions.SortIndex],
+                $"Library function '{function.Name}' should not have been reordered");
+        }
+
+        controller.Uninitialise();
+    }
+
+    [TestMethod]
+    public async Task MoveFunctionFolderUp_UndoRedo_RestoresPosition()
+    {
+        var controller = await LoadTemplateController("English");
+        controller.CreateNewFunction("f1");
+        controller.CreateNewFunction("f2");
+        controller.SetFunctionFolder("f2", "Group");
+
+        var before = GetSortIndex(controller, "f1") < GetSortIndex(controller, "f2");
+        Assert.IsTrue(before, "f1 should start before the Group folder");
+
+        controller.MoveFunctionFolderUp("Group");
+        Assert.IsTrue(GetSortIndex(controller, "f2") < GetSortIndex(controller, "f1"), "Group should now precede f1");
+
+        await controller.Undo();
+        Assert.IsTrue(GetSortIndex(controller, "f1") < GetSortIndex(controller, "f2"), "Undo should restore f1 before Group");
+
+        controller.Redo();
+        Assert.IsTrue(GetSortIndex(controller, "f2") < GetSortIndex(controller, "f1"), "Redo should reapply the move");
+
+        controller.Uninitialise();
+    }
+
+    [TestMethod]
+    public async Task UpdateTree_ReflectsSortIndexOrder_AfterFolderReassignmentInterleavesUntouchedFunction()
+    {
+        // Regression test: UpdateTree()'s full-rebuild traversal used to walk elements in raw
+        // creation/storage order rather than SortIndex order - fine normally since the two
+        // coincide, but SetFunctionFolder (and MoveFunctionFolderUp/Down) explicitly reorders
+        // functions by adjusting SortIndex alone, which a full rebuild must reflect or the
+        // reordered elements silently revert to their pre-reorder display position. Reproduces
+        // the exact pattern that exposed it: an untouched function (Gamma) created between two
+        // reassigned ones (Alpha, Beta), then a brand new one (Delta) created and assigned
+        // afterwards.
+        var controller = await LoadTemplateController("English");
+        controller.CreateNewFunction("Alpha");
+        controller.CreateNewFunction("Beta");
+        controller.CreateNewFunction("Gamma");
+        controller.SetFunctionFolder("Alpha", "Math");
+        controller.SetFunctionFolder("Beta", "Math");
+        controller.CreateNewFunction("Delta");
+        controller.SetFunctionFolder("Delta", "Math");
+
+        var addedOrder = new List<string>();
+        controller.AddedNode += (_, e) => addedOrder.Add(e.Key);
+        controller.UpdateTree();
+
+        var userFunctionOrder = addedOrder.Where(k => k is "Alpha" or "Beta" or "Gamma" or "Delta").ToArray();
+        CollectionAssert.AreEqual(new[] { "Gamma", "Alpha", "Beta", "Delta" }, userFunctionOrder);
+
+        controller.Uninitialise();
+    }
+
     private static string GetFolder(EditorController controller, string key) =>
         controller.WorldModel.Elements.Get(key).Fields[FieldDefinitions.EditorFolder];
 

--- a/tests/e2e/verify-appshell-folder-move-and-add-here.mjs
+++ b/tests/e2e/verify-appshell-folder-move-and-add-here.mjs
@@ -1,0 +1,228 @@
+// Manual verification for the "move a function folder up/down", "Add Function here" (from a
+// folder's own "..." menu, pre-filling the create modal's folder picker), and "Add Object here"
+// (now offered on objects too, not just rooms, with a create-modal parent picker scoped to the
+// clicked object's own ancestor chain) features.
+// Requires the AppShell dev server running locally:
+//   cd src/AppShell && npm run dev
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+function selectTreeNode(name) {
+    return page.locator(`[data-value="${name}"][data-part="item"], [data-value="${name}"][data-part="branch-control"]`).first().click();
+}
+
+// Locates a folder/library group's own branch-control row by its visible label (these synthetic
+// nodes have no stable data-value - see TreePanel's groupLibraryChildren).
+function groupRow(label) {
+    return page.locator('[data-part="branch-control"]', { hasText: label }).first();
+}
+
+async function openNodeMenu(rowLocator) {
+    await rowLocator.locator('[title="Options"]').click();
+    const dropdown = page.locator('.tree-dropdown');
+    await dropdown.waitFor({ state: 'visible', timeout: 5000 });
+    return dropdown;
+}
+
+// The tree's "..." dropdown only closes on an outside mousedown (see TreePanel's onOutside) - it
+// has no Escape-key handling, so closing it means clicking somewhere else in the page instead.
+async function closeNodeMenu() {
+    await page.locator('input[placeholder="Filter..."]').click();
+}
+
+// Expands a branch via its own chevron button (idempotent - a no-op if already expanded).
+// Double-clicking the row also works (see TreePanel's ondblclick) but doesn't select it - the
+// chevron button's own onclick stops propagation, so selecting a node is always a separate click.
+async function expandNode(rowLocator) {
+    const expandBtn = rowLocator.getByRole('button', { name: 'Expand' });
+    if (await expandBtn.count() > 0) await expandBtn.click();
+}
+
+async function fillAndConfirmAddModal(name) {
+    await page.waitForSelector('#element-name', { timeout: 10000 });
+    await page.fill('#element-name', name);
+    await page.click('[role="dialog"] button:has-text("Add")');
+    // 'attached' rather than the default 'visible' - a newly-created function inside an
+    // already-collapsed folder (e.g. via "Add Function here") is in the DOM but not shown until
+    // the folder is expanded, which is fine; this only confirms creation actually happened.
+    await page.locator(`text=${name}`).first().waitFor({ state: 'attached', timeout: 10000 });
+}
+
+// Picks an existing option by exact label if present, otherwise types the name as free text and
+// commits it by blurring (creating a new folder) - mirrors how a real user would use this
+// combobox. Deliberately blurs rather than pressing Enter: the modal wrapper's own onkeydown also
+// treats Enter as "confirm", and since the combobox's Enter handler commits the value into the
+// same synchronous state read by that outer handler, a real Enter keypress bubbles up and
+// immediately submits the whole dialog too - a double-submit this helper must avoid so the
+// caller's own explicit submit-button click has a dialog left to click on.
+async function chooseOrCreateOption(combo, label) {
+    await combo.click();
+    await combo.fill(label);
+    try {
+        await page.locator('[role="option"]', { hasText: label }).first().click({ timeout: 2000 });
+    } catch {
+        await page.locator('[role="dialog"] h2').click();
+    }
+}
+
+async function comboboxOptionTexts(locator) {
+    await locator.click();
+    const options = page.locator('[role="option"]');
+    await options.first().waitFor({ timeout: 5000 });
+    return options.allTextContents();
+}
+
+function assertIncludes(actual, expected, context) {
+    if (!actual.some(t => t.trim() === expected)) {
+        throw new Error(`${context}: expected "${expected}" to be present, got [${actual.join(', ')}]`);
+    }
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Folder Move Add Here Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Add element"]', { timeout: 30000 });
+    console.log('PASS: text adventure local draft created');
+
+    // ── Fixture: three top-level functions, two of them grouped into a "Math" folder ──────────
+    // "Functions" has no dedicated tree branch until it's non-empty (empty advanced categories
+    // collapse into the "Advanced" node's own generic "+ Add X" buttons - see TreePanel's empty-
+    // category handling), so the very first function is created from there.
+    const advancedRow = page.locator('[data-part="branch-control"]', { hasText: 'Advanced' }).first();
+    await advancedRow.click(); // selects it, showing its "+ Add X" panel
+    await expandNode(advancedRow); // the chevron button stops propagation, so expand needs its own click
+    await page.getByRole('button', { name: '+ Add Function', exact: true }).click();
+    await fillAndConfirmAddModal('Alpha');
+    for (const name of ['Beta', 'Gamma']) {
+        // Creating a function selects it (see afterCreate/selectNode), which swaps the properties
+        // panel away from the Functions header's own "+ Add Function" button - reselect it first.
+        await selectTreeNode('_functions');
+        await page.getByRole('button', { name: '+ Add Function', exact: true }).click();
+        await fillAndConfirmAddModal(name);
+    }
+    for (const name of ['Alpha', 'Beta']) {
+        const row = page.locator('[data-part="item"]', { hasText: name }).first();
+        const dropdown = await openNodeMenu(row);
+        await dropdown.getByRole('button', { name: 'Move to folder…' }).click();
+        await page.waitForSelector('text=Move "' + name + '" to folder', { timeout: 10000 });
+        await chooseOrCreateOption(page.locator('[role="dialog"] [role="combobox"]'), 'Math');
+        await page.click('[role="dialog"] button:has-text("Move")');
+        await page.waitForTimeout(300);
+    }
+    console.log('PASS: Alpha and Beta grouped into "Math" folder (final order: Gamma, Math[Alpha, Beta])');
+
+    // ── Folder "..." menu: Move up present (Gamma precedes), Move down absent (nothing follows) ─
+    const mathRow = groupRow('Math');
+    await mathRow.waitFor({ timeout: 10000 });
+    let dropdown = await openNodeMenu(mathRow);
+    const menuTexts = await dropdown.locator('button').allTextContents();
+    if (!menuTexts.includes('Add Function here')) throw new Error(`Folder menu missing "Add Function here": [${menuTexts.join(', ')}]`);
+    if (!menuTexts.includes('Move up')) throw new Error(`Folder menu missing "Move up": [${menuTexts.join(', ')}]`);
+    if (menuTexts.includes('Move down')) throw new Error(`Folder menu should not offer "Move down" (nothing follows it): [${menuTexts.join(', ')}]`);
+    console.log('PASS: "Math" folder\'s "..." menu offers "Add Function here" and "Move up" only');
+    await closeNodeMenu();
+
+    // ── "Add Function here" defaults the create modal's folder picker to "Math" ────────────────
+    dropdown = await openNodeMenu(mathRow);
+    await dropdown.getByRole('button', { name: 'Add Function here' }).click();
+    await page.waitForSelector('#element-name', { timeout: 10000 });
+    const folderPicker = page.locator('[role="dialog"] [role="combobox"]');
+    const folderPickerValue = await folderPicker.inputValue();
+    if (folderPickerValue !== 'Math') throw new Error(`Expected folder picker to default to "Math", got "${folderPickerValue}"`);
+    console.log('PASS: "Add Function here" pre-fills the folder picker with "Math"');
+    await fillAndConfirmAddModal('Delta');
+    // createFunction() and setFunctionFolder() both fire their own tree-rebuild event
+    // (see handleAddConfirm) - give the second (folder-assignment) rebuild's reactive grouping
+    // recompute a moment to settle before inspecting the tree, so this doesn't catch the
+    // intermediate state where Delta briefly exists as a bare top-level function.
+    await page.waitForTimeout(500);
+
+    // Confirm Delta landed inside Math, not at the top level: expand the folder and check for it.
+    await expandNode(mathRow);
+    await page.locator('[data-part="item"]', { hasText: 'Delta' }).waitFor({ timeout: 10000 });
+    console.log('PASS: "Delta" was created inside the "Math" folder');
+
+    // ── Move folder up: "Math" should now precede "Gamma" ──────────────────────────────────────
+    async function topLevelFunctionOrder() {
+        // Every row's own label text, in document order - only the relative order of "Gamma" vs
+        // "Math" is checked below, so rows for unrelated nodes elsewhere in the tree don't matter.
+        return page.locator('[data-part="item"], [data-part="branch-control"]').allTextContents();
+    }
+    const before = (await topLevelFunctionOrder()).map(t => t.trim());
+    const gammaIdx = before.findIndex(t => t.includes('Gamma'));
+    const mathIdx = before.findIndex(t => t.includes('Math'));
+    if (!(gammaIdx >= 0 && mathIdx >= 0 && gammaIdx < mathIdx)) {
+        throw new Error(`Expected Gamma before Math folder before the move, got: [${before.join(', ')}]`);
+    }
+
+    dropdown = await openNodeMenu(mathRow);
+    await dropdown.getByRole('button', { name: 'Move up', exact: true }).click();
+    await page.waitForTimeout(300);
+
+    const after = (await topLevelFunctionOrder()).map(t => t.trim());
+    const gammaIdx2 = after.findIndex(t => t.includes('Gamma'));
+    const mathIdx2 = after.findIndex(t => t.includes('Math'));
+    if (!(mathIdx2 >= 0 && gammaIdx2 >= 0 && mathIdx2 < gammaIdx2)) {
+        throw new Error(`Expected Math folder before Gamma after "Move up", got: [${after.join(', ')}]`);
+    }
+    console.log('PASS: "Move up" moved the whole "Math" folder block ahead of "Gamma"');
+
+    // ── "Add Object here" on an object (not just rooms), with a scoped parent picker ───────────
+    // Uses the room's own "..." menu (pre-existing action) rather than the Objects-tab toolbar
+    // button, consistent with how the folder/function actions above are driven.
+    const roomRow = page.locator('[data-part="item"], [data-part="branch-control"]', { hasText: 'room' }).first();
+    dropdown = await openNodeMenu(roomRow);
+    await dropdown.getByRole('button', { name: 'Add Object here' }).click();
+    await fillAndConfirmAddModal('Test Object');
+
+    const objectRow = page.locator('[data-part="item"], [data-part="branch-control"]', { hasText: 'Test Object' }).first();
+    dropdown = await openNodeMenu(objectRow);
+    const objectMenuTexts = await dropdown.locator('button').allTextContents();
+    if (!objectMenuTexts.includes('Add Object here')) {
+        throw new Error(`Expected "Test Object"'s "..." menu to offer "Add Object here", got: [${objectMenuTexts.join(', ')}]`);
+    }
+    console.log('PASS: an object\'s own "..." menu now offers "Add Object here"');
+
+    await dropdown.getByRole('button', { name: 'Add Object here' }).click();
+    await page.waitForSelector('#element-name', { timeout: 10000 });
+    const parentPicker = page.locator('[role="dialog"] [role="combobox"]');
+    const parentDefault = await parentPicker.inputValue();
+    if (parentDefault !== 'Test Object') throw new Error(`Expected parent picker to default to "Test Object", got "${parentDefault}"`);
+    const parentOptions = await comboboxOptionTexts(parentPicker);
+    // The template's default "room" has no Parent element of its own (true top level), so the
+    // ancestor chain for an object nested two levels under it is just [room, Test Object] - no
+    // synthetic "game"/"_objects" entry (this mirrors GetPossibleNewObjectParentsForCurrentSelection
+    // walking Element.Parent directly, not the tree's own "_objects" sentinel).
+    assertIncludes(parentOptions, 'room', 'Add Object parent picker');
+    assertIncludes(parentOptions, 'Test Object', 'Add Object parent picker');
+    if (parentOptions.length !== 2) throw new Error(`Expected only [room, Test Object], got [${parentOptions.join(', ')}]`);
+    console.log('PASS: parent picker defaults to "Test Object" and is scoped to its ancestor chain (room, Test Object) only');
+    // Close the combobox's own popup (not the whole modal - Escape would also cancel the dialog).
+    await page.locator('[role="dialog"] h2').click();
+    await fillAndConfirmAddModal('Inner Thing');
+
+    await expandNode(objectRow);
+    await page.locator('[data-part="item"]', { hasText: 'Inner Thing' }).waitFor({ timeout: 10000 });
+    console.log('PASS: "Inner Thing" was created nested inside "Test Object" (the default parent)');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-folder-move-and-add-here-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary

- Function folders can now be moved up/down as a whole block from the tree's "..." menu (mirroring the existing per-function move up/down), and the same menu gains **Add Function here**, which opens the create-function modal with its folder picker pre-filled to that folder.
- Objects gain **Add Object here** (previously room-only), and the create-object modal now shows a parent picker scoped to just the clicked object's own ancestor chain — via `GetPossibleNewObjectParentsForCurrentSelection`, a v5-desktop-editor method that was already ported into `EditorController` but never exposed through the WASM bridge.
- Both the mobile/panel `ElementsList` view and the sidebar `TreePanel` get these affordances.

## Bug fix found along the way

While testing folder moves, `UpdateTree()`'s full-rebuild traversal turned out to iterate elements in **raw creation order** rather than `SortIndex` order. This is invisible normally (the two coincide until something reorders `SortIndex` without touching storage order — e.g. `SetFunctionFolder`, or the new folder move), but a full rebuild after such a reorder could silently revert reordered elements back to their pre-reorder position whenever an untouched sibling sat between them. Fixed by sorting both the top-level and nested-children enumeration in `UpdateTree`/`AddElementAndChildrenToTree` by `SortIndex`, with a regression test covering the exact pattern that exposed it.

## Test plan

- [x] `dotnet test --configuration Release` — 384 tests pass (44 in `EditorCoreTests`, including 8 new ones for folder move-up/down, the ancestor-chain method, and the `UpdateTree` ordering regression)
- [x] `dotnet build --configuration Release` — full solution builds clean
- [x] `npm run lint` and `npx svelte-check` in `src/AppShell` — both clean
- [x] New Playwright e2e script (`tests/e2e/verify-appshell-folder-move-and-add-here.mjs`) exercising the full flow in a real browser: create/group functions into a folder, folder "..." menu contents, "Add Function here" pre-fill, folder move-up reordering, object "Add Object here" + scoped parent picker, nested object creation — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)