### PR TITLE
feat(AppShell): IntelliSense-style autocomplete for the script editor

### DIFF
--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -1804,6 +1804,14 @@ export function getExpressionFunctions(): ExpressionFunctionInfo[] {
     catch { return []; }
 }
 
+// Every attribute name ever set on any object in the game — feeds the code view's attribute-name
+// autocomplete (e.g. inside GetAttribute(obj, "...")).
+export function getAttributeNames(): string[] {
+    if (!_bridge) return [];
+    try { return JSON.parse(_bridge.GetAttributeNames()); }
+    catch { return []; }
+}
+
 // A new custom verb also creates a game-wide command element (visible under the Commands tree
 // node), so unlike createExitInDirection() this needs refreshTree() too, not just refreshSelectedData().
 export function addVerb(elementKey: string, verbPattern: string): string {

--- a/src/AppShell/src/lib/quest-script-completions.ts
+++ b/src/AppShell/src/lib/quest-script-completions.ts
@@ -15,12 +15,21 @@ function functionSnippet(name: string, parameters: string[]): string {
 // library functions such as DiceRoll). Data comes from EditorController.GetExpressionFunctions
 // via the WasmEditor bridge — the same list that already powers the visual editor's
 // expression-insert helper (ExpressionInput.svelte / ScriptEditor.svelte's Call-function picker).
+//
+// Filtered to a case-insensitive prefix match ourselves (rather than returning the whole ~250-ish
+// list and letting CodeMirror's default fuzzy scorer loose on it): fuzzy matching against that
+// many candidates surfaces arbitrary, barely-related functions for perfectly ordinary text (e.g.
+// typing "true" fuzzy-matched an unrelated function whose letters happened to appear in order),
+// which is worse than not completing at all. `filter: false` tells CodeMirror to trust this
+// pre-filtered, boost-ordered list as-is; omitting validFor makes the source re-run (and
+// re-filter) on every keystroke rather than reusing a stale snapshot of the first character typed.
 export function questFunctionCompletions(context: CompletionContext): CompletionResult | null {
     const word = context.matchBefore(/[a-zA-Z_][a-zA-Z0-9_]*/);
     if (!word) return null;
     if (word.from === word.to && !context.explicit) return null;
 
-    const functions = getExpressionFunctions();
+    const typed = word.text.toLowerCase();
+    const functions = getExpressionFunctions().filter(f => f.name.toLowerCase().startsWith(typed));
     if (functions.length === 0) return null;
 
     const options: Completion[] = functions.map(f => snippetCompletion(functionSnippet(f.name, f.parameters), {
@@ -32,7 +41,7 @@ export function questFunctionCompletions(context: CompletionContext): Completion
         boost: f.isUserDefined && !f.isLibrary ? 1 : 0,
     }));
 
-    return { from: word.from, options, validFor: /^[a-zA-Z_][a-zA-Z0-9_]*$/ };
+    return { from: word.from, options, filter: false };
 }
 
 // Names of the built-in functions/script commands whose (single) string argument right after the
@@ -51,7 +60,8 @@ const attributeArgPattern = new RegExp(
 // attribute name used anywhere in the game (EditorController.GetPropertyNames, via the bridge's
 // GetAttributeNames), not just ones already typed in the currently open script. This DSL is
 // line-oriented (see quest-script-lang.ts), so the "are we inside one of these calls" check only
-// looks at text on the current line, matching the tokenizer's own per-line scope.
+// looks at text on the current line, matching the tokenizer's own per-line scope. Prefix-filtered
+// for the same reason as questFunctionCompletions above.
 export function questAttributeCompletions(context: CompletionContext): CompletionResult | null {
     const inString = context.matchBefore(/"[^"]*$/);
     if (!inString) return null;
@@ -60,11 +70,12 @@ export function questAttributeCompletions(context: CompletionContext): Completio
     const prefix = line.text.slice(0, inString.from - line.from);
     if (!attributeArgPattern.test(prefix)) return null;
 
-    const names = getAttributeNames();
+    const typed = inString.text.slice(1).toLowerCase();
+    const names = getAttributeNames().filter(n => n.toLowerCase().startsWith(typed));
     if (names.length === 0) return null;
 
     const options: Completion[] = names.map(name => ({ label: name, type: "property" }));
-    return { from: inString.from + 1, options, validFor: /^[^"]*$/ };
+    return { from: inString.from + 1, options, filter: false };
 }
 
 // Completes the attribute name after `object.` dot-access syntax (e.g. `player.parent`,
@@ -73,6 +84,7 @@ export function questAttributeCompletions(context: CompletionContext): Completio
 // SetScript resolves `lhs.name = value` the same way for writes (see Core.aslx's pervasive
 // `player.parent = ...` / `oldPOV.alias = ...` style) — so this is exactly as valid a spelling of
 // "get/set an attribute" as the quoted-string forms above, and arguably the more common one.
+// Prefix-filtered for the same reason as questFunctionCompletions above.
 export function questDotAttributeCompletions(context: CompletionContext): CompletionResult | null {
     const word = context.matchBefore(/\.[a-zA-Z0-9_]*/);
     if (!word) return null;
@@ -81,9 +93,85 @@ export function questDotAttributeCompletions(context: CompletionContext): Comple
     const before = context.state.sliceDoc(Math.max(0, word.from - 60), word.from);
     if (!/[a-zA-Z_][a-zA-Z0-9_]*$/.test(before)) return null;
 
-    const names = getAttributeNames();
+    const typed = word.text.slice(1).toLowerCase();
+    const names = getAttributeNames().filter(n => n.toLowerCase().startsWith(typed));
     if (names.length === 0) return null;
 
     const options: Completion[] = names.map(name => ({ label: name, type: "property" }));
-    return { from: word.from + 1, options, validFor: /^[a-zA-Z0-9_]*$/ };
+    return { from: word.from + 1, options, filter: false };
+}
+
+// Real script-command keyword forms (if/foreach/msg/set/create timer/...). These are Script
+// objects (src/Engine/Scripts/*.cs) rather than expression functions, so none of them appear in
+// GetExpressionFunctions — without this list, typing "if" or "foreach" only ever offered fuzzy
+// function-name noise, never the keyword itself. Snippet bodies mirror the exact template each
+// script's own <create> element uses in src/Engine/Core/CoreEditorScripts*.aslx (what the visual
+// editor's "Add script" picker inserts), cross-checked against each Script(Constructor)'s real
+// ExpectedParameters/param names for the ones whose <create> template only shows blank commas.
+const SCRIPT_KEYWORDS: { label: string; snippet: string }[] = [
+    { label: "msg", snippet: "msg (\"${1:text}\")" },
+    { label: "if", snippet: "if (${1:condition}) {\n\t${2}\n}" },
+    { label: "else if", snippet: "else if (${1:condition}) {\n\t${2}\n}" },
+    { label: "else", snippet: "else {\n\t${1}\n}" },
+    { label: "otherwise", snippet: "otherwise {\n\t${1}\n}" },
+    { label: "foreach", snippet: "foreach (${1:item}, ${2:list}) {\n\t${3}\n}" },
+    { label: "for", snippet: "for (${1:i}, ${2:from}, ${3:to}) {\n\t${4}\n}" },
+    { label: "while", snippet: "while (${1:condition}) {\n\t${2}\n}" },
+    { label: "switch", snippet: "switch (${1:expression}) {\n\tcase (\"${2:value}\") {\n\t\t${3}\n\t}\n\tdefault {\n\t\t${4}\n\t}\n}" },
+    { label: "do", snippet: "do (${1:object}, \"${2:action}\", QuickParams(\"${3:param}\", ${4:value}))" },
+    { label: "set", snippet: "set (${1:object}, \"${2:attribute}\", ${3:value})" },
+    { label: "get input", snippet: "get input {\n\t${1}\n}" },
+    { label: "list add", snippet: "list add (${1:list}, ${2:item})" },
+    { label: "list remove", snippet: "list remove (${1:list}, ${2:item})" },
+    { label: "dictionary add", snippet: "dictionary add (${1:dict}, \"${2:key}\", ${3:value})" },
+    { label: "dictionary remove", snippet: "dictionary remove (${1:dict}, \"${2:key}\")" },
+    { label: "create", snippet: "create (\"${1:name}\")" },
+    { label: "create exit", snippet: "create exit (\"${1:name}\", ${2:from}, ${3:to})" },
+    { label: "create timer", snippet: "create timer (\"${1:name}\")" },
+    { label: "create turnscript", snippet: "create turnscript (\"${1:name}\")" },
+    { label: "destroy", snippet: "destroy (${1:object})" },
+    { label: "ask", snippet: "ask (\"${1:question}\") {\n\t${2}\n}" },
+    { label: "insert", snippet: "insert (\"${1:text}\")" },
+    { label: "invoke", snippet: "invoke (${1:script})" },
+    { label: "finish", snippet: "finish" },
+    { label: "error", snippet: "error (\"${1:message}\")" },
+    { label: "picture", snippet: "picture (\"${1:filename}\")" },
+    { label: "requestsave", snippet: "requestsave" },
+    { label: "firsttime", snippet: "firsttime {\n\t${1}\n}" },
+    { label: "on ready", snippet: "on ready {\n\t${1}\n}" },
+    { label: "play sound", snippet: "play sound (\"${1:filename}\", ${2:synchronous}, ${3:loop})" },
+    { label: "stop sound", snippet: "stop sound" },
+    { label: "wait", snippet: "wait {\n\t${1}\n}" },
+    { label: "undo", snippet: "undo" },
+    { label: "return", snippet: "return (${1:value})" },
+    { label: "request", snippet: "request (${1:type}, ${2:value})" },
+];
+
+// Boolean/null literals — real NCalc/Quest expression literals (e.g. Core.aslx's
+// `return (null)`), but not functions, objects, or attributes, so nothing else here suggests them.
+const LITERAL_KEYWORDS: { label: string; snippet: string }[] = [
+    { label: "true", snippet: "true" },
+    { label: "false", snippet: "false" },
+    { label: "null", snippet: "null" },
+];
+
+// boost only orders options within this source's own block (see the registration-order comment in
+// quest-script-lang.ts/xml-with-script-lang.ts for why cross-source ordering is controlled there
+// instead) — set here so e.g. "create" sorts above the longer "create exit"/"create timer"/
+// "create turnscript" it's also a prefix of.
+const KEYWORD_OPTIONS: Completion[] = [...SCRIPT_KEYWORDS, ...LITERAL_KEYWORDS].map(k =>
+    snippetCompletion(k.snippet, { label: k.label, type: "keyword", boost: k.label.includes(" ") ? 1 : 2 }));
+
+// Matches a run of up to two space-separated words ending at the cursor, so typing "create t"
+// (partway through "create turnscript") is recognised as one candidate string to prefix-match
+// against multi-word keyword labels, not just the bare trailing word "t".
+export function questKeywordCompletions(context: CompletionContext): CompletionResult | null {
+    const word = context.matchBefore(/[a-zA-Z_][a-zA-Z0-9_]*(?: [a-zA-Z_][a-zA-Z0-9_]*)?$/);
+    if (!word) return null;
+
+    const typed = word.text.toLowerCase();
+    const options = KEYWORD_OPTIONS.filter(c => (c.label ?? "").toLowerCase().startsWith(typed));
+    if (options.length === 0) return null;
+
+    return { from: word.from, options, filter: false };
 }

--- a/src/AppShell/src/lib/quest-script-completions.ts
+++ b/src/AppShell/src/lib/quest-script-completions.ts
@@ -165,16 +165,23 @@ function keywordSnippet(keyword: string, createString: string): string {
 }
 
 // A tiny handful of commands where the mechanical <create>-template transform above can't capture
-// genuinely useful structure: "switch"'s <create> is just `switch ()` (its case/default children
-// are, like other block bodies, a structural tree child with no textual trace to derive from), and
-// "do"'s <create> is only the 2-arg form (`do (,"")`) even though a third QuickParams argument is
-// idiomatic and common enough to be worth offering outright. Everything else still comes from the
-// generic mechanism above and stays automatically in sync with the engine; only these two are
-// overridden entirely, bypassing keywordSnippet (including its NEEDS_TRAILING_BLOCK handling —
-// both snippets below already include whatever braces they need).
+// genuinely useful structure. Right now that's just "switch": its <create> is `switch ()` (its
+// case/default children are, like other block bodies, a structural tree child with no textual
+// trace to derive from), so the generic transform alone would only ever offer a bare, empty body.
+// Everything else still comes from the generic mechanism above and stays automatically in sync
+// with the engine; only entries here are overridden entirely, bypassing keywordSnippet (including
+// its NEEDS_TRAILING_BLOCK handling — the snippet below already includes the braces it needs).
+//
+// "do"'s optional third QuickParams argument (do (object, "action", QuickParams("key", value)))
+// was special-cased here too at first, but it's a rare pattern in practice — across every .aslx
+// file in this repo, only 2 of 103 real `do (...)` call sites use it, and both are Core.aslx's own
+// internals dispatching to its own extensibility hooks (CoreCommands' "ondrop", CoreParser's
+// "unresolved"), passing extra context a game author's own override reads back as local variables
+// in scope — not something an ordinary game author's own `do` call needs. Defaulting the
+// suggestion to that form would've pushed the rare case into the common slot, so "do" now falls
+// back to the plain, generic 2-arg form that matches the other 101 call sites.
 const SPECIAL_CASE_SNIPPETS: Record<string, string> = {
     switch: "switch (${1:expression}) {\n\tcase (\"${2:value}\") {\n\t\t${3}\n\t}\n\tdefault {\n\t\t${4}\n\t}\n}",
-    do: "do (${1:object}, \"${2:action}\", QuickParams(\"${3:param}\", ${4:value}))",
 };
 
 // boost only orders options within this source's own block (see the registration-order comment in
@@ -200,19 +207,23 @@ const EXTRA_KEYWORDS: Completion[] = [
 
 let cachedKeywordOptions: Completion[] = EXTRA_KEYWORDS;
 let loadedFromScriptCommandCategories = false;
-let keywordLoadInFlight = false;
+let keywordLoadPromise: Promise<void> | null = null;
 
 // getScriptCommandCategories() is async (its EditorController data carries per-command
 // onlydisplayif visibility checks) and hits the WASM bridge, which may not be ready yet the first
-// time a completion is requested (this module loads well before any game does) — so this retries
-// on each call until it succeeds once, then never re-fetches for the rest of the session. The
-// hand-kept EXTRA_KEYWORDS above are usable immediately, before this ever resolves.
-async function loadKeywordCompletions(): Promise<void> {
-    if (keywordLoadInFlight) return;
-    keywordLoadInFlight = true;
-    try {
+// time a completion is requested (this module loads well before any game does). Concurrent callers
+// share the same in-flight promise rather than each kicking off their own fetch; on failure (bridge
+// still not ready) the promise is cleared so the next request gets a fresh attempt, but once it
+// succeeds this never re-fetches for the rest of the session. The hand-kept EXTRA_KEYWORDS above
+// are usable immediately, before this ever resolves.
+function ensureKeywordsLoaded(): Promise<void> {
+    if (loadedFromScriptCommandCategories) return Promise.resolve();
+    keywordLoadPromise ??= (async () => {
         const data = await getScriptCommandCategories();
-        if (!data) return;
+        if (!data) {
+            keywordLoadPromise = null;
+            return;
+        }
 
         const options = [...EXTRA_KEYWORDS];
         const seen = new Set(options.map(o => o.label));
@@ -235,23 +246,31 @@ async function loadKeywordCompletions(): Promise<void> {
         }
         cachedKeywordOptions = options;
         loadedFromScriptCommandCategories = true;
-    } finally {
-        keywordLoadInFlight = false;
-    }
+    })();
+    return keywordLoadPromise;
+}
+
+function matchKeywords(typed: string, from: number): CompletionResult | null {
+    const options = cachedKeywordOptions.filter(c => (c.label ?? "").toLowerCase().startsWith(typed));
+    return options.length ? { from, options, filter: false } : null;
 }
 
 // Matches a run of up to two space-separated words ending at the cursor, so typing "create t"
 // (partway through "create turnscript") is recognised as one candidate string to prefix-match
-// against multi-word keyword labels, not just the bare trailing word "t".
-export function questKeywordCompletions(context: CompletionContext): CompletionResult | null {
-    if (!loadedFromScriptCommandCategories) void loadKeywordCompletions();
-
+// against multi-word keyword labels, not just the bare trailing word "t". Returns a Promise (which
+// CodeMirror's autocomplete natively supports and waits on) rather than firing the load and
+// immediately answering from a possibly-still-cold cache — the first completion request of a
+// session would otherwise silently render without any of the generated keywords and never
+// refresh once the fetch actually completes, since nothing re-triggers the popup on its own.
+export function questKeywordCompletions(
+    context: CompletionContext,
+): CompletionResult | Promise<CompletionResult | null> | null {
     const word = context.matchBefore(/[a-zA-Z_][a-zA-Z0-9_]*(?: [a-zA-Z_][a-zA-Z0-9_]*)?$/);
     if (!word) return null;
 
     const typed = word.text.toLowerCase();
-    const options = cachedKeywordOptions.filter(c => (c.label ?? "").toLowerCase().startsWith(typed));
-    if (options.length === 0) return null;
-
-    return { from: word.from, options, filter: false };
+    if (!loadedFromScriptCommandCategories) {
+        return ensureKeywordsLoaded().then(() => matchKeywords(typed, word.from));
+    }
+    return matchKeywords(typed, word.from);
 }

--- a/src/AppShell/src/lib/quest-script-completions.ts
+++ b/src/AppShell/src/lib/quest-script-completions.ts
@@ -1,0 +1,89 @@
+import { snippetCompletion } from "@codemirror/autocomplete";
+import type { Completion, CompletionContext, CompletionResult } from "@codemirror/autocomplete";
+import { getExpressionFunctions, getAttributeNames } from "./editor-store";
+
+// Turns a function's real parameter names into a tab-stop snippet, e.g. GetAttribute(object,
+// property) -> "GetAttribute(${1:object}, ${2:property})", so accepting the completion lets the
+// author Tab through each argument in turn rather than just inserting the bare name.
+function functionSnippet(name: string, parameters: string[]): string {
+    if (parameters.length === 0) return `${name}()`;
+    const args = parameters.map((p, i) => `\${${i + 1}:${p}}`).join(", ");
+    return `${name}(${args})`;
+}
+
+// Completes calls to built-in engine functions and the game's own user-defined Functions (and
+// library functions such as DiceRoll). Data comes from EditorController.GetExpressionFunctions
+// via the WasmEditor bridge — the same list that already powers the visual editor's
+// expression-insert helper (ExpressionInput.svelte / ScriptEditor.svelte's Call-function picker).
+export function questFunctionCompletions(context: CompletionContext): CompletionResult | null {
+    const word = context.matchBefore(/[a-zA-Z_][a-zA-Z0-9_]*/);
+    if (!word) return null;
+    if (word.from === word.to && !context.explicit) return null;
+
+    const functions = getExpressionFunctions();
+    if (functions.length === 0) return null;
+
+    const options: Completion[] = functions.map(f => snippetCompletion(functionSnippet(f.name, f.parameters), {
+        label: f.name,
+        type: "function",
+        detail: `(${f.parameters.join(", ")})`,
+        // Game-authored functions are the more likely thing an author wants to call, so rank
+        // them above library/built-in functions of the same relevance.
+        boost: f.isUserDefined && !f.isLibrary ? 1 : 0,
+    }));
+
+    return { from: word.from, options, validFor: /^[a-zA-Z_][a-zA-Z0-9_]*$/ };
+}
+
+// Names of the built-in functions/script commands whose (single) string argument right after the
+// first comma is an attribute name — reflected from ExpressionOwner's real parameter names
+// ("property"/"attribute") plus the "set" script command, which takes the same shape
+// (object, "attribute", value) but isn't an expression function so it isn't in that list.
+const ATTRIBUTE_ARG_CALLS = [
+    "GetAttribute", "HasAttribute", "GetBoolean", "GetInt", "GetDouble", "GetString", "TypeOf", "set",
+];
+
+const attributeArgPattern = new RegExp(
+    `\\b(?:${ATTRIBUTE_ARG_CALLS.join("|")})\\s*\\(\\s*[a-zA-Z_][a-zA-Z0-9_.]*\\s*,\\s*$`,
+);
+
+// Completes the attribute-name argument of GetAttribute/HasAttribute/set/etc. with every
+// attribute name used anywhere in the game (EditorController.GetPropertyNames, via the bridge's
+// GetAttributeNames), not just ones already typed in the currently open script. This DSL is
+// line-oriented (see quest-script-lang.ts), so the "are we inside one of these calls" check only
+// looks at text on the current line, matching the tokenizer's own per-line scope.
+export function questAttributeCompletions(context: CompletionContext): CompletionResult | null {
+    const inString = context.matchBefore(/"[^"]*$/);
+    if (!inString) return null;
+
+    const line = context.state.doc.lineAt(inString.from);
+    const prefix = line.text.slice(0, inString.from - line.from);
+    if (!attributeArgPattern.test(prefix)) return null;
+
+    const names = getAttributeNames();
+    if (names.length === 0) return null;
+
+    const options: Completion[] = names.map(name => ({ label: name, type: "property" }));
+    return { from: inString.from + 1, options, validFor: /^[^"]*$/ };
+}
+
+// Completes the attribute name after `object.` dot-access syntax (e.g. `player.parent`,
+// `oldPOV.alias`). This isn't just cosmetic sugar: QuestNCalcLogicalExpressionParser's
+// propertyAccessSuffix rewrites `receiver.name` into GetAttribute(receiver, "name") for reads, and
+// SetScript resolves `lhs.name = value` the same way for writes (see Core.aslx's pervasive
+// `player.parent = ...` / `oldPOV.alias = ...` style) — so this is exactly as valid a spelling of
+// "get/set an attribute" as the quoted-string forms above, and arguably the more common one.
+export function questDotAttributeCompletions(context: CompletionContext): CompletionResult | null {
+    const word = context.matchBefore(/\.[a-zA-Z0-9_]*/);
+    if (!word) return null;
+
+    // Require an identifier (not e.g. a decimal number like "3.5") immediately before the dot.
+    const before = context.state.sliceDoc(Math.max(0, word.from - 60), word.from);
+    if (!/[a-zA-Z_][a-zA-Z0-9_]*$/.test(before)) return null;
+
+    const names = getAttributeNames();
+    if (names.length === 0) return null;
+
+    const options: Completion[] = names.map(name => ({ label: name, type: "property" }));
+    return { from: word.from + 1, options, validFor: /^[a-zA-Z0-9_]*$/ };
+}

--- a/src/AppShell/src/lib/quest-script-completions.ts
+++ b/src/AppShell/src/lib/quest-script-completions.ts
@@ -164,6 +164,19 @@ function keywordSnippet(keyword: string, createString: string): string {
     return snippet;
 }
 
+// A tiny handful of commands where the mechanical <create>-template transform above can't capture
+// genuinely useful structure: "switch"'s <create> is just `switch ()` (its case/default children
+// are, like other block bodies, a structural tree child with no textual trace to derive from), and
+// "do"'s <create> is only the 2-arg form (`do (,"")`) even though a third QuickParams argument is
+// idiomatic and common enough to be worth offering outright. Everything else still comes from the
+// generic mechanism above and stays automatically in sync with the engine; only these two are
+// overridden entirely, bypassing keywordSnippet (including its NEEDS_TRAILING_BLOCK handling —
+// both snippets below already include whatever braces they need).
+const SPECIAL_CASE_SNIPPETS: Record<string, string> = {
+    switch: "switch (${1:expression}) {\n\tcase (\"${2:value}\") {\n\t\t${3}\n\t}\n\tdefault {\n\t\t${4}\n\t}\n}",
+    do: "do (${1:object}, \"${2:action}\", QuickParams(\"${3:param}\", ${4:value}))",
+};
+
 // boost only orders options within this source's own block (see the registration-order comment in
 // quest-script-lang.ts/xml-with-script-lang.ts for why cross-source ordering is controlled there
 // instead) — used so e.g. "create" sorts above the longer "create exit"/"create timer"/
@@ -211,7 +224,9 @@ async function loadKeywordCompletions(): Promise<void> {
                 if (!/^[a-zA-Z]/.test(command.keyword)) continue;
                 if (seen.has(command.keyword)) continue;
                 seen.add(command.keyword);
-                options.push(snippetCompletion(keywordSnippet(command.keyword, command.createString), {
+                const snippet = SPECIAL_CASE_SNIPPETS[command.keyword]
+                    ?? keywordSnippet(command.keyword, command.createString);
+                options.push(snippetCompletion(snippet, {
                     label: command.keyword,
                     type: "keyword",
                     boost: keywordBoost(command.keyword),

--- a/src/AppShell/src/lib/quest-script-completions.ts
+++ b/src/AppShell/src/lib/quest-script-completions.ts
@@ -1,6 +1,8 @@
 import { snippetCompletion } from "@codemirror/autocomplete";
 import type { Completion, CompletionContext, CompletionResult } from "@codemirror/autocomplete";
-import { getExpressionFunctions, getAttributeNames } from "./editor-store";
+import {
+    getExpressionFunctions, getAttributeNames, getObjectNames, getExitNames, getScriptCommandCategories,
+} from "./editor-store";
 
 // Turns a function's real parameter names into a tab-stop snippet, e.g. GetAttribute(object,
 // property) -> "GetAttribute(${1:object}, ${2:property})", so accepting the completion lets the
@@ -101,76 +103,139 @@ export function questDotAttributeCompletions(context: CompletionContext): Comple
     return { from: word.from + 1, options, filter: false };
 }
 
-// Real script-command keyword forms (if/foreach/msg/set/create timer/...). These are Script
-// objects (src/Engine/Scripts/*.cs) rather than expression functions, so none of them appear in
-// GetExpressionFunctions — without this list, typing "if" or "foreach" only ever offered fuzzy
-// function-name noise, never the keyword itself. Snippet bodies mirror the exact template each
-// script's own <create> element uses in src/Engine/Core/CoreEditorScripts*.aslx (what the visual
-// editor's "Add script" picker inserts), cross-checked against each Script(Constructor)'s real
-// ExpectedParameters/param names for the ones whose <create> template only shows blank commas.
-const SCRIPT_KEYWORDS: { label: string; snippet: string }[] = [
-    { label: "msg", snippet: "msg (\"${1:text}\")" },
-    { label: "if", snippet: "if (${1:condition}) {\n\t${2}\n}" },
-    { label: "else if", snippet: "else if (${1:condition}) {\n\t${2}\n}" },
-    { label: "else", snippet: "else {\n\t${1}\n}" },
-    { label: "otherwise", snippet: "otherwise {\n\t${1}\n}" },
-    { label: "foreach", snippet: "foreach (${1:item}, ${2:list}) {\n\t${3}\n}" },
-    { label: "for", snippet: "for (${1:i}, ${2:from}, ${3:to}) {\n\t${4}\n}" },
-    { label: "while", snippet: "while (${1:condition}) {\n\t${2}\n}" },
-    { label: "switch", snippet: "switch (${1:expression}) {\n\tcase (\"${2:value}\") {\n\t\t${3}\n\t}\n\tdefault {\n\t\t${4}\n\t}\n}" },
-    { label: "do", snippet: "do (${1:object}, \"${2:action}\", QuickParams(\"${3:param}\", ${4:value}))" },
-    { label: "set", snippet: "set (${1:object}, \"${2:attribute}\", ${3:value})" },
-    { label: "get input", snippet: "get input {\n\t${1}\n}" },
-    { label: "list add", snippet: "list add (${1:list}, ${2:item})" },
-    { label: "list remove", snippet: "list remove (${1:list}, ${2:item})" },
-    { label: "dictionary add", snippet: "dictionary add (${1:dict}, \"${2:key}\", ${3:value})" },
-    { label: "dictionary remove", snippet: "dictionary remove (${1:dict}, \"${2:key}\")" },
-    { label: "create", snippet: "create (\"${1:name}\")" },
-    { label: "create exit", snippet: "create exit (\"${1:name}\", ${2:from}, ${3:to})" },
-    { label: "create timer", snippet: "create timer (\"${1:name}\")" },
-    { label: "create turnscript", snippet: "create turnscript (\"${1:name}\")" },
-    { label: "destroy", snippet: "destroy (${1:object})" },
-    { label: "ask", snippet: "ask (\"${1:question}\") {\n\t${2}\n}" },
-    { label: "insert", snippet: "insert (\"${1:text}\")" },
-    { label: "invoke", snippet: "invoke (${1:script})" },
-    { label: "finish", snippet: "finish" },
-    { label: "error", snippet: "error (\"${1:message}\")" },
-    { label: "picture", snippet: "picture (\"${1:filename}\")" },
-    { label: "requestsave", snippet: "requestsave" },
-    { label: "firsttime", snippet: "firsttime {\n\t${1}\n}" },
-    { label: "on ready", snippet: "on ready {\n\t${1}\n}" },
-    { label: "play sound", snippet: "play sound (\"${1:filename}\", ${2:synchronous}, ${3:loop})" },
-    { label: "stop sound", snippet: "stop sound" },
-    { label: "wait", snippet: "wait {\n\t${1}\n}" },
-    { label: "undo", snippet: "undo" },
-    { label: "return", snippet: "return (${1:value})" },
-    { label: "request", snippet: "request (${1:type}, ${2:value})" },
-];
+// Completes game object/room/dialogue-page names (getObjectNames — Quest has no separate "room"
+// ObjectType, rooms/objects/pages are all plain objects, see Element.cs's ObjectType enum) plus
+// exit names (a distinct ObjectType, hence its own call). Mirrors the same two calls
+// ScriptEditor.svelte's own name pickers already combine (see e.g. its object/exit dropdown setup)
+// — not a new data source, just reusing it for the code view. Prefix-filtered for the same reason
+// as questFunctionCompletions above.
+export function questObjectCompletions(context: CompletionContext): CompletionResult | null {
+    const word = context.matchBefore(/[a-zA-Z_][a-zA-Z0-9_]*/);
+    if (!word) return null;
+    if (word.from === word.to && !context.explicit) return null;
 
-// Boolean/null literals — real NCalc/Quest expression literals (e.g. Core.aslx's
-// `return (null)`), but not functions, objects, or attributes, so nothing else here suggests them.
-const LITERAL_KEYWORDS: { label: string; snippet: string }[] = [
-    { label: "true", snippet: "true" },
-    { label: "false", snippet: "false" },
-    { label: "null", snippet: "null" },
-];
+    const typed = word.text.toLowerCase();
+    const names = [...(getObjectNames() ?? []), ...(getExitNames() ?? [])]
+        .filter(n => n.toLowerCase().startsWith(typed));
+    if (names.length === 0) return null;
+
+    const options: Completion[] = names.map(name => ({ label: name, type: "variable" }));
+    return { from: word.from, options, filter: false };
+}
+
+// Real script-command keywords (if/foreach/msg/set/create timer/...) that the visual editor's own
+// "Add script" picker offers, minus a handful it deliberately doesn't (see below). These are
+// Script objects (src/Engine/Scripts/*.cs), not expression functions, so none of them appear in
+// GetExpressionFunctions — without this, typing "if" or "foreach" only ever offered fuzzy
+// function-name noise, never the keyword itself.
+//
+// Rather than a hand-copied list of every command's syntax (which silently drifts out of sync the
+// moment a new one is added to the engine), this is generated from getScriptCommandCategories() —
+// the exact same data EditorController.GetScriptEditorData()/WasmEditorBridge.GetScriptCommandCategories
+// feeds to ScriptEditor.svelte's "Add script" dropdown — by turning each command's <create> template
+// (e.g. `create timer ("")`, `for (,,,1)`) into a tab-stop snippet. A "(function)Name" keyword is a
+// convenience shortcut for a built-in function (e.g. "(function)MoveObject") that's already covered,
+// with real parameter names, by questFunctionCompletions; "()" is the picker's generic "Call
+// function" entry. Both are skipped here rather than duplicated with a worse, nameless snippet.
+const NEEDS_TRAILING_BLOCK = new Set(["if", "foreach", "for", "while", "switch", "firsttime"]);
+
+function keywordSnippet(keyword: string, createString: string): string {
+    let n = 0;
+    let snippet = createString.replace(/\(([^()]*)\)/, (_whole, argsText: string) => {
+        // Genuinely empty parens (no comma at all, e.g. "invoke ()"/"if ()") still get one tab
+        // stop rather than being left bare — same reasoning as the blank-comma-slot case below,
+        // there's just no comma to split on here since there's only one slot to begin with.
+        if (argsText === "") return `(\${${++n}})`;
+        const args = argsText.split(",").map(arg => {
+            const trimmed = arg.trim();
+            const quoted = trimmed.match(/^"(.*)"$/);
+            if (quoted) return `"\${${++n}${quoted[1] ? `:${quoted[1]}` : ""}}"`;
+            if (trimmed === "") return `\${${++n}}`;
+            return `\${${++n}:${trimmed}}`;
+        });
+        return `(${args.join(", ")})`;
+    });
+    // Block-bodied commands (if/foreach/for/while/switch/firsttime) get no trailing braces in their
+    // <create> template — the visual editor represents their body as a structural tree child, not
+    // literal text, so there's nothing to strip there; the code view needs real braces though.
+    if (NEEDS_TRAILING_BLOCK.has(keyword) && !/\{\s*\}\s*$/.test(snippet)) {
+        snippet += ` {\n\t\${${++n}}\n}`;
+    }
+    return snippet;
+}
 
 // boost only orders options within this source's own block (see the registration-order comment in
 // quest-script-lang.ts/xml-with-script-lang.ts for why cross-source ordering is controlled there
-// instead) — set here so e.g. "create" sorts above the longer "create exit"/"create timer"/
+// instead) — used so e.g. "create" sorts above the longer "create exit"/"create timer"/
 // "create turnscript" it's also a prefix of.
-const KEYWORD_OPTIONS: Completion[] = [...SCRIPT_KEYWORDS, ...LITERAL_KEYWORDS].map(k =>
-    snippetCompletion(k.snippet, { label: k.label, type: "keyword", boost: k.label.includes(" ") ? 1 : 2 }));
+function keywordBoost(label: string): number {
+    return label.includes(" ") ? 1 : 2;
+}
+
+// A handful of real keywords/literals that never come from getScriptCommandCategories(), kept by
+// hand since there's no generic data source for either: "else"/"else if"/"otherwise" are added to
+// an existing `if` via a dedicated tree-editor action rather than through the generic "Add script"
+// picker, and true/false/null are expression literals, not script commands, at all.
+const EXTRA_KEYWORDS: Completion[] = [
+    { label: "else if", snippet: "else if (${1:condition}) {\n\t${2}\n}" },
+    { label: "else", snippet: "else {\n\t${1}\n}" },
+    { label: "otherwise", snippet: "otherwise {\n\t${1}\n}" },
+    { label: "true", snippet: "true" },
+    { label: "false", snippet: "false" },
+    { label: "null", snippet: "null" },
+].map(k => snippetCompletion(k.snippet, { label: k.label, type: "keyword", boost: keywordBoost(k.label) }));
+
+let cachedKeywordOptions: Completion[] = EXTRA_KEYWORDS;
+let loadedFromScriptCommandCategories = false;
+let keywordLoadInFlight = false;
+
+// getScriptCommandCategories() is async (its EditorController data carries per-command
+// onlydisplayif visibility checks) and hits the WASM bridge, which may not be ready yet the first
+// time a completion is requested (this module loads well before any game does) — so this retries
+// on each call until it succeeds once, then never re-fetches for the rest of the session. The
+// hand-kept EXTRA_KEYWORDS above are usable immediately, before this ever resolves.
+async function loadKeywordCompletions(): Promise<void> {
+    if (keywordLoadInFlight) return;
+    keywordLoadInFlight = true;
+    try {
+        const data = await getScriptCommandCategories();
+        if (!data) return;
+
+        const options = [...EXTRA_KEYWORDS];
+        const seen = new Set(options.map(o => o.label));
+        for (const category of data.categories) {
+            for (const command of category.commands) {
+                if (command.keyword === "()" || command.keyword.startsWith("(function)")) continue;
+                // Symbolic entries (=, =>, //, JS.) can never be reached anyway: this source's own
+                // trigger regex below only ever matches typed text starting with a letter.
+                if (!/^[a-zA-Z]/.test(command.keyword)) continue;
+                if (seen.has(command.keyword)) continue;
+                seen.add(command.keyword);
+                options.push(snippetCompletion(keywordSnippet(command.keyword, command.createString), {
+                    label: command.keyword,
+                    type: "keyword",
+                    boost: keywordBoost(command.keyword),
+                }));
+            }
+        }
+        cachedKeywordOptions = options;
+        loadedFromScriptCommandCategories = true;
+    } finally {
+        keywordLoadInFlight = false;
+    }
+}
 
 // Matches a run of up to two space-separated words ending at the cursor, so typing "create t"
 // (partway through "create turnscript") is recognised as one candidate string to prefix-match
 // against multi-word keyword labels, not just the bare trailing word "t".
 export function questKeywordCompletions(context: CompletionContext): CompletionResult | null {
+    if (!loadedFromScriptCommandCategories) void loadKeywordCompletions();
+
     const word = context.matchBefore(/[a-zA-Z_][a-zA-Z0-9_]*(?: [a-zA-Z_][a-zA-Z0-9_]*)?$/);
     if (!word) return null;
 
     const typed = word.text.toLowerCase();
-    const options = KEYWORD_OPTIONS.filter(c => (c.label ?? "").toLowerCase().startsWith(typed));
+    const options = cachedKeywordOptions.filter(c => (c.label ?? "").toLowerCase().startsWith(typed));
     if (options.length === 0) return null;
 
     return { from: word.from, options, filter: false };

--- a/src/AppShell/src/lib/quest-script-lang.ts
+++ b/src/AppShell/src/lib/quest-script-lang.ts
@@ -2,7 +2,7 @@ import { StreamLanguage, LanguageSupport, foldService } from "@codemirror/langua
 import type { StreamParser, StringStream } from "@codemirror/language";
 import { completeAnyWord } from "@codemirror/autocomplete";
 import type { EditorState } from "@codemirror/state";
-import { questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions } from "./quest-script-completions";
+import { questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions, questKeywordCompletions } from "./quest-script-completions";
 
 // Approximate, non-validating highlighter for Quest's own line-oriented script
 // DSL (e.g. `msg ("Hello")`, `if (x = 1) { ... }`) — distinct from the ASLX XML
@@ -101,11 +101,20 @@ export const questScriptFoldService = foldService.of((state: EditorState, lineSt
 export const questScriptLanguage = StreamLanguage.define(questScriptParser);
 
 export function questScript(): LanguageSupport {
+    // Each of these sets `filter: false` (see quest-script-completions.ts) to do its own
+    // prefix-matching rather than CodeMirror's default fuzzy scorer — but that also means `boost`
+    // only orders options *within* one source's own block, not across sources: multiple filter:false
+    // results are shown concatenated in the order their sources are listed here, not globally
+    // re-sorted by boost. So the ordering below is itself the priority list, most useful first:
+    // exact language keywords/literals, then callable functions, then the two attribute-name
+    // sources (mutually exclusive by trigger context, so their relative order rarely matters), and
+    // finally completeAnyWord's generic in-buffer word matching as the least-precise fallback.
     return new LanguageSupport(questScriptLanguage, [
         questScriptFoldService,
-        questScriptLanguage.data.of({ autocomplete: completeAnyWord }),
+        questScriptLanguage.data.of({ autocomplete: questKeywordCompletions }),
         questScriptLanguage.data.of({ autocomplete: questFunctionCompletions }),
         questScriptLanguage.data.of({ autocomplete: questAttributeCompletions }),
         questScriptLanguage.data.of({ autocomplete: questDotAttributeCompletions }),
+        questScriptLanguage.data.of({ autocomplete: completeAnyWord }),
     ]);
 }

--- a/src/AppShell/src/lib/quest-script-lang.ts
+++ b/src/AppShell/src/lib/quest-script-lang.ts
@@ -2,7 +2,10 @@ import { StreamLanguage, LanguageSupport, foldService } from "@codemirror/langua
 import type { StreamParser, StringStream } from "@codemirror/language";
 import { completeAnyWord } from "@codemirror/autocomplete";
 import type { EditorState } from "@codemirror/state";
-import { questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions, questKeywordCompletions } from "./quest-script-completions";
+import {
+    questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions, questKeywordCompletions,
+    questObjectCompletions,
+} from "./quest-script-completions";
 
 // Approximate, non-validating highlighter for Quest's own line-oriented script
 // DSL (e.g. `msg ("Hello")`, `if (x = 1) { ... }`) — distinct from the ASLX XML
@@ -106,13 +109,15 @@ export function questScript(): LanguageSupport {
     // only orders options *within* one source's own block, not across sources: multiple filter:false
     // results are shown concatenated in the order their sources are listed here, not globally
     // re-sorted by boost. So the ordering below is itself the priority list, most useful first:
-    // exact language keywords/literals, then callable functions, then the two attribute-name
-    // sources (mutually exclusive by trigger context, so their relative order rarely matters), and
-    // finally completeAnyWord's generic in-buffer word matching as the least-precise fallback.
+    // exact language keywords/literals, then callable functions, then object/exit names, then the
+    // two attribute-name sources (mutually exclusive by trigger context, so their relative order
+    // rarely matters), and finally completeAnyWord's generic in-buffer word matching as the
+    // least-precise fallback.
     return new LanguageSupport(questScriptLanguage, [
         questScriptFoldService,
         questScriptLanguage.data.of({ autocomplete: questKeywordCompletions }),
         questScriptLanguage.data.of({ autocomplete: questFunctionCompletions }),
+        questScriptLanguage.data.of({ autocomplete: questObjectCompletions }),
         questScriptLanguage.data.of({ autocomplete: questAttributeCompletions }),
         questScriptLanguage.data.of({ autocomplete: questDotAttributeCompletions }),
         questScriptLanguage.data.of({ autocomplete: completeAnyWord }),

--- a/src/AppShell/src/lib/quest-script-lang.ts
+++ b/src/AppShell/src/lib/quest-script-lang.ts
@@ -2,6 +2,7 @@ import { StreamLanguage, LanguageSupport, foldService } from "@codemirror/langua
 import type { StreamParser, StringStream } from "@codemirror/language";
 import { completeAnyWord } from "@codemirror/autocomplete";
 import type { EditorState } from "@codemirror/state";
+import { questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions } from "./quest-script-completions";
 
 // Approximate, non-validating highlighter for Quest's own line-oriented script
 // DSL (e.g. `msg ("Hello")`, `if (x = 1) { ... }`) — distinct from the ASLX XML
@@ -103,5 +104,8 @@ export function questScript(): LanguageSupport {
     return new LanguageSupport(questScriptLanguage, [
         questScriptFoldService,
         questScriptLanguage.data.of({ autocomplete: completeAnyWord }),
+        questScriptLanguage.data.of({ autocomplete: questFunctionCompletions }),
+        questScriptLanguage.data.of({ autocomplete: questAttributeCompletions }),
+        questScriptLanguage.data.of({ autocomplete: questDotAttributeCompletions }),
     ]);
 }

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -94,6 +94,7 @@ export interface WasmBridge {
   // Verbs editor API
   GetVerbAttributesInfo(): string
   GetExpressionFunctions(): string
+  GetAttributeNames(): string
   AddVerb(elementKey: string, verbPattern: string): string
   CreateTurnScript(parent: string): string
   CreateCommand(parent: string): string

--- a/src/AppShell/src/lib/xml-with-script-lang.ts
+++ b/src/AppShell/src/lib/xml-with-script-lang.ts
@@ -4,7 +4,10 @@ import { xmlLanguage, autoCloseTags } from "@codemirror/lang-xml";
 import { LanguageSupport } from "@codemirror/language";
 import { completeAnyWord } from "@codemirror/autocomplete";
 import { questScriptLanguage, questScriptFoldService } from "./quest-script-lang";
-import { questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions, questKeywordCompletions } from "./quest-script-completions";
+import {
+    questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions, questKeywordCompletions,
+    questObjectCompletions,
+} from "./quest-script-completions";
 
 // ASLX marks every script-bearing attribute the same way regardless of the wrapping element's own
 // name — e.g. <start type="script">, <script type="script">, <take type="script">, <lock
@@ -54,6 +57,7 @@ export function xmlWithScript(): LanguageSupport {
         questScriptFoldService,
         xmlWithScriptLanguage.data.of({ autocomplete: questKeywordCompletions }),
         xmlWithScriptLanguage.data.of({ autocomplete: questFunctionCompletions }),
+        xmlWithScriptLanguage.data.of({ autocomplete: questObjectCompletions }),
         xmlWithScriptLanguage.data.of({ autocomplete: questAttributeCompletions }),
         xmlWithScriptLanguage.data.of({ autocomplete: questDotAttributeCompletions }),
         xmlWithScriptLanguage.data.of({ autocomplete: completeAnyWord }),

--- a/src/AppShell/src/lib/xml-with-script-lang.ts
+++ b/src/AppShell/src/lib/xml-with-script-lang.ts
@@ -4,7 +4,7 @@ import { xmlLanguage, autoCloseTags } from "@codemirror/lang-xml";
 import { LanguageSupport } from "@codemirror/language";
 import { completeAnyWord } from "@codemirror/autocomplete";
 import { questScriptLanguage, questScriptFoldService } from "./quest-script-lang";
-import { questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions } from "./quest-script-completions";
+import { questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions, questKeywordCompletions } from "./quest-script-completions";
 
 // ASLX marks every script-bearing attribute the same way regardless of the wrapping element's own
 // name — e.g. <start type="script">, <script type="script">, <take type="script">, <lock
@@ -45,13 +45,17 @@ export function xmlWithScript(): LanguageSupport {
     // are registered document-wide for the same reason: parseMixed embeds questScriptLanguage.parser
     // as a bare Parser rather than a full Language, so completions registered on
     // questScriptLanguage.data wouldn't reliably be picked up inside the embedded <... type="script">
-    // regions of this view.
+    // regions of this view. Ordering mirrors questScript() in quest-script-lang.ts (see its own
+    // comment): each of these sources sets filter: false, so multiple sources' results are shown
+    // concatenated in registration order rather than globally re-sorted by boost — most useful
+    // first (keywords, functions, attribute names), completeAnyWord's generic fallback last.
     return new LanguageSupport(xmlWithScriptLanguage, [
         autoCloseTags,
         questScriptFoldService,
-        xmlWithScriptLanguage.data.of({ autocomplete: completeAnyWord }),
+        xmlWithScriptLanguage.data.of({ autocomplete: questKeywordCompletions }),
         xmlWithScriptLanguage.data.of({ autocomplete: questFunctionCompletions }),
         xmlWithScriptLanguage.data.of({ autocomplete: questAttributeCompletions }),
         xmlWithScriptLanguage.data.of({ autocomplete: questDotAttributeCompletions }),
+        xmlWithScriptLanguage.data.of({ autocomplete: completeAnyWord }),
     ]);
 }

--- a/src/AppShell/src/lib/xml-with-script-lang.ts
+++ b/src/AppShell/src/lib/xml-with-script-lang.ts
@@ -4,6 +4,7 @@ import { xmlLanguage, autoCloseTags } from "@codemirror/lang-xml";
 import { LanguageSupport } from "@codemirror/language";
 import { completeAnyWord } from "@codemirror/autocomplete";
 import { questScriptLanguage, questScriptFoldService } from "./quest-script-lang";
+import { questFunctionCompletions, questAttributeCompletions, questDotAttributeCompletions } from "./quest-script-completions";
 
 // ASLX marks every script-bearing attribute the same way regardless of the wrapping element's own
 // name — e.g. <start type="script">, <script type="script">, <take type="script">, <lock
@@ -40,10 +41,17 @@ export function xmlWithScript(): LanguageSupport {
     // that the base xmlLanguage's foldNodeProp can't see into. completeAnyWord is similarly
     // document-wide: lang-xml's own schema completion is near-useless without a schema, so suggest
     // words already in the file (tag/attribute names) instead — it combines with (and never
-    // replaces) the XML language's built-in source.
+    // replaces) the XML language's built-in source. questFunctionCompletions/questAttributeCompletions
+    // are registered document-wide for the same reason: parseMixed embeds questScriptLanguage.parser
+    // as a bare Parser rather than a full Language, so completions registered on
+    // questScriptLanguage.data wouldn't reliably be picked up inside the embedded <... type="script">
+    // regions of this view.
     return new LanguageSupport(xmlWithScriptLanguage, [
         autoCloseTags,
         questScriptFoldService,
         xmlWithScriptLanguage.data.of({ autocomplete: completeAnyWord }),
+        xmlWithScriptLanguage.data.of({ autocomplete: questFunctionCompletions }),
+        xmlWithScriptLanguage.data.of({ autocomplete: questAttributeCompletions }),
+        xmlWithScriptLanguage.data.of({ autocomplete: questDotAttributeCompletions }),
     ]);
 }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -3025,6 +3025,22 @@ public partial class WasmEditorBridge
         return JsonSerializer.Serialize(functions, WasmEditorJsonContext.Default.ListExpressionFunctionData);
     }
 
+    // Feeds the code view's attribute-name autocomplete: every attribute name ever set on any
+    // object in the game (the values GetAttribute/HasAttribute/set/etc. take as their attribute
+    // argument), so authors get suggestions for attributes defined on other objects, not just
+    // ones already typed in the file open in the editor.
+    [JSExport]
+    public static string GetAttributeNames()
+    {
+        if (_controller == null)
+        {
+            return "[]";
+        }
+
+        var names = _controller.GetPropertyNames().ToList();
+        return JsonSerializer.Serialize(names, WasmEditorJsonContext.Default.ListString);
+    }
+
     [JSExport]
     public static string AddVerb(string elementKey, string verbPattern)
     {


### PR DESCRIPTION
## Summary

The code view's autocomplete used to be CodeMirror's generic `completeAnyWord` — it only suggested words already typed elsewhere in the currently open file, with no actual knowledge of the ASLX language (e.g. `GetAttribute` wouldn't even autocomplete unless it already appeared in the file, and script commands like `if`/`foreach` never autocompleted at all). This adds four language-aware completion sources, layered alongside the existing one (never replacing it):

- **Function/Script calls** — built-in engine functions plus the game's own user-defined Functions (and library functions), with real parameter names inserted as a Tab-through snippet (e.g. typing `GetAtt` → `GetAttribute(${obj}, ${property})`). Reuses `EditorController.GetExpressionFunctions`, already bridged to JS and used by the visual editor's expression-insert helper.
- **Script-command keywords** — `if`, `foreach`, `for`, `while`, `switch`, `set`, `create timer`, `list add`, etc., each as a tab-stop snippet, plus `true`/`false`/`null` literals. Rather than a hand-copied list (which would silently drift out of sync whenever a new command is added to the engine), these are generated from `getScriptCommandCategories()` — the exact same data that already feeds the visual editor's own "Add script" dropdown — by turning each command's `<create>` template into a snippet. A small hard-kept set covers the handful of things with no generic source at all: `else`/`else if`/`otherwise` (added via a dedicated tree action, not the generic picker), the boolean/null literals, and two explicit overrides (`switch`'s case/default scaffold, which the generic template can't express since it's a structural tree child; `do`'s plain 2-arg form, since the QuickParams flourish it originally had turned out to appear in only 2 of 103 real `do (...)` call sites across the whole repo — both Core.aslx's own internals — so defaulting to it was actively unhelpful for ordinary authors).
- **Attribute names in quoted-string calls** — `GetAttribute`, `HasAttribute`, `GetBoolean`, `GetInt`, `GetDouble`, `GetString`, `TypeOf`, and `set` all take an attribute name as a string argument right after the first comma; typing the opening quote suggests every attribute name ever used anywhere in the game. Required a new `GetAttributeNames` bridge export wrapping the previously frontend-unreachable `EditorController.GetPropertyNames`.
- **Attribute names after `object.` dot-access syntax** — e.g. `player.parent`, `oldPOV.alias`. Verified this is real, working syntax (not cosmetic sugar): `QuestNCalcLogicalExpressionParser`'s `propertyAccessSuffix` rewrites `receiver.name` into an attribute read, and `SetScript` resolves `lhs.name = value` the same way for writes — pervasive in `Core.aslx`.
- **Object/exit names** — reuses the existing `getObjectNames()`/`getExitNames()` bridge calls (the same two `ScriptEditor.svelte`'s own name pickers already combine), so e.g. `MoveObjectHere(roo` → `room`. No new bridge plumbing.

Design notes:
- All sources do their own case-insensitive **prefix filtering** rather than handing CodeMirror an unfiltered candidate list and letting its default fuzzy scorer loose on it — fuzzy matching against ~250 functions surfaced arbitrary, barely-related suggestions for perfectly ordinary text (e.g. typing "true" fuzzy-matched an unrelated function).
- Since prefix-filtered (`filter: false`) sources are shown concatenated in registration order rather than globally re-sorted by `boost` across sources, the registration order in `quest-script-lang.ts`/`xml-with-script-lang.ts` **is** the display-priority list: keywords/literals first, then functions, then object names, then attribute names, with `completeAnyWord`'s generic fallback last.
- The keyword list's data source is async (hits the WASM bridge); the source properly returns a Promise on cold start so CodeMirror waits for it, rather than answering from a possibly-still-empty cache on the very first completion request of a session.

Prompted by a user suggestion asking for function/attribute IntelliSense beyond the existing script-command autocomplete, then iterated based on feedback that script commands/keywords and object names were still missing, and that the generated keyword list shouldn't be a second hand-maintained copy of the engine's command list.

## Test plan

- [x] `npm run check` (svelte-check) and `npm run lint` (eslint) pass in `src/AppShell`
- [x] `dotnet build src/WasmEditor/WasmEditor.csproj` succeeds
- [x] Manually verified end-to-end in a running AppShell dev server against local draft games:
  - Function completion + snippet tab-stops (`GetAtt` → `GetAttribute (obj, property)`)
  - Quoted-string and dot-notation attribute completion (`GetAttribute(player, "desc` and `player.par` → `parent`)
  - Object-name completion (`MoveObjectHere(roo` → `room`)
  - Generated keyword snippets against live `getScriptCommandCategories()` data: `if` → `if () { }`, `for` → `for (, , , 1) { }` (default step preserved), `create exit` → `create exit ("", , )`, `switch` → full case/default scaffold, `do` → plain `do (, "")`
  - Keyword completion on the very first request of a fresh session (cold-start race fix)
  - `true`/`false` no longer buried under fuzzy function-name noise
- Known limitation (pre-existing, not a regression): none of these completions — including the old baseline `completeAnyWord` — fire inside the raw XML view's embedded `<... type="script">` regions specifically, because that view's `parseMixed` embed passes a bare `Parser` rather than a full `Language`, so CodeMirror can't resolve language-data-based completion sources there. Completions do work in the raw XML view's plain markup/attribute text, and fully work in the primary script-editing surface (the per-script Code View panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)