### PR TITLE
fix: support running multiple dev.sh instances concurrently

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -14,8 +14,12 @@
 #                       textadventures.co.uk has its own site navigation and
 #                       doesn't want a game-browser homepage. Default (no flag)
 #                       is play.questviva.com behaviour: local-only, Home shown.
+#   --port <n>          AppShell port (default 5174). WasmPlayer runs on <n>+1.
+#                       Set this to a different value per checkout (e.g. when
+#                       reviewing a PR in a git worktree alongside your main
+#                       checkout) so the two dev.sh instances don't collide.
 #
-# Servers started:
+# Servers started (ports shift together with --port):
 #   http://localhost:5174   AppShell (Vite / SvelteKit) — root shows Play/Create
 #                           Home when nothing's loaded (unless --api-proxy);
 #                           /open is the Create tab's content; proxies /player
@@ -29,13 +33,16 @@ cd "$SCRIPT_DIR"
 
 API_PROXY=""
 RELEASE=false
+APPSHELL_PORT=5174
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --release) RELEASE=true; shift;;
         --api-proxy) API_PROXY="$2"; shift 2;;
+        --port) APPSHELL_PORT="$2"; shift 2;;
         *) echo "Unknown argument: $1" >&2; exit 1;;
     esac
 done
+PLAYER_PORT=$((APPSHELL_PORT + 1))
 
 echo "Building WasmEditor..."
 if [[ "$RELEASE" == true ]]; then
@@ -52,14 +59,20 @@ else
     dotnet build src/WasmPlayer/WasmPlayer.csproj
 fi
 
+if [[ ! -d src/AppShell/node_modules ]]; then
+    echo ""
+    echo "src/AppShell/node_modules missing, installing (fresh checkout/worktree)..."
+    npm --prefix src/AppShell install
+fi
+
 echo ""
 echo "Starting dev servers..."
 echo ""
 
 if [[ "$RELEASE" == true ]]; then
-    node src/WasmPlayer/dev-server.mjs --release &
+    WASM_PLAYER_PORT="$PLAYER_PORT" node src/WasmPlayer/dev-server.mjs --release &
 else
-    node src/WasmPlayer/dev-server.mjs &
+    WASM_PLAYER_PORT="$PLAYER_PORT" node src/WasmPlayer/dev-server.mjs &
 fi
 PLAYER_PID=$!
 
@@ -71,7 +84,9 @@ if [[ -n "$API_PROXY" ]]; then
 fi
 
 VITE_ENV=(
-    "PUBLIC_WASM_PLAYER_URL=http://localhost:5174/player/"
+    "PORT=$APPSHELL_PORT"
+    "WASM_PLAYER_PORT=$PLAYER_PORT"
+    "PUBLIC_WASM_PLAYER_URL=http://localhost:$APPSHELL_PORT/player/"
     "PUBLIC_SHOW_HOME=$SHOW_HOME"
 )
 if [[ "$RELEASE" == true ]]; then
@@ -93,8 +108,8 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-echo "  AppShell:    http://localhost:5174"
-echo "  WasmPlayer:  http://localhost:5175/?game=/examples/simple.aslx"
+echo "  AppShell:    http://localhost:$APPSHELL_PORT"
+echo "  WasmPlayer:  http://localhost:$PLAYER_PORT/?game=/examples/simple.aslx"
 [[ -n "$API_PROXY" ]] && echo "  API proxy →  $API_PROXY"
 echo ""
 echo "Ctrl+C to stop."

--- a/src/AppShell/vite.config.ts
+++ b/src/AppShell/vite.config.ts
@@ -27,6 +27,11 @@ const mimeTypes: Record<string, string> = {
 // /api requests during development. Not needed in production (same-origin).
 const apiProxy = process.env.VITE_API_PROXY
 
+// Overridable so multiple dev.sh instances (e.g. main checkout + a PR worktree) can run
+// concurrently without port clashes — see dev.sh's --port flag.
+const appShellPort = Number(process.env.PORT) || 5174
+const playerPort = Number(process.env.WASM_PLAYER_PORT) || 5175
+
 // CI workflows set PUBLIC_APPSHELL_VERSION explicitly (to github.sha or github.ref_name);
 // locally it's blank, so fall back to the repo-root VERSION file — the same source
 // WasmPlayer's inject-version.mjs uses — so `npm run dev`/plain `npm run build` show a real version too.
@@ -66,11 +71,11 @@ export default defineConfig({
     }
   ],
   server: {
-    port: 5174,
+    port: appShellPort,
     proxy: {
       // Proxy WasmPlayer through the same origin so BroadcastChannel works between editor and player tabs.
       '/player': {
-        target: 'http://localhost:5175',
+        target: `http://localhost:${playerPort}`,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/player/, ''),
       },
@@ -89,8 +94,8 @@ export default defineConfig({
       // fetching itself. Every /api/* call this app itself makes is under
       // /api/editor/* (checked via grep), so /api/editor taking priority above
       // is safe and doesn't shadow any real editor save-API call.
-      '/api': { target: 'http://localhost:5175', changeOrigin: true },
-      '/game-resource': { target: 'http://localhost:5175', changeOrigin: true },
+      '/api': { target: `http://localhost:${playerPort}`, changeOrigin: true },
+      '/game-resource': { target: `http://localhost:${playerPort}`, changeOrigin: true },
     },
   }
 })

--- a/src/WasmPlayer/dev-server.mjs
+++ b/src/WasmPlayer/dev-server.mjs
@@ -19,7 +19,7 @@ const config = isRelease ? 'Release' : 'Debug';
 const appBundleDir = path.resolve(__dirname, `bin/${config}/net10.0/browser-wasm/AppBundle`);
 const examplesDir = path.resolve(__dirname, '../../examples');
 const e2eFixturesDir = path.resolve(__dirname, '../../tests/e2e/fixtures');
-const port = 5175;
+const port = Number(process.env.WASM_PLAYER_PORT) || 5175;
 
 const mimeTypes = {
   '.html': 'text/html',


### PR DESCRIPTION
## Summary
- `dev.sh` hardcoded AppShell on port 5174 and WasmPlayer on 5175, with those values also baked into `vite.config.ts`'s proxy targets and `dev-server.mjs`. Running `dev.sh` a second time (e.g. reviewing a PR in a git worktree alongside the main checkout) collided with an already-running instance instead of failing cleanly or working.
- Added a `--port <n>` flag to `dev.sh`: AppShell runs on `<n>`, WasmPlayer on `<n>+1`, threaded through new `PORT`/`WASM_PLAYER_PORT` env vars that `vite.config.ts` and `dev-server.mjs` now read (defaulting to the old 5174/5175 so behavior is unchanged without the flag).
- `dev.sh` now auto-runs `npm --prefix src/AppShell install` when `src/AppShell/node_modules` is missing — fresh git worktree checkouts don't carry over `node_modules`, so `npm run dev` would otherwise fail outright.

## Test plan
- [x] Built `WasmEditor` and `WasmPlayer` in Debug — succeeded, no warnings/errors.
- [x] Ran `./dev.sh` (default ports) and `./dev.sh --port 5274` concurrently from the same checkout — both started cleanly with no port collisions.
- [x] Verified in-browser that the AppShell on the alternate port (5274) correctly proxied `/player/*` requests to its own WasmPlayer instance (5275), not the other instance's.
- [x] Confirmed the auto-install path targets worktrees missing `node_modules` (two of the repo's current worktrees lack it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)