### PR TITLE
test(e2e): match textarea in switch-cases-editor message locator

### DIFF
--- a/tests/e2e/verify-appshell-switch-cases-editor.mjs
+++ b/tests/e2e/verify-appshell-switch-cases-editor.mjs
@@ -111,7 +111,10 @@ try {
     await page.click('[role="dialog"] button:has-text("OK")');
     await page.waitForTimeout(300);
 
-    const messageInput = caseBody.locator('input[type=text]').last();
+    // Print's message field renders as a <textarea> (multiline, see ScriptEditor.svelte's
+    // `ctrl.multiline` branch), not an `input[type=text]` - match both so `.last()` finds it
+    // rather than falling back to the case's own key input.
+    const messageInput = caseBody.locator('input[type=text], textarea').last();
     await messageInput.fill('You found a sword!');
     await messageInput.blur();
     await page.waitForTimeout(300);


### PR DESCRIPTION
## Summary
- Today's scheduled e2e run failed in `verify-appshell-switch-cases-editor.mjs`: the test filled the Print message field expecting an `input[type=text]`, but #2115 switched that field to a `<textarea>` for multiline support. The locator's `.last()` silently fell back to the case's own key `<input>`, so the "message" text overwrote the case key instead (`case (You found a sword!) { msg ("") }` in the saved XML).
- Widened the locator to match both `input[type=text]` and `textarea` so it correctly targets the nested message field.

This is a test-only fix — no product code changed; the message field itself works correctly, only the e2e locator was stale.

## Test plan
- [x] Ran `node tests/e2e/verify-appshell-switch-cases-editor.mjs` locally against the AppShell dev server — all checks now pass.
- [x] CI will re-run the full e2e suite on this PR.