### PR TITLE
fix(Engine): announce game output and label controls for screen readers

### DIFF
--- a/src/Engine/Core/Languages/Deutsch.aslx
+++ b/src/Engine/Core/Languages/Deutsch.aslx
@@ -582,6 +582,8 @@
   <template name="RestartingBusy">Startet neu…</template>
   <template name="DeleteSaveConfirm">„[name]“ löschen? Das kann nicht rückgängig gemacht werden.</template>
   <template name="SavedGameDefaultLabel">Spielstand — [timestamp]</template>
+  <template name="CommandInputLabel">Gib deinen Befehl ein</template>
+  <template name="ShowPanesButton">Bereiche anzeigen</template>
 
   <!-- Explicit copies of English.aslx's own values (both already reached via
        the <include ref="English.aslx"/> above, so this changes nothing at

--- a/src/Engine/Core/Languages/English.aslx
+++ b/src/Engine/Core/Languages/English.aslx
@@ -526,5 +526,7 @@
   <template name="RestartingBusy">Restarting…</template>
   <template name="DeleteSaveConfirm">Delete "[name]"? This can't be undone.</template>
   <template name="SavedGameDefaultLabel">Saved game — [timestamp]</template>
+  <template name="CommandInputLabel">Type your command</template>
+  <template name="ShowPanesButton">Show panels</template>
 
 </library>

--- a/src/Engine/Core/Languages/Espanol.aslx
+++ b/src/Engine/Core/Languages/Espanol.aslx
@@ -737,5 +737,7 @@
   <template name="RestartingBusy">Reiniciando…</template>
   <template name="DeleteSaveConfirm">¿Eliminar «[name]»? Esto no se puede deshacer.</template>
   <template name="SavedGameDefaultLabel">Partida guardada — [timestamp]</template>
+  <template name="CommandInputLabel">Escribe tu comando</template>
+  <template name="ShowPanesButton">Mostrar paneles</template>
 
 </library>

--- a/src/PlayerCore/ChromeStrings.cs
+++ b/src/PlayerCore/ChromeStrings.cs
@@ -31,6 +31,8 @@ public static class ChromeStrings
         ["RestartingBusy"] = "Restarting…",
         ["DeleteSaveConfirm"] = "Delete \"[name]\"? This can't be undone.",
         ["SavedGameDefaultLabel"] = "Saved game — [timestamp]",
+        ["CommandInputLabel"] = "Type your command",
+        ["ShowPanesButton"] = "Show panels",
     };
 
     public static Dictionary<string, string> Resolve(WorldModel worldModel)

--- a/src/PlayerCore/Resources/playercore.htm
+++ b/src/PlayerCore/Resources/playercore.htm
@@ -3,7 +3,7 @@
         <div id="controlButtons">
             <button id="cmdDebug" style="display: none" type="button">Debug</button>
             <button id="cmdSave" type="button" data-chrome-key="SaveLoadTitle">Save / Load</button>
-            <button id="cmdShowPanes" type="button">&#9776;</button>
+            <button id="cmdShowPanes" type="button" data-chrome-key-aria-label="ShowPanesButton" aria-label="Show panels">&#9776;</button>
         </div>
         <div id="location">
         </div>
@@ -87,23 +87,24 @@
                                     <tr>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassNW" onclick="compassClick(_compassDirs[0]);"
-                                                    title="go northwest"
+                                                    title="go northwest" aria-label="go northwest"
                                                     type="button"></button>
                                         </td>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassN" onclick="compassClick(_compassDirs[1]);"
-                                                    title="go north"
+                                                    title="go north" aria-label="go north"
                                                     type="button"></button>
                                         </td>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassNE" onclick="compassClick(_compassDirs[2]);"
-                                                    title="go northeast"
+                                                    title="go northeast" aria-label="go northeast"
                                                     type="button"></button>
                                         </td>
                                     </tr>
                                     <tr>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassW" onclick="compassClick(_compassDirs[3]);" title="go west"
+                                                    aria-label="go west"
                                                     type="button"></button>
                                         </td>
                                         <td>
@@ -111,23 +112,24 @@
                                         </td>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassE" onclick="compassClick(_compassDirs[4]);" title="go east"
+                                                    aria-label="go east"
                                                     type="button"></button>
                                         </td>
                                     </tr>
                                     <tr>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassSW" onclick="compassClick(_compassDirs[5]);"
-                                                    title="go southwest"
+                                                    title="go southwest" aria-label="go southwest"
                                                     type="button"></button>
                                         </td>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassS" onclick="compassClick(_compassDirs[6]);"
-                                                    title="go south"
+                                                    title="go south" aria-label="go south"
                                                     type="button"></button>
                                         </td>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassSE" onclick="compassClick(_compassDirs[7]);"
-                                                    title="go southeast"
+                                                    title="go southeast" aria-label="go southeast"
                                                     type="button"></button>
                                         </td>
                                     </tr>
@@ -138,10 +140,12 @@
                                     <tr>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassU" onclick="compassClick(_compassDirs[8]);" title="go up"
+                                                    aria-label="go up"
                                                     type="button"></button>
                                         </td>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassIn" onclick="compassClick(_compassDirs[10]);" title="go in"
+                                                    aria-label="go in"
                                                     type="button">in
                                             </button>
                                         </td>
@@ -149,11 +153,12 @@
                                     <tr>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassD" onclick="compassClick(_compassDirs[9]);" title="go down"
+                                                    aria-label="go down"
                                                     type="button"></button>
                                         </td>
                                         <td>
                                             <button class="compassbutton" id="cmdCompassOut" onclick="compassClick(_compassDirs[11]);"
-                                                    title="go out"
+                                                    title="go out" aria-label="go out"
                                                     type="button">out
                                             </button>
                                         </td>
@@ -174,7 +179,7 @@
     <div id="gamePanel"></div>
     <div id="gridPanel"></div>
     <div id="gameContent">
-        <div id="divOutput">
+        <div id="divOutput" role="log" aria-live="polite">
             <div data-divcount="0" id="outputData" style="display: none"></div>
             <h1 id="gameTitle">
                 Loading...</h1>
@@ -189,6 +194,7 @@
                 <input autofocus id="txtCommand" onkeydown="return commandKey(event);" placeholder="Type here..."
                        type="text"
                        autocapitalize="off"
+                       data-chrome-key-aria-label="CommandInputLabel" aria-label="Type your command"
                        x-webkit-speech/>
             </div>
         </div>

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -752,18 +752,18 @@ function setCompassDirections(directions) {
     } else {
         _compassDirs = directions;
     }
-    $("#cmdCompassNW").attr("title", _compassDirs[0]);
-    $("#cmdCompassN").attr("title", _compassDirs[1]);
-    $("#cmdCompassNE").attr("title", _compassDirs[2]);
-    $("#cmdCompassW").attr("title", _compassDirs[3]);
-    $("#cmdCompassE").attr("title", _compassDirs[4]);
-    $("#cmdCompassSW").attr("title", _compassDirs[5]);
-    $("#cmdCompassS").attr("title", _compassDirs[6]);
-    $("#cmdCompassSE").attr("title", _compassDirs[7]);
-    $("#cmdCompassU").attr("title", _compassDirs[8]);
-    $("#cmdCompassD").attr("title", _compassDirs[9]);
-    $("#cmdCompassIn").attr("title", _compassDirs[10]);
-    $("#cmdCompassOut").attr("title", _compassDirs[11]);
+    $("#cmdCompassNW").attr("title", _compassDirs[0]).attr("aria-label", _compassDirs[0]);
+    $("#cmdCompassN").attr("title", _compassDirs[1]).attr("aria-label", _compassDirs[1]);
+    $("#cmdCompassNE").attr("title", _compassDirs[2]).attr("aria-label", _compassDirs[2]);
+    $("#cmdCompassW").attr("title", _compassDirs[3]).attr("aria-label", _compassDirs[3]);
+    $("#cmdCompassE").attr("title", _compassDirs[4]).attr("aria-label", _compassDirs[4]);
+    $("#cmdCompassSW").attr("title", _compassDirs[5]).attr("aria-label", _compassDirs[5]);
+    $("#cmdCompassS").attr("title", _compassDirs[6]).attr("aria-label", _compassDirs[6]);
+    $("#cmdCompassSE").attr("title", _compassDirs[7]).attr("aria-label", _compassDirs[7]);
+    $("#cmdCompassU").attr("title", _compassDirs[8]).attr("aria-label", _compassDirs[8]);
+    $("#cmdCompassD").attr("title", _compassDirs[9]).attr("aria-label", _compassDirs[9]);
+    $("#cmdCompassIn").attr("title", _compassDirs[10]).attr("aria-label", _compassDirs[10]);
+    $("#cmdCompassOut").attr("title", _compassDirs[11]).attr("aria-label", _compassDirs[11]);
 }
 
 function updateLocation(text) {

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -125,7 +125,7 @@
     </div>
 </div>
 
-<dialog id="qv-saves" class="qv-chrome" data-mode="boot">
+<dialog id="qv-saves" class="qv-chrome" data-mode="boot" aria-labelledby="qv-saves-heading-boot">
     <!-- ICONS_SPRITE: spliced in at build time by scripts/build-icons.mjs (into
          generated/index.html) — a hidden <symbol> defs block, kept inside
          #qv-saves so it survives the dialog's detach/reattach around the
@@ -134,8 +134,8 @@
          Chrome), so the sprite must live in the same document as its <use>s. -->
     <div class="card preset-filled-surface-100-900 w-full p-6 space-y-4" data-theme="wintry">
         <div class="flex items-start justify-between gap-4">
-            <h2 class="h3" data-mode-text="boot" data-chrome-key="ContinueYourGamePrompt">Continue your game?</h2>
-            <h2 class="h3 qv-manage-only" data-mode-text="manage" data-chrome-key="SaveLoadTitle">Save / Load</h2>
+            <h2 class="h3" id="qv-saves-heading-boot" data-mode-text="boot" data-chrome-key="ContinueYourGamePrompt">Continue your game?</h2>
+            <h2 class="h3 qv-manage-only" id="qv-saves-heading-manage" data-mode-text="manage" data-chrome-key="SaveLoadTitle">Save / Load</h2>
             <button id="qv-saves-close" type="button" class="qv-manage-only btn-icon preset-tonal-surface" aria-label="Close" data-chrome-key-aria-label="CloseDialog">
                 <svg class="qv-icon" aria-hidden="true"><use href="#x"></use></svg>
             </button>
@@ -152,7 +152,7 @@
         <div class="qv-manage-only space-y-3">
             <hr class="hr">
             <div class="flex gap-2">
-                <input id="qv-saves-name-input" class="input" type="text" placeholder="Save name" autocomplete="off" data-chrome-key-placeholder="SaveNamePlaceholder">
+                <input id="qv-saves-name-input" class="input" type="text" placeholder="Save name" aria-label="Save name" autocomplete="off" data-chrome-key-placeholder="SaveNamePlaceholder" data-chrome-key-aria-label="SaveNamePlaceholder">
                 <button id="qv-saves-save-new" type="button" class="btn preset-filled-primary-500" data-chrome-key="SaveNew">Save new</button>
             </div>
             <div class="flex gap-2">
@@ -175,10 +175,10 @@
      so the whole card is a flex column filling exactly the applied
      width/height — #qv-debugger-panes (and List/Detail inside it) flex-fill
      the remaining vertical space rather than a fixed rem height. -->
-<dialog id="questVivaDebugger" class="qv-chrome">
+<dialog id="questVivaDebugger" class="qv-chrome" aria-labelledby="qv-debugger-heading">
     <div class="card preset-filled-surface-100-900 p-6 flex flex-col h-full" id="qv-debugger-card" data-theme="wintry">
         <div id="qv-debugger-titlebar" class="flex items-start justify-between gap-4 mb-4">
-            <h2 class="h3">Debugger</h2>
+            <h2 class="h3" id="qv-debugger-heading">Debugger</h2>
             <button id="qv-debugger-close" type="button" class="btn-icon preset-tonal-surface" aria-label="Close">
                 <svg class="qv-icon" aria-hidden="true"><use href="#x"></use></svg>
             </button>

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -1017,6 +1017,7 @@ async function openSavesDialog(mode, gameId = WebPlayer.gameId) {
     const dlg = document.getElementById('qv-saves');
     hideSavesError();
     dlg.dataset.mode = mode;
+    dlg.setAttribute('aria-labelledby', mode === 'boot' ? 'qv-saves-heading-boot' : 'qv-saves-heading-manage');
     renderSavesList(await GameSaver.listSaves(gameId), mode);
 
     if (mode === 'boot') {

--- a/src/WebPlayer/Components/Debugger/Debugger.razor
+++ b/src/WebPlayer/Components/Debugger/Debugger.razor
@@ -43,7 +43,7 @@
     }
 </style>
 
-<dialog id="questVivaDebugger">
+<dialog id="questVivaDebugger" aria-label="Debugger">
     <div class="debugger-container">
         <ul class="nav nav-tabs">
             @TabItem("Walkthrough")

--- a/src/WebPlayer/Components/Slots.razor
+++ b/src/WebPlayer/Components/Slots.razor
@@ -25,17 +25,17 @@
     }
 </style>
 
-<dialog id="questVivaSlots" tabindex="0">
+<dialog id="questVivaSlots" tabindex="0" aria-labelledby="questVivaSlotsHeading">
     @if (ManageMode)
     {
         <div class="d-flex justify-content-between align-items-center">
-            <h3 class="m-0">@ChromeStrings["SaveLoadTitle"]</h3>
+            <h3 class="m-0" id="questVivaSlotsHeading">@ChromeStrings["SaveLoadTitle"]</h3>
             <button type="button" class="btn-close" aria-label="@ChromeStrings["CloseDialog"]" @onclick="() => OnClose.InvokeAsync()"></button>
         </div>
     }
     else
     {
-        <h3>@ChromeStrings["ContinueYourGamePrompt"]</h3>
+        <h3 id="questVivaSlotsHeading">@ChromeStrings["ContinueYourGamePrompt"]</h3>
     }
 
     @if (!string.IsNullOrEmpty(ErrorMessage))
@@ -65,7 +65,7 @@
     {
         <hr/>
         <div class="input-group mt-2">
-            <input class="form-control" placeholder="@ChromeStrings["SaveNamePlaceholder"]" @bind="newSaveName"/>
+            <input class="form-control" placeholder="@ChromeStrings["SaveNamePlaceholder"]" aria-label="@ChromeStrings["SaveNamePlaceholder"]" @bind="newSaveName"/>
             <button class="btn btn-primary" @onclick="SaveNew">@ChromeStrings["SaveNew"]</button>
         </div>
         <div class="d-flex gap-2 mt-2">


### PR DESCRIPTION
## Summary
- Adds `role="log" aria-live="polite"` to `#divOutput` (the game transcript, shared by WebPlayer and WasmPlayer) so new turn text is announced by screen readers as it appears.
- Labels the command input, hamburger menu, compass buttons, and save-name inputs, which previously had no accessible name (or relied on `title` alone).
- Wires `aria-labelledby` on the Save/Load and Debugger dialogs in both WebPlayer (Razor) and WasmPlayer.
- Adds two new `ChromeStrings` keys (`CommandInputLabel`, `ShowPanesButton`) following the existing per-language localization convention.

First of a planned series of accessibility PRs covering both the player and the AppShell editor.

## Test plan
- [x] `dotnet build --configuration Release` — succeeds
- [x] `dotnet test --configuration Release` — all 384 tests pass
- [x] Verified in a WasmPlayer dev build via the accessibility tree: `#divOutput` reports `role="log"`/`aria-live="polite"`, typing a command appends new narrative text into that same live region, and the command input/hamburger/compass buttons/save dialogs all report the expected accessible names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)