### PR TITLE
feat(Engine): keyboard support for the item/verb popup menu

### DIFF
--- a/src/Engine/Core/CoreFunctions.aslx
+++ b/src/Engine/Core/CoreFunctions.aslx
@@ -225,7 +225,7 @@
         else {
           error ("ShowMenu cannot handle a " + TypeOf(option))
         }
-        msg (count + ": <a class=\"cmdlink\" style=\"" + style + "\" onclick=\"ASLEvent('ShowMenuResponse','" + EscapeQuotes(optiontag) + "')\">" + optionText + "</a>")
+        msg (count + ": <a class=\"cmdlink\" style=\"" + style + "\" tabindex=\"0\" onclick=\"ASLEvent('ShowMenuResponse','" + EscapeQuotes(optiontag) + "')\">" + optionText + "</a>")
       }
       EndOutputSection (outputsection)
       game.menuoptions = options

--- a/src/Engine/Core/CoreOutput.aslx
+++ b/src/Engine/Core/CoreOutput.aslx
@@ -558,7 +558,7 @@
             colour = GetLinkTextColour()
           }
           style = GetCurrentTextFormat(colour)
-          return ("<a id=\"" + linkid + "\" style=\"" + style + "\" class=\"cmdlink elementmenu\" data-elementid=\"" + object.name + "\">" + text + "</a>")
+          return ("<a id=\"" + linkid + "\" style=\"" + style + "\" class=\"cmdlink elementmenu\" tabindex=\"0\" data-elementid=\"" + object.name + "\">" + text + "</a>")
         }
         else {
           return (text)
@@ -603,7 +603,7 @@
         dataattrs = dataattrs + "data-deactivateonclick=\"true\" "
       }
       dataattrs = dataattrs + "data-command=\"" + command + "\""
-      return ("<a id=\"" + linkid + "\" style=\"" + style + "\" class=\"cmdlink commandlink\" data-elementid=\"" + elementid + "\" " + dataattrs + ">" + ProcessTextSection(text, data) + "</a>")
+      return ("<a id=\"" + linkid + "\" style=\"" + style + "\" class=\"cmdlink commandlink\" tabindex=\"0\" data-elementid=\"" + elementid + "\" " + dataattrs + ">" + ProcessTextSection(text, data) + "</a>")
     ]]>
   </function>
 
@@ -619,7 +619,7 @@
         alias = GetDisplayAlias(exit)
         command = LCase(StringListItem(verbs, 0)) + " " + alias
         style = GetCurrentLinkTextFormat()
-        return ("<a style=\"" + style + "\" class=\"cmdlink exitlink\" data-elementid=\"" + exit.name + "\" data-command=\"" + command + "\">" + alias + "</a>")
+        return ("<a style=\"" + style + "\" class=\"cmdlink exitlink\" tabindex=\"0\" data-elementid=\"" + exit.name + "\" data-command=\"" + command + "\">" + alias + "</a>")
       }
     ]]>
   </function>

--- a/src/Engine/Core/GamebookCore.aslx
+++ b/src/Engine/Core/GamebookCore.aslx
@@ -463,7 +463,7 @@
         else {
           error ("ShowMenu cannot handle a " + TypeOf(option))
         }
-        msg (count + ": <a class=\"cmdlink\" style=\"" + style + "\" onclick=\"ASLEvent('ShowMenuResponse','" + EscapeQuotes(optiontag) + "')\">" + optionText + "</a>")
+        msg (count + ": <a class=\"cmdlink\" style=\"" + style + "\" tabindex=\"0\" onclick=\"ASLEvent('ShowMenuResponse','" + EscapeQuotes(optiontag) + "')\">" + optionText + "</a>")
       }
       EndOutputSection (outputsection)
       game.menuoptions = options

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -330,6 +330,7 @@ function initPlayerUI() {
 
 function loadHtml(html) {
     $("#divOutput").html(html);
+    makeCmdlinksFocusable($("#divOutput"));
     // The injected HTML carries its own divOutputAlign<N> ids from whenever the
     // game was saved, but _currentDiv/_divCount (used by addText/createNewDiv)
     // are untouched by the line above. If a div was already created before this
@@ -941,8 +942,22 @@ function addText(text) {
     if (savingTranscript && !noTranscript) {
         writeToTranscript(text);
     }
-    getCurrentDiv().append(text);
+    var $div = getCurrentDiv();
+    $div.append(text);
+    makeCmdlinksFocusable($div);
     $("#divOutput").css("min-height", $("#divOutput").height());
+}
+
+// .cmdlink links (.elementmenu/.exitlink/.commandlink/bare ShowMenu ones - see the
+// keydown handler above) come from Engine/Core/*.aslx, which is inlined into each
+// game at save/publish time - a game published before tabindex="0" was added there
+// (see CLAUDE.md's Core library semantics) still emits links with no tabindex, so
+// they'd never be reachable by keyboard no matter how new a *player* build runs
+// them. Unlike that markup, this file is shared player-chrome JS with no per-game
+// snapshot, so patching tabindex on here at the point each link enters the DOM
+// closes the gap for every already-published game too, not just newly-saved ones.
+function makeCmdlinksFocusable($scope) {
+    $scope.find("a.cmdlink:not([tabindex])").attr("tabindex", "0");
 }
 
 function createNewDiv(alignment) {

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -159,6 +159,23 @@ function initPlayerUI() {
         }
     });
 
+    // .cmdlink links (.elementmenu/.exitlink/.commandlink above, plus the bare
+    // ShowMenu-style links with their own inline onclick) are all <a> elements
+    // with no href, so activating one by keyboard needs an explicit Enter/Space
+    // handler - the browser only auto-fires click on Enter for a real link/button.
+    // Delegated here (not baked into each class's own click handler above) so it
+    // covers every .cmdlink regardless of which Core.aslx function produced it,
+    // and - unlike the tabindex="0" on the link markup itself, which only reaches
+    // games saved after this change (see CLAUDE.md's Core library semantics) -
+    // this part is shared player-chrome JS, so it also benefits any already-
+    // published game whose links happen to already be focusable some other way.
+    $(document).on("keydown", ".cmdlink", function (event) {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            this.click();
+        }
+    });
+
     // ShowMenu (and anything built on it - Ask, disambiguation) renders each
     // choice as a bare <a class="cmdlink" onclick="ASLEvent(...)"> baked into the
     // game's own compiled script - unlike .commandlink, it gets no client-side

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -2361,8 +2361,19 @@ function Grid_DrawShape(id, border, fill, opacity) {
 
 (function ($) {
 
+    // The element that opened the currently-shown menu, so keyboard close paths
+    // (Escape/Tab) and the click-outside handler below can return focus to it -
+    // otherwise focus is dropped to <body> and a keyboard user loses their place.
+    var _jjmenuInvoker = null;
+
+    function closeMenu(restoreFocus) {
+        $("div[id^=jjmenu]").remove();
+        if (restoreFocus && _jjmenuInvoker) _jjmenuInvoker.focus();
+        _jjmenuInvoker = null;
+    }
+
     $(document).click(function (event) {
-        if (event.button != 2) $("div[id^=jjmenu]").remove();
+        if (event.button != 2) closeMenu(false);
     });
 
     $.fn.jjmenu = function (param) {
@@ -2370,13 +2381,13 @@ function Grid_DrawShape(id, border, fill, opacity) {
             event.preventDefault();
             event.stopPropagation();
             $(this).jjmenu_popup(param);
-            $(this).blur();
             return false;
         });
     };
 
     $.fn.jjmenu_popup = function (param) {
         var el = this;
+        _jjmenuInvoker = el.get(0);
 
         if (typeof param === "undefined") {
             var verbs = el.data("verbs");
@@ -2399,6 +2410,7 @@ function Grid_DrawShape(id, border, fill, opacity) {
 
         m.className = "jjmenu";
         m.id = "jjmenu_main";
+        m.setAttribute("role", "menu");
         $(m).css({display: 'none'});
         $(document.body).append(m);
 
@@ -2410,6 +2422,7 @@ function Grid_DrawShape(id, border, fill, opacity) {
 
         checkPosition();
         showMenu();
+        $(ms).children().first().trigger("focus");
 
         function positionMenu() {
             var pos = $(el).offset();
@@ -2473,8 +2486,24 @@ function Grid_DrawShape(id, border, fill, opacity) {
             $(m).fadeIn(speed);
         }
 
+        function activateItem(item, n) {
+            closeMenu(false);
+            n.action.callback(n.title);
+        }
+
+        function moveFocus(fromItem, delta) {
+            var items = $(ms).children().get();
+            var index = items.indexOf(fromItem);
+            var next = items[(index + delta + items.length) % items.length];
+            $(next).trigger("focus");
+        }
+
         function putItem(n) {
             var item = document.createElement('div');
+            item.className = "jj_menu_item";
+            item.setAttribute("role", "menuitem");
+            item.tabIndex = -1;
+
             $(item).hover(function () {
                     $(this).addClass("jj_menu_item_hover");
                 },
@@ -2482,16 +2511,45 @@ function Grid_DrawShape(id, border, fill, opacity) {
                     $(this).removeClass("jj_menu_item_hover");
                 });
 
+            $(item).on("focus", function () {
+                $(this).addClass("jj_menu_item_hover");
+            }).on("blur", function () {
+                $(this).removeClass("jj_menu_item_hover");
+            });
+
             $(item).click(function (event) {
                 event.stopPropagation();
-                $("div[id^=jjmenu]").remove();
-                n.action.callback(n.title);
+                activateItem(item, n);
+            });
+
+            $(item).on("keydown", function (event) {
+                switch (event.key) {
+                    case "ArrowDown":
+                        event.preventDefault();
+                        moveFocus(item, 1);
+                        break;
+                    case "ArrowUp":
+                        event.preventDefault();
+                        moveFocus(item, -1);
+                        break;
+                    case "Enter":
+                    case " ":
+                        event.preventDefault();
+                        activateItem(item, n);
+                        break;
+                    case "Escape":
+                        event.preventDefault();
+                        event.stopPropagation();
+                        closeMenu(true);
+                        break;
+                    case "Tab":
+                        closeMenu(true);
+                        break;
+                }
             });
 
             var span = document.createElement('span');
             $(item).append(span);
-
-            item.className = "jj_menu_item";
 
             $(span).html(n.title);
             $(ms).append(item);


### PR DESCRIPTION
## Summary
- The `jjmenu` item-verb popup (opened by clicking an inventory/places object like "thing" → "Look at"/"Take") was entirely mouse-only: plain hover/click `<div>`s with no ARIA role, no way to reach items by keyboard, no Escape to dismiss.
- Adds `role="menu"` to the popup and `role="menuitem" tabindex="-1"` to each item (roving-tabindex pattern).
- Moves focus to the first item automatically when the menu opens.
- Arrow-key (Up/Down) roving focus between items, with wraparound.
- Enter/Space activates the focused item (same code path the existing click handler used).
- Escape and Tab close the menu; when the element that opened it is itself focusable, focus returns there.

## Making it reachable at all
The popup's real-world trigger is an inline object link in game output text (e.g. `<a class="cmdlink elementmenu">thing</a>`), generated by `Engine/Core/*.aslx`. That markup had no `href`, so it wasn't in the Tab order in the first place — fixed by adding `tabindex="0"` to the four link-generating sites (`ProcessTextCommand_*` in `CoreOutput.aslx`, `ShowMenu` in `CoreFunctions.aslx`/`GamebookCore.aslx`), plus a generic Enter/Space-to-click handler in `playercore.js` covering every `.cmdlink`.

Since `Engine/Core/*.aslx` is inlined into a game's saved package at publish time (see `CLAUDE.md`'s Core library semantics), that `tabindex="0"` only reaches games saved from now on — an already-published game's stored markup is frozen without it. CSS can't fill that gap (there's no style-level hook into tabindex/focus order), but `playercore.js` itself isn't frozen per-game, so the fix is to patch `tabindex="0"` onto `.cmdlink` links at the point they actually enter the DOM instead of relying on the markup carrying it. Added `makeCmdlinksFocusable()`, called from both places such markup can land in `#divOutput`: `addText()` (normal per-turn output) and `loadHtml()` (restoring a saved game's stored transcript HTML, a separate path that bypasses `addText` entirely). This closes the gap for every game regardless of when it was published — not a small niche after all.

## Test plan
- [x] `dotnet build --configuration Release` — succeeds
- [x] `dotnet test --configuration Release` — all 384 tests pass
- [x] Verified in a WasmPlayer dev build: the in-text object link carries `tabindex="0"` and is reachable/focusable; pressing Enter on it opens the menu with focus already on the first `menuitem`; ArrowDown/ArrowUp move focus between items with wraparound; Escape closes the menu and returns focus to the link; clicking outside still closes it; activating an item runs the same `sendCommand` callback as before.
- [x] Verified the already-published-game path directly against the served `playercore.js`: synthetic markup with no `tabindex` (matching what a pre-existing game's saved `.quest` package still emits) passed through both `addText()` and `loadHtml()` and came out genuinely focusable (`document.activeElement` lands on it after `.focus()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)