### PR TITLE
feat(Engine): accessible accordion sidebar panels

### DIFF
--- a/src/PlayerCore/Resources/playercore.css
+++ b/src/PlayerCore/Resources/playercore.css
@@ -215,6 +215,19 @@ h3 .accordion-header-text {
     padding-left: 1.8em;
 }
 
+button.accordion-header-text {
+    display: block;
+    width: 100%;
+    text-align: left;
+    -webkit-appearance: none;
+    appearance: none;
+    border: none;
+    background: transparent;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+}
+
 #gamePanes .ui-widget {
     font-size: 12px;
 }

--- a/src/PlayerCore/Resources/playercore.htm
+++ b/src/PlayerCore/Resources/playercore.htm
@@ -11,7 +11,7 @@
     <div id="sidebar">
         <div id="gamePanes" style="background:transparent;">
             <div id="gamePanesRunning">
-                <h3 id="inventoryLabel"><span class="accordion-header-text">Inventory</span></h3>
+                <h3 id="inventoryLabel"><button type="button" class="accordion-header-text" aria-controls="inventoryAccordion" aria-expanded="true">Inventory</button></h3>
                 <div id="inventoryAccordion">
                     <div class="elementListWrapper" id="inventoryWrapper">
                         <ol class="elementList" id="lstInventory">
@@ -38,12 +38,12 @@
                                 type="button"></button>
                     </div>
                 </div>
-                <h3 id="statusVarsLabel"><span class="accordion-header-text">Status</span></h3>
+                <h3 id="statusVarsLabel"><button type="button" class="accordion-header-text" aria-controls="statusVarsAccordion" aria-expanded="true">Status</button></h3>
                 <div id="statusVarsAccordion">
                     <div id="statusVars">
                     </div>
                 </div>
-                <h3 id="placesObjectsLabel"><span class="accordion-header-text">Places and Objects</span></h3>
+                <h3 id="placesObjectsLabel"><button type="button" class="accordion-header-text" aria-controls="placesObjectsAccordion" aria-expanded="true">Places and Objects</button></h3>
                 <div id="placesObjectsAccordion">
                     <div class="elementListWrapper" id="placesObjectsWrapper">
                         <ol class="elementList" id="lstPlacesObjects">
@@ -78,7 +78,7 @@
                      style="border-radius: 5px;text-align:center;display:none;padding:2px;min-height: 25px;margin-top:10px; border-top:1px solid rgb(121, 183, 231)">
                     <h3><span class="accordion-header-text">Status</span></h3>
                 </div>
-                <h3 id="compassLabel"><span class="accordion-header-text">Compass</span></h3>
+                <h3 id="compassLabel"><button type="button" class="accordion-header-text" aria-controls="compassAccordion" aria-expanded="true">Compass</button></h3>
                 <div id="compassAccordion">
                     <table id="compassTable">
                         <tr>

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -57,8 +57,17 @@ function initPlayerUI() {
         }
     });
 
-    $("#gameBorder button").button();
+    // Excludes the accordion header buttons (.accordion-header-text) - the
+    // multiOpenAccordion plugin below already styles those itself
+    // (.ui-accordion-header etc.), and jQuery UI's own .button() widget would
+    // wrap their text in a nested .ui-button-text span, breaking the plain
+    // .html(text) writes setInterfaceString does against them.
+    $("#gameBorder button:not(.accordion-header-text)").button();
     $("#gamePanesRunning").multiOpenAccordion({active: [0, 1, 2, 3]});
+    $("#gamePanesRunning").on("multiopenaccordiontabshown multiopenaccordiontabhidden", function (event, ui) {
+        ui.tab.children("button.accordion-header-text")
+            .attr("aria-expanded", event.type === "multiopenaccordiontabshown");
+    });
     showStatusVisible(false);
 
     const cmdSave = document.getElementById("cmdSave");
@@ -1170,16 +1179,16 @@ function addExternalStylesheet(source) {
 function setInterfaceString(name, text) {
     switch (name) {
         case "InventoryLabel":
-            $("#inventoryLabel span.accordion-header-text").html(text);
+            $("#inventoryLabel button.accordion-header-text").html(text);
             break;
         case "StatusLabel":
-            $("#statusVarsLabel span.accordion-header-text").html(text);
+            $("#statusVarsLabel button.accordion-header-text").html(text);
             break;
         case "PlacesObjectsLabel":
-            $("#placesObjectsLabel span.accordion-header-text").html(text);
+            $("#placesObjectsLabel button.accordion-header-text").html(text);
             break;
         case "CompassLabel":
-            $("#compassLabel span.accordion-header-text").html(text);
+            $("#compassLabel button.accordion-header-text").html(text);
             break;
         case "InButtonLabel":
             $("#cmdCompassIn span").html(text);


### PR DESCRIPTION
## Summary
- The Inventory/Status/Places and Objects/Compass sidebar accordion (backed by the vendored `jquery.multi-open-accordion` plugin) exposed no ARIA state: headers were plain `<span>` text, so there was no way for a screen reader to know a panel was expanded/collapsed, and no way to reach or toggle a header by keyboard.
- Turns each accordion header's `<span class="accordion-header-text">` into a real `<button type="button">` with `aria-controls`/`aria-expanded` — gets native focusability and Enter/Space activation for free (the plugin binds its click handler on the parent `<h3>`, which still fires via event bubbling from the inner button).
- Listens for the plugin's own `multiopenaccordiontabshown`/`tabhidden` widget-factory events (fired from its `_showTab`/`_hideTab`, confirmed by reading the vendored plugin source) to keep `aria-expanded` in sync on every toggle — without editing the vendored plugin file itself.
- Excludes these new buttons from the existing blanket `$("#gameBorder button").button()` call, since jQuery UI's `.button()` widget would nest their text in a `.ui-button-text` span and break the plain `.html(text)` writes `setInterfaceString` does against them for header-text localization; adds a small CSS reset so the button fills the header bar the same way the old `<span>` did.

## Test plan
- [x] `dotnet build --configuration Release` — succeeds
- [x] `dotnet test --configuration Release` — all 384 tests pass
- [x] Verified structurally in a WasmPlayer dev build: `initPlayerUI()` runs through the new accordion setup without error, and each header renders as `<h3><span class="ui-icon ...">...<button class="accordion-header-text" aria-controls="inventoryAccordion" aria-expanded="true">Inventory</button></h3>` as expected.
- [ ] Live toggle-and-observe check (clicking a header and confirming `aria-expanded` flips) — the dev browser environment became unresponsive partway through this session (confirmed independent of this change: an unmodified baseline build hung identically), so I could not complete this specific interaction test live. The wiring is based directly on reading the vendored widget-factory's event-emission code and jQuery UI's own event-naming convention, not a guess, but flagging this gap rather than claiming full interactive verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)