### PR TITLE
fix(AppShell): label PropertyEditor fields and announce validation errors

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -975,6 +975,7 @@
                             <textarea
                                 id={textProcessorTextareaId(ctrl.subAttribute)}
                                 autocapitalize="off"
+                                aria-label={label}
                                 class="input text-xs py-0.5 px-1.5 flex-1 min-h-32 resize-y"
                                 value={attrValue(ctrl.subAttribute) ?? ""}
                                 onchange={(e) => onTextChange(ctrl.subAttribute!, "richtext", (e.target as HTMLTextAreaElement).value)}
@@ -983,6 +984,7 @@
                     {:else}
                         <textarea
                             autocapitalize="off"
+                            aria-label={label}
                             class="input text-xs py-0.5 px-1.5 w-full min-h-24 resize-y"
                             value={attrValue(ctrl.subAttribute) ?? ""}
                             onchange={(e) => onTextChange(ctrl.subAttribute!, "richtext", (e.target as HTMLTextAreaElement).value)}
@@ -992,6 +994,7 @@
                     <input
                         type="text"
                         autocapitalize="off"
+                        aria-label={label}
                         class="input text-xs py-0.5 px-1.5 w-full"
                         value={attrValue(ctrl.subAttribute) ?? ""}
                         onchange={(e) => onTextChange(ctrl.subAttribute!, "textbox", (e.target as HTMLInputElement).value)}
@@ -1000,12 +1003,15 @@
                     <input
                         type="text"
                         autocapitalize="off"
+                        aria-label={label}
                         class="input text-xs py-0.5 px-1.5 w-full"
                         value={attrValue(ctrl.subAttribute) ?? ""}
                         onchange={(e) => onPatternTextChange(ctrl.subAttribute!, (e.target as HTMLInputElement).value)}
                     />
                 {:else if subEditorType === "script" && ctrl.subAttribute !== null && $selectedKey !== null}
-                    <ScriptEditor elementKey={$selectedKey} attribute={ctrl.subAttribute} />
+                    <div role="group" aria-label={label} class="contents">
+                        <ScriptEditor elementKey={$selectedKey} attribute={ctrl.subAttribute} />
+                    </div>
                 {:else if subEditorType === "boolean" && ctrl.subAttribute !== null}
                     <label class="flex items-center gap-2">
                         <input
@@ -1017,12 +1023,14 @@
                         <span class="text-xs text-surface-600-400">{ctrl.checkboxCaption ?? ctrl.subAttribute}</span>
                     </label>
                 {:else if subEditorType === "scriptdictionary" && ctrl.subAttribute !== null && $selectedKey !== null}
-                    <ScriptDictionaryEditor
-                        elementKey={$selectedKey}
-                        attribute={ctrl.subAttribute}
-                        value={attrValue(ctrl.subAttribute)}
-                        keySource={ctrl.source === "object" ? "object" : "text"}
-                    />
+                    <div role="group" aria-label={label} class="contents">
+                        <ScriptDictionaryEditor
+                            elementKey={$selectedKey}
+                            attribute={ctrl.subAttribute}
+                            value={attrValue(ctrl.subAttribute)}
+                            keySource={ctrl.source === "object" ? "object" : "text"}
+                        />
+                    </div>
                 {/if}
             </div>
         {:else}

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -956,7 +956,7 @@
             {@const selectedType = attrValue(ctrl.attribute!) ?? "null"}
             {@const subEditorType = ctrl.subEditors?.find(e => e.value === selectedType)?.label ?? selectedType}
             <div class="flex flex-col gap-1 px-3 py-1.5">
-                <div class="flex items-center gap-2">
+                <label class="flex items-center gap-2">
                     <span class="text-xs text-surface-600-400 whitespace-nowrap">{label}:</span>
                     <select
                         class="select text-xs py-0.5 px-1.5 w-auto"
@@ -967,7 +967,7 @@
                             <option value={opt.value}>{opt.label}</option>
                         {/each}
                     </select>
-                </div>
+                </label>
                 {#if subEditorType === "richtext" && ctrl.subAttribute !== null}
                     {#if ctrl.textProcessorCommands?.length}
                         <div class="flex flex-col gap-1 w-full">
@@ -1031,22 +1031,29 @@
             {@const stacksBelowLabel = label.length > 20 || isMultiline}
             {#if stacksBelowLabel}
                 <div class="flex flex-col gap-1 px-3 py-1.5">
-                    {#if ctrl.controlType !== "texteditor"}
-                        <span class="text-xs text-surface-600-400">{label}:</span>
-                    {/if}
-                    {@render controlOnly(ctrl)}
+                    <svelte:element
+                        this={isMultiline ? "div" : "label"}
+                        role={isMultiline ? "group" : undefined}
+                        aria-label={isMultiline ? label : undefined}
+                        class="contents"
+                    >
+                        {#if ctrl.controlType !== "texteditor"}
+                            <span class="text-xs text-surface-600-400">{label}:</span>
+                        {/if}
+                        {@render controlOnly(ctrl)}
+                    </svelte:element>
                     {#if ctrl.attribute && attributeErrors[ctrl.attribute]}
-                        <p class="text-xs text-error-500">{attributeErrors[ctrl.attribute]}</p>
+                        <p class="text-xs text-error-500" role="alert">{attributeErrors[ctrl.attribute]}</p>
                     {/if}
                 </div>
             {:else}
                 <div class="flex flex-col gap-1 px-3 py-1.5">
-                    <div class="flex items-center gap-2 min-h-8">
+                    <label class="flex items-center gap-2 min-h-8 cursor-pointer">
                         <span class="text-xs text-surface-600-400 w-32 flex-shrink-0">{label}:</span>
                         {@render controlOnly(ctrl)}
-                    </div>
+                    </label>
                     {#if ctrl.attribute && attributeErrors[ctrl.attribute]}
-                        <p class="text-xs text-error-500">{attributeErrors[ctrl.attribute]}</p>
+                        <p class="text-xs text-error-500" role="alert">{attributeErrors[ctrl.attribute]}</p>
                     {/if}
                 </div>
             {/if}


### PR DESCRIPTION
## Summary
- `PropertyEditor.svelte` is the main form for editing every game object property — the largest surface in the editor. Every field's caption was a plain `<span>` next to its control with no `id`/`for`/`aria-labelledby` link, so a screen reader announced every number/dropdown/textbox/checkbox field as an unlabeled control. Validation error messages were plain `<p>` text with no live-region semantics, so they were never announced either.
- For the common single-control case, wraps the caption `<span>` and the control together in a `<label>` instead of a `<div>` — relies on implicit label association through the first labelable descendant, which works transparently through child component boundaries (`Combobox`, `ExpressionInput`, `AssetPicker`, etc. all render a native input/select/button as their first focusable element) without needing to thread an `id`/`aria-label` prop through every branch of the large `controlOnly` snippet.
- For compound multi-widget fields (`richtext`/`script`/`list`/dictionary types, already distinguished by the existing `isMultiline` check), uses `role="group" aria-label` on the wrapper instead — a single label-for-first-control association doesn't meaningfully describe a whole cluster of controls (e.g. a dictionary editor's several inputs/buttons). Uses `<svelte:element>` with a `contents` class so this doesn't disturb the existing flex layout.
- Also labels the "multi" (union-type) field's type-selector `<select>` the same way, **and its per-selected-type value editors**: `aria-label={label}` on the three bare native controls (richtext/textbox/simplepattern), and `role="group" aria-label={label}` wrapping the two compound sub-editors (`ScriptEditor`/`ScriptDictionaryEditor`) — same treatment as the other compound fields above.
- Validation error `<p>`s get `role="alert"` so they're announced as soon as they appear.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run lint` (eslint) — clean
- [ ] Live browser verification — the dev browser environment (both the WasmPlayer and WasmEditor/AppShell WASM bridges) has been intermittently unresponsive this session and didn't recover across a full restart, so I could not complete an interactive accessibility-tree check here. Relying on `svelte-check`/`eslint` plus careful reading of the affected child components' root markup (confirmed each renders a native input/select/button as its first child) instead of claiming live verification I didn't actually get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)