### PR TITLE
feat(AppShell): trap and restore focus in modal dialogs

### DIFF
--- a/src/AppShell/src/components/AddElementModal.svelte
+++ b/src/AppShell/src/components/AddElementModal.svelte
@@ -2,6 +2,7 @@
     import { untrack } from "svelte";
     import { validateName, getFunctionFolders, getPossibleNewObjectParents } from "$lib/editor-store";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import Combobox from "$components/Combobox.svelte";
     import type { ControlOption } from "$lib/types";
 
@@ -81,6 +82,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
+    use:trapFocus
 >
     <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-80 p-6 flex flex-col gap-4">
         <h2 class="text-base font-semibold">

--- a/src/AppShell/src/components/AddJavascriptModal.svelte
+++ b/src/AppShell/src/components/AddJavascriptModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { assets, treeNodes, uniqueAssetName, putAssetText } from "$lib/editor-store";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import AssetPicker from "./AssetPicker.svelte";
 
     interface Props {
@@ -57,6 +58,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
+    use:trapFocus
 >
     <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-96 p-6 flex flex-col gap-4">
         <h2 class="text-base font-semibold">{t("elementAdders.javascript")}</h2>

--- a/src/AppShell/src/components/AddLibraryModal.svelte
+++ b/src/AppShell/src/components/AddLibraryModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { treeNodes, uploadAsset } from "$lib/editor-store";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import FileIcon from "@lucide/svelte/icons/file";
 
     interface Props {
@@ -68,6 +69,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
+    use:trapFocus
 >
     <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-96 p-6 flex flex-col gap-4">
         <h2 class="text-base font-semibold">{t("addLibraryModal.title")}</h2>

--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { ScriptCategoryInfo, ScriptCommandInfo } from "$lib/types";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import Search from "@lucide/svelte/icons/search";
     import X from "@lucide/svelte/icons/x";
 
@@ -192,6 +193,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={onKeydown}
+    use:trapFocus
 >
     <div class="bg-surface-50-950 rounded-xl shadow-xl w-full max-w-[600px] h-[min(520px,85dvh)] flex flex-col overflow-hidden ring-1 ring-surface-200-800">
 

--- a/src/AppShell/src/components/AssetManagerModal.svelte
+++ b/src/AppShell/src/components/AssetManagerModal.svelte
@@ -3,6 +3,7 @@
     import { assets, treeNodes, refreshAssets, uploadAsset, deleteAssetAndOwner, resolveAssetUrl, isImageAsset } from "$lib/editor-store";
     import { confirmDialog } from "$lib/confirm";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import FileIcon from "@lucide/svelte/icons/file";
 
     interface Props {
@@ -85,6 +86,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
+    use:trapFocus
 >
     <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-[32rem] max-h-[85dvh] p-6 flex flex-col gap-4">
         <div class="flex items-center justify-between">

--- a/src/AppShell/src/components/ConfirmDialog.svelte
+++ b/src/AppShell/src/components/ConfirmDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { dialogState } from "$lib/confirm";
+    import { trapFocus } from "$lib/actions/trapFocus";
 
     let dialogEl = $state<HTMLDivElement>();
     $effect(() => { if ($dialogState) dialogEl?.focus(); });
@@ -32,6 +33,7 @@
         class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
         onclick={onBackdropClick}
         onkeydown={handleKeydown}
+        use:trapFocus
     >
         <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-sm p-6 flex flex-col gap-4">
             <p class="text-sm">{state.message}</p>

--- a/src/AppShell/src/components/LinkPickerModal.svelte
+++ b/src/AppShell/src/components/LinkPickerModal.svelte
@@ -2,6 +2,7 @@
     import Combobox from "./Combobox.svelte";
     import AssetPicker from "./AssetPicker.svelte";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import type { ControlOption } from "$lib/types";
 
     interface Props {
@@ -60,6 +61,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
+    use:trapFocus
 >
     <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-96 p-6 flex flex-col gap-4">
         <h2 class="text-base font-semibold">{title}</h2>

--- a/src/AppShell/src/components/MoveElementModal.svelte
+++ b/src/AppShell/src/components/MoveElementModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { getMovePossibleParents, treeNodes } from "$lib/editor-store";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import Combobox from "$components/Combobox.svelte";
     import type { ControlOption } from "$lib/types";
 
@@ -51,6 +52,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
+    use:trapFocus
 >
     <div class="card bg-white rounded-xl shadow-xl w-full max-w-80 p-6 flex flex-col gap-4">
         <h2 class="text-base font-semibold">{t("moveElementModal.heading", { name: elementKey })}</h2>

--- a/src/AppShell/src/components/MoveToFolderModal.svelte
+++ b/src/AppShell/src/components/MoveToFolderModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { getFunctionFolders } from "$lib/editor-store";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import Combobox from "$components/Combobox.svelte";
     import type { ControlOption } from "$lib/types";
 
@@ -47,6 +48,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
+    use:trapFocus
 >
     <div class="card bg-white rounded-xl shadow-xl w-full max-w-80 p-6 flex flex-col gap-4">
         <h2 class="text-base font-semibold">{t("moveToFolderModal.heading", { name: elementKey })}</h2>

--- a/src/AppShell/src/components/PublishModal.svelte
+++ b/src/AppShell/src/components/PublishModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { publishGame, canPublishToServer } from "$lib/editor-store";
     import { t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
 
     interface Props {
         oncancel: () => void;
@@ -43,6 +44,7 @@
     class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     onclick={onBackdropClick}
     onkeydown={handleKeydown}
+    use:trapFocus
 >
     <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-[28rem] p-6 flex flex-col gap-4">
         <div class="flex items-center justify-between">

--- a/src/AppShell/src/components/SettingsModal.svelte
+++ b/src/AppShell/src/components/SettingsModal.svelte
@@ -2,6 +2,7 @@
     import { Switch } from "@skeletonlabs/skeleton-svelte";
     import { settingsModalOpen } from "$lib/settings-store";
     import { locale, setLocale, SUPPORTED_LOCALES, t } from "$lib/i18n";
+    import { trapFocus } from "$lib/actions/trapFocus";
     import { theme, setTheme, type ThemePreference } from "$lib/theme-store";
     import { defaultCodeView, setDefaultCodeView } from "$lib/code-view-store";
 
@@ -58,6 +59,7 @@
         class="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
         onclick={onBackdropClick}
         onkeydown={handleKeydown}
+        use:trapFocus
     >
         <div class="card bg-surface-50-950 rounded-xl shadow-xl w-full max-w-80 p-6 flex flex-col gap-4">
             <div class="flex items-center justify-between">

--- a/src/AppShell/src/lib/actions/trapFocus.ts
+++ b/src/AppShell/src/lib/actions/trapFocus.ts
@@ -1,0 +1,45 @@
+const FOCUSABLE_SELECTOR =
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusable(node: HTMLElement): HTMLElement[] {
+    return Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+        .filter(el => el.offsetParent !== null);
+}
+
+// Traps Tab/Shift+Tab within `node` and restores focus to whatever was focused
+// before the node appeared once it's gone - for a modal dialog's root element,
+// so Tab can't leave the dialog to the page behind it, and closing it (by any
+// path - Escape, a button, the backdrop) puts focus back where the user was.
+export function trapFocus(node: HTMLElement) {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    function onKeydown(event: KeyboardEvent) {
+        if (event.key !== "Tab") return;
+        const focusable = getFocusable(node);
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+
+        if (event.shiftKey) {
+            if (active === first || !node.contains(active)) {
+                event.preventDefault();
+                last.focus();
+            }
+        } else {
+            if (active === last || !node.contains(active)) {
+                event.preventDefault();
+                first.focus();
+            }
+        }
+    }
+
+    node.addEventListener("keydown", onKeydown);
+
+    return {
+        destroy() {
+            node.removeEventListener("keydown", onKeydown);
+            previouslyFocused?.focus();
+        },
+    };
+}


### PR DESCRIPTION
## Summary
- All 11 modal components (`ConfirmDialog`, `AddElementModal`, `SettingsModal`, `PublishModal`, `AddScriptModal`, `AssetManagerModal`, `MoveElementModal`, `MoveToFolderModal`, `LinkPickerModal`, `AddLibraryModal`, `AddJavascriptModal`) use `role="dialog" aria-modal="true"` and focus themselves on open, but Tab was never trapped inside them — a keyboard user could Tab straight through to the page behind the backdrop — and focus was never returned to the triggering element when a dialog closed.
- Adds a shared `trapFocus` Svelte action (`src/lib/actions/trapFocus.ts`): captures the previously-focused element when the action mounts, cycles Tab/Shift+Tab between the dialog's focusable descendants (wrapping at both ends), and restores focus to the captured element once the dialog is removed from the DOM — covering every close path (Escape, backdrop click, an explicit close/cancel button) without each modal needing its own logic.
- Applied via `use:trapFocus` on each modal's existing dialog root `<div>` — one line per file, same pattern each time.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run lint` (eslint) — clean
- [ ] Live browser verification (tabbing through a dialog, confirming wraparound and focus restoration) — not possible this session; the dev browser environment's WASM bridges are hanging at boot independent of these changes (see #2137's test plan for the same note). The action's logic was written and reviewed against the standard focus-trap pattern (query focusable descendants, intercept Tab at the boundaries, restore on teardown) rather than live-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)