### PR TITLE
feat(AppShell): keyboard-operable dropdown menu and icon button labels

### DIFF
--- a/src/AppShell/src/components/DropdownMenu.svelte
+++ b/src/AppShell/src/components/DropdownMenu.svelte
@@ -20,13 +20,19 @@
 
     let open = $state(false);
     let rootEl = $state<HTMLDivElement | undefined>();
+    let triggerEl: HTMLElement | undefined;
+    let itemEls: (HTMLButtonElement | undefined)[] = $state([]);
 
     function toggle(e: MouseEvent) {
         e.stopPropagation();
+        triggerEl = e.currentTarget as HTMLElement;
         open = !open;
     }
 
-    function close() { open = false; }
+    function close(restoreFocus = true) {
+        open = false;
+        if (restoreFocus) triggerEl?.focus();
+    }
 
     function select(item: DropdownMenuItem) {
         if (item.disabled) return;
@@ -34,10 +40,56 @@
         close();
     }
 
+    function focusItem(index: number) {
+        itemEls[index]?.focus();
+    }
+
+    // Roving focus between enabled items, wrapping past either end.
+    function moveFocus(fromIndex: number, delta: number) {
+        const n = items.length;
+        if (n === 0) return;
+        let i = fromIndex;
+        for (let step = 0; step < n; step++) {
+            i = (i + delta + n) % n;
+            if (!items[i].disabled) {
+                focusItem(i);
+                return;
+            }
+        }
+    }
+
+    function onMenuKeydown(e: KeyboardEvent) {
+        const currentIndex = itemEls.indexOf(document.activeElement as HTMLButtonElement);
+        switch (e.key) {
+            case "ArrowDown":
+                e.preventDefault();
+                moveFocus(currentIndex, 1);
+                break;
+            case "ArrowUp":
+                e.preventDefault();
+                moveFocus(currentIndex === -1 ? 0 : currentIndex, -1);
+                break;
+            case "Home":
+                e.preventDefault();
+                moveFocus(-1, 1);
+                break;
+            case "End":
+                e.preventDefault();
+                moveFocus(0, -1);
+                break;
+        }
+    }
+
+    $effect(() => {
+        if (!open) return;
+        const firstEnabled = items.findIndex(it => !it.disabled);
+        if (firstEnabled !== -1) focusItem(firstEnabled);
+    });
+
     $effect(() => {
         if (!open) return;
         function onOutside(e: MouseEvent) {
-            if (!rootEl?.contains(e.target as Node)) close();
+            if (!rootEl?.contains(e.target as Node)) close(false);
         }
         function onKeydown(e: KeyboardEvent) {
             if (e.key === "Escape") close();
@@ -54,8 +106,13 @@
 <div class="relative" bind:this={rootEl}>
     {@render trigger(toggle, open)}
     {#if open}
-        <div class="absolute {align === "right" ? "right-0" : "left-0"} top-full z-[999] mt-1 w-56 bg-surface-50-950 border border-surface-200-800 rounded shadow-lg py-1">
-            {#each items as item (item.label)}
+        <div
+            role="menu"
+            tabindex="-1"
+            class="absolute {align === "right" ? "right-0" : "left-0"} top-full z-[999] mt-1 w-56 bg-surface-50-950 border border-surface-200-800 rounded shadow-lg py-1"
+            onkeydown={onMenuKeydown}
+        >
+            {#each items as item, i (item.label)}
                 {#if item.divider}
                     <div class="my-1 border-t border-surface-200-800"></div>
                 {/if}
@@ -63,7 +120,10 @@
                     <div class="px-3 pt-1.5 pb-1 text-[11px] font-semibold text-surface-600-400 uppercase tracking-wide">{item.heading}</div>
                 {/if}
                 <button
+                    bind:this={itemEls[i]}
                     type="button"
+                    role="menuitem"
+                    tabindex="-1"
                     class="w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 hover:bg-surface-200-800 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                     disabled={item.disabled}
                     onclick={() => select(item)}

--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -136,6 +136,7 @@
                     type="button"
                     class="text-surface-600-400 hover:text-primary-600-400 flex-shrink-0"
                     title={t("exitsEditor.editExit")}
+                    aria-label={t("exitsEditor.editExit")}
                     onclick={() => selectNode(dir.exitKey!)}
                 ><Pencil size={11} /></button>
             </div>
@@ -154,6 +155,7 @@
                     type="button"
                     class="btn btn-sm preset-outlined-error-500 px-1 py-0 text-xs leading-none flex-shrink-0"
                     title={t("common.delete")}
+                    aria-label={t("common.delete")}
                     onclick={() => void deleteExit(dir.exitKey!, dir.direction, dir.to, dir.lookOnly)}
                 >×</button>
             </div>
@@ -195,6 +197,8 @@
                     <button
                         type="button"
                         class="text-xs text-surface-600-400 hover:text-surface-600-400"
+                        title={t("common.close")}
+                        aria-label={t("common.close")}
                         onclick={() => { openDirection = null; }}
                     >✕</button>
                 </div>
@@ -255,12 +259,14 @@
                                 type="button"
                                 class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none flex items-center"
                                 title={t("exitsEditor.editExit")}
+                                aria-label={t("exitsEditor.editExit")}
                                 onclick={() => selectNode(exit.key)}
                             ><Pencil size={12} /></button>
                             <button
                                 type="button"
                                 class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
                                 title={t("common.moveUp")}
+                                aria-label={t("common.moveUp")}
                                 disabled={i === 0}
                                 onclick={() => moveUp(i)}
                             >↑</button>
@@ -268,6 +274,7 @@
                                 type="button"
                                 class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none"
                                 title={t("common.moveDown")}
+                                aria-label={t("common.moveDown")}
                                 disabled={i === data.allExits.length - 1}
                                 onclick={() => moveDown(i)}
                             >↓</button>
@@ -275,6 +282,7 @@
                                 type="button"
                                 class="btn btn-sm preset-tonal-error px-1 py-0 text-xs leading-none"
                                 title={t("common.delete")}
+                                aria-label={t("common.delete")}
                                 onclick={() => void deleteExit(exit.key, exit.alias, exit.to, exit.lookOnly)}
                             >×</button>
                         </div>

--- a/src/AppShell/src/components/ListEditor.svelte
+++ b/src/AppShell/src/components/ListEditor.svelte
@@ -77,6 +77,8 @@
             <button
                 type="button"
                 class="btn btn-sm preset-outlined-error-500 text-xs px-1.5 py-0.5"
+                title={t("common.delete")}
+                aria-label={t("common.delete")}
                 onclick={() => removeListItem(elementKey, attribute, item.key)}
             >✕</button>
         </div>

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -481,11 +481,13 @@
         {/each}
         <span class="w-px h-5 bg-surface-200-800 mx-0.5"></span>
         <DropdownMenu items={buildInsertMenuItems(commands, attribute, controlType)} align="left">
-            {#snippet trigger(toggle)}
+            {#snippet trigger(toggle, open)}
                 <button
                     type="button"
                     class="btn btn-sm preset-outlined-primary-500 text-xs px-2 py-0.5 gap-1"
                     onclick={toggle}
+                    aria-haspopup="menu"
+                    aria-expanded={open}
                 ><ListPlus size={14} aria-hidden="true" />{t("common.insert")}<ChevronDown size={12} aria-hidden="true" /></button>
             {/snippet}
         </DropdownMenu>

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -224,6 +224,7 @@
                         onclick={() => navigateBack()}
                         disabled={!$canGoBack}
                         title={t("toolbar.back")}
+                        aria-label={t("toolbar.back")}
                     ><ArrowLeft size={16} /></button>
                     <button
                         type="button"
@@ -231,6 +232,7 @@
                         onclick={() => navigateForward()}
                         disabled={!$canGoForward}
                         title={t("toolbar.forward")}
+                        aria-label={t("toolbar.forward")}
                     ><ArrowRight size={16} /></button>
                 {/if}
                 {#if showHome}
@@ -239,6 +241,7 @@
                         class="toolbar-icon-btn mr-2 shrink-0"
                         onclick={handleHome}
                         title={t("toolbar.backToHome")}
+                        aria-label={t("toolbar.backToHome")}
                     ><Home size={16} /></button>
                 {/if}
                 {#if $gameFilename}
@@ -271,13 +274,15 @@
                      there's no tree selection context there, and the tree itself isn't even
                      mounted (see edit/+page.svelte), so these actions have nothing to act on. -->
                 <DropdownMenu items={addOptions}>
-                    {#snippet trigger(toggle)}
+                    {#snippet trigger(toggle, open)}
                         <button
                             type="button"
                             class="btn btn-sm preset-outlined-primary-500"
                             onclick={toggle}
                             disabled={$codeViewPanelOpen}
                             title={t("toolbar.addElement")}
+                            aria-haspopup="menu"
+                            aria-expanded={open}
                         ><Plus size={14} /> <span class="hidden md:inline">{t("toolbar.add")}</span> <ChevronDown size={12} class="hidden md:inline" /></button>
                     {/snippet}
                 </DropdownMenu>
@@ -293,16 +298,17 @@
                     title={canDelete ? t("toolbar.deleteTitleNamed", { name: selectedNode?.text ?? "" }) : t("toolbar.deleteTitle")}
                 ><Trash2 size={14} /> {t("common.delete")}</button>
                 <div class="toolbar-divider hidden md:block"></div>
-                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={() => assetManagerOpen.set(true)} title={t("toolbar.manageAssets")}><ImageIcon size={16} /></button>
-                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleUndo} disabled={$hasActiveCmView ? false : !$canUndo} title={$hasActiveCmView ? t("toolbar.undoInCodeEditor") : t("toolbar.undo")}><Undo2 size={16} /></button>
-                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleRedo} disabled={$hasActiveCmView ? false : !$canRedo} title={$hasActiveCmView ? t("toolbar.redoInCodeEditor") : t("toolbar.redo")}><Redo2 size={16} /></button>
-                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleToggleCodeView} title={t("toolbar.rawXmlCodeView")}><FileCode size={16} /></button>
+                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={() => assetManagerOpen.set(true)} title={t("toolbar.manageAssets")} aria-label={t("toolbar.manageAssets")}><ImageIcon size={16} /></button>
+                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleUndo} disabled={$hasActiveCmView ? false : !$canUndo} title={$hasActiveCmView ? t("toolbar.undoInCodeEditor") : t("toolbar.undo")} aria-label={$hasActiveCmView ? t("toolbar.undoInCodeEditor") : t("toolbar.undo")}><Undo2 size={16} /></button>
+                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleRedo} disabled={$hasActiveCmView ? false : !$canRedo} title={$hasActiveCmView ? t("toolbar.redoInCodeEditor") : t("toolbar.redo")} aria-label={$hasActiveCmView ? t("toolbar.redoInCodeEditor") : t("toolbar.redo")}><Redo2 size={16} /></button>
+                <button type="button" class="toolbar-icon-btn !hidden md:!inline-flex" onclick={handleToggleCodeView} title={t("toolbar.rawXmlCodeView")} aria-label={t("toolbar.rawXmlCodeView")}><FileCode size={16} /></button>
                 <div class="toolbar-divider hidden md:block"></div>
                 {#if fileMenuItems.length > 0}
                     <div class="hidden md:block">
                         <DropdownMenu items={fileMenuItems}>
-                            {#snippet trigger(toggle)}
+                            {#snippet trigger(toggle, open)}
                                 <button type="button" class="btn btn-sm preset-outlined-primary-500" onclick={toggle} disabled={saving} title={t("toolbar.file")}
+                                    aria-haspopup="menu" aria-expanded={open}
                                 >{t("toolbar.file")} <ChevronDown size={12} /></button>
                             {/snippet}
                         </DropdownMenu>
@@ -314,8 +320,8 @@
                 <!-- Overflow menu: community links + Settings on desktop; also Delete/Assets/
                      Undo/Redo/File-menu items on mobile (see overflowItems) -->
                 <DropdownMenu items={overflowItems}>
-                    {#snippet trigger(toggle)}
-                        <button type="button" class="toolbar-icon-btn" onclick={toggle} title={t("toolbar.more")}><Ellipsis size={16} /></button>
+                    {#snippet trigger(toggle, open)}
+                        <button type="button" class="toolbar-icon-btn" onclick={toggle} title={t("toolbar.more")} aria-label={t("toolbar.more")} aria-haspopup="menu" aria-expanded={open}><Ellipsis size={16} /></button>
                     {/snippet}
                 </DropdownMenu>
             </div>

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -671,13 +671,15 @@
             {/if}
         </div>
         <DropdownMenu items={libraryMenuItems}>
-            {#snippet trigger(toggle)}
+            {#snippet trigger(toggle, open)}
                 <button
                     type="button"
                     class="size-6 flex-shrink-0 flex items-center justify-center rounded {$showLibraryElements ? "text-primary-500" : "text-surface-400"} hover:text-primary-500 hover:bg-surface-200-800"
                     onclick={toggle}
                     title={t("treePanel.viewOptions")}
                     aria-label={t("treePanel.viewOptions")}
+                    aria-haspopup="menu"
+                    aria-expanded={open}
                 ><SlidersHorizontal class="size-3.5" /></button>
             {/snippet}
         </DropdownMenu>


### PR DESCRIPTION
## Summary
- `DropdownMenu.svelte`'s items were already real `<button>`s (baseline Tab/Enter/Space worked), but the panel had no menu semantics and no way to move between items except tabbing through each one individually. Adds `role="menu"`/`role="menuitem"`, roving arrow-key focus (ArrowUp/ArrowDown/Home/End, skipping disabled items) with focus moving to the first enabled item when the menu opens, and restores focus to whichever button opened the menu when it closes via Escape or after selecting an item — but not on an outside click, where focus should go wherever the user actually clicked instead.
- Wires `aria-haspopup="menu" aria-expanded={open}` on each of the 5 call sites' trigger buttons (`TreePanel`, `Toolbar` ×3, `PropertyEditor`), using the `open` value the trigger snippet already receives as its second parameter.
- Labels icon-only buttons that relied on `title` alone: `Toolbar.svelte`'s back/forward/home/manageAssets/undo/redo/rawXmlCodeView/overflow buttons, `ExitsEditor.svelte`'s edit/move-up/move-down/delete row actions (both the compass-grid and flat-list variants).
- Adds a first `aria-label` (and `title`, for the one that had neither) to two bare "✕" buttons: `ListEditor.svelte`'s remove-item button and `ExitsEditor.svelte`'s create-exit-panel close button.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings (the compiler's own a11y check actually caught a real issue mid-implementation: the new `role="menu"` div needed an explicit `tabindex="-1"` per `a11y_interactive_supports_focus` — fixed)
- [x] `npm run lint` (eslint) — clean
- [ ] Live browser verification — not possible this session; see #2137/#2138 for the same dev-environment note (both WASM bridges hanging at boot, confirmed unrelated to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)