### PR TITLE
fix(AppShell): keep hover-revealed row actions visible to keyboard focus

### DIFF
--- a/src/AppShell/src/components/ExitsEditor.svelte
+++ b/src/AppShell/src/components/ExitsEditor.svelte
@@ -250,7 +250,7 @@
                         {:else}
                             <span class="flex-1 text-xs px-1.5 py-1 pr-28 text-surface-600-400 truncate">{exit.alias ?? t("common.none")} → {exit.lookOnly ? t("exitsEditor.lookOnly") : t("exitsEditor.nowhere")}</span>
                         {/if}
-                        <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-10">
+                        <div class="absolute right-1 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity z-10">
                             <button
                                 type="button"
                                 class="btn btn-sm preset-outlined-primary-500 px-1 py-0 text-xs leading-none flex items-center"

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -744,7 +744,7 @@
                     </button>
                     <Icon class="flex-shrink-0 size-3.5 text-surface-500 {node.isLibrary ? "opacity-60" : ""}" />
                     <TreeView.BranchText class="flex-1 min-w-0 truncate {node.isLibrary ? "text-surface-600-400" : ""} {$cutElementKeys.has(node.id) ? "opacity-50 italic" : ""}">{node.text}</TreeView.BranchText>
-                    <span class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100">
+                    <span class="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 pointer-coarse:opacity-100">
                         {@render nodeActions(node)}
                     </span>
                 </TreeView.BranchControl>
@@ -759,7 +759,7 @@
             <TreeView.Item class="group flex items-center gap-1.5" onclick={() => activateIfAlreadySelected(node.id)}>
                 <Icon class="flex-shrink-0 size-3.5 text-surface-500 {node.isLibrary ? "opacity-60" : ""}" />
                 <span class="flex-1 min-w-0 truncate {node.isLibrary ? "text-surface-600-400" : ""} {$cutElementKeys.has(node.id) ? "opacity-50 italic" : ""}">{node.text}</span>
-                <span class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100">
+                <span class="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 pointer-coarse:opacity-100">
                     {@render nodeActions(node)}
                 </span>
             </TreeView.Item>


### PR DESCRIPTION
## Summary
- `ExitsEditor.svelte`'s flat-list row actions (edit/move/delete) and `TreePanel.svelte`'s tree-node "…" options button are only revealed via `group-hover:opacity-100`, with no focus-visible equivalent — a keyboard user tabbing to one of these controls got an invisible target, since it only becomes visible on mouse hover.
- Adds `group-focus-within:opacity-100` (and `group-focus-within:pointer-events-auto` for `ExitsEditor`'s version, which also toggles `pointer-events` off when hidden) alongside the existing hover variant in all three spots.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run lint` (eslint) — clean
- [ ] Live browser verification — not possible this session; see #2137-#2139 for the same dev-environment note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)