### PR TITLE
fix(Engine): announce the actual message in msgbox-family dialogs

### DIFF
--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -476,12 +476,23 @@ function runCommand() {
 // button, not the wrapper - confirmed by manual testing (VoiceOver/NVDA read the
 // dialog's title on open but never the actual message). Setting it on the buttons
 // too closes that gap regardless of which one ends up focused.
+//
+// That still reads button-before-message though ("Yes, button" - only *then* the
+// question, since the description is announced as part of the focused button, not
+// before it) - confirmed by manual testing again. jQuery UI's own _focusTabbable
+// always prefers a tabbable control over the wrapper (see jquery-ui.min.js), so
+// explicitly re-focusing the wrapper (tabIndex=-1, already set by its own
+// _createWrapper) right after "open" overrides that: focus lands on the
+// role="dialog" element itself first, which reads title + description together in
+// the right order, and Tab from there reaches the buttons - the WAI-ARIA APG's
+// "focus the dialog when content must be read before interaction" pattern.
 function openMsgbox(options) {
     $("#msgbox").dialog(options);
     var $widget = $("#msgbox").dialog("widget");
     $widget.attr("aria-describedby", "msgboxCaption");
     $widget.find(".ui-dialog-buttonpane button").attr("aria-describedby", "msgboxCaption");
     $("#msgbox").dialog("open");
+    $widget.trigger("focus");
 }
 
 function showQuestion(title) {

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -465,17 +465,22 @@ function runCommand() {
 
 // jQuery UI's dialog widget puts role="dialog"/aria-labelledby on the wrapper it
 // creates around #msgbox (accessible via the "widget" API, not #msgbox itself -
-// see _createWrapper in jquery-ui.min.js), and wires aria-labelledby to the title
-// bar automatically. It does NOT wire the dialog's own body text (#msgboxCaption,
-// set separately by each caller below) to anything - a screen reader landing on
-// the dialog's first focusable control (typically a button) has no guarantee of
-// ever reading that text, which is what "the dialog isn't announced" looks like
-// in practice even though the dialog *itself* technically is. aria-describedby
-// closes that gap. Centralised here since all four msgbox-opening functions below
-// share the same underlying element and the same gap.
+// see _createWrapper in jquery-ui.min.js), wires aria-labelledby to the title bar
+// automatically, and moves focus to the first button in the button pane on open -
+// never to the wrapper itself. It does NOT wire the dialog's own body text
+// (#msgboxCaption, set separately by each caller below) to anything.
+//
+// aria-describedby on the wrapper alone isn't enough: a screen reader computes a
+// focused element's accessible description from *that element's own*
+// aria-describedby, not an ancestor's, and jQuery UI's initial focus lands on a
+// button, not the wrapper - confirmed by manual testing (VoiceOver/NVDA read the
+// dialog's title on open but never the actual message). Setting it on the buttons
+// too closes that gap regardless of which one ends up focused.
 function openMsgbox(options) {
     $("#msgbox").dialog(options);
-    $("#msgbox").dialog("widget").attr("aria-describedby", "msgboxCaption");
+    var $widget = $("#msgbox").dialog("widget");
+    $widget.attr("aria-describedby", "msgboxCaption");
+    $widget.find(".ui-dialog-buttonpane button").attr("aria-describedby", "msgboxCaption");
     $("#msgbox").dialog("open");
 }
 

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -463,6 +463,22 @@ function runCommand() {
     }
 }
 
+// jQuery UI's dialog widget puts role="dialog"/aria-labelledby on the wrapper it
+// creates around #msgbox (accessible via the "widget" API, not #msgbox itself -
+// see _createWrapper in jquery-ui.min.js), and wires aria-labelledby to the title
+// bar automatically. It does NOT wire the dialog's own body text (#msgboxCaption,
+// set separately by each caller below) to anything - a screen reader landing on
+// the dialog's first focusable control (typically a button) has no guarantee of
+// ever reading that text, which is what "the dialog isn't announced" looks like
+// in practice even though the dialog *itself* technically is. aria-describedby
+// closes that gap. Centralised here since all four msgbox-opening functions below
+// share the same underlying element and the same gap.
+function openMsgbox(options) {
+    $("#msgbox").dialog(options);
+    $("#msgbox").dialog("widget").attr("aria-describedby", "msgboxCaption");
+    $("#msgbox").dialog("open");
+}
+
 function showQuestion(title) {
     $("#msgboxCaption").html(title);
 
@@ -489,8 +505,7 @@ function showQuestion(title) {
         }    // suppresses "close" button
     };
 
-    $("#msgbox").dialog(msgboxOptions);
-    $("#msgbox").dialog("open");
+    openMsgbox(msgboxOptions);
 }
 
 function uiShow(element) {
@@ -1730,8 +1745,7 @@ function showPopup(title, text) {
         closeOnEscape: false,
     };
 
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
+    openMsgbox(msgboxOptions);
 }
 
 function showPopupCustomSize(title, text, width, height) {
@@ -1754,8 +1768,7 @@ function showPopupCustomSize(title, text, width, height) {
         closeOnEscape: false,
     };
 
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
+    openMsgbox(msgboxOptions);
 }
 
 function showPopupFullscreen(title, text) {
@@ -1778,8 +1791,7 @@ function showPopupFullscreen(title, text) {
         closeOnEscape: false,
     };
 
-    $('#msgbox').dialog(msgboxOptions);
-    $('#msgbox').dialog('open');
+    openMsgbox(msgboxOptions);
 }
 
 // Log functions


### PR DESCRIPTION
## Summary
Found by manual testing (the game "L Too" shows a modal dialog at game start that wasn't being announced).

- `showQuestion`/`showPopup`/`showPopupCustomSize`/`showPopupFullscreen` all open the same `#msgbox` jQuery UI dialog. jQuery UI's dialog widget sets `role="dialog"` and `aria-labelledby` (pointing at the title bar) automatically on the wrapper it creates, and moves focus to the first button in the button pane on open — never to the wrapper itself. It never wires the dialog's actual message (`#msgboxCaption`, set separately by each caller) to anything.
- **Attempt 1** (superseded): `aria-describedby="msgboxCaption"` on the wrapper alone. Confirmed by testing this wasn't enough — the title was announced, the question wasn't. A focused element's accessible description comes from *its own* `aria-describedby`, not an ancestor's, and focus lands on a button, not the wrapper.
- **Attempt 2** (superseded): also set `aria-describedby` on every button in the pane. This got the message read, but in the wrong order — "Yes, button" first, *then* the question, since the description is announced as part of the focused button rather than before it.
- **Fix:** explicitly re-focus the dialog wrapper itself (already `tabIndex=-1` from jQuery UI's own setup) right after `.dialog("open")`, overriding jQuery UI's default preference for a tabbable button. Focus now lands on the `role="dialog"` element first, reading title + message together in the right order — the WAI-ARIA APG's pattern for a dialog whose content must be read before the user acts on it. Tab from there still reaches the buttons normally. `aria-describedby` stays on both the wrapper and the buttons, since both are correct and harmless.
- Centralized in a shared `openMsgbox()` wrapping the common `.dialog(options)`/`.dialog("open")` pair all four functions used.

## Test plan
- [x] `dotnet build --configuration Release` — succeeds
- [x] `dotnet test --configuration Release` — all 384 tests pass
- [x] Verified directly against the served `playercore.js` for both `showQuestion` and `showPopup`: `document.activeElement` after opening is the dialog wrapper itself (`role="dialog"`), with `aria-labelledby`/`aria-describedby` both resolving to the real title/message, and the button pane's first tabbable control still being the expected button (Tab order unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)