### PR TITLE
test(e2e): match menuitem role for Toolbar dropdown items

### DIFF
--- a/tests/e2e/verify-appshell-dialogue-pages.mjs
+++ b/tests/e2e/verify-appshell-dialogue-pages.mjs
@@ -41,8 +41,10 @@ async function run() {
     const tabBar = page.locator('.flex.border-b.border-surface-200-800.overflow-x-auto.flex-shrink-0');
 
     // "Add Page" is available immediately - no feature toggle to enable first.
+    // Menu items carry role="menuitem" (see DropdownMenu.svelte), not the
+    // default "button" role, per the WAI-ARIA menu pattern.
     await page.click('button[title="Add element"]');
-    await page.getByRole('button', { name: 'Add Page', exact: true }).waitFor({ state: 'visible', timeout: 5000 });
+    await page.getByRole('menuitem', { name: 'Add Page', exact: true }).waitFor({ state: 'visible', timeout: 5000 });
     console.log('PASS: "Add Page" available without any feature toggle');
     await page.keyboard.press('Escape');
 

--- a/tests/e2e/verify-appshell-gamebook-mode.mjs
+++ b/tests/e2e/verify-appshell-gamebook-mode.mjs
@@ -35,18 +35,20 @@ try {
     console.log('PASS: tree header reads "Pages" (not "Objects")');
 
     // Toolbar "+" menu: only "Add Page" — none of the text-adventure adders.
+    // Menu items carry role="menuitem" (see DropdownMenu.svelte), not the
+    // default "button" role, per the WAI-ARIA menu pattern.
     await page.click('button[title="Add element"]');
-    await page.getByRole('button', { name: 'Add Page', exact: true }).waitFor({ state: 'visible', timeout: 5000 });
+    await page.getByRole('menuitem', { name: 'Add Page', exact: true }).waitFor({ state: 'visible', timeout: 5000 });
     console.log('PASS: toolbar "+" menu offers "Add Page"');
 
     for (const label of ['Add Room', 'Add Object', 'Add Exit', 'Add Verb', 'Add Command', 'Add Turn Script']) {
-        const visible = await page.getByRole('button', { name: label, exact: true }).isVisible().catch(() => false);
+        const visible = await page.getByRole('menuitem', { name: label, exact: true }).isVisible().catch(() => false);
         if (visible) throw new Error(`Toolbar "+" menu should not offer "${label}" in gamebook mode`);
     }
     console.log('PASS: toolbar "+" menu has no text-adventure-only adders');
 
     // Add a page via the toolbar, flat (no parent prompt).
-    await page.getByRole('button', { name: 'Add Page', exact: true }).click();
+    await page.getByRole('menuitem', { name: 'Add Page', exact: true }).click();
     await page.fill('#element-name', 'MyNewPage');
     await page.getByRole('button', { name: 'Add Page', exact: true }).click();
     await tree.getByText('MyNewPage', { exact: true }).waitFor({ state: 'visible', timeout: 5000 });


### PR DESCRIPTION
DropdownMenu.svelte's items got an explicit role="menuitem" in #2139
(the keyboard-operable dropdown menu PR), overriding their implicit
"button" role per the WAI-ARIA menu pattern. That PR only ran
check_e2e_manifest (appshell_chromium is nightly/manual-only, gated
off pull_request), so the resulting locator mismatch first surfaced
in last night's nightly run: verify-appshell-gamebook-mode.mjs timed
out waiting for getByRole('button', { name: 'Add Page' }) on the
Toolbar "+" menu, which no longer matches since the item's role is
now "menuitem". Same stale assumption in
verify-appshell-dialogue-pages.mjs. Other "Add Page" locators in both
files target the AddElementModal's own submit button or the tree's
separate .tree-dropdown context menu, both still plain buttons, so
they're untouched.