### PR TITLE
fix(Engine): remove no-op RequestSpeak function

### DIFF
--- a/src/Engine/Core/CoreFunctions.aslx
+++ b/src/Engine/Core/CoreFunctions.aslx
@@ -185,11 +185,6 @@
     request (RequestSave, "")
   </function>
 
-  <function name="RequestSpeak" parameters="s">
-    // Deprecated
-    request (Speak, s)
-  </function>
-
   <function name="ShowMenu" parameters="caption, options, allowCancel, callback"><![CDATA[
       outputsection = StartNewOutputSection()
       msg (caption)

--- a/src/Engine/Core/CoreOutput.aslx
+++ b/src/Engine/Core/CoreOutput.aslx
@@ -10,7 +10,6 @@
       format = GetCurrentTextFormat("")
       JS.addText("<span style=\"" + format + "\">" + text + "</span><br/>")
       ResetCommandBarFormat
-      RequestSpeak (text)
     ]]>
   </function>
 
@@ -37,7 +36,6 @@
   <function name="OutputTextRawNoBr" parameters="text">
     <![CDATA[
       JS.addText("<span style=\"" + GetCurrentTextFormat("") + "\">" + text + "</span>")
-      RequestSpeak (text)
     ]]>
   </function>
 

--- a/src/Engine/Core/GamebookCore.aslx
+++ b/src/Engine/Core/GamebookCore.aslx
@@ -504,8 +504,4 @@
     game.menucallback = null
   </function>
 
-  <function name="RequestSpeak" parameters="s">
-    request (Speak, s)
-  </function>
-
 </library>


### PR DESCRIPTION
## Summary
- Removes the `RequestSpeak` Core.aslx function from `CoreFunctions.aslx` and `GamebookCore.aslx` — every `IPlayer.Speak` implementation (WebPlayer, PlayerCore, WasmPlayer) is a no-op, so the function did nothing.
- Removes the two internal calls to it (via `requestspeak`) in `CoreOutput.aslx`'s `OutputTextRaw`/`OutputTextRawNoBr`, since those are no-ops too.
- Leaves the `request (Speak, ...)` script command and the `requestspeak` script keyword in place, for compatibility with already-published games that call either directly.

## Test plan
- [x] `dotnet build --configuration Release src/Engine/Engine.csproj` succeeds
- [x] `dotnet test tests/EngineTests --configuration Release` — 311/311 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)