### PR TITLE
fix(AppShell): wire up <freetext/> control hint for dropdowns

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -516,12 +516,26 @@
             onchange={(e) => onNumberChange(ctrl.attribute!, "numberdouble", (e.target as HTMLInputElement).value)}
         />
     {:else if ctrl.controlType === "dropdown" && ctrl.options}
-        <Combobox
-            value={attrValue(ctrl.attribute!) ?? ""}
-            options={ctrl.options}
-            onchange={(v) => onDropdownChange(ctrl.attribute!, v)}
-            class="input text-xs py-0.5 px-1.5 w-auto min-w-24"
-        />
+        {#if ctrl.freetext}
+            <Combobox
+                value={attrValue(ctrl.attribute!) ?? ""}
+                options={ctrl.options}
+                onchange={(v) => onDropdownChange(ctrl.attribute!, v)}
+                class="input text-xs py-0.5 px-1.5 w-auto min-w-24"
+            />
+        {:else}
+            <!-- No <freetext/> hint - restrict to the listed options, unlike Combobox which
+                 always accepts arbitrary typed text. -->
+            <select
+                class="select text-xs py-0.5 px-1.5 w-auto"
+                value={attrValue(ctrl.attribute!) ?? ""}
+                onchange={(e) => onDropdownChange(ctrl.attribute!, (e.target as HTMLSelectElement).value)}
+            >
+                {#each ctrl.options as opt (opt.value)}
+                    <option value={opt.value}>{opt.label || opt.value || t("common.none")}</option>
+                {/each}
+            </select>
+        {/if}
     {:else if ctrl.controlType === "dropdowntypes" && ctrl.options && ctrl.attribute}
         <select
             class="select text-xs py-0.5 px-1.5 w-auto"

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -803,6 +803,15 @@
                             <option value={name}>{name}</option>
                         {/each}
                     </select>
+                {:else if ctrl.simpleEditor === "dropdown" && ctrl.options && ctrl.freetext}
+                    <!-- <freetext/> - lets the user type a value not in the list, e.g. a
+                         drawing command's colour parameter. -->
+                    <Combobox
+                        value={toSimpleDisplay(ctrl)}
+                        options={ctrl.options}
+                        onchange={(v) => onSimpleValueChange(scriptIndex, ctrl, v)}
+                        class="input text-xs py-0 px-1 max-w-32"
+                    />
                 {:else if ctrl.simpleEditor === "dropdown" && ctrl.options}
                     <select
                         class="select text-xs py-0 px-1 max-w-32"
@@ -899,6 +908,13 @@
             onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).checked.toString())}
         />
         {#if ctrl.caption}<span class="text-surface-600-400">{ctrl.caption}</span>{/if}
+    {:else if ctrl.controlType === "dropdown" && ctrl.options && ctrl.freetext}
+        <Combobox
+            value={ctrl.value ?? ""}
+            options={ctrl.options}
+            onchange={(v) => onSetParam(scriptIndex, ctrl.attribute!, v)}
+            class="input text-xs py-0 px-1 max-w-32"
+        />
     {:else if ctrl.controlType === "dropdown" && ctrl.options}
         <select
             class="select text-xs py-0 px-1 max-w-32"

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -63,6 +63,9 @@ export interface ControlInfo {
   href?: string | null
   newFile?: string | null
   lockedAfterCreate?: boolean
+  // <freetext/> - a "dropdown" control should let the user type a value not in its
+  // <validvalues> list, instead of being restricted to picking one of the listed options.
+  freetext?: boolean
 }
 
 export interface TabInfo {
@@ -134,6 +137,10 @@ export interface ScriptControlData {
   // <expand/> - this control should grow to fill the remaining width of its row instead of
   // being capped to a fixed max-width.
   expand?: boolean
+  // <freetext/> - a "dropdown" controltype or expression's "dropdown" simpleeditor should let
+  // the user type a value not in its <validvalues> list, instead of being restricted to
+  // picking one of the listed options.
+  freetext?: boolean
 }
 
 export interface ElseIfClauseData {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -45,7 +45,10 @@ internal record ControlInfo(
     bool IsWalkthrough = false,
     string? Href = null,
     string? NewFile = null,
-    bool LockedAfterCreate = false);
+    bool LockedAfterCreate = false,
+    // <freetext/> - a "dropdown" control should let the user type a value not in its
+    // <validvalues> list, instead of being restricted to picking one of the listed options.
+    bool Freetext = false);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -93,7 +96,11 @@ internal record ScriptControlData(
     bool Multiline = false,
     // <expand/> - this control should grow to fill the remaining width of its row instead of
     // being capped to a fixed max-width.
-    bool Expand = false
+    bool Expand = false,
+    // <freetext/> - a "dropdown" controltype or expression's "dropdown" simpleeditor should let
+    // the user type a value not in its <validvalues> list, instead of being restricted to
+    // picking one of the listed options.
+    bool Freetext = false
 );
 
 internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
@@ -3994,6 +4001,7 @@ public partial class WasmEditorBridge
         var breakBefore = ctrl.GetBool("breakbefore");
         var multiline = ctrl.GetBool("multiline");
         var expand = ctrl.Expand;
+        var freetext = ctrl.GetBool("freetext");
 
         string? useTemplates = null;
 
@@ -4058,7 +4066,8 @@ public partial class WasmEditorBridge
             useTemplates,
             cases,
             multiline,
-            expand
+            expand,
+            freetext
         );
     }
 
@@ -4130,9 +4139,11 @@ public partial class WasmEditorBridge
     {
         List<ControlOption>? options = null;
         var attribute = ctrl.Attribute;
+        var freetext = false;
 
         if (ctrl.ControlType == "dropdown")
         {
+            freetext = ctrl.GetBool("freetext");
             var list = ctrl.GetListString("validvalues");
             if (list != null)
             {
@@ -4246,7 +4257,8 @@ public partial class WasmEditorBridge
             null, null, textProcessorCommands, addPrompt, Source: source,
             Advanced: !ctrl.IsControlVisibleInSimpleMode,
             KeyPrompt: keyPrompt, ValuePrompt: valuePrompt, SourceExclude: sourceExclude, SourceType: sourceType,
-            IsWalkthrough: isWalkthrough, Href: href, NewFile: newFile, LockedAfterCreate: lockedAfterCreate);
+            IsWalkthrough: isWalkthrough, Href: href, NewFile: newFile, LockedAfterCreate: lockedAfterCreate,
+            Freetext: freetext);
     }
 
     [JSExport]


### PR DESCRIPTION
## Summary
- Part of #2116 (v5 `.aslx` editor control hints not wired through to AppShell).
- `<freetext/>` was fully dead: every "dropdown" control (property panel and script editor) either always or never allowed typing a value outside its `<validvalues>` list, regardless of the tag.
- Property panel (`ToControlInfo`/`PropertyEditor.svelte`): `Combobox` was used unconditionally, so non-freetext dropdowns (function return type, expression compare operator, exit light strength, ~31 uses) silently accepted arbitrary typed text. These now render a strict `<select>` unless `<freetext/>` is set.
- Script editor (`BuildScriptControlData`/`ScriptEditor.svelte`): the opposite problem — always a strict `<select>`, so the 10 freetext-tagged script dropdowns (e.g. drawing/output command colour parameters) couldn't actually accept free text. These now render `Combobox` when `<freetext/>` is set.

## Test plan
- [x] `dotnet build --configuration Release`
- [x] `dotnet test --configuration Release` (all passing)
- [x] `npm run check` / `npm run lint` in `src/AppShell` (clean)
- [x] `node tests/e2e/find-affected-tests.mjs` + ran the relevant flagged scripts against a local dev server (verify-appshell-exits-editor, verify-appshell-unlock-exit-picker, verify-appshell-gamebook-language-picker — exercises a freetext dropdown directly, verify-appshell-verbs-editor, verify-appshell-scriptadder-advanced-commands, verify-appshell-switch-cases-editor, verify-advanced-tree, verify-appshell-code-view) — all pass. (`verify-appshell-multi-control-editors` fails identically on `main` before this change — pre-existing, unrelated.)
- [x] Manual check: a freetext dropdown (game Category) still accepts arbitrary typed text; a non-freetext dropdown (Function return type) now renders a real `<select>` restricted to its listed options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)