### PR TITLE
fix(AppShell): wire up <minimum>/<maximum>/<increment> control hints

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -503,6 +503,9 @@
     {#if ctrl.controlType === "number"}
         <input
             type="number"
+            min={ctrl.minimum ?? undefined}
+            max={ctrl.maximum ?? undefined}
+            step={ctrl.increment ?? undefined}
             class="input text-xs py-0.5 px-1.5 w-auto"
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onNumberChange(ctrl.attribute!, "number", (e.target as HTMLInputElement).value)}
@@ -510,7 +513,9 @@
     {:else if ctrl.controlType === "numberdouble"}
         <input
             type="number"
-            step="any"
+            min={ctrl.minimum ?? undefined}
+            max={ctrl.maximum ?? undefined}
+            step={ctrl.increment ?? "any"}
             class="input text-xs py-0.5 px-1.5 w-auto"
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onNumberChange(ctrl.attribute!, "numberdouble", (e.target as HTMLInputElement).value)}

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -825,6 +825,9 @@
                 {:else if ctrl.simpleEditor === "number" || ctrl.simpleEditor === "numberdouble"}
                     <input
                         type="number"
+                        min={ctrl.minimum ?? undefined}
+                        max={ctrl.maximum ?? undefined}
+                        step={ctrl.increment ?? (ctrl.simpleEditor === "numberdouble" ? "any" : undefined)}
                         class="input text-xs py-0 px-1 min-w-12 max-w-24"
                         value={ctrl.value ?? "0"}
                         onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -145,6 +145,11 @@ export interface ScriptControlData {
   // the user type a value not in its <validvalues> list, instead of being restricted to
   // picking one of the listed options.
   freetext?: boolean
+  // <minimum>/<maximum>/<increment> - bounds and step for a "number"/"numberdouble" simple
+  // editor.
+  minimum?: number | null
+  maximum?: number | null
+  increment?: number | null
 }
 
 export interface ElseIfClauseData {

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -66,6 +66,10 @@ export interface ControlInfo {
   // <freetext/> - a "dropdown" control should let the user type a value not in its
   // <validvalues> list, instead of being restricted to picking one of the listed options.
   freetext?: boolean
+  // <minimum>/<maximum>/<increment> - bounds and step for a "number"/"numberdouble" control.
+  minimum?: number | null
+  maximum?: number | null
+  increment?: number | null
 }
 
 export interface TabInfo {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -48,7 +48,11 @@ internal record ControlInfo(
     bool LockedAfterCreate = false,
     // <freetext/> - a "dropdown" control should let the user type a value not in its
     // <validvalues> list, instead of being restricted to picking one of the listed options.
-    bool Freetext = false);
+    bool Freetext = false,
+    // <minimum>/<maximum>/<increment> - bounds and step for a "number"/"numberdouble" control.
+    double? Minimum = null,
+    double? Maximum = null,
+    double? Increment = null);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -4253,12 +4257,26 @@ public partial class WasmEditorBridge
 
         var href = ctrl.ControlType == "label" ? ctrl.GetString("href") : null;
 
+        var isNumeric = ctrl.ControlType is "number" or "numberdouble";
+        var minimum = isNumeric ? GetNumericHint(ctrl, "minimum") : null;
+        var maximum = isNumeric ? GetNumericHint(ctrl, "maximum") : null;
+        var increment = isNumeric ? GetNumericHint(ctrl, "increment") : null;
+
         return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
             null, null, textProcessorCommands, addPrompt, Source: source,
             Advanced: !ctrl.IsControlVisibleInSimpleMode,
             KeyPrompt: keyPrompt, ValuePrompt: valuePrompt, SourceExclude: sourceExclude, SourceType: sourceType,
             IsWalkthrough: isWalkthrough, Href: href, NewFile: newFile, LockedAfterCreate: lockedAfterCreate,
-            Freetext: freetext);
+            Freetext: freetext,
+            Minimum: minimum, Maximum: maximum, Increment: increment);
+    }
+
+    // <minimum>/<maximum>/<increment> can be authored as either an int or a double literal in
+    // the .aslx (e.g. a whole-number bound vs. "0.1") - GetInt/GetDouble each only match their
+    // own literal type, so try both instead of assuming which one a given hint was written as.
+    private static double? GetNumericHint(IEditorControl ctrl, string tag)
+    {
+        return ctrl.GetDouble(tag) ?? (double?)ctrl.GetInt(tag);
     }
 
     [JSExport]

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -104,7 +104,12 @@ internal record ScriptControlData(
     // <freetext/> - a "dropdown" controltype or expression's "dropdown" simpleeditor should let
     // the user type a value not in its <validvalues> list, instead of being restricted to
     // picking one of the listed options.
-    bool Freetext = false
+    bool Freetext = false,
+    // <minimum>/<maximum>/<increment> - bounds and step for a "number"/"numberdouble" simple
+    // editor (e.g. Grid_DrawShape's opacity, 0.0-1.0 step 0.1).
+    double? Minimum = null,
+    double? Maximum = null,
+    double? Increment = null
 );
 
 internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
@@ -4053,6 +4058,11 @@ public partial class WasmEditorBridge
             }
         }
 
+        var isNumericSimpleEditor = simpleEditor is "number" or "numberdouble";
+        var minimum = isNumericSimpleEditor ? GetNumericHint(ctrl, "minimum") : null;
+        var maximum = isNumericSimpleEditor ? GetNumericHint(ctrl, "maximum") : null;
+        var increment = isNumericSimpleEditor ? GetNumericHint(ctrl, "increment") : null;
+
         return new ScriptControlData(
             ctrl.ControlType,
             ctrl.Caption,
@@ -4071,7 +4081,10 @@ public partial class WasmEditorBridge
             cases,
             multiline,
             expand,
-            freetext
+            freetext,
+            minimum,
+            maximum,
+            increment
         );
     }
 


### PR DESCRIPTION
## Summary
- Part of #2116.
- `IEditorControl.GetInt`/`GetDouble` already existed but nothing in `WasmEditorBridge.cs` called them for numeric control hints - `<minimum>`/`<maximum>`/`<increment>` were fully dead (34+9+2 uses across 11 `.aslx` files), e.g. Timer's interval (`minimum=1`), Game's background opacity (`minimum=0.0 maximum=1.0 increment=0.1`), Grid_DrawShape's opacity script parameter (`minimum=0.0 maximum=1.0 increment=0.1`).
- **Property panel**: adds `Minimum`/`Maximum`/`Increment` to `ControlInfo`, read for `number`/`numberdouble` controls in `ToControlInfo` (tries `GetDouble` then `GetInt`, since a hint may be authored as either), threaded into `min`/`max`/`step` on the number `<input>` in `PropertyEditor.svelte`.
- **Script editor** (added after initial review feedback - the first version of this PR missed this half): adds the same three fields to `ScriptControlData`, read in `BuildScriptControlData` for a `"number"`/`"numberdouble"` `simpleeditor` on an `expression` control, threaded into `min`/`max`/`step` on the number input in `ScriptEditor.svelte`. This is a separate rendering pipeline from the property panel, so needed its own fix - script command parameters like Grid_DrawShape's opacity were still unbounded until this.
- Out of scope, flagged separately (background task in progress): `simpleeditor="number"` inside the *expression template* picker (`RandomChance`'s percentile) is a third, distinct rendering pipeline that isn't even given a number `<input>` today - a pre-existing, unrelated gap, not touched here.

## Test plan
- [x] `dotnet build --configuration Release`
- [x] `dotnet test --configuration Release` (all passing)
- [x] `npm run check` / `npm run lint` in `src/AppShell` (clean)
- [x] `node tests/e2e/find-affected-tests.mjs` + ran the relevant flagged scripts (verify-advanced-tree, verify-appshell-attributes-panel-pinned, verify-appshell-gamebook-mode, verify-appshell-object-pickers-exclude-pages, verify-appshell-code-view, verify-appshell-scriptadder-advanced-commands, verify-appshell-switch-cases-editor, verify-appshell-verbs-editor, verify-appshell-script-label-stacks-below, verify-appshell-scripteditor-row-buttons) against a local dev server - all pass.
- [x] Manual check in-browser: Timer's Interval field has `min="1"`; Game's background Opacity field has `min="0" max="1" step="0.1"`; an unrelated number field (Font size) is unaffected (no min/max/step); Grid_DrawShape's Opacity script parameter now has `min="0" max="1" step="0.1"` too (previously unbounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)