### PR TITLE
fix(AppShell): wire up <width/> control hint to the frontend

### DIFF
--- a/src/AppShell/src/components/AssetPicker.svelte
+++ b/src/AppShell/src/components/AssetPicker.svelte
@@ -4,7 +4,7 @@
     import FileIcon from "@lucide/svelte/icons/file";
     import { t } from "$lib/i18n";
 
-    let { value, source = null, creatable = false, readonly = false, exclude = [], onchange, onEnter, class: className = "input text-xs py-0.5 px-1.5 w-full min-w-0", containerClass = "", style = "" }: {
+    let { value, source = null, creatable = false, readonly = false, exclude = [], onchange, onEnter, class: className = "input text-xs py-0.5 px-1.5 w-full min-w-0", containerClass = "" }: {
         value: string;
         source?: string | null;
         // When true, typing a filename that isn't an existing asset creates a blank one under
@@ -26,11 +26,6 @@
         // (e.g. PropertyEditor), and leave unset for inline/wrapping layouts (e.g. ScriptEditor)
         // where growing to fill would force everything else in the row onto the next line.
         containerClass?: string;
-        // Inline style for the outer row — e.g. a per-instance pixel width (<width> control
-        // hint) that Tailwind's static class scanning can't express since it's only known at
-        // runtime. Applies to the whole row (icon + combobox/readonly text + upload button),
-        // matching how the width hint constrains other control types as a single unit.
-        style?: string;
     } = $props();
 
     let filter = $derived(parseAssetSource(source));
@@ -81,7 +76,7 @@
     }
 </script>
 
-<div class="flex items-center gap-1.5 min-w-0 {containerClass}" {style}>
+<div class="flex items-center gap-1.5 min-w-0 {containerClass}">
     {#if filter.kind === "image" && value}
         {#if thumbUrl}
             <img src={thumbUrl} alt="" class="h-6 w-6 object-cover rounded border border-surface-200-800 shrink-0" />

--- a/src/AppShell/src/components/AssetPicker.svelte
+++ b/src/AppShell/src/components/AssetPicker.svelte
@@ -4,7 +4,7 @@
     import FileIcon from "@lucide/svelte/icons/file";
     import { t } from "$lib/i18n";
 
-    let { value, source = null, creatable = false, readonly = false, exclude = [], onchange, onEnter, class: className = "input text-xs py-0.5 px-1.5 w-full min-w-0", containerClass = "" }: {
+    let { value, source = null, creatable = false, readonly = false, exclude = [], onchange, onEnter, class: className = "input text-xs py-0.5 px-1.5 w-full min-w-0", containerClass = "", style = "" }: {
         value: string;
         source?: string | null;
         // When true, typing a filename that isn't an existing asset creates a blank one under
@@ -26,6 +26,11 @@
         // (e.g. PropertyEditor), and leave unset for inline/wrapping layouts (e.g. ScriptEditor)
         // where growing to fill would force everything else in the row onto the next line.
         containerClass?: string;
+        // Inline style for the outer row — e.g. a per-instance pixel width (<width> control
+        // hint) that Tailwind's static class scanning can't express since it's only known at
+        // runtime. Applies to the whole row (icon + combobox/readonly text + upload button),
+        // matching how the width hint constrains other control types as a single unit.
+        style?: string;
     } = $props();
 
     let filter = $derived(parseAssetSource(source));
@@ -76,7 +81,7 @@
     }
 </script>
 
-<div class="flex items-center gap-1.5 min-w-0 {containerClass}">
+<div class="flex items-center gap-1.5 min-w-0 {containerClass}" {style}>
     {#if filter.kind === "image" && value}
         {#if thumbUrl}
             <img src={thumbUrl} alt="" class="h-6 w-6 object-cover rounded border border-surface-200-800 shrink-0" />

--- a/src/AppShell/src/components/Combobox.svelte
+++ b/src/AppShell/src/components/Combobox.svelte
@@ -2,7 +2,7 @@
     import type { ControlOption } from "$lib/types";
     import { t } from "$lib/i18n";
 
-    let { value, options, onchange, oninput, onEnter, class: className = "", wrapperClass = "" }: {
+    let { value, options, onchange, oninput, onEnter, class: className = "", wrapperClass = "", style = "" }: {
         value: string;
         options: ControlOption[];
         onchange: (value: string) => void;
@@ -20,6 +20,9 @@
         // row relies on this component itself (not just the input inside it) to grow/shrink,
         // since flex sizing classes on the input don't affect its own wrapping element.
         wrapperClass?: string;
+        // Inline style for the <input> — e.g. a per-instance pixel width (<width> control hint)
+        // that Tailwind's static class scanning can't express since it's only known at runtime.
+        style?: string;
     } = $props();
 
     // Unique ID prefix for ARIA references
@@ -187,6 +190,7 @@
         aria-activedescendant={activeDescendant}
         aria-controls="{uid}-listbox"
         class={className}
+        {style}
         placeholder={value === "" && hasEmptyOption ? t("common.none") : ""}
         value={inputValue}
         onfocus={handleFocus}

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -202,6 +202,12 @@
         return $selectedData?.attributes[attribute] ?? null;
     }
 
+    // <width> - a per-instance pixel width, only known at runtime, so it has to be an inline
+    // style rather than a Tailwind class (Tailwind's static scanning can't see a dynamic value).
+    function widthStyle(ctrl: ControlInfo): string | undefined {
+        return ctrl.width ? `width: ${ctrl.width}px` : undefined;
+    }
+
     function boolValue(attribute: string): boolean {
         const v = attrValue(attribute);
         return v === "True" || v === "true";
@@ -522,6 +528,7 @@
             max={ctrl.maximum ?? undefined}
             step={ctrl.increment ?? undefined}
             class="input text-xs py-0.5 px-1.5 w-auto"
+            style={widthStyle(ctrl)}
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onNumberChange(ctrl.attribute!, "number", (e.target as HTMLInputElement).value)}
         />
@@ -532,6 +539,7 @@
             max={ctrl.maximum ?? undefined}
             step={ctrl.increment ?? "any"}
             class="input text-xs py-0.5 px-1.5 w-auto"
+            style={widthStyle(ctrl)}
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onNumberChange(ctrl.attribute!, "numberdouble", (e.target as HTMLInputElement).value)}
         />
@@ -542,12 +550,14 @@
                 options={ctrl.options}
                 onchange={(v) => onDropdownChange(ctrl.attribute!, v, ctrl.nullable)}
                 class="input text-xs py-0.5 px-1.5 w-auto min-w-24"
+                style={widthStyle(ctrl)}
             />
         {:else}
             <!-- No <freetext/> hint - restrict to the listed options, unlike Combobox which
                  always accepts arbitrary typed text. -->
             <select
                 class="select text-xs py-0.5 px-1.5 w-auto"
+                style={widthStyle(ctrl)}
                 value={attrValue(ctrl.attribute!) ?? ""}
                 onchange={(e) => onDropdownChange(ctrl.attribute!, (e.target as HTMLSelectElement).value)}
             >
@@ -559,6 +569,7 @@
     {:else if ctrl.controlType === "dropdowntypes" && ctrl.options && ctrl.attribute}
         <select
             class="select text-xs py-0.5 px-1.5 w-auto"
+            style={widthStyle(ctrl)}
             value={attrValue(ctrl.attribute) ?? "*"}
             onchange={(e) => $selectedKey && setDropdownType($selectedKey, ctrl.attribute!, (e.target as HTMLSelectElement).value)}
         >
@@ -590,7 +601,8 @@
         <input
             type="text"
             autocapitalize="off"
-            class={"input text-xs py-0.5 px-1.5 w-full" + (ctrl.attribute && attributeErrors[ctrl.attribute] ? " !border-error-500" : "")}
+            class={"input text-xs py-0.5 px-1.5" + (ctrl.width ? "" : " w-full") + (ctrl.attribute && attributeErrors[ctrl.attribute] ? " !border-error-500" : "")}
+            style={widthStyle(ctrl)}
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => onTextChange(ctrl.attribute!, ctrl.controlType, (e.target as HTMLInputElement).value, ctrl.nullable)}
         />
@@ -604,6 +616,7 @@
     {:else if ctrl.controlType === "filter" && ctrl.options}
         <select
             class="select text-xs py-0.5 px-1.5 w-auto"
+            style={widthStyle(ctrl)}
             value={attrValue(ctrl.attribute!) ?? ""}
             onchange={(e) => $selectedKey && setSelectedFilter($selectedKey, ctrl.subAttribute!, (e.target as HTMLSelectElement).value)}
         >
@@ -781,6 +794,7 @@
             options={ctrl.options}
             onchange={(v) => $selectedKey && setObjectReference($selectedKey, ctrl.attribute!, v)}
             class="input text-xs py-0.5 px-1.5 w-auto min-w-24"
+            style={widthStyle(ctrl)}
         />
     {:else if ctrl.controlType === "multi" && ctrl.options}
         {@const selectedType = attrValue(ctrl.attribute!) ?? "null"}

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -646,8 +646,7 @@
             creatable={!!ctrl.newFile}
             readonly={!!(ctrl.lockedAfterCreate && attrValue(ctrl.attribute!))}
             onchange={(v) => onTextChange(ctrl.attribute!, ctrl.controlType, v)}
-            containerClass={ctrl.width ? "" : "w-full"}
-            style={widthStyle(ctrl)}
+            containerClass="w-full"
         />
     {:else if ctrl.controlType === "list" && ctrl.attribute && $selectedKey}
         <ListEditor elementKey={$selectedKey} attribute={ctrl.attribute} value={attrValue(ctrl.attribute)} addPrompt={ctrl.addPrompt ?? undefined} isWalkthrough={ctrl.isWalkthrough ?? false} />

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -646,7 +646,8 @@
             creatable={!!ctrl.newFile}
             readonly={!!(ctrl.lockedAfterCreate && attrValue(ctrl.attribute!))}
             onchange={(v) => onTextChange(ctrl.attribute!, ctrl.controlType, v)}
-            containerClass="w-full"
+            containerClass={ctrl.width ? "" : "w-full"}
+            style={widthStyle(ctrl)}
         />
     {:else if ctrl.controlType === "list" && ctrl.attribute && $selectedKey}
         <ListEditor elementKey={$selectedKey} attribute={ctrl.attribute} value={attrValue(ctrl.attribute)} addPrompt={ctrl.addPrompt ?? undefined} isWalkthrough={ctrl.isWalkthrough ?? false} />

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -74,6 +74,8 @@ export interface ControlInfo {
   // entirely (reverting to unset/inherited) instead of saving an explicit "". Matches the old
   // Quest 5 desktop editor's behaviour for the same hint.
   nullable?: boolean
+  // <width> - fixed pixel width for this control, instead of the default flexible sizing.
+  width?: number | null
 }
 
 export interface TabInfo {

--- a/src/Engine/Core/CoreEditorExit.aslx
+++ b/src/Engine/Core/CoreEditorExit.aslx
@@ -17,7 +17,6 @@
         <caption>[EditorExitType]</caption>
         <controltype>dropdowntypes</controltype>
         <types>*=[TypeExitNon];northwestdirection=[CompassNW];northdirection=[CompassN];northeastdirection=[CompassNE];westdirection=[CompassW];eastdirection=[CompassE];southwestdirection=[CompassSW];southdirection=[CompassS];southeastdirection=[CompassSE];updirection=[CompassUp];downdirection=[CompassDown];indirection=[CompassIn];outdirection=[CompassOut]</types>
-        <width>150</width>
       </control>
 
       <control>

--- a/src/Engine/Core/CoreEditorFunction.aslx
+++ b/src/Engine/Core/CoreEditorFunction.aslx
@@ -14,7 +14,6 @@
         <caption>[EditorFunctionReturntype]</caption>
         <controltype>dropdown</controltype>
         <attribute>returntype</attribute>
-        <width>150</width>
         <validvalues type="simplestringdictionary">=None; string=String; boolean=Boolean; int=Integer; double=Double; object=Object; list=List; stringlist=String List; objectlist=Object List; dictionary=Dictionary; stringdictionary=String Dictionary; objectdictionary=Object Dictionary; scriptdictionary=Script Dictionary</validvalues>
       </control>
 

--- a/src/Engine/Core/CoreEditorGame.aslx
+++ b/src/Engine/Core/CoreEditorGame.aslx
@@ -163,7 +163,6 @@
         <caption>[EditorGameTheme]</caption>
         <controltype>dropdowntypes</controltype>
         <types>*=[TypeThemeStandard]; theme_novella=[TypeThemeNovella]; theme_retro=[TypeThemeRetro]; theme_typewriter=[TypeThemeTypewriter]; theme_hotdogstand=[TypeThemeHotDog]</types>
-        <width>150</width>
       </control>
 
       <control>

--- a/src/Engine/Core/CoreEditorIncludedLibrary.aslx
+++ b/src/Engine/Core/CoreEditorIncludedLibrary.aslx
@@ -9,7 +9,6 @@
         <attribute>filename</attribute>
         <caption>[EditorIncludedLibraryFilename]</caption>
         <source>*.aslx</source>
-        <width>300</width>
         <filefiltername>Libraries</filefiltername>
         <lockedaftercreate/>
       </control>

--- a/src/Engine/Core/CoreEditorJavascript.aslx
+++ b/src/Engine/Core/CoreEditorJavascript.aslx
@@ -9,7 +9,6 @@
         <attribute>src</attribute>
         <caption>[EditorJavascriptFilename]</caption>
         <source>*.js</source>
-        <width>300</width>
         <filefiltername>Javascript Files</filefiltername>
         <newfile>javascript.js</newfile>
         <lockedaftercreate/>

--- a/src/Engine/Core/CoreEditorObjectContainer.aslx
+++ b/src/Engine/Core/CoreEditorObjectContainer.aslx
@@ -9,7 +9,6 @@
       <controltype>dropdowntypes</controltype>
       <caption>[EditorObjectContainerContainertype]</caption>
       <types>*=[TypeContainerNot]; container_open=[TypeContainer]; container_closed=[TypeContainerClosed]; surface=[TypeContainerSurface]; container_limited=[TypeContainerLinited]; openable=[TypeContainerOpenable]</types>
-      <width>150</width>
     </control>
 
     <control>
@@ -196,7 +195,6 @@
       <controltype>dropdowntypes</controltype>
       <caption>[EditorObjectContainerLocktype]</caption>
       <types>*=[TypeContainerNotLockable]; container_lockable=[TypeContainerLockable]</types>
-      <width>150</width>
       <onlydisplayif>(DoesInherit(this, "container_base") or DoesInherit(this, "openable")) and not DoesInherit(this, "surface")</onlydisplayif>
     </control>
 

--- a/src/Engine/Core/CoreEditorObjectOptions.aslx
+++ b/src/Engine/Core/CoreEditorObjectOptions.aslx
@@ -9,7 +9,6 @@
       <controltype>dropdowntypes</controltype>
       <caption>[EditorObjectOptionsSwitchable2]</caption>
       <types>*=[TypeCannotSwitched]; switchable=[TypeCanSwitched]</types>
-      <width>150</width>
     </control>
 
     <control>

--- a/src/Engine/Core/CoreEditorObjectSetup.aslx
+++ b/src/Engine/Core/CoreEditorObjectSetup.aslx
@@ -8,7 +8,6 @@
       <caption>[EditorObjectSetupType]</caption>
       <controltype>dropdowntypes</controltype>
       <types>editor_room=[TypeObjectRoom]; editor_object=[TypeObjectObject]; editor_room_object=[TypeObjectAndOr]; *=[TypeObjectUndefined]</types>
-      <width>150</width>
       <advanced/>
     </control>
 
@@ -64,7 +63,6 @@
       <controltype>dropdowntypes</controltype>
       <caption>[EditorObjectSetupType]</caption>
       <types>*=[TypeInanimateObject]; plural=[TypeInanimateObjects]; [LanguageSpecificObjectTypes]male=[TypeMaleCharacter]; namedmale=[TypeMaleCharacterNamed]; maleplural=[TypeMaleCharacters]; female=[TypeFemaleCharacter]; namedfemale=[TypeFemaleCharacterNamed]; femaleplural=[TypeFemaleCharacters]</types>
-      <width>150</width>
     </control>
 
     <control>

--- a/src/Engine/Core/CoreEditorObjectWearable.aslx
+++ b/src/Engine/Core/CoreEditorObjectWearable.aslx
@@ -9,7 +9,6 @@
       <controltype>dropdowntypes</controltype>
       <caption>[EditorObjectWearableCanBeWorn]</caption>
       <types>*=[EditorObjectWearableTypCannotBeWorn]; wearable=[EditorObjectWearableTypCanBeWorn]</types>
-      <width>150</width>
     </control>
 
     <control>

--- a/src/Engine/Core/CoreEditorPage.aslx
+++ b/src/Engine/Core/CoreEditorPage.aslx
@@ -21,7 +21,6 @@
       <controltype>dropdowntypes</controltype>
       <caption>[EditorGBPageType]</caption>
       <types>*=Text; pagescript=[EditorGBPageTypeScript]; pagescripttext=[EditorGBPageTypeScriptText]</types>
-      <width>150</width>
     </control>
 
     <control>

--- a/src/Engine/Core/CoreEditorVerb.aslx
+++ b/src/Engine/Core/CoreEditorVerb.aslx
@@ -24,7 +24,6 @@
         <caption>[EditorVerbDefault]</caption>
         <controltype>filter</controltype>
         <filters>text=[EditorVerbText]; template=[EditorVerbTemplate]; expression=[EditorVerbExpression]</filters>
-        <width>150</width>
         <filtergroupname>responsetype</filtergroupname>
       </control>
 

--- a/src/Engine/Core/GamebookCoreEditor.aslx
+++ b/src/Engine/Core/GamebookCoreEditor.aslx
@@ -456,7 +456,6 @@
         <controltype>dropdowntypes</controltype>
         <caption>[EditorGBPageType]</caption>
         <types>*=Text; picture=[EditorGBPageTypePicture]; youtube=YouTube; link=[EditorGBPageTypeExternalLink]; script=[EditorGBPageTypeScript]; scripttext=[EditorGBPageTypeScriptText]</types>
-        <width>150</width>
       </control>
 
       <control>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -56,7 +56,10 @@ internal record ControlInfo(
     // <nullable/> - emptying this control's value reverts the attribute to unset/inherited (as
     // opposed to just an empty string, which is still an explicit override) - the frontend calls
     // RemoveAttribute instead of SetAttribute("") when the new value is empty.
-    bool Nullable = false);
+    bool Nullable = false,
+    // <width> - fixed pixel width for this control (e.g. an exit's "to" object picker), instead
+    // of the default flexible sizing.
+    int? Width = null);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -4208,7 +4211,7 @@ public partial class WasmEditorBridge
             options = dict?.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
 
             return new ControlInfo(ctrl.Id, "filter", ctrl.Caption, options, null,
-                ctrl.GetString("filtergroupname"), Advanced: !ctrl.IsControlVisibleInSimpleMode);
+                ctrl.GetString("filtergroupname"), Advanced: !ctrl.IsControlVisibleInSimpleMode, Width: ctrl.Width);
         }
         else if (ctrl.ControlType == "objects")
         {
@@ -4291,7 +4294,8 @@ public partial class WasmEditorBridge
             IsWalkthrough: isWalkthrough, Href: href, NewFile: newFile, LockedAfterCreate: lockedAfterCreate,
             Freetext: freetext,
             Minimum: minimum, Maximum: maximum, Increment: increment,
-            Nullable: nullable);
+            Nullable: nullable,
+            Width: ctrl.Width);
     }
 
     // <minimum>/<maximum>/<increment> can be authored as either an int or a double literal in


### PR DESCRIPTION
## Summary
- Part of #2116, which described this as "half-wired": `IEditorControl.Width` was already parsed on the backend (`EditorControl.cs`) but `ControlInfo` had no field for it and `ToControlInfo` never read it, so every `<width>` hint was silently dropped before reaching the frontend.
- Threads `ctrl.Width` through `ControlInfo` into an inline pixel-width `style` on `number`/`numberdouble`/`dropdown`/`dropdowntypes`/`objects`/`textbox`/`filter` controls in `PropertyEditor.svelte` (a plain Tailwind class can't express a value only known at runtime). `Combobox.svelte` gains an optional `style` prop for the `dropdown`/`objects` cases.
- Measured the actual rendered effect of every existing `<width>` hint in-browser before deciding what to keep:
  - **Kept (10 hints, real visible change):** Exit "To"/"Alias" (200px vs ~154px auto), 7 `number` fields - Price/Max objects/Volume/Max volume/Starting money etc (100px vs ~154px auto), and Game's money format `textbox` (50px vs full-width, the most dramatic case).
  - **Removed (12 hints, no-op):** every `dropdowntypes`/`dropdown`/`filter` hint pinned at 150px (Exit Type, Game Theme, ObjectSetup Type x2, Verb response type, Page type x2, ObjectOptions/Wearable/Container type toggles). A native `<select>` already auto-sizes to its widest `<option>`, which lands within ~10-15px of 150 for every one of these lists - confirmed by temporarily stripping the inline style and re-measuring, e.g. the Function return-type dropdown rendered at 138.5px unstyled vs 150px pinned.
  - **Removed (2 hints, dead code twice over):** `CoreEditorJavascript.aslx`/`CoreEditorIncludedLibrary.aslx`'s `<width>300</width>` on their `file` controltype. Tried wiring `AssetPicker.svelte` up to honor it, but the readonly filename display is a plain borderless `<span>` - a short filename looks identical whether capped or not, and the one case where it's not a no-op (truncating a long filename earlier) only applies to the editable Combobox+Upload state, which never actually occurs for these two controls: both lock the filename immediately after creation (`<lockedaftercreate/>`) and both "Add" modals require picking a name before the element exists. Not worth the extra prop for that, so reverted the passthrough and just dropped the hints.

## Test plan
- [x] `dotnet build --configuration Release` / `dotnet test --configuration Release` (all passing)
- [x] `npm run check` / `npm run lint` in `src/AppShell` (clean)
- [x] `node tests/e2e/find-affected-tests.mjs` + ran the flagged scripts (verify-appshell-unlock-exit-picker, verify-appshell-verbs-editor, verify-appshell-switch-cases-editor) against a local dev server - all pass. (`verify-default-tree-state` / `verify-appshell-tree-filter` fail identically on unmodified `main` before this change on an unrelated "Add Room" toolbar timeout - pre-existing, unrelated flake.)
- [x] Manual in-browser verification of both the kept and removed hints: Exit "To" measures `width: 200px`; Exit "Type" (hint removed) has no inline style and renders unchanged at its natural ~152px; a long Javascript filename renders untruncated now that the `file`-control hints are gone, matching pre-PR behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
