### PR TITLE
fix(AppShell): expression-editor parity for if/set/foreach templates

### DIFF
--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -2,6 +2,7 @@
     import Wand2 from "@lucide/svelte/icons/wand-2";
     import { getExpressionFunctions } from "$lib/editor-store";
     import { t } from "$lib/i18n";
+    import { measureTextPx } from "$lib/text-measure";
     import type { ExpressionFunctionInfo } from "$lib/types";
 
     interface Props {
@@ -12,11 +13,42 @@
         // have every field independently re-fetch it.
         objectNames: string[];
         class?: string;
+        // When set, the field's own width tracks its typed content (clamped to this ch range)
+        // instead of being fixed by `class`'s width utilities - e.g. a template control's
+        // expression fallback, which should be no wider than it needs to be by default but grow
+        // as the user types a longer expression. Left unset, width is whatever `class` says.
+        minCh?: number;
+        maxCh?: number;
     }
 
-    let { value, onchange, objectNames, class: className = "" }: Props = $props();
+    let { value, onchange, objectNames, class: className = "", minCh, maxCh }: Props = $props();
+
+    // Mirrors `value` so the width (and the field itself) can react on every keystroke, not just
+    // on the commit-triggering change event - `value` only advances when the caller's onchange
+    // round-trips a new committed value back down as a prop. A writable $derived: assigning to
+    // it below overrides the mirrored value until `value` itself changes, at which point it
+    // resets to that (e.g. undo, or switching to a different control).
+    let liveText = $derived(value);
 
     let inputEl = $state<HTMLInputElement | undefined>();
+
+    // Sized to the field's own measured text rather than a `ch`-per-character estimate, which
+    // is off by an amount that depends on the actual character mix (a "0"-glyph-width "ch"
+    // overestimates a lowercase-and-space-heavy phrase, for instance) - not noticeable for a
+    // short value, but visible slack for a long one. `minCh`/`maxCh` stay expressed in roughly
+    // character terms for callers, converted using this font's own "0" width. The small flat
+    // reserve is this field's own padding - unlike a <select>, there's no dropdown-arrow chrome
+    // to leave extra room for.
+    let widthStyle = $derived.by(() => {
+        if (minCh === undefined || !inputEl) return "";
+        const font = getComputedStyle(inputEl).font;
+        const chPx = measureTextPx("0", font) || 8;
+        const rootPx = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+        const textPx = measureTextPx(liveText, font);
+        const minPx = minCh * chPx;
+        const maxPx = (maxCh ?? Number.POSITIVE_INFINITY) * chPx;
+        return `width: ${Math.max(minPx, Math.min(maxPx, textPx + 0.75 * rootPx))}px;`;
+    });
     let buttonEl = $state<HTMLButtonElement | undefined>();
     let popoverRootEl = $state<HTMLDivElement | undefined>();
     let open = $state(false);
@@ -87,11 +119,15 @@
     // the field never had focus), then restores focus/cursor there once Svelte has re-rendered
     // the now-longer value.
     function insertAtCursor(text: string) {
-        const start = inputEl?.selectionStart ?? value.length;
-        const end = inputEl?.selectionEnd ?? value.length;
-        const newValue = value.slice(0, start) + text + value.slice(end);
+        // Insert into whatever's actually in the field (liveText), not the last-committed
+        // `value` prop, so opening the picker mid-typing (before a blur/Enter commit) doesn't
+        // discard uncommitted keystrokes.
+        const start = inputEl?.selectionStart ?? liveText.length;
+        const end = inputEl?.selectionEnd ?? liveText.length;
+        const newValue = liveText.slice(0, start) + text + liveText.slice(end);
         const cursorPos = start + text.length;
         close();
+        liveText = newValue;
         onchange(newValue);
         requestAnimationFrame(() => {
             inputEl?.focus();
@@ -149,7 +185,9 @@
         type="text"
         autocapitalize="off"
         class={className || "input text-xs py-0.5 px-1.5 w-full"}
-        {value}
+        style={widthStyle}
+        value={liveText}
+        oninput={(e) => (liveText = (e.target as HTMLInputElement).value)}
         onchange={(e) => onchange((e.target as HTMLInputElement).value)}
     />
     <button

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -1074,6 +1074,20 @@
                         <option value={name}>{name}</option>
                     {/each}
                 </select>
+            {:else if ctrl.simpleEditor === "number" || ctrl.simpleEditor === "numberdouble"}
+                <input
+                    type="number"
+                    min={ctrl.minimum ?? undefined}
+                    max={ctrl.maximum ?? undefined}
+                    step={ctrl.increment ?? (ctrl.simpleEditor === "numberdouble" ? "any" : undefined)}
+                    class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
+                    placeholder={ctrl.simpleLabel ?? ctrl.name}
+                    value={ctrl.value ?? ""}
+                    onchange={(e) => {
+                        const newVal = (e.target as HTMLInputElement).value;
+                        onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                    }}
+                />
             {:else}
                 <input
                     type="text"

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -44,12 +44,14 @@
         renameScriptDictCase,
     } from "$lib/editor-store";
     import { defaultCodeView } from "$lib/code-view-store";
+    import { measureTextPx } from "$lib/text-measure";
     import type {
         ScriptBlockData,
         ScriptNodeData,
         ScriptControlData,
         ScriptCategoryInfo,
         ExpressionTemplateData,
+        ExpressionTemplateControlData,
         ExpressionTemplate,
         ExpressionFunctionInfo,
         CaseScriptData,
@@ -86,6 +88,10 @@
     // Tracks which expression controls the user has explicitly forced into expression mode,
     // overriding the default simple-mode detection based on value shape.
     const expressionOverrides = new SvelteSet<string>();
+    // Same idea as expressionOverrides, but for a single parameter *inside* an expression
+    // template (e.g. RandomChance's "percentile") rather than a whole script command param -
+    // keyed by `${overrideKey}::${ctrl.name}`, see expressionField/templateParamKey.
+    const templateParamOverrides = new SvelteSet<string>();
     // Tracks which switch cases (scriptdictionary control entries) are expanded, keyed by
     // `${scriptIndex}:${paramAttribute}:${caseKey}` - see switchCasesEditor.
     const expandedCases = new SvelteSet<string>();
@@ -184,6 +190,7 @@
             scriptData = getScriptData(elementKey, attribute);
         }
         expressionOverrides.clear();
+        templateParamOverrides.clear();
     }
 
     function mutate(fn: () => string): boolean {
@@ -207,7 +214,13 @@
         return objectNames;
     }
 
-    function isSimpleValue(ctrl: ScriptControlData): boolean {
+    // Loosened to a minimal structural shape (rather than ScriptControlData specifically) so
+    // this same simple/expression-shape check works for both an ordinary script command param
+    // and a control nested inside an expression template (e.g. RandomChance's "percentile") -
+    // see inTemplateParamSimpleMode below, which is the only other caller of this shape.
+    type SimpleValueLike = { simpleEditor: string | null; value: string | null };
+
+    function isSimpleValue(ctrl: SimpleValueLike): boolean {
         const v = ctrl.value ?? "";
         switch (ctrl.simpleEditor) {
             case "boolean":
@@ -229,6 +242,79 @@
         const key = exprKey(scriptIndex, ctrl.attribute!);
         if (expressionOverrides.has(key)) return false;
         return isSimpleValue(ctrl);
+    }
+
+    // Same intent as onSwitchToSimple's inline switch below, but as a pure function (a template
+    // control's toggle has no scriptIndex/onSetParam to hang that logic off) and with "objects"
+    // broken out from the default case: an object reference resets to a bare "" (nothing
+    // selected), not the quoted empty string a textbox/dropdown simple editor wants.
+    function defaultSimpleValue(simpleEditor: string): string {
+        switch (simpleEditor) {
+            case "number":
+            case "numberdouble":
+                return "0";
+            case "objects":
+                return "";
+            default:
+                return '""';
+        }
+    }
+
+    function templateParamKey(overrideKey: string, ctrlName: string): string {
+        return `${overrideKey}::${ctrlName}`;
+    }
+
+    function inTemplateParamSimpleMode(overrideKey: string, ctrl: ExpressionTemplateControlData): boolean {
+        if (!ctrl.simpleEditor) return false;
+        if (templateParamOverrides.has(templateParamKey(overrideKey, ctrl.name))) return false;
+        return isSimpleValue(ctrl);
+    }
+
+    // Svelte action: sizes a <select> (the condition/template picker, or a template control's
+    // object picker) to fit its own currently selected text rather than a fixed Tailwind max-w
+    // class - a plain width class either truncates a long value or, since a native <select>
+    // without an explicit width sizes to its widest *option* rather than the selected one, stays
+    // wide even once a short option is picked (e.g. Got(#object#) offering an object list that
+    // includes some long name).
+    //
+    // A canvas-measured text width plus a guessed flat reserve for the select's own native
+    // dropdown-arrow chrome was tried here first and still clipped the last character or so in
+    // practice - that chrome's actual footprint is drawn by the OS/browser itself, not something
+    // any fixed constant can promise to match everywhere. Instead, this asks the browser
+    // directly: an offscreen probe <select> - same classes, single option matching the real
+    // text, width left to size itself naturally - lays out exactly as wide as this browser wants
+    // to render that text with its own arrow, on this exact system. `minCh`/`maxCh` stay
+    // expressed in roughly character terms for callers, converted using this element's own
+    // "0"-glyph width (measureTextPx), since only they still need an actual estimate.
+    function autoWidthSelect(node: HTMLSelectElement, opts: { text: string; minCh: number; maxCh: number }) {
+        const probe = document.createElement("select");
+        probe.className = node.className;
+        probe.style.width = "auto";
+        probe.style.position = "fixed";
+        probe.style.visibility = "hidden";
+        probe.style.left = "-9999px";
+        probe.setAttribute("aria-hidden", "true");
+        probe.tabIndex = -1;
+        document.body.appendChild(probe);
+
+        function apply(o: typeof opts) {
+            probe.innerHTML = "";
+            const opt = document.createElement("option");
+            opt.textContent = o.text || " ";
+            probe.appendChild(opt);
+            const naturalWidth = probe.getBoundingClientRect().width;
+            const chPx = measureTextPx("0", getComputedStyle(node).font) || 8;
+            const minPx = o.minCh * chPx;
+            const maxPx = o.maxCh * chPx;
+            node.style.width = `${Math.max(minPx, Math.min(maxPx, naturalWidth))}px`;
+        }
+        apply(opts);
+        return {
+            update: apply,
+            destroy() {
+                probe.remove();
+            },
+        };
     }
 
     // Grows a multiline textbox to exactly fit its content (one line when empty/single-line,
@@ -255,7 +341,7 @@
         };
     }
 
-    function toSimpleDisplay(ctrl: ScriptControlData): string {
+    function toSimpleDisplay(ctrl: SimpleValueLike): string {
         const v = ctrl.value ?? "";
         switch (ctrl.simpleEditor) {
             case "boolean":
@@ -1036,9 +1122,17 @@
     {@const tmplData = expressionType && templates.length > 0 ? getExpressionTemplateData(value, expressionType) : null}
     {@const inTemplateMode = tmplData !== null && !expressionOverrides.has(overrideKey)}
     {#if templates.length > 0}
-        <!-- Template / expression mode toggle -->
+        <!-- Template / expression mode toggle - sized to the selected label (not a fixed
+             max-width) for the same reason as the object picker below: a native <select>
+             otherwise sizes to its widest *option* (e.g. "player answers a yes/no question"),
+             staying that wide even once a much shorter condition like "random chance" is picked. -->
         <select
-            class="select text-xs py-0 px-1 max-w-40"
+            class="select text-xs py-0 px-1"
+            use:autoWidthSelect={{
+                text: inTemplateMode ? tmplData!.templateName : t("scriptEditor.expressionOption"),
+                minCh: 8,
+                maxCh: 36,
+            }}
             value={inTemplateMode ? tmplData!.templateName : "expression"}
             onchange={(e) => {
                 const v = (e.target as HTMLSelectElement).value;
@@ -1060,45 +1154,139 @@
     {#if inTemplateMode && tmplData}
         <!-- Template controls (e.g. object picker for Got(#object#)) -->
         {#each tmplData.controls as ctrl (ctrl.name)}
-            {#if ctrl.simpleEditor === "objects"}
+            {#if ctrl.controlType === "label"}
+                <!-- Static caption between controls, e.g. RandomChance's "% of the time" -->
+                <span class="text-surface-600-400 select-none">{ctrl.caption ?? ""}</span>
+            {:else if ctrl.simpleEditor === "boolean"}
+                {@const boolSimple = inTemplateParamSimpleMode(overrideKey, ctrl)}
+                <!-- Boolean: yes / no / expression dropdown, no separate widget - mirrors
+                     valueControl's non-template boolean handling. -->
                 <select
-                    class="select text-xs py-0 px-1 max-w-40"
-                    value={ctrl.value ?? ""}
+                    class="select text-xs py-0 px-1 max-w-32"
+                    value={boolSimple ? ctrl.value : "expression"}
                     onchange={(e) => {
-                        const newVal = (e.target as HTMLSelectElement).value;
-                        onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                        const v = (e.target as HTMLSelectElement).value;
+                        const paramKey = templateParamKey(overrideKey, ctrl.name);
+                        if (v === "expression") {
+                            templateParamOverrides.add(paramKey);
+                        } else {
+                            templateParamOverrides.delete(paramKey);
+                            onchange(buildTemplateExpression(tmplData!, ctrl.name, v));
+                        }
                     }}
                 >
-                    <option value=""></option>
-                    {#each objectNames as name (name)}
-                        <option value={name}>{name}</option>
-                    {/each}
+                    <option value="true">{t("scriptEditor.yesOption")}</option>
+                    <option value="false">{t("scriptEditor.noOption")}</option>
+                    <option value="expression">{t("scriptEditor.expressionOption")}</option>
                 </select>
-            {:else if ctrl.simpleEditor === "number" || ctrl.simpleEditor === "numberdouble"}
-                <input
-                    type="number"
-                    min={ctrl.minimum ?? undefined}
-                    max={ctrl.maximum ?? undefined}
-                    step={ctrl.increment ?? (ctrl.simpleEditor === "numberdouble" ? "any" : undefined)}
-                    class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
-                    placeholder={ctrl.simpleLabel ?? ctrl.name}
-                    value={ctrl.value ?? ""}
+                {#if !boolSimple}
+                    <ExpressionInput
+                        value={ctrl.value ?? ""}
+                        onchange={(v) => onchange(buildTemplateExpression(tmplData!, ctrl.name, v))}
+                        {objectNames}
+                        class="input text-xs py-0 px-1"
+                        minCh={16}
+                        maxCh={64}
+                    />
+                {/if}
+            {:else if ctrl.simpleEditor}
+                {@const paramKey = templateParamKey(overrideKey, ctrl.name)}
+                {@const paramSimple = inTemplateParamSimpleMode(overrideKey, ctrl)}
+                <!-- Labelled mode toggle (e.g. "object"/"flag name" vs "expression") - every
+                     simple editor gets one, since even a plain quoted-string field (e.g.
+                     GetBoolean's "flag name") needs an escape hatch to an arbitrary expression,
+                     not just object/number pickers whose own widget can't hold one at all. -->
+                <select
+                    class="select text-xs py-0 px-1 max-w-28"
+                    value={paramSimple ? (ctrl.simpleLabel ?? "simple") : "expression"}
                     onchange={(e) => {
-                        const newVal = (e.target as HTMLInputElement).value;
-                        onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                        const v = (e.target as HTMLSelectElement).value;
+                        if (v === "expression") {
+                            templateParamOverrides.add(paramKey);
+                        } else {
+                            templateParamOverrides.delete(paramKey);
+                            // Switching back to the simple widget only takes effect visually if
+                            // the stored value is already simple-shaped (see
+                            // inTemplateParamSimpleMode) - an arbitrary leftover expression (e.g.
+                            // a function call) would otherwise leave the toggle showing
+                            // "object"/"flag name" while the expression box stays put, since
+                            // paramSimple is re-derived from the value's shape on every render.
+                            // Reset to a blank/zero default so the switch is visible immediately,
+                            // mirroring onSwitchToSimple's non-template twin.
+                            if (!isSimpleValue(ctrl)) {
+                                onchange(buildTemplateExpression(tmplData!, ctrl.name, defaultSimpleValue(ctrl.simpleEditor!)));
+                            }
+                        }
                     }}
-                />
+                >
+                    <option value={ctrl.simpleLabel ?? t("scriptEditor.simpleOption")}>{ctrl.simpleLabel ?? t("scriptEditor.simpleOption")}</option>
+                    <option value="expression">{t("scriptEditor.expressionOption")}</option>
+                </select>
+                {#if paramSimple && ctrl.simpleEditor === "objects"}
+                    <select
+                        class="select text-xs py-0 px-1"
+                        use:autoWidthSelect={{ text: ctrl.value ?? "", minCh: 4, maxCh: 46 }}
+                        value={ctrl.value ?? ""}
+                        onchange={(e) => {
+                            const newVal = (e.target as HTMLSelectElement).value;
+                            onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                        }}
+                    >
+                        <option value=""></option>
+                        {#each objectNames as name (name)}
+                            <option value={name}>{name}</option>
+                        {/each}
+                    </select>
+                {:else if paramSimple && (ctrl.simpleEditor === "number" || ctrl.simpleEditor === "numberdouble")}
+                    <input
+                        type="number"
+                        min={ctrl.minimum ?? undefined}
+                        max={ctrl.maximum ?? undefined}
+                        step={ctrl.increment ?? (ctrl.simpleEditor === "numberdouble" ? "any" : undefined)}
+                        class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
+                        placeholder={ctrl.simpleLabel ?? ctrl.name}
+                        value={ctrl.value ?? ""}
+                        onchange={(e) => {
+                            const newVal = (e.target as HTMLInputElement).value;
+                            onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                        }}
+                    />
+                {:else if paramSimple}
+                    <!-- textbox (default): quoted NCalc string literal <-> plain text, matching
+                         valueControl's own textbox handling. -->
+                    <input
+                        type="text"
+                        autocapitalize="off"
+                        class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+                        placeholder={ctrl.simpleLabel ?? ctrl.name}
+                        value={toSimpleDisplay(ctrl)}
+                        onchange={(e) => {
+                            const newVal = fromSimpleToExpression((e.target as HTMLInputElement).value, ctrl.simpleEditor!);
+                            onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
+                        }}
+                    />
+                {:else}
+                    <ExpressionInput
+                        value={ctrl.value ?? ""}
+                        onchange={(v) => onchange(buildTemplateExpression(tmplData!, ctrl.name, v))}
+                        {objectNames}
+                        class="input text-xs py-0 px-1"
+                        minCh={16}
+                        maxCh={64}
+                    />
+                {/if}
             {:else}
-                <input
-                    type="text"
-                    autocapitalize="off"
-                    class="input text-xs py-0 px-1 min-w-16 max-w-32 flex-1"
-                    placeholder={ctrl.simpleLabel ?? ctrl.name}
+                <!-- No <simple>/<simpleeditor> at all (e.g. HasAttribute's "object" field, or
+                     #object#.#property# = #value#'s "value") - there's no simple mode to toggle
+                     to, so always show the full expression editor, same as this snippet's own
+                     top-level fallback below. -->
+                <ExpressionInput
                     value={ctrl.value ?? ""}
-                    onchange={(e) => {
-                        const newVal = (e.target as HTMLInputElement).value;
-                        onchange(buildTemplateExpression(tmplData!, ctrl.name, newVal));
-                    }}
+                    onchange={(v) => onchange(buildTemplateExpression(tmplData!, ctrl.name, v))}
+                    {objectNames}
+                    class="input text-xs py-0 px-1"
+                    minCh={16}
+                    maxCh={64}
                 />
             {/if}
         {/each}

--- a/src/AppShell/src/lib/text-measure.ts
+++ b/src/AppShell/src/lib/text-measure.ts
@@ -1,0 +1,16 @@
+let ctx: CanvasRenderingContext2D | null = null;
+
+// Measures a string's rendered width for a given CSS `font` shorthand (as returned by
+// getComputedStyle(el).font) - used to size a control (a <select> or <input>) to its own
+// current text precisely, rather than approximating via a `ch`-per-character count. That
+// approximation is off by an amount that depends on the actual character mix (the "0" glyph
+// that defines 1ch is wider than the average lowercase letter or space), and the error scales
+// with string length - fine for a short word, visibly wrong for a long phrase.
+export function measureTextPx(text: string, font: string): number {
+    if (!ctx) {
+        ctx = document.createElement("canvas").getContext("2d");
+    }
+    if (!ctx) return 0;
+    ctx.font = font;
+    return ctx.measureText(text).width;
+}

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -187,6 +187,10 @@ export interface ExpressionTemplateControlData {
   simpleEditor: string | null
   simpleLabel: string | null
   options: ControlOption[] | null
+  // <minimum>/<maximum>/<increment> - bounds and step for a "number"/"numberdouble" control.
+  minimum?: number | null
+  maximum?: number | null
+  increment?: number | null
 }
 
 export interface ExpressionTemplateData {

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -183,6 +183,8 @@ export interface ScriptCommandCategoriesData {
 
 export interface ExpressionTemplateControlData {
   name: string
+  controlType: string
+  caption: string | null
   value: string | null
   simpleEditor: string | null
   simpleLabel: string | null

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -121,6 +121,8 @@ internal record ScriptCommandCategoriesData(List<ScriptCategoryInfo> Categories)
 
 internal record ExpressionTemplateControlData(
     string Name,
+    string ControlType,
+    string? Caption,
     string? Value,
     string? SimpleEditor,
     string? SimpleLabel,
@@ -2175,7 +2177,10 @@ public partial class WasmEditorBridge
         }
 
         var controls = definition.Controls
-            .Where(ctrl => ctrl.Attribute != null)
+            // A "label" control (e.g. RandomChance's "% of the time") has no <attribute> - it's
+            // static caption text, not a value - but it still needs to reach the UI in sequence
+            // with the value controls around it, so it can't be dropped by the attribute filter.
+            .Where(ctrl => ctrl.Attribute != null || ctrl.ControlType == "label")
             .Select(ctrl =>
             {
                 var simpleLabel = ctrl.GetString("simple");
@@ -2201,13 +2206,16 @@ public partial class WasmEditorBridge
                 }
 
                 string? paramValue = null;
-                try
+                if (ctrl.Attribute != null)
                 {
-                    paramValue = (string?) templateData.GetAttribute(ctrl.Attribute!);
-                }
-                catch
-                {
-                    /* parameter not present in expression */
+                    try
+                    {
+                        paramValue = (string?) templateData.GetAttribute(ctrl.Attribute);
+                    }
+                    catch
+                    {
+                        /* parameter not present in expression */
+                    }
                 }
 
                 var isNumeric = simpleEditor is "number" or "numberdouble";
@@ -2216,7 +2224,9 @@ public partial class WasmEditorBridge
                 var increment = isNumeric ? GetNumericHint(ctrl, "increment") : null;
 
                 return new ExpressionTemplateControlData(
-                    ctrl.Attribute!,
+                    ctrl.Attribute ?? ctrl.Id,
+                    ctrl.ControlType,
+                    ctrl.Caption,
                     paramValue,
                     simpleEditor,
                     simpleLabel,

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -124,7 +124,11 @@ internal record ExpressionTemplateControlData(
     string? Value,
     string? SimpleEditor,
     string? SimpleLabel,
-    List<ControlOption>? Options
+    List<ControlOption>? Options,
+    // <minimum>/<maximum>/<increment> - bounds and step for a "number"/"numberdouble" control.
+    double? Minimum = null,
+    double? Maximum = null,
+    double? Increment = null
 );
 
 internal record ExpressionTemplateData(
@@ -2206,12 +2210,20 @@ public partial class WasmEditorBridge
                     /* parameter not present in expression */
                 }
 
+                var isNumeric = simpleEditor is "number" or "numberdouble";
+                var minimum = isNumeric ? GetNumericHint(ctrl, "minimum") : null;
+                var maximum = isNumeric ? GetNumericHint(ctrl, "maximum") : null;
+                var increment = isNumeric ? GetNumericHint(ctrl, "increment") : null;
+
                 return new ExpressionTemplateControlData(
                     ctrl.Attribute!,
                     paramValue,
                     simpleEditor,
                     simpleLabel,
-                    options
+                    options,
+                    minimum,
+                    maximum,
+                    increment
                 );
             })
             .ToList();
@@ -2224,6 +2236,14 @@ public partial class WasmEditorBridge
             ),
             WasmEditorJsonContext.Default.ExpressionTemplateData
         );
+    }
+
+    // <minimum>/<maximum>/<increment> can be authored as either an int or a double literal in
+    // the .aslx (e.g. a whole-number bound vs. "0.1") - GetInt/GetDouble each only match their
+    // own literal type, so try both instead of assuming which one a given hint was written as.
+    private static double? GetNumericHint(IEditorControl ctrl, string tag)
+    {
+        return ctrl.GetDouble(tag) ?? (double?)ctrl.GetInt(tag);
     }
 
     // ── Element creation / deletion ───────────────────────────────────────────

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -2271,14 +2271,6 @@ public partial class WasmEditorBridge
         );
     }
 
-    // <minimum>/<maximum>/<increment> can be authored as either an int or a double literal in
-    // the .aslx (e.g. a whole-number bound vs. "0.1") - GetInt/GetDouble each only match their
-    // own literal type, so try both instead of assuming which one a given hint was written as.
-    private static double? GetNumericHint(IEditorControl ctrl, string tag)
-    {
-        return ctrl.GetDouble(tag) ?? (double?)ctrl.GetInt(tag);
-    }
-
     // ── Element creation / deletion ───────────────────────────────────────────
 
     [JSExport]


### PR DESCRIPTION
## Summary
- The expression-template control renderer (`ScriptEditor.svelte`'s `expressionField` snippet, used for `if`/`set`/`foreach` template controls) only offered a simple/expression toggle for `objects` and `number`/`numberdouble` controls.
  - `RandomChance`'s percentile control (`Engine/Core/CoreEditorExpressions.aslx`, `<minimum>0</minimum><maximum>100</maximum>`) now renders a proper `<input type="number" min max step>`, and the equivalent `GamebookCoreEditorExpressions.aslx` control does too.
  - Every other simple-editor kind — the implicit `textbox` default (`GetBoolean`'s "flag name", `GetInt`'s "counter name", `Ask`'s "question", etc.) and `boolean` (`ShowMenu`'s "allow cancel") — now also gets the toggle, matching the property-panel/script-param pipelines.
  - A control with no `<simple>` tag at all (`HasAttribute`'s "object", `#object#.#property# = #value#`'s "value") now renders the full wand-equipped `ExpressionInput`, matching v5, instead of a bare unstyled textbox.
- `WasmEditorBridge.cs` no longer drops "label" controls (e.g. `RandomChance`'s "% of the time", `HasAttribute`'s "Object"/"Attribute" captions) from the attribute-only filter, and threads `ControlType`/`Caption` through `ExpressionTemplateControlData` so the frontend can render them in sequence with the value controls.
- Fixed a bug where switching a control's toggle back to "simple" only cleared the override flag without resetting a non-simple-shaped value, so the simple widget never actually reappeared until the expression was manually cleared.
- Fixed control widths: the condition/template picker and object-picker `<select>`s now size to their actual selected content instead of a fixed max-width, which either truncated long values or (since an unconstrained native `<select>` sizes to its widest *option*) stayed wide once a short one was picked. Landed on measuring the browser's own natural single-option layout via an offscreen probe `<select>` rather than any fixed/estimated reserve, since a native select's dropdown-arrow footprint is drawn by the OS/browser itself and no constant can promise to match it across environments.
- `ExpressionInput.svelte` gained optional `minCh`/`maxCh` props so a field can size itself to its own live-typed content (grows as you type, not just after blur/Enter) instead of a fixed class; `insertAtCursor` now splices into that live text instead of the last-committed value, so opening the insert-object/function picker mid-typing no longer discards unsaved keystrokes.

## Test plan
- [x] `dotnet build --configuration Release` (full solution) — succeeds
- [x] `dotnet test --configuration Release` — all tests pass
- [x] `npm run check` (svelte-check) in `src/AppShell` — 0 errors/warnings
- [x] `npm run lint` (eslint) in `src/AppShell` — clean
- [x] Manual verification in a local draft, per condition/template:
  - `RandomChance`, `Got`/`not Got`, `GetBoolean`/`not GetBoolean`, `GetInt`, `HasAttribute` all round-trip correctly between the visual editor and code view (e.g. `RandomChance(GetRandomInt(1, 50))`, `GetBoolean(player, "opened")`, `HasAttribute(player, "described")`)
  - Toggling a control to "expression" and back to "simple" resets a non-simple value instead of getting stuck
  - Condition/object `<select>`s render their full selected text at any length, confirmed via a diff check between the live control and an offscreen probe (`actualWidth - naturalWidth === 0` in every case)
  - Typing a long expression grows the field live, mid-keystroke
- [x] `node tests/e2e/find-affected-tests.mjs` run; all flagged scripts pass except four pre-existing flakes (`verify-appshell-multi-control-editors`, `verify-appshell-script-adder-filter`, `verify-appshell-tree-filter`, `verify-default-tree-state`, `verify-rename-invalid-name`) individually confirmed via `git stash` to fail identically on the unmodified base branch — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
