### PR TITLE
fix(AppShell): wire up <bold/> control hint for labels

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -963,10 +963,10 @@
                 href={ctrl.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="block px-3 py-1 text-xs text-primary-600-400 italic hover:underline"
+                class={"block px-3 py-1 text-xs text-primary-600-400 italic hover:underline" + (ctrl.bold ? " font-semibold" : "")}
             >{ctrl.caption ?? ""}</a>
         {:else}
-            <div class="px-3 py-1 text-xs text-surface-600-400 italic">
+            <div class={"px-3 py-1 text-xs text-surface-600-400 italic" + (ctrl.bold ? " font-semibold" : "")}>
                 {ctrl.caption ?? ""}
             </div>
         {/if}

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -76,6 +76,8 @@ export interface ControlInfo {
   nullable?: boolean
   // <width> - fixed pixel width for this control, instead of the default flexible sizing.
   width?: number | null
+  // <bold/> - renders a "label" control's caption in bold.
+  bold?: boolean
 }
 
 export interface TabInfo {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -59,7 +59,10 @@ internal record ControlInfo(
     bool Nullable = false,
     // <width> - fixed pixel width for this control (e.g. an exit's "to" object picker), instead
     // of the default flexible sizing.
-    int? Width = null);
+    int? Width = null,
+    // <bold/> - renders a "label" control's caption in bold, e.g. to draw attention to a
+    // warning-style label (a locked exit's "to unlock this" note, a disabled-feature notice).
+    bool Bold = false);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls);
 
@@ -4298,6 +4301,7 @@ public partial class WasmEditorBridge
         var sourceType = isDictionary ? ctrl.GetString("sourcetype") : null;
 
         var href = ctrl.ControlType == "label" ? ctrl.GetString("href") : null;
+        var bold = ctrl.ControlType == "label" && ctrl.GetBool("bold");
 
         var isNumeric = ctrl.ControlType is "number" or "numberdouble";
         var minimum = isNumeric ? GetNumericHint(ctrl, "minimum") : null;
@@ -4317,7 +4321,8 @@ public partial class WasmEditorBridge
             Freetext: freetext,
             Minimum: minimum, Maximum: maximum, Increment: increment,
             Nullable: nullable,
-            Width: ctrl.Width);
+            Width: ctrl.Width,
+            Bold: bold);
     }
 
     // <minimum>/<maximum>/<increment> can be authored as either an int or a double literal in


### PR DESCRIPTION
## Summary
- Part of #2116.
- `<bold/>` was fully dead (2 uses: an exit's "to unlock this exit..." warning-style note in `CoreEditorExit.aslx:50`, and a container's disabled-feature notice in `CoreEditorObjectContainer.aslx:20`) - a `"label"` control's caption always rendered in normal weight regardless of the tag.
- Threads `ctrl.GetBool("bold")` through `ToControlInfo` into a conditional `font-semibold` class on both label rendering branches (plain text and `href` link) in `PropertyEditor.svelte`.

## Test plan
- [x] `dotnet build --configuration Release`
- [x] `dotnet test --configuration Release` (all passing)
- [x] `npm run check` / `npm run lint` in `src/AppShell` (clean)
- [x] `node tests/e2e/find-affected-tests.mjs` + ran verify-appshell-exits-editor against a local dev server - passes.
- [x] Manual check in-browser: checked an exit's "Locked" box (with no name set) to surface the "To unlock this exit during the game or to change its visibility using a script, you must give it a name below." label, and confirmed via computed style that it now renders with `font-weight: 600` (previously 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)