### PR TITLE
test(e2e): fix stale Pattern-row locator in multi-control-editors script

### DIFF
--- a/tests/e2e/verify-appshell-multi-control-editors.mjs
+++ b/tests/e2e/verify-appshell-multi-control-editors.mjs
@@ -75,12 +75,13 @@ try {
     await page.waitForSelector('text=Command:', { timeout: 10000 });
 
     // Scoped tightly to the Pattern row's own wrapper (two levels up from the "Pattern:" label:
-    // span -> label/select row -> flex-col wrapper) and to its *direct* children only - a plain
-    // input[type=text].first() would instead match the sidebar's "Filter game objects" textbox,
-    // and an unscoped descendant search would also catch the "Unresolved object text" control
-    // that shares the same outer flex-col ancestor.
+    // span -> label/select row -> flex-col wrapper). The select is a descendant (not necessarily
+    // a direct child - PropertyEditor.svelte wraps it in a <label> for accessibility, see #2137)
+    // but this scoping still avoids matching the sidebar's "Filter game objects" textbox and the
+    // "Unresolved object text" control that shares the same outer flex-col ancestor, since
+    // neither is a descendant of patternRow.
     const patternRow = page.getByText('Pattern:', { exact: true }).locator('xpath=../..');
-    const patternModeSelect = patternRow.locator(':scope > select, :scope > div > select').first();
+    const patternModeSelect = patternRow.locator('select').first();
     await patternModeSelect.waitFor({ state: 'visible', timeout: 5000 });
     const patternInput = patternRow.locator(':scope > input[type=text]');
     await patternInput.waitFor({ state: 'visible', timeout: 5000 });


### PR DESCRIPTION
## Summary
- `verify-appshell-multi-control-editors.mjs` timed out on `getByText('Pattern:', { exact: true }).locator('../..').locator(':scope > select, :scope > div > select').first()`, failing consistently on both `main` and this branch.
- Root cause: #2137 (the accessibility pass) wrapped the Pattern control's mode `<select>` in a `<label>` instead of a plain `<div>` for correct native label association (`src/AppShell/src/components/PropertyEditor.svelte`) — a deliberate, correct app change. The test's CSS locator hardcoded the `div` tag, so it stopped matching and the script started failing on every run.
- Fix is test-only: scope the select lookup by descendant (`patternRow.locator('select').first()`) instead of direct-child-with-tag. This still avoids matching the sidebar's "Filter game objects" textbox and the "Unresolved object text" control, since neither is a descendant of the Pattern row's own wrapper.

## Test plan
- [x] `dotnet build src/WasmEditor/WasmEditor.csproj && dotnet build src/WasmPlayer/WasmPlayer.csproj`
- [x] `./dev.sh --port 5199`
- [x] `node tests/e2e/verify-appshell-multi-control-editors.mjs http://localhost:5199` — all 16 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)