### PR TITLE
fix(AppShell): wire up <colour> control hint for script textboxes

### DIFF
--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -977,11 +977,24 @@
             class="input text-xs py-0 px-1"
             wrapperClass="min-w-32 max-w-96 flex-1"
         />
+    {:else if (ctrl.controlType === "textbox" || ctrl.controlType === "richtext") && ctrl.multiline}
+        <!-- multiline textbox (e.g. @failed's fallback-script text, a // comment) - keeps
+             embedded newlines, auto-sized to the height of its content. -->
+        <textarea
+            autocapitalize="off"
+            rows="1"
+            class={"input text-xs py-0.5 px-1 min-w-16 resize-none overflow-hidden" + (ctrl.expand ? " w-full" : " max-w-48")}
+            style={ctrl.colour ? `color: ${ctrl.colour}` : undefined}
+            value={ctrl.value ?? ""}
+            use:autoResizeTextarea={ctrl.value ?? ""}
+            onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLTextAreaElement).value)}
+        ></textarea>
     {:else if ctrl.controlType === "textbox" || ctrl.controlType === "richtext"}
         <input
             type="text"
             autocapitalize="off"
-            class="input text-xs py-0 px-1 min-w-16 max-w-48 flex-1"
+            class={"input text-xs py-0 px-1 min-w-16 flex-1" + (ctrl.expand ? " w-full" : " max-w-48")}
+            style={ctrl.colour ? `color: ${ctrl.colour}` : undefined}
             value={ctrl.value ?? ""}
             onchange={(e) => onSetParam(scriptIndex, ctrl.attribute!, (e.target as HTMLInputElement).value)}
         />

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -158,6 +158,9 @@ export interface ScriptControlData {
   minimum?: number | null
   maximum?: number | null
   increment?: number | null
+  // <colour> - renders a "textbox" control's text in the given CSS colour name (e.g. "Red" for
+  // @failed's fallback-script text, "Green" for a // comment) as warning/info styling.
+  colour?: string | null
 }
 
 export interface ElseIfClauseData {

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -119,7 +119,10 @@ internal record ScriptControlData(
     // editor (e.g. Grid_DrawShape's opacity, 0.0-1.0 step 0.1).
     double? Minimum = null,
     double? Maximum = null,
-    double? Increment = null
+    double? Increment = null,
+    // <colour> - renders a "textbox" control's text in the given CSS colour name (e.g. "Red"
+    // for @failed's fallback-script text, "Green" for a // comment) as warning/info styling.
+    string? Colour = null
 );
 
 internal record ElseIfClauseData(string Id, string Expression, List<ScriptNodeData> Scripts);
@@ -4043,6 +4046,7 @@ public partial class WasmEditorBridge
         var multiline = ctrl.GetBool("multiline");
         var expand = ctrl.Expand;
         var freetext = ctrl.GetBool("freetext");
+        var colour = ctrl.GetString("colour");
 
         string? useTemplates = null;
 
@@ -4116,7 +4120,8 @@ public partial class WasmEditorBridge
             freetext,
             minimum,
             maximum,
-            increment
+            increment,
+            colour
         );
     }
 


### PR DESCRIPTION
## Summary
- Part of #2116, and closes out the issue's full tag list.
- `<colour>` was fully dead (2 uses: `@failed`'s fallback-script text in red, a `//` comment's text in green, both `CoreEditorScriptsScripts.aslx`) - same family as #2115's `<multiline/>`/`<expand/>` fix (a script-control hint, not a property-panel one).
- While wiring it up, found that `@failed`/`//`'s controls also declare `<multiline/>`/`<expand/>` (the tags #2115 fixed) but never actually got that fix. #2115 only patched the `"expression"` controltype's textbox *simple editor* rendering path (used by e.g. Print's message); `@failed`/`//` use `controltype=textbox` directly, a separate branch in `ScriptEditor.svelte` that still rendered a plain single-line `<input>` regardless of the hints. `ScriptControlData.Multiline`/`Expand` were already read unconditionally in `BuildScriptControlData` - the gap was purely on the frontend, in a code path #2115 didn't touch. Coloring a still-single-line box for what's meant to be multi-line fallback-script/comment text would have been a confusing half-fix, so this PR completes multiline/expand for that controltype too, in the same branch, alongside colour.
- Adds `Colour` to `ScriptControlData`, and mirrors the existing simple-editor multiline/expand rendering (growing textarea) into the direct `"textbox"`/`"richtext"` controlType branch of `ScriptEditor.svelte`, with the colour applied as an inline `color` style on both the textarea and the (still-used-by-other-controls) plain input.

## Test plan
- [x] `dotnet build --configuration Release`
- [x] `dotnet test --configuration Release` (all passing)
- [x] `npm run check` / `npm run lint` in `src/AppShell` (clean)
- [x] `node tests/e2e/find-affected-tests.mjs` + ran the relevant flagged scripts (verify-appshell-code-view, verify-appshell-script-label-stacks-below, verify-appshell-scripteditor-row-buttons, verify-appshell-scripteditor-selection-toolbar) against a local dev server - all pass.
- [x] Manual check in-browser: added a `// Comment` script command and confirmed via computed style it's now a `<textarea>` (`rows: 1`, auto-growing height) with `color: green` (previously a plain `<input>` with no color). Typed multi-line text into it and confirmed the box grows to fit, staying green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)