### PR TITLE
fix(AppShell): wire up <keyprompt> for multi controltype

### DIFF
--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -820,6 +820,7 @@
                     value={attrValue(ctrl.subAttribute)}
                     keySource={ctrl.source === "object" ? "object" : "text"}
                     keyLabel={ctrl.keyName}
+                    keyPrompt={ctrl.keyPrompt}
                 />
             {/if}
         </div>
@@ -1031,6 +1032,7 @@
                             value={attrValue(ctrl.subAttribute)}
                             keySource={ctrl.source === "object" ? "object" : "text"}
                             keyLabel={ctrl.keyName}
+                            keyPrompt={ctrl.keyPrompt}
                         />
                     </div>
                 {/if}

--- a/src/AppShell/src/components/ScriptDictionaryEditor.svelte
+++ b/src/AppShell/src/components/ScriptDictionaryEditor.svelte
@@ -18,9 +18,13 @@
         // <keyname> - overrides the generic "entry key" wording in the add-row placeholder/
         // labels with a more specific noun (e.g. "Object" for useon/selfuseon/give/giveto).
         keyLabel?: string | null;
+        // <keyprompt> - a longer descriptive sentence (e.g. "Please enter the name of the
+        // object..."), shown as a tooltip on the add-row input alongside keyLabel's shorter
+        // placeholder/aria-label wording.
+        keyPrompt?: string | null;
     }
 
-    let { elementKey, attribute, value, isLocked = false, keySource = "text", keyLabel = null }: Props = $props();
+    let { elementKey, attribute, value, isLocked = false, keySource = "text", keyLabel = null, keyPrompt = null }: Props = $props();
 
     let items = $derived.by<{key: string, value: string}[]>(() => {
         try {
@@ -153,6 +157,7 @@
                 <select
                     class="select text-xs py-0.5 px-1.5 flex-1"
                     aria-label={keyLabel ? t("scriptDictionaryEditor.addEntryKeyAriaLabelWithLabel", { label: keyLabel }) : t("scriptDictionaryEditor.addEntryKeyAriaLabel")}
+                    title={keyPrompt ?? undefined}
                     data-staging
                     bind:value={newKey}
                 >
@@ -168,6 +173,7 @@
                     class="input text-xs py-0.5 px-1.5 flex-1"
                     placeholder={keyLabel ? t("scriptDictionaryEditor.addEntryKeyPlaceholderWithLabel", { label: keyLabel }) : t("scriptDictionaryEditor.addEntryKeyPlaceholder")}
                     aria-label={keyLabel ? t("scriptDictionaryEditor.addEntryKeyAriaLabelWithLabel", { label: keyLabel }) : t("scriptDictionaryEditor.addEntryKeyAriaLabel")}
+                    title={keyPrompt ?? undefined}
                     data-staging
                     bind:value={newKey}
                     onkeydown={(e) => { if (e.key === "Enter") onAdd(); }}

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -4213,7 +4213,7 @@ public partial class WasmEditorBridge
             var caption = ctrl.Caption ?? ctrl.GetString("selfcaption");
             return new ControlInfo(ctrl.Id, ctrl.ControlType, caption, options, subEditors, ctrl.Attribute,
                 multiTpCommands, Source: ctrl.GetString("source"), Advanced: !ctrl.IsControlVisibleInSimpleMode, CheckboxCaption: ctrl.GetString("checkbox"),
-                KeyName: ctrl.GetString("keyname"));
+                KeyName: ctrl.GetString("keyname"), KeyPrompt: ctrl.GetString("keyprompt"));
         }
         else if (ctrl.ControlType == "elementslist")
         {


### PR DESCRIPTION
## Summary
- `<keyprompt>` was silently dropped whenever declared on a "multi" controltype control (useon/selfuseon/give/giveto in `CoreEditorObjectUseGive.aslx`) — `ToControlInfo`'s `"multi"` branch never read it, even though `ControlInfo.KeyPrompt` and the reading pattern for it already exist for stringdictionary/gamebookoptions controls.
- Threads `ctrl.GetString("keyprompt")` through the `"multi"` branch alongside the just-added `KeyName` (#2153), and wires it into `ScriptDictionaryEditor.svelte`'s existing `keyLabel` prop as a tooltip (`title` attribute) on the add-row input — `keyPrompt`'s longer descriptive sentence (e.g. "Please enter the object name") doesn't fit as placeholder/aria-label text the way `keyLabel`'s short noun ("Object") does.

Stacked on #2153 (base branch set to `fix/editor-keyname-hint`) since it depends on the `KeyName`/`keyLabel` plumbing added there. Part of #2116.

## Test plan
- [x] `dotnet build --configuration Release` / `dotnet test --configuration Release` — all pass
- [x] `npm run check` / `npm run lint` in `src/AppShell` — clean
- [x] `node tests/e2e/find-affected-tests.mjs` — ran all 41 flagged scripts; 36 pass, 5 confirmed pre-existing failures unrelated to this change (verified via `git stash` A/B comparison on the same server)
- [x] Manual verification in-browser: enabled Use/Give on an object, set "Use (other object) on this" to "Handle objects individually" — the add-object dropdown now shows `title="Please enter the object name"` (resolved `[EditorObjectUseGivePleaseenter]` text) alongside the existing "Select Object…"/"Add Object" wording from `<keyname>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)