### PR TITLE
test(e2e): disambiguate toast locator in verify-rename-invalid-name

### DIFF
--- a/tests/e2e/verify-rename-invalid-name.mjs
+++ b/tests/e2e/verify-rename-invalid-name.mjs
@@ -72,8 +72,11 @@ async function run() {
     if (!borderClass?.includes('border-error-500')) throw new Error('Expected name input to get an error border');
     console.log('PASS: name input gets an error border');
 
-    // A toast should also have fired, rendered at the layout level.
-    const toast = page.locator('[role="alert"]', { hasText: /invalid/i });
+    // A toast should also have fired, rendered at the layout level. Scoped to Toast.svelte's
+    // "preset-filled-*" class (not just [role="alert"]) since PropertyEditor's tab-scoped inline
+    // error paragraph also picked up role="alert" in a later accessibility pass, making the two
+    // ambiguous under a bare role selector.
+    const toast = page.locator('[role="alert"][class*="preset-filled"]', { hasText: /invalid/i });
     await toast.waitFor({ timeout: 5000 });
     console.log(`PASS: toast notification shown: "${await toast.textContent()}"`);
 


### PR DESCRIPTION
## Summary
- `tests/e2e/verify-rename-invalid-name.mjs` failed on `main` (verified against a clean checkout) with a Playwright strict-mode violation: `[role="alert"]` matched both the toast and the tab-scoped inline validation error.
- `PropertyEditor.svelte`'s inline error `<p>` picked up `role="alert"` in a later accessibility pass, which wasn't the case when this test was originally written — it now collides with `Toast.svelte`'s layout-level toast under a bare role selector.
- Scoped the test's toast locator to `[role="alert"][class*="preset-filled"]`, which is unique to `Toast.svelte`, rather than touching the inline error's (correct) accessibility role.

## Test plan
- [x] Ran `node verify-rename-invalid-name.mjs` against a live dev server (`./dev.sh --port 5274`) — all 11 assertions pass.
- [x] No source (non-test) files changed, so no lint/build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)