### PR TITLE
fix(AppShell): stop Enter-confirm from re-triggering the trigger button in modals

### DIFF
--- a/src/AppShell/src/components/AddElementModal.svelte
+++ b/src/AppShell/src/components/AddElementModal.svelte
@@ -55,7 +55,10 @@
     });
 
     function handleKeydown(e: KeyboardEvent) {
-        if (e.key === "Enter" && name && !error) confirm();
+        if (e.key === "Enter" && name && !error) {
+            e.preventDefault();
+            confirm();
+        }
         if (e.key === "Escape") oncancel();
     }
 

--- a/src/AppShell/src/components/AddScriptModal.svelte
+++ b/src/AppShell/src/components/AddScriptModal.svelte
@@ -175,7 +175,10 @@
             }
             onClose();
         }
-        if (e.key === "Enter" && selectedCommand) onOk();
+        if (e.key === "Enter" && selectedCommand) {
+            e.preventDefault();
+            onOk();
+        }
         if (e.key === "ArrowDown") { e.preventDefault(); moveSelection(1); }
         if (e.key === "ArrowUp") { e.preventDefault(); moveSelection(-1); }
     }

--- a/src/AppShell/src/components/Combobox.svelte
+++ b/src/AppShell/src/components/Combobox.svelte
@@ -157,11 +157,10 @@
             if (!open) return;
             activeIndex = Math.max(activeIndex - 1, 0);
         } else if (e.key === "Enter") {
+            e.preventDefault();
             if (open && activeIndex >= 0) {
-                e.preventDefault();
                 select(filtered[activeIndex].value);
             } else if (open && filtered.length === 1) {
-                e.preventDefault();
                 select(filtered[0].value);
             } else if (open) {
                 open = false;

--- a/src/AppShell/src/components/ConfirmDialog.svelte
+++ b/src/AppShell/src/components/ConfirmDialog.svelte
@@ -15,7 +15,10 @@
     function handleKeydown(e: KeyboardEvent) {
         if (!$dialogState) return;
         if (e.key === "Escape") respond(null);
-        if (e.key === "Enter") respond($dialogState.choices.at(-1)?.value);
+        if (e.key === "Enter") {
+            e.preventDefault();
+            respond($dialogState.choices.at(-1)?.value);
+        }
     }
 
     function onBackdropClick(e: MouseEvent) {

--- a/src/AppShell/src/components/LinkPickerModal.svelte
+++ b/src/AppShell/src/components/LinkPickerModal.svelte
@@ -43,7 +43,10 @@
     }
 
     function handleTextKeydown(e: KeyboardEvent) {
-        if (e.key === "Enter") confirm();
+        if (e.key === "Enter") {
+            e.preventDefault();
+            confirm();
+        }
     }
 
     let canConfirm = $derived(!!target && (textMode !== "required" || !!text.trim()));

--- a/src/AppShell/src/components/MoveElementModal.svelte
+++ b/src/AppShell/src/components/MoveElementModal.svelte
@@ -30,7 +30,10 @@
     $effect(() => { dialogEl?.focus(); });
 
     function handleKeydown(e: KeyboardEvent) {
-        if (e.key === "Enter" && target) confirm();
+        if (e.key === "Enter" && target) {
+            e.preventDefault();
+            confirm();
+        }
         if (e.key === "Escape") oncancel();
     }
 

--- a/src/AppShell/src/components/MoveToFolderModal.svelte
+++ b/src/AppShell/src/components/MoveToFolderModal.svelte
@@ -27,7 +27,10 @@
     $effect(() => { dialogEl?.focus(); });
 
     function handleKeydown(e: KeyboardEvent) {
-        if (e.key === "Enter" && hasChosen) confirm();
+        if (e.key === "Enter" && hasChosen) {
+            e.preventDefault();
+            confirm();
+        }
         if (e.key === "Escape") oncancel();
     }
 


### PR DESCRIPTION
## Summary

Several modals/pickers handle `Enter` as "confirm" without calling `e.preventDefault()`. When confirming unmounts the modal, `use:trapFocus` (or a dropdown's `close()`) synchronously refocuses the button that opened it — and since the keydown's default action was never prevented, the browser's native "Enter on a focused button fires a click" then re-clicks that trigger, reopening whatever was just closed.

This is what caused the two reported bugs:
- Add Room: type a name, hit Enter → room is created, but the toolbar's Add dropdown reopens.
- Script command picker: select a command via Enter → command is added, but the picker doesn't appear to close (it briefly closes then reopens in the same tick).

An audit of every `trapFocus` consumer and dropdown/combobox-shaped component in `src/AppShell/src` turned up the same gap in five more places, fixed here too:

- `AddElementModal.svelte` — Add Room/Object/Page via Enter (original report)
- `AddScriptModal.svelte` — selecting a script command via Enter (original report)
- `MoveToFolderModal.svelte` — moving a function to a folder via Enter
- `MoveElementModal.svelte` — "Move to..." on a tree item via Enter
- `LinkPickerModal.svelte` — inserting a link via Enter
- `ConfirmDialog.svelte` — confirming *any* destructive action (delete room/object/asset/local draft) via Enter — arguably the highest-impact instance, since it backs every delete confirmation in the app
- `Combobox.svelte` — the shared combobox itself; 2 of its 4 Enter branches (committing typed/pre-filled text, and accepting a default without typing) were missing `preventDefault()`, which indirectly affected any modal wiring `Combobox`'s `onEnter` as its confirm path (e.g. `AddJavascriptModal`)

## Fix

Add `e.preventDefault()` to each Enter branch before the confirming call, matching the pattern already used correctly elsewhere (e.g. `AttributesEditor.svelte`, `VerbsEditor.svelte`, and the other branches of `Combobox`'s own handler).

## Testing

- Verified manually in a local AppShell dev server: created a room via Enter (dropdown stays closed), added a script command via Enter (picker closes), deleted a local draft via Enter on the confirm dialog (dialog closes, no re-trigger), and moved an object via "Move to..." + Enter (modal closes, no reopen of the context menu).
- `npm run lint` and `npm run check` (svelte-check) both clean in `src/AppShell`.
- Ran all 50 e2e scripts flagged by `node tests/e2e/find-affected-tests.mjs` against a local dev server. 4 failed, but all 4 reproduce identically on unmodified `main` (verified by stashing this change and re-running), so they're pre-existing/environmental, not caused by this change:
  - `verify-rename-invalid-name.mjs` — an unrelated ambiguous `role="alert"` locator issue (separately flagged for a follow-up fix)
  - `verify-appshell-assetpicker-mobile-overflow.mjs`, `verify-appshell-mobile-master-detail.mjs`, `verify-preview-custom-library.mjs` — timeouts/403/502 errors that look environmental to the dev session

🤖 Generated with [Claude Code](https://claude.com/claude-code)