### PR TITLE
fix(AppShell): default new rooms to top level, fix Combobox label/value mixup

### DIFF
--- a/src/AppShell/src/components/AddElementModal.svelte
+++ b/src/AppShell/src/components/AddElementModal.svelte
@@ -17,7 +17,6 @@
     const { elementType, parent = null, folder = null, onconfirm, oncancel }: Props = $props();
 
     let label = $derived(t(`addElementModal.labels.${elementType}`));
-    let heading = $derived(parent ? t("addElementModal.addHeadingIn", { label, parent }) : t("addElementModal.addHeading", { label }));
 
     // Folder picker (Functions only) — lets a function be created straight into an existing or
     // brand-new folder, defaulting to the folder whose "..." menu was used (if any). Mirrors
@@ -30,16 +29,35 @@
     // nothing later to stay in sync with (mirrors CodeEditor's own initial-value-only props).
     let folderTarget = $state(untrack(() => folder ?? ""));
 
-    // Parent picker (Objects only, and only when created under another Object rather than a Room
-    // or at the top level) — scoped to just the clicked object's own ancestor chain, not every
+    // Parent picker (Objects and Rooms, and only when created under another element rather than
+    // at the top level) — scoped to just the clicked element's own ancestor chain, not every
     // object in the game (that's MoveElementModal's job for an existing object). Mirrors
-    // MoveElementModal's own options/Combobox.
+    // MoveElementModal's own options/Combobox. Rooms additionally get an explicit "(top level)"
+    // entry, defaulted to — rooms should default to being created at the top level even when
+    // opened from a room's own "Add Room" menu item, with that room still offered as a
+    // selectable (non-default) option.
     let objectParentOptions: ControlOption[] = $derived(
         elementType === "object" && parent
             ? getPossibleNewObjectParents(parent).map(name => ({ value: name, label: name }))
+            : elementType === "room" && parent
+            ? [
+                { value: "", label: t("moveToFolderModal.topLevel") },
+                ...getPossibleNewObjectParents(parent).map(name => ({ value: name, label: name })),
+            ]
             : []
     );
-    let objectParentTarget = $state(untrack(() => parent ?? ""));
+    let objectParentTarget = $state(untrack(() => elementType === "room" ? "" : (parent ?? "")));
+
+    // Tracks the picker's live selection (when one is shown) rather than the static `parent`
+    // prop, so the heading doesn't keep claiming "in {clicked room}" after the user has changed
+    // the Parent field away from it — most visibly for rooms, whose default is now top level
+    // rather than the clicked room.
+    let effectiveParent = $derived(
+        (elementType === "object" || elementType === "room") && objectParentOptions.length > 0
+            ? (objectParentTarget || null)
+            : parent
+    );
+    let heading = $derived(effectiveParent ? t("addElementModal.addHeadingIn", { label, parent: effectiveParent }) : t("addElementModal.addHeading", { label }));
 
     let dialogEl: HTMLDivElement;
     let inputEl: HTMLInputElement;
@@ -71,7 +89,7 @@
         const result = validateName(name);
         if (result !== "ok") { error = result; return; }
         const target = elementType === "function" ? folderTarget
-            : elementType === "object" && objectParentOptions.length > 0 ? objectParentTarget
+            : (elementType === "object" || elementType === "room") && objectParentOptions.length > 0 ? objectParentTarget
             : null;
         onconfirm(name, target);
     }
@@ -118,7 +136,7 @@
                     class="input bg-surface-50-950 px-2 py-1 text-sm w-full"
                 />
             </div>
-        {:else if elementType === "object" && objectParentOptions.length > 0}
+        {:else if (elementType === "object" || elementType === "room") && objectParentOptions.length > 0}
             <div class="flex flex-col gap-1">
                 <span class="text-xs text-surface-600-400">{t("addElementModal.parentLabel")}</span>
                 <Combobox

--- a/src/AppShell/src/components/Combobox.svelte
+++ b/src/AppShell/src/components/Combobox.svelte
@@ -30,6 +30,13 @@
 
     let open = $state(false);
     let inputValue = $state("");
+    // True only while inputValue holds live typed text the user hasn't committed yet (via
+    // handleInput) — false once it's just redisplaying an already-committed value/selection's
+    // label (select(), the closed-state effect, Escape). Needed because inputValue is now the
+    // *label*, not the raw value: handleBlur used to be able to re-send inputValue as-is after a
+    // select() (label happened to equal the raw value), but doing that today would send the
+    // display label instead of the option's value.
+    let dirty = $state(false);
     let activeIndex = $state(-1);
     let listboxEl = $state<HTMLDivElement | null>(null);
     let inputEl = $state<HTMLInputElement | null>(null);
@@ -51,6 +58,13 @@
 
     let hasEmptyOption = $derived(options.some(o => o.value === ""));
 
+    // The input shows an option's label while closed, never its raw value — e.g. a "(top
+    // level)" option can have an internal sentinel value like "_objects" that a user should
+    // never see.
+    function labelFor(v: string) {
+        return options.find(o => o.value === v)?.label ?? v;
+    }
+
     // Opens downward by default, flips upward when there isn't room below.
     function updatePosition() {
         if (!inputEl) return;
@@ -64,7 +78,7 @@
     }
 
     $effect(() => {
-        if (!open) inputValue = value;
+        if (!open) inputValue = labelFor(value);
     });
 
     // Reset highlight when filtered list changes
@@ -111,7 +125,8 @@
     );
 
     function select(optValue: string) {
-        inputValue = optValue;
+        inputValue = labelFor(optValue);
+        dirty = false;
         open = false;
         activeIndex = -1;
         onchange(optValue);
@@ -119,6 +134,7 @@
 
     function handleFocus() {
         inputValue = "";
+        dirty = false;
         updatePosition();
         open = true;
     }
@@ -126,6 +142,7 @@
     function handleClick() {
         if (!open) {
             inputValue = "";
+            dirty = false;
             updatePosition();
             open = true;
         }
@@ -134,15 +151,17 @@
     function handleBlur() {
         open = false;
         activeIndex = -1;
-        if (inputValue === "") {
-            inputValue = value;
+        if (!dirty || inputValue === "") {
+            inputValue = labelFor(value);
         } else {
             onchange(inputValue);
         }
+        dirty = false;
     }
 
     function handleInput(e: Event) {
         inputValue = (e.target as HTMLInputElement).value;
+        dirty = true;
         open = true;
         oninput?.(inputValue);
     }
@@ -168,11 +187,13 @@
                 // means "leave it as-is", not "clear the field" — e.g. accepting a pre-filled
                 // default by tabbing in and pressing Enter without typing over it.
                 onchange(inputValue === "" ? value : inputValue);
+                dirty = false;
             }
             onEnter?.();
         } else if (e.key === "Escape") {
             open = false;
-            inputValue = value;
+            inputValue = labelFor(value);
+            dirty = false;
             activeIndex = -1;
         }
     }

--- a/src/AppShell/src/components/TreePanel.svelte
+++ b/src/AppShell/src/components/TreePanel.svelte
@@ -563,7 +563,7 @@
         } else if (nt === "room") {
             opts.push(
                 { label: t("elementAdders.objectHere"), action: () => openAddModal("object", id) },
-                { label: t("elementAdders.roomHere"), action: () => openAddModal("room", id) },
+                { label: t("elementAdders.room"), action: () => openAddModal("room", id) },
                 { label: t("elementAdders.exit"), action: () => createExit(id) },
                 { label: t("elementAdders.command"), action: () => createCommand(id) },
                 { label: t("elementAdders.verb"), action: () => createVerb(id) },

--- a/src/AppShell/src/routes/edit/+page.svelte
+++ b/src/AppShell/src/routes/edit/+page.svelte
@@ -149,7 +149,7 @@
         addElementModal.set(null);
         await tick();
         if (!mode) return;
-        if (mode.type === "room") createRoom(name, mode.parent);
+        if (mode.type === "room") createRoom(name, target ?? mode.parent);
         else if (mode.type === "object") createObject(name, target ?? mode.parent);
         else if (mode.type === "page") createPage(name, mode.parent);
         else if (mode.type === "function") {

--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -105,7 +105,6 @@
     "common.moveDown": "Nach unten schieben",
 
     "elementAdders.room": "Neuer Raum",
-    "elementAdders.roomHere": "Neuer Raum hier",
     "elementAdders.object": "Neues Objekt",
     "elementAdders.objectHere": "Neues Objekt hier",
     "elementAdders.pageHere": "Seite hier hinzufügen",

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -105,7 +105,6 @@
     "common.moveDown": "Move down",
 
     "elementAdders.room": "Add Room",
-    "elementAdders.roomHere": "Add Room here",
     "elementAdders.object": "Add Object",
     "elementAdders.objectHere": "Add Object here",
     "elementAdders.pageHere": "Add Page here",

--- a/src/AppShell/static/locales/es.json
+++ b/src/AppShell/static/locales/es.json
@@ -105,7 +105,6 @@
     "common.moveDown": "Bajar",
 
     "elementAdders.room": "Añadir Lugar",
-    "elementAdders.roomHere": "Añadir Lugar aquí",
     "elementAdders.object": "Añadir Objeto",
     "elementAdders.objectHere": "Añadir Objeto aquí",
     "elementAdders.pageHere": "Añadir página aquí",

--- a/src/AppShell/static/locales/xx.json
+++ b/src/AppShell/static/locales/xx.json
@@ -92,7 +92,6 @@
     "common.moveUp": "[Móvé úp]",
     "common.moveDown": "[Móvé dówn]",
     "elementAdders.room": "[Ádd Róóm]",
-    "elementAdders.roomHere": "[Ádd Róóm héré]",
     "elementAdders.object": "[Ádd Óbjéct]",
     "elementAdders.objectHere": "[Ádd Óbjéct héré]",
     "elementAdders.pageHere": "[Ádd Págé héré]",


### PR DESCRIPTION
## Summary

- New rooms created via a room's "..." context menu now default to the top level in the "Add Room" dialog's Parent picker, with the clicked room still offered as a selectable (non-default) option — matches the equivalent "Add Object" flow's picker pattern.
- The menu item itself is renamed from "Add Room here" to "Add Room" (reusing the existing `elementAdders.room` string) since it no longer implies nesting under the clicked room; the unused `elementAdders.roomHere` locale key is removed from en/de/es/xx.
- The dialog's heading now tracks the Parent picker's live selection instead of always assuming the clicked element, so it no longer says `Add Room in "room"` when the picker is set to "(top level)".
- `Combobox` now always displays an option's **label** while closed/typing-committed, instead of its raw **value** — fixes "Move to" showing the internal `_objects` sentinel instead of "(top level)" in the textbox.
- Fixing the above surfaced a second, more serious bug: the blur handler was re-sending the just-displayed label text as the committed `onchange` value, which silently broke "Move to (top level)" for *any* element whenever an option's label differs from its value (confirmed via the raw XML view — the move visually looked like it succeeded but the underlying data never changed). Fixed by tracking whether the input currently holds live-typed text versus a redisplayed label, and only re-committing on blur in the former case.

## Test plan

- [x] `npm run lint` (eslint) in `src/AppShell` — clean
- [x] `npm run check` (svelte-check) in `src/AppShell` — clean
- [x] Manually verified in a local dev server against a fresh draft game:
  - "Add Room" from a room's menu defaults to "(top level)", with the clicked room selectable; confirmed both the top-level and nested outcomes land correctly by inspecting the raw XML (not just the tree UI).
  - Dialog heading updates live between `Add Room` and `Add Room in "room"` as the Parent picker changes.
  - "Move to" → "(top level)" now displays `(top level)` in the textbox (previously showed `_objects`) and the move now actually persists (previously silently no-opped) — verified for both a Room and a plain Object, via raw XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)