### PR TITLE
fix: add expression control and hide-when-empty to script-parameter editors

### DIFF
--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -19,9 +19,10 @@
         // as the user types a longer expression. Left unset, width is whatever `class` says.
         minCh?: number;
         maxCh?: number;
+        ariaLabel?: string;
     }
 
-    let { value, onchange, objectNames, class: className = "", minCh, maxCh }: Props = $props();
+    let { value, onchange, objectNames, class: className = "", minCh, maxCh, ariaLabel }: Props = $props();
 
     // Mirrors `value` so the width (and the field itself) can react on every keystroke, not just
     // on the commit-triggering change event - `value` only advances when the caller's onchange
@@ -187,6 +188,7 @@
         class={className || "input text-xs py-0.5 px-1.5 w-full"}
         style={widthStyle}
         value={liveText}
+        aria-label={ariaLabel}
         oninput={(e) => (liveText = (e.target as HTMLInputElement).value)}
         onchange={(e) => onchange((e.target as HTMLInputElement).value)}
     />

--- a/src/AppShell/src/components/ScriptEditor.svelte
+++ b/src/AppShell/src/components/ScriptEditor.svelte
@@ -968,6 +968,15 @@
             exprKey(scriptIndex, ctrl.attribute!),
             "input text-xs py-0 px-1 min-w-16 max-w-48 flex-1",
         )}
+    {:else if ctrl.controlType === "addparametersbutton"}
+        <!-- Reveals a sibling parameter control that <relatedattribute>/<relatedattributedisplaytype>
+             hides while its attribute is empty (e.g. do/invoke's parameter dictionary) - see
+             CoreEditorScriptsScripts.aslx's "addparametersbutton" controls. -->
+        <button
+            type="button"
+            class="btn btn-sm preset-outlined-primary-500 text-xs py-0 px-1.5 leading-none"
+            onclick={() => onSetParam(scriptIndex, ctrl.attribute!, "{}")}
+        >+ {ctrl.caption}</button>
     {:else if ctrl.controlType === "textbox" && ctrl.isFunctionPicker}
         {@const functionOptions = functionPickerOptions()}
         <Combobox
@@ -1042,12 +1051,11 @@
             {#each matchedFn.parameters as paramName, pi (pi)}
                 <span class="flex items-center gap-1">
                     <span class="text-surface-600-400 text-[10px] whitespace-nowrap">{paramName}:</span>
-                    <input
-                        type="text"
-                        autocapitalize="off"
-                        class="input text-xs py-0 px-1 w-20"
+                    <ExpressionInput
                         value={items[pi].value}
-                        onchange={(e) => onUpdateParam(scriptIndex, ctrl.attribute!, items[pi].key, (e.target as HTMLInputElement).value)}
+                        onchange={(v) => onUpdateParam(scriptIndex, ctrl.attribute!, items[pi].key, v)}
+                        {objectNames}
+                        class="input text-xs py-0 px-1 w-20"
                     />
                 </span>
             {/each}
@@ -1056,12 +1064,11 @@
         <span class="flex flex-wrap items-center gap-1">
             {#each items as item (item.key)}
                 <span class="flex items-center gap-0.5">
-                    <input
-                        type="text"
-                        autocapitalize="off"
-                        class="input text-xs py-0 px-1 w-20"
+                    <ExpressionInput
                         value={item.value}
-                        onchange={(e) => onUpdateParam(scriptIndex, ctrl.attribute!, item.key, (e.target as HTMLInputElement).value)}
+                        onchange={(v) => onUpdateParam(scriptIndex, ctrl.attribute!, item.key, v)}
+                        {objectNames}
+                        class="input text-xs py-0 px-1 w-20"
                     />
                     <button
                         type="button"
@@ -1094,13 +1101,12 @@
                         class="text-surface-600-400 hover:text-primary-600-400 text-xs"
                         onclick={() => toggleCaseExpanded(scriptIndex, paramAttribute, item.key)}
                     >{expanded ? "▼" : "▶"}</button>
-                    <input
-                        type="text"
-                        autocapitalize="off"
-                        class="input text-xs py-0 px-1 min-w-16 max-w-48"
-                        aria-label={t("scriptEditor.caseKeyAriaLabel")}
+                    <ExpressionInput
                         value={item.key}
-                        onchange={(e) => onRenameCase(scriptIndex, paramAttribute, item.key, (e.target as HTMLInputElement).value)}
+                        onchange={(v) => onRenameCase(scriptIndex, paramAttribute, item.key, v)}
+                        {objectNames}
+                        ariaLabel={t("scriptEditor.caseKeyAriaLabel")}
+                        class="input text-xs py-0 px-1 min-w-16 max-w-48"
                     />
                     <button
                         type="button"

--- a/src/EditorCore/EditableIfScript.cs
+++ b/src/EditorCore/EditableIfScript.cs
@@ -408,6 +408,11 @@ public class IfExpressionControlDefinition : IEditorControl
         return Task.FromResult(true);
     }
 
+    public bool IsControlVisibleSync(IEditorData data)
+    {
+        return true;
+    }
+
     public IEditorDefinition Parent => null;
 
     public bool IsControlVisibleInSimpleMode => true;

--- a/src/EditorCore/EditorControl.cs
+++ b/src/EditorCore/EditorControl.cs
@@ -99,6 +99,11 @@ internal class EditorControl : IEditorControl
         return m_visibilityHelper.IsVisible(data);
     }
 
+    public bool IsControlVisibleSync(IEditorData data)
+    {
+        return m_visibilityHelper.IsVisibleIgnoringExpression(data);
+    }
+
     public IEditorDefinition Parent => m_parent;
 
     public bool IsControlVisibleInSimpleMode { get; }

--- a/src/EditorCore/EditorVisibilityHelper.cs
+++ b/src/EditorCore/EditorVisibilityHelper.cs
@@ -12,6 +12,7 @@ internal class EditorVisibilityHelper
     private readonly IList<string> m_notVisibleIfElementInheritsType;
     private readonly EditorDefinition m_parent;
     private readonly string m_relatedAttribute;
+    private readonly bool m_relatedAttributeNegate;
     private readonly Expression<bool> m_visibilityExpression;
     private readonly IList<string> m_visibleIfElementInheritsType;
     private readonly string m_visibleIfRelatedAttributeIsType;
@@ -29,6 +30,7 @@ internal class EditorVisibilityHelper
             m_alwaysVisible = false;
         }
 
+        m_relatedAttributeNegate = source.Fields.GetAsType<bool>("relatedattributenegate");
         m_visibleIfRelatedAttributeIsType = source.Fields.GetString("relatedattributedisplaytype");
         m_visibleIfElementInheritsType = source.Fields.GetAsType<QuestList<string>>("mustinherit");
         m_notVisibleIfElementInheritsType = source.Fields.GetAsType<QuestList<string>>("mustnotinherit");
@@ -81,6 +83,26 @@ internal class EditorVisibilityHelper
             }
         }
 
+        return IsVisibleSyncCore(data);
+    }
+
+    // Synchronous subset of IsVisible, used by callers (e.g. script-command control building) that
+    // can't await an <onlydisplayif> expression evaluation. A control that declares <onlydisplayif>
+    // is treated as always visible here - this mirrors those callers' previous behaviour of applying
+    // no visibility filtering at all, rather than silently hiding controls whose gate can't be
+    // evaluated synchronously.
+    public bool IsVisibleIgnoringExpression(IEditorData data)
+    {
+        if (m_alwaysVisible)
+        {
+            return true;
+        }
+
+        return IsVisibleSyncCore(data);
+    }
+
+    private bool IsVisibleSyncCore(IEditorData data)
+    {
         if (m_notVisibleIfElementInheritsType != null)
         {
             if (m_notVisibleIfElementInheritsTypeElement == null)
@@ -112,10 +134,19 @@ internal class EditorVisibilityHelper
                 relatedAttributeValue = ((IDataWrapper) relatedAttributeValue).GetUnderlyingValue();
             }
 
+            // An empty string (e.g. an unset script-parameter expression, which saves as "" rather
+            // than null once touched - see DoScript/InvokeScript) counts as "no value" here, the same
+            // as null, so <relatedattributedisplaytype> can mean "has a real value" rather than "has
+            // any value including empty".
+            if (relatedAttributeValue is string stringValue && string.IsNullOrEmpty(stringValue))
+            {
+                relatedAttributeValue = null;
+            }
+
             var relatedAttributeType = relatedAttributeValue == null
                 ? "null"
                 : WorldModel.ConvertTypeToTypeName(relatedAttributeValue.GetType());
-            return relatedAttributeType == m_visibleIfRelatedAttributeIsType;
+            return (relatedAttributeType == m_visibleIfRelatedAttributeIsType) != m_relatedAttributeNegate;
         }
 
         if (m_visibleIfElementInheritsType != null)

--- a/src/EditorCore/IEditorControl.cs
+++ b/src/EditorCore/IEditorControl.cs
@@ -18,4 +18,5 @@ public interface IEditorControl
     double? GetDouble(string tag);
     bool GetBool(string tag);
     Task<bool> IsControlVisible(IEditorData data);
+    bool IsControlVisibleSync(IEditorData data);
 }

--- a/src/EditorCore/SubEditorControlData.cs
+++ b/src/EditorCore/SubEditorControlData.cs
@@ -92,6 +92,11 @@ public class AttributeSubEditorControlData : IEditorControl
         return Task.FromResult(true);
     }
 
+    public bool IsControlVisibleSync(IEditorData data)
+    {
+        return true;
+    }
+
     public int? Width => null;
 
     public IEditorDefinition Parent => null;

--- a/src/Engine/Core/CoreEditorScriptsScripts.aslx
+++ b/src/Engine/Core/CoreEditorScriptsScripts.aslx
@@ -196,8 +196,6 @@
       <breakbefore/>
     </control>
 
-    <!-- TO DO (#2070): Popup needs to have ExpressionControl in it -->
-
     <control>
       <controltype>scriptdictionary</controltype>
       <caption>[EditorScriptsScriptsCases2]</caption>
@@ -268,8 +266,6 @@
       <caption>[EditorScriptsScriptsWithparameters]</caption>
     </control>
 
-    <!-- TO DO (#2070): Popup needs to have ExpressionControl in it -->
-
     <control>
       <controltype>list</controltype>
       <caption>[EditorScriptsScriptsParameters]</caption>
@@ -281,7 +277,6 @@
 
   <editor>
     <appliesto>do</appliesto>
-    <!-- TO DO (#2070): Don't display parameter #2 if it's null or empty -->
     <display>Run #0's '#1' script with parameters from dictionary #2</display>
     <category>[EditorScriptsScriptsScripts]</category>
     <add>[EditorScriptsScriptsRunanobjects]</add>
@@ -316,17 +311,30 @@
       <controltype>label</controltype>
       <caption>[EditorScriptsScriptsUsingparameter]</caption>
       <breakbefore/>
+      <relatedattribute>2</relatedattribute>
+      <relatedattributedisplaytype>string</relatedattributedisplaytype>
     </control>
 
     <control>
       <controltype>expression</controltype>
       <attribute>2</attribute>
+      <relatedattribute>2</relatedattribute>
+      <relatedattributedisplaytype>string</relatedattributedisplaytype>
+    </control>
+
+    <control>
+      <controltype>addparametersbutton</controltype>
+      <caption>[EditorScriptsScriptsAddParameters]</caption>
+      <attribute>2</attribute>
+      <breakbefore/>
+      <relatedattribute>2</relatedattribute>
+      <relatedattributedisplaytype>string</relatedattributedisplaytype>
+      <relatedattributenegate/>
     </control>
   </editor>
 
   <editor>
     <appliesto>invoke</appliesto>
-    <!-- TO DO (#2070): Don't display parameter #1 if it's null or empty -->
     <display>Run '#0' script with parameters from dictionary #1</display>
     <category>[EditorScriptsScriptsScripts]</category>
     <add>[EditorScriptsScriptsRunascript]</add>
@@ -347,11 +355,25 @@
       <controltype>label</controltype>
       <caption>[EditorScriptsScriptsUsingparameter]</caption>
       <breakbefore/>
+      <relatedattribute>1</relatedattribute>
+      <relatedattributedisplaytype>string</relatedattributedisplaytype>
     </control>
 
     <control>
       <controltype>expression</controltype>
       <attribute>1</attribute>
+      <relatedattribute>1</relatedattribute>
+      <relatedattributedisplaytype>string</relatedattributedisplaytype>
+    </control>
+
+    <control>
+      <controltype>addparametersbutton</controltype>
+      <caption>[EditorScriptsScriptsAddParameters]</caption>
+      <attribute>1</attribute>
+      <breakbefore/>
+      <relatedattribute>1</relatedattribute>
+      <relatedattributedisplaytype>string</relatedattributedisplaytype>
+      <relatedattributenegate/>
     </control>
   </editor>
 
@@ -428,8 +450,6 @@
       <caption>[EditorScriptsScriptsWithparameters]</caption>
       <breakbefore/>
     </control>
-
-    <!-- TO DO (#2070): Popup needs to have ExpressionControl in it -->
 
     <control>
       <controltype>list</controltype>

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -686,6 +686,7 @@
   <template name="EditorScriptsScriptsRunobject">Führe vom Objekt</template>
   <template name="EditorScriptsScriptsscriptattribute">folgendendes Skriptattribut aus</template>
   <template name="EditorScriptsScriptsUsingparameter">Verwende zusätzlich Wörterbuch-Parameter</template>
+  <template name="EditorScriptsScriptsAddParameters">Parameter hinzufügen</template>
   <template name="EditorScriptsScriptsRunascript">Ein Skript starten, jenes einen Ausdruck zurückgibt</template>
   <template name="EditorScriptsScriptsInvokescript">Ein Skript starten</template>
   <template name="EditorScriptsScriptsRaiseanerror">Einen Fehler anzeigen</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -685,6 +685,7 @@
   <template name="EditorScriptsScriptsRunobject">Run object</template>
   <template name="EditorScriptsScriptsscriptattribute">script attribute</template>
   <template name="EditorScriptsScriptsUsingparameter">Using parameter dictionary</template>
+  <template name="EditorScriptsScriptsAddParameters">Add parameters</template>
   <template name="EditorScriptsScriptsRunascript">Run a script returned by an expression</template>
   <template name="EditorScriptsScriptsInvokescript">Invoke script</template>
   <template name="EditorScriptsScriptsRaiseanerror">Raise an error</template>

--- a/src/Engine/Core/Languages/EditorEspanol.aslx
+++ b/src/Engine/Core/Languages/EditorEspanol.aslx
@@ -689,6 +689,7 @@
   <template name="EditorScriptsScriptsRunobject">Ejecutar objeto</template>
   <template name="EditorScriptsScriptsscriptattribute">atributo de programa</template>
   <template name="EditorScriptsScriptsUsingparameter">Usando diccionario de parámetros</template>
+  <template name="EditorScriptsScriptsAddParameters">Añadir parámetros</template>
   <template name="EditorScriptsScriptsRunascript">Ejecutar un programa devuelto por una expresión</template>
   <template name="EditorScriptsScriptsInvokescript">Invocar programa</template>
   <template name="EditorScriptsScriptsRaiseanerror">Producir un error</template>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -3966,7 +3966,10 @@ public partial class WasmEditorBridge
             var def = _controller!.GetEditorDefinition(script);
             var editorData = _controller.GetScriptEditorData(script);
             displayString = script.DisplayString();
-            controls = def.Controls.Select(c => BuildScriptControlData(c, editorData)).ToList();
+            controls = def.Controls
+                .Where(c => c.IsControlVisibleSync(editorData))
+                .Select(c => BuildScriptControlData(c, editorData))
+                .ToList();
         }
         catch
         {

--- a/tests/e2e/verify-appshell-switch-cases-editor.mjs
+++ b/tests/e2e/verify-appshell-switch-cases-editor.mjs
@@ -158,7 +158,10 @@ try {
     // ── Remove the "buckler" case ────────────────────────────────────────────────────
     const bucklerCaseRowAfterReload = await caseKeyInput(switchRow, '"buckler"');
     if (!bucklerCaseRowAfterReload) throw new Error('"buckler" case not found after returning to the Scripts tab');
-    const bucklerCaseRow = bucklerCaseRowAfterReload.locator('xpath=..');
+    // Two levels up, not one - the case-key input is now wrapped in ExpressionInput's own
+    // "input + wand button" container (see issue #2070), so its immediate parent no longer has
+    // the row's × remove button as a sibling; the row container is one level above that.
+    const bucklerCaseRow = bucklerCaseRowAfterReload.locator('xpath=../..');
     await bucklerCaseRow.locator('button', { hasText: '×' }).click();
     await page.waitForTimeout(300);
 


### PR DESCRIPTION
## Summary
- Adds the expression wand-picker (`ExpressionInput`) to `switch`'s case-key field and the `()` call-function / `rundelegate` parameter-value fields, instead of plain text boxes.
- Hides `do`/`invoke`'s "Using parameter dictionary" row until it's actually populated, with a new "+ Add parameters" button to reveal it (there was previously no way to bring the row back once hidden, so this closes that gap rather than doing a literal always-hide).
- Closes out all five `TO DO (#2070)` markers in `CoreEditorScriptsScripts.aslx`.

Fixes textadventures/quest#2070.

### Implementation notes
- `EditorVisibilityHelper` gained a synchronous visibility path (`IsVisibleIgnoringExpression`/`IsControlVisibleSync`) since script-command editor controls previously had **no** visibility filtering applied at all (`WasmEditorBridge.BuildScriptNodeData` mapped every control unconditionally) — `<onlydisplayif>` can't be used here since `ScriptCommandEditorData.Name` is always null, so `<relatedattribute>`/`<relatedattributedisplaytype>` is the gate that actually works for this data path.
- Added `<relatedattributenegate/>` to `EditorVisibilityHelper` so the new "+ Add parameters" button can use the inverse of its sibling field's visibility condition.
- An empty string now counts the same as null for `<relatedattributedisplaytype>` purposes, since `do`/`invoke`'s parameter attribute legitimately saves as `""` once touched (see `DoScript`/`InvokeScript`).
- Added an `ariaLabel` passthrough prop to `ExpressionInput.svelte` to preserve the "Case key" accessibility label after the swap.

## Test plan
- [x] `dotnet build --configuration Release` / `dotnet test --configuration Release` (373 tests pass)
- [x] `npm run lint` / `npm run check` in `src/AppShell` (clean)
- [x] `node tests/e2e/find-affected-tests.mjs` run, all 18 flagged scripts pass against a local dev server (one, `verify-appshell-switch-cases-editor.mjs`, needed a locator fix for the new DOM nesting `ExpressionInput` introduces — confirmed via a before/after comparison against `main` that this is a real shape change from this PR, not a flake)
- [x] Manually verified in the browser: `do`/`invoke` parameter row hides by default, "+ Add parameters" reveals it, clearing it back to empty re-hides it; switch case-keys and call-function/delegate parameter values show the wand-button picker
- [x] Confirmed existing `<relatedattribute>` consumers (Inventory tab's take/drop message fields) are unaffected by the `EditorVisibilityHelper` refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)