### PR TITLE
fix(WasmEditor): convert richtext newlines to <br/> on save, and back on load

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,6 +136,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-appshell-code-view.mjs http://localhost:5174
         working-directory: tests/e2e
+      - run: node verify-appshell-description-newline-roundtrip.mjs http://localhost:5174
+        working-directory: tests/e2e
       - run: node verify-appshell-download-button.mjs http://localhost:5174
         working-directory: tests/e2e
       - run: node verify-appshell-empty-advanced-categories.mjs http://localhost:5174

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -637,6 +637,10 @@ public partial class WasmEditorBridge
                 CultureInfo.InvariantCulture, out var d)
                 ? (object) d
                 : value,
+            // Matches the old Quest 5 desktop editor's RichTextControl: a multi-line textbox's
+            // linebreaks are stored as literal <br/> tags, not raw newlines (which the player
+            // would otherwise collapse). Reversed for display in GetEditorData/ConvertRichtextValuesForEditing.
+            "richtext" => value.Replace("\r\n", "<br/>").Replace("\n", "<br/>"),
             _ => value
         };
 
@@ -1476,6 +1480,16 @@ public partial class WasmEditorBridge
                 IEditableDictionary<IEditableScripts> => "scriptdictionary",
                 _ => "null"
             };
+
+            // Matches the old Quest 5 desktop editor's RichTextControl.Populate: a <multi> control
+            // whose active string sub-editor is richtext (e.g. object descriptions, via
+            // <editors>string=richtext</editors>) shows real linebreaks, not the <br/> markup
+            // they're stored as (see SetAttribute).
+            if (val is string strVal && ctrl.GetDictionary("editors") is { } editors &&
+                editors.TryGetValue("string", out var stringSubEditor) && stringSubEditor == "richtext")
+            {
+                attrs[ctrl.Attribute!] = strVal.Replace("<br/>", "\n").Replace("<br />", "\n");
+            }
         }
 
         foreach (var ctrl in controls.Where(c => c.ControlType == "filter"))
@@ -1488,6 +1502,16 @@ public partial class WasmEditorBridge
 
             attrs[ctrl.Id] = data.GetSelectedFilter(filterGroupName)
                 ?? ctrl.Parent.GetDefaultFilterName(filterGroupName, data);
+        }
+
+        // Matches the old Quest 5 desktop editor's RichTextControl.Populate: show real linebreaks
+        // in the textarea rather than the <br/> markup they're stored as (see SetAttribute).
+        foreach (var ctrl in controls.Where(c => c.ControlType == "richtext" && c.Attribute != null))
+        {
+            if (attrs.TryGetValue(ctrl.Attribute!, out var richtextValue) && richtextValue != null)
+            {
+                attrs[ctrl.Attribute!] = richtextValue.Replace("<br/>", "\n").Replace("<br />", "\n");
+            }
         }
     }
 

--- a/tests/e2e/verify-appshell-description-newline-roundtrip.mjs
+++ b/tests/e2e/verify-appshell-description-newline-roundtrip.mjs
@@ -1,0 +1,87 @@
+// Verifies the fix for room descriptions collapsing linebreaks in the player: a multi-line
+// richtext field (e.g. Room > Description) must be saved as literal <br/> tags in the underlying
+// ASLX (FieldSaver.StringSaver, src/Engine/GameLoader/FieldSaver.cs), matching the old Quest 5
+// desktop editor's RichTextControl save format - and, symmetrically, must show real linebreaks
+// (not literal <br/> markup) when the field is redisplayed for editing (WasmEditorBridge's
+// AddDropdownTypeValues richtext-reversal, src/WasmEditor/WasmEditorBridge.cs), matching
+// RichTextControl.Populate.
+import { chromium } from './lib/tracked-chromium.mjs';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+async function openRoomDescription(page) {
+    await page.click('text=room');
+    await page.getByRole('button', { name: /^Room$/ }).click();
+    await page.waitForSelector('#richtext-description', { timeout: 5000 });
+}
+
+try {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    const gameName = `Description Newline Test ${Date.now()}`;
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', gameName);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    await openRoomDescription(page);
+    await page.locator('#richtext-description').fill('Line one\nLine two');
+    await page.keyboard.press('Tab'); // blur to fire the textarea's onchange handler
+    console.log('PASS: typed a multi-line description into the richtext field');
+
+    // --- Saved form: underlying ASLX must contain literal <br/>, not a raw newline ---
+    await page.click('button[title="Raw XML code view"]');
+    await page.waitForSelector('.cm-editor', { timeout: 5000 });
+    const xmlText = await page.locator('.cm-content').first().innerText();
+    if (!xmlText.includes('Line one<br/>Line two')) {
+        throw new Error(`Expected the raw XML to contain "Line one<br/>Line two", got description area: ${xmlText.match(/<description>[\s\S]{0,80}/)?.[0]}`);
+    }
+    if (xmlText.includes('Line one\nLine two') && !xmlText.includes('Line one<br/>Line two')) {
+        throw new Error('Raw XML contains a literal unconverted newline in the description field');
+    }
+    console.log('PASS: saved ASLX stores the description with a literal <br/> tag, not a raw newline');
+    await page.click('button[title="Raw XML code view"]'); // close (no edits made, so this shouldn't prompt)
+    await page.waitForSelector('[data-value="game"][data-part="branch-control"]', { timeout: 5000 });
+
+    // --- Editing UX: navigating away and back must show real linebreaks, not "<br/>" markup ---
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+    await openRoomDescription(page);
+    const reopenedValue = await page.locator('#richtext-description').inputValue();
+    if (reopenedValue.includes('<br')) {
+        throw new Error(`Expected the richtext textarea to show real linebreaks, but found literal markup: ${JSON.stringify(reopenedValue)}`);
+    }
+    if (reopenedValue !== 'Line one\nLine two') {
+        throw new Error(`Expected textarea value "Line one\\nLine two", got ${JSON.stringify(reopenedValue)}`);
+    }
+    console.log('PASS: reopening the field shows real linebreaks, not <br/> markup (matches v5 desktop editor UX)');
+
+    // --- Persists across a full reload (autosave -> OPFS -> reopen -> re-populate) ---
+    // A bare page.reload() just redirects to /open (isLoaded is in-memory SPA state), so reopen
+    // the draft by name via /open instead, matching verify-appshell-autosave.mjs's convention.
+    await page.locator('.save-chip-saved').waitFor({ state: 'visible', timeout: 10000 });
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('text=Your local drafts', { timeout: 10000 });
+    await page.click(`button:has-text("${gameName}.aslx")`);
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+    await openRoomDescription(page);
+    const afterReloadValue = await page.locator('#richtext-description').inputValue();
+    if (afterReloadValue !== 'Line one\nLine two') {
+        throw new Error(`Expected textarea value "Line one\\nLine two" after reload, got ${JSON.stringify(afterReloadValue)}`);
+    }
+    console.log('PASS: round-trip survives a full page reload (autosaved draft reloaded from OPFS)');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- Room descriptions and other multi-line richtext fields typed with real linebreaks were saved as raw newline characters, which HTML collapses when rendered to the player — linebreaks silently disappeared in-game.
- The old Quest 5 desktop editor's `RichTextControl` did this conversion in both directions (newline → `<br/>` on save, `<br/>` → newline when populating the field for editing), but that logic was dropped when the editor was rewritten as the WasmEditor/AppShell SPA and never reimplemented.
- Restores it at the equivalent point in the new architecture: `WasmEditorBridge.SetAttribute` now converts on commit for the `"richtext"` control type (covers both direct richtext controls and `multi`-control string sub-editors like Room description), and `AddDropdownTypeValues` reverses the conversion when populating the field for editing.
- Deliberately scoped to just the richtext control path (not a blanket engine-level save transform) — an earlier draft of this fix converted newlines for every string field in `FieldSaver`, but that would have also mangled any script-set string containing a literal `\n` for non-display purposes on every save, including `SaveMode.SavedGame`. Matching v5's actual scope (the UI control, not the engine) avoids that.

## Test plan
- [x] `dotnet test --configuration Release` — 384 tests pass
- [x] New browser e2e script `tests/e2e/verify-appshell-description-newline-roundtrip.mjs` (run against a local AppShell dev server): typed a multi-line description, confirmed the saved ASLX contains literal `<br/>` (via the Raw XML code view), confirmed reopening the field shows real linebreaks (not `<br/>` markup), and confirmed it survives a full reload of the autosaved local draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)