### PR TITLE
test(e2e): fix stale "GAME OBJECTS"/"PROPERTIES" pane-header locators

### DIFF
--- a/tests/e2e/lib/tracked-chromium.mjs
+++ b/tests/e2e/lib/tracked-chromium.mjs
@@ -1,7 +1,10 @@
 // Drop-in replacement for `import { chromium } from 'playwright'`, used by every
-// verify-appshell-*.mjs script instead of importing 'playwright' directly. When
-// QUEST_TOUCHED_FILES_DIR is unset (every normal run, local or CI) this is a pure
-// passthrough to the real `chromium` export with zero behavioral difference.
+// verify-appshell-*.mjs script instead of importing 'playwright' directly.
+//
+// Always mocks GitHub's releases API (see mockReleasesApi below) on every
+// context/page a launched browser creates. Beyond that, when
+// QUEST_TOUCHED_FILES_DIR is unset (every normal run, local or CI) this adds no
+// other behavior over the real `chromium` export.
 //
 // When QUEST_TOUCHED_FILES_DIR is set, records real V8 JS coverage for every page
 // a launched browser opens and, on browser.close(), writes the set of AppShell
@@ -39,7 +42,62 @@ import { join, basename } from 'node:path';
 const outDir = process.env.QUEST_TOUCHED_FILES_DIR;
 const SNAPSHOT_INTERVAL_MS = 4000;
 
-export const chromium = outDir ? withTracking(realChromium, outDir) : realChromium;
+// HomeHeader mounts DownloadButton (src/AppShell/src/lib/download-links.ts)
+// on every page load when PUBLIC_SHOW_HOME is set (every appshell_chromium
+// e2e script does, via the workflow's dev-server env), which fires this
+// exact request unauthenticated. Almost every verify-appshell-*.mjs script
+// navigates to / or /open at least once, so left unmocked here this was
+// hitting GitHub's 60-req/hour unauthenticated rate limit across a full
+// suite run - default-mocked for every context/page so individual scripts
+// don't each need their own copy. A script that wants specific release data
+// (or to test the failure path) can still override with its own page.route()
+// for the same URL - Playwright always prefers a page-level route over this
+// context-level one, regardless of registration order.
+const RELEASES_API_URL = 'https://api.github.com/repos/textadventures/quest/releases/latest';
+const SAMPLE_RELEASE = {
+    tag_name: 'v6.0.0-beta.42',
+    published_at: '2026-07-19T07:30:55Z',
+    assets: [
+        { name: 'Quest.Viva.Setup.6.0.0-beta.42.exe', browser_download_url: 'https://example.com/win.exe' },
+        { name: 'Quest.Viva-6.0.0-beta.42-arm64.dmg', browser_download_url: 'https://example.com/mac.dmg' },
+        { name: 'Quest.Viva-6.0.0-beta.42.deb', browser_download_url: 'https://example.com/linux.deb' },
+        { name: 'Quest.Viva-6.0.0-beta.42.AppImage', browser_download_url: 'https://example.com/linux.AppImage' },
+    ],
+};
+
+async function mockReleasesApi(context) {
+    await context.route(RELEASES_API_URL, route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SAMPLE_RELEASE),
+    }));
+}
+
+function withDefaultMocks(real) {
+    return {
+        ...real,
+        async launch(...args) {
+            const browser = await real.launch(...args);
+            for (const ctx of browser.contexts()) await mockReleasesApi(ctx);
+            const origNewContext = browser.newContext.bind(browser);
+            browser.newContext = async (...a) => {
+                const ctx = await origNewContext(...a);
+                await mockReleasesApi(ctx);
+                return ctx;
+            };
+            const origNewPage = browser.newPage.bind(browser);
+            browser.newPage = async (...a) => {
+                const page = await origNewPage(...a);
+                await mockReleasesApi(page.context());
+                return page;
+            };
+            return browser;
+        },
+    };
+}
+
+const withDefaults = withDefaultMocks(realChromium);
+export const chromium = outDir ? withTracking(withDefaults, outDir) : withDefaults;
 
 function withTracking(real, outDir) {
     return {

--- a/tests/e2e/verify-appshell-assetpicker-mobile-overflow.mjs
+++ b/tests/e2e/verify-appshell-assetpicker-mobile-overflow.mjs
@@ -25,8 +25,7 @@ try {
     await mobilePage.click('text=room');
     await mobilePage.waitForSelector('button:has-text("room")', { timeout: 5000 });
     await mobilePage.click('button:has-text("room")'); // back to tree
-    await mobilePage.waitForSelector('text=GAME OBJECTS', { timeout: 5000 });
-    // Exact match — "text=game" (substring) also matches the "GAME OBJECTS" heading.
+    await mobilePage.waitForSelector('input[placeholder="Filter..."]', { timeout: 5000 });
     await mobilePage.click('text="game"');
     await mobilePage.waitForSelector('button:has-text("Setup")', { timeout: 5000 });
 

--- a/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
+++ b/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
@@ -55,27 +55,8 @@ const baseUrl = process.argv[2] || 'http://localhost:5180';
 const browser = await chromium.launch();
 const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
 page.on('pageerror', err => console.log('[pageerror]', err.message));
-
-// DownloadButton (checked below) hits GitHub's real releases API
-// unauthenticated (src/AppShell/src/lib/download-links.ts) — mocked here so
-// this script doesn't depend on network access or GitHub's unauthenticated
-// rate limit (60 req/hour/IP, easily exhausted by repeated e2e runs from the
-// same CI runner). Mirrors the sample release used in
-// verify-appshell-download-button.mjs.
-await page.route('https://api.github.com/repos/textadventures/quest/releases/latest', route => route.fulfill({
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify({
-        tag_name: 'v6.0.0-beta.42',
-        published_at: '2026-07-19T07:30:55Z',
-        assets: [
-            { name: 'Quest.Viva.Setup.6.0.0-beta.42.exe', browser_download_url: 'https://example.com/win.exe' },
-            { name: 'Quest.Viva-6.0.0-beta.42-arm64.dmg', browser_download_url: 'https://example.com/mac.dmg' },
-            { name: 'Quest.Viva-6.0.0-beta.42.deb', browser_download_url: 'https://example.com/linux.deb' },
-            { name: 'Quest.Viva-6.0.0-beta.42.AppImage', browser_download_url: 'https://example.com/linux.AppImage' },
-        ],
-    }),
-}));
+// DownloadButton's GitHub releases API call is mocked by default for every
+// script via lib/tracked-chromium.mjs — see that file for why.
 
 function assertPseudo(label, text) {
     if (text == null) throw new Error(`[${label}] element not found`);

--- a/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
+++ b/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
@@ -231,7 +231,7 @@ async function run() {
     const viewOptionsBtn = page.locator('#workspace-content button[aria-label]').first();
     assertPseudo('TreePanel view-options title', await viewOptionsBtn.getAttribute('title'));
     await viewOptionsBtn.click();
-    assertPseudo('TreePanel "Show Library Elements" menu item', await page.textContent('.absolute button'));
+    assertPseudo('TreePanel "Show Library Elements" menu item', await page.textContent('[role="menu"] button'));
     await page.keyboard.press('Escape');
 
     // --- TreePanel context menu (via "room", the only movable node in a
@@ -423,15 +423,19 @@ async function run() {
 
     // --- LibraryElementBanner — via a library-origin verb. Library verbs are
     // hidden from the tree by default, so enable "Show Library Elements" first
-    // (TreePanel's view-options menu — the same one checked earlier). ---
+    // (TreePanel's view-options menu — the same one checked earlier). Scoped to
+    // [role="menu"] rather than a bare ".absolute" class, which by this point in
+    // the flow also matches unrelated hover-action overlays in other components. ---
     await page.locator('#workspace-content button[aria-label]').first().click();
-    await page.click('.absolute button');
-    // With libraries shown, the Verbs header has children (drink & co.); it
-    // starts collapsed like everything else (#827), so expand it before the
-    // click below. (A fresh game's empty Verbs header renders as a leaf item,
-    // which is why this can't happen earlier.)
+    await page.click('[role="menu"] button');
+    // With libraries shown, the Verbs header has children (drink & co.). It
+    // normally starts collapsed like everything else (#827) — but the "juggle"
+    // verb added above (VerbsEditor section) created a new command element
+    // under this same Verbs tree node, which may already have auto-expanded
+    // it — so only click to expand if "drink" isn't visible yet, rather than
+    // assuming collapsed and risking a click that re-collapses it instead.
     const verbsRow = page.locator('[data-part="branch-control"]:has-text("[Vérbs]")');
-    if (await verbsRow.count()) {
+    if (await verbsRow.count() && !(await page.locator('text="drink"').first().isVisible().catch(() => false))) {
         await verbsRow.locator('button').first().click();
     }
     await page.click('text="drink"');

--- a/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
+++ b/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
@@ -224,7 +224,11 @@ async function run() {
     // only TreePanel's own chrome (buttons/menus/placeholders) is pseudo here.
     assertPseudo('TreePanel filter placeholder', await page.getAttribute('input[placeholder]', 'placeholder'));
     assertPseudo('TreePanel filter aria-label', await page.getAttribute('input[aria-label]', 'aria-label'));
-    const viewOptionsBtn = page.locator('button[aria-label]').first();
+    // Scoped to #workspace-content (everything below Toolbar) — #2139 added
+    // aria-label to Toolbar's Back/Forward/BackToHome buttons too, and those
+    // render first in the DOM (and start disabled, with no history yet), so
+    // an unscoped `button[aria-label]` locator grabs one of those instead.
+    const viewOptionsBtn = page.locator('#workspace-content button[aria-label]').first();
     assertPseudo('TreePanel view-options title', await viewOptionsBtn.getAttribute('title'));
     await viewOptionsBtn.click();
     assertPseudo('TreePanel "Show Library Elements" menu item', await page.textContent('.absolute button'));
@@ -420,7 +424,7 @@ async function run() {
     // --- LibraryElementBanner — via a library-origin verb. Library verbs are
     // hidden from the tree by default, so enable "Show Library Elements" first
     // (TreePanel's view-options menu — the same one checked earlier). ---
-    await page.locator('button[aria-label]').first().click();
+    await page.locator('#workspace-content button[aria-label]').first().click();
     await page.click('.absolute button');
     // With libraries shown, the Verbs header has children (drink & co.); it
     // starts collapsed like everything else (#827), so expand it before the

--- a/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
+++ b/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
@@ -56,6 +56,27 @@ const browser = await chromium.launch();
 const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
 page.on('pageerror', err => console.log('[pageerror]', err.message));
 
+// DownloadButton (checked below) hits GitHub's real releases API
+// unauthenticated (src/AppShell/src/lib/download-links.ts) — mocked here so
+// this script doesn't depend on network access or GitHub's unauthenticated
+// rate limit (60 req/hour/IP, easily exhausted by repeated e2e runs from the
+// same CI runner). Mirrors the sample release used in
+// verify-appshell-download-button.mjs.
+await page.route('https://api.github.com/repos/textadventures/quest/releases/latest', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+        tag_name: 'v6.0.0-beta.42',
+        published_at: '2026-07-19T07:30:55Z',
+        assets: [
+            { name: 'Quest.Viva.Setup.6.0.0-beta.42.exe', browser_download_url: 'https://example.com/win.exe' },
+            { name: 'Quest.Viva-6.0.0-beta.42-arm64.dmg', browser_download_url: 'https://example.com/mac.dmg' },
+            { name: 'Quest.Viva-6.0.0-beta.42.deb', browser_download_url: 'https://example.com/linux.deb' },
+            { name: 'Quest.Viva-6.0.0-beta.42.AppImage', browser_download_url: 'https://example.com/linux.AppImage' },
+        ],
+    }),
+}));
+
 function assertPseudo(label, text) {
     if (text == null) throw new Error(`[${label}] element not found`);
     const trimmed = text.trim();

--- a/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
+++ b/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
@@ -428,16 +428,24 @@ async function run() {
     // the flow also matches unrelated hover-action overlays in other components. ---
     await page.locator('#workspace-content button[aria-label]').first().click();
     await page.click('[role="menu"] button');
-    // With libraries shown, the Verbs header has children (drink & co.). It
-    // normally starts collapsed like everything else (#827) — but the "juggle"
-    // verb added above (VerbsEditor section) created a new command element
-    // under this same Verbs tree node, which may already have auto-expanded
-    // it — so only click to expand if "drink" isn't visible yet, rather than
-    // assuming collapsed and risking a click that re-collapses it instead.
-    const verbsRow = page.locator('[data-part="branch-control"]:has-text("[Vérbs]")');
-    if (await verbsRow.count() && !(await page.locator('text="drink"').first().isVisible().catch(() => false))) {
-        await verbsRow.locator('button').first().click();
-    }
+    // With libraries shown, the Verbs header has children — but CoreCommands.aslx
+    // alone defines 20+ consecutive <verb> elements including "drink", so
+    // groupLibraryChildren folds them into a nested, separately-collapsed
+    // "librarygroup" node (see TreePanel.svelte). A single expand click on the
+    // Verbs branch itself only opens the outer level; "drink" stays hidden one
+    // level deeper. Use the node's own "Expand all below" context action
+    // instead, so it doesn't matter how many levels are actually collapsed.
+    await page.evaluate(() => {
+        // Scoped to branch-control spans, not a bare span search — "Vérbs" is
+        // also the room's own VerbsEditor tab header text (same locale key),
+        // which would otherwise be an ambiguous first match.
+        const verbsText = Array.from(document.querySelectorAll('[data-part="branch-control"] span'))
+            .find(el => el.textContent.trim() === '[Vérbs]');
+        const control = verbsText?.closest('[data-part="branch-control"]');
+        control?.querySelector('.node-actions button')?.click();
+    });
+    await page.waitForSelector('.tree-dropdown', { timeout: 10000 });
+    await page.click('.tree-dropdown button:has-text("[Éxpánd áll bélów]")');
     await page.click('text="drink"');
     await page.waitForSelector('.bg-warning-100-900', { timeout: 10000 });
     assertPseudo('LibraryElementBanner message', await page.textContent('.bg-warning-100-900 span'));

--- a/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
+++ b/tests/e2e/verify-appshell-i18n-pseudoloc.mjs
@@ -314,12 +314,12 @@ async function run() {
     await page.click('span:text-is("room")');
     await page.click('button:has-text("Attributes")');
     await page.waitForSelector('[data-attr="isroom"]', { timeout: 10000 });
-    // index 0 is PropertyEditor's own "Properties" header (same span classes,
-    // rendered above every tab's content) — AttributesEditor's own headers start at 1.
+    // #2144 removed PropertyEditor's own static "Properties" fallback header
+    // (same span classes), so AttributesEditor's own headers now start at 0.
     const attrHeaders = await page.$$eval('span.font-semibold.uppercase', els => els.map(el => el.textContent ?? ''));
-    if (attrHeaders.length < 3) throw new Error(`AttributesEditor: expected 3+ headers (incl. PropertyEditor's), found ${attrHeaders.length}`);
-    assertPseudo('AttributesEditor "Inherited types" header', attrHeaders[1]);
-    assertPseudo('AttributesEditor "Attributes" header', attrHeaders[2]);
+    if (attrHeaders.length < 2) throw new Error(`AttributesEditor: expected 2+ headers, found ${attrHeaders.length}`);
+    assertPseudo('AttributesEditor "Inherited types" header', attrHeaders[0]);
+    assertPseudo('AttributesEditor "Attributes" header', attrHeaders[1]);
     const attrThs = await page.$$eval('th', els => els.map(el => el.textContent?.trim() ?? '').filter(Boolean));
     if (attrThs.length === 0) throw new Error('AttributesEditor: no table headers found');
     for (const text of attrThs) assertPseudo('AttributesEditor table header', text);

--- a/tests/e2e/verify-appshell-mobile-master-detail.mjs
+++ b/tests/e2e/verify-appshell-mobile-master-detail.mjs
@@ -27,8 +27,8 @@ try {
     const desktopPage = await createDraftAndGetPage(desktopCtx);
     await desktopPage.waitForSelector('[role="separator"][aria-orientation="vertical"]', { timeout: 5000 });
     console.log('PASS: desktop still shows the splitter');
-    const treeVisible = await desktopPage.locator('text=GAME OBJECTS').isVisible();
-    const propsVisible = await desktopPage.locator('text=PROPERTIES').isVisible();
+    const treeVisible = await desktopPage.locator('input[placeholder="Filter..."]').isVisible();
+    const propsVisible = await desktopPage.locator('button:has-text("Setup")').isVisible();
     if (!treeVisible || !propsVisible) throw new Error('Desktop should show both tree and properties panes');
     console.log('PASS: desktop shows tree and properties panes side by side');
     await desktopCtx.close();
@@ -39,8 +39,8 @@ try {
     const splitterCount = await mobilePage.locator('[role="separator"][aria-orientation="vertical"]').count();
     if (splitterCount !== 0) throw new Error('Mobile should not render the splitter');
     console.log('PASS: mobile hides the splitter');
-    if (!(await mobilePage.locator('text=GAME OBJECTS').isVisible())) throw new Error('Mobile should start on the tree pane');
-    if (await mobilePage.locator('text=PROPERTIES').isVisible()) throw new Error('Mobile should not show the properties pane yet');
+    if (!(await mobilePage.locator('input[placeholder="Filter..."]').isVisible())) throw new Error('Mobile should start on the tree pane');
+    if (await mobilePage.locator('button:has-text("Setup")').isVisible()) throw new Error('Mobile should not show the properties pane yet');
     console.log('PASS: mobile starts on the tree pane, full width');
     await mobilePage.screenshot({ path: '/tmp/mobile-tree-pane.png' });
 
@@ -48,7 +48,7 @@ try {
     // must NOT trigger onactivate), so tap "room" to actually change selection.
     await mobilePage.click('text=room');
     await mobilePage.waitForSelector('button:has-text("room")', { timeout: 5000 }); // back header
-    if (await mobilePage.locator('text=GAME OBJECTS').isVisible()) throw new Error('Tree pane should be hidden after activating a node');
+    if (await mobilePage.locator('input[placeholder="Filter..."]').isVisible()) throw new Error('Tree pane should be hidden after activating a node');
     console.log('PASS: tapping a tree node pushes the properties pane with a back header showing its name');
     await mobilePage.screenshot({ path: '/tmp/mobile-props-pane.png' });
 
@@ -57,14 +57,14 @@ try {
     // sure of that (in case state left it collapsed), then verify the
     // expansion survives the pane switch (the original intent of this check).
     await mobilePage.click('button:has-text("room")');
-    await mobilePage.waitForSelector('text=GAME OBJECTS', { timeout: 5000 });
+    await mobilePage.waitForSelector('input[placeholder="Filter..."]', { timeout: 5000 });
     const roomCaret = mobilePage.locator('[data-part="branch-control"]:has-text("room") >> button[aria-label="Expand"]');
     if (await roomCaret.count()) { await roomCaret.first().click(); }
     await mobilePage.waitForSelector('text=player', { timeout: 5000 });
     await mobilePage.click('text=player');
     await mobilePage.waitForSelector('button:has-text("player")', { timeout: 5000 });
     await mobilePage.click('button:has-text("player")'); // back to tree
-    await mobilePage.waitForSelector('text=GAME OBJECTS', { timeout: 5000 });
+    await mobilePage.waitForSelector('input[placeholder="Filter..."]', { timeout: 5000 });
     const playerVisibleAfterBack = await mobilePage.locator('text=player').first().isVisible();
     if (!playerVisibleAfterBack) throw new Error('Tree expansion state should survive switching panes');
     console.log('PASS: back button returns to tree pane with expansion state intact');

--- a/tests/e2e/verify-electron-selectall-textbox.mjs
+++ b/tests/e2e/verify-electron-selectall-textbox.mjs
@@ -51,7 +51,7 @@ try {
     await templateRadio.click();
     await win.click('button:has-text("Create"):near(:text("Will be created as a new folder"))');
 
-    await win.waitForSelector('text=GAME OBJECTS', { timeout: 30000 });
+    await win.waitForSelector('input[placeholder="Filter..."]', { timeout: 30000 });
     console.log('[editor] editor loaded');
 
     // Structural check: the custom Edit menu must actually list a selectAll-role item now.

--- a/tests/e2e/verify-electron-undo-textarea.mjs
+++ b/tests/e2e/verify-electron-undo-textarea.mjs
@@ -61,7 +61,7 @@ try {
     await win.click('button:has-text("Create"):near(:text("Will be created as a new folder"))');
 
     // Editor loaded once the tree's default "room" object is selectable.
-    await win.waitForSelector('text=GAME OBJECTS', { timeout: 30000 });
+    await win.waitForSelector('input[placeholder="Filter..."]', { timeout: 30000 });
     console.log('[editor] editor loaded');
 
     // Record every app-level menu-action the renderer receives, alongside the +layout.svelte subscriber already listening.
@@ -113,7 +113,7 @@ try {
     console.log('PASS: text-field-focused Undo took the native webContents.undo() path, not app-level undo');
 
     // --- Case B: no text field focused (blur to the tree) -> app-level Undo should still fire ---
-    await win.locator('text=GAME OBJECTS').click();
+    await win.evaluate(() => document.activeElement instanceof HTMLElement && document.activeElement.blur());
     await win.waitForTimeout(100);
     await app.evaluate(({ Menu, BrowserWindow }) => {
         const menu = Menu.getApplicationMenu();


### PR DESCRIPTION
## Summary
- The nightly `e2e` workflow on `main` was failing (`appshell_chromium` and `electron` jobs both stuck on `waiting for locator('text=GAME OBJECTS') to be visible`).
- Root cause: #2144 removed TreePanel's static "Game Objects"/"Game Pages" header and PropertyEditor's static "Properties" fallback header as redundant, and updated 3 e2e scripts that referenced that text — but missed 4 more.
- Swaps the stale `text=GAME OBJECTS` / `text=PROPERTIES` locators for stable substitutes already used elsewhere in the suite: the tree pane's always-present filter input (`input[placeholder="Filter..."]`) as the "tree pane active" marker, and the properties pane's "Setup" tab button as the "properties pane active" marker. `verify-electron-undo-textarea.mjs`'s "blur to the tree" step (which clicked the removed header) now calls `document.activeElement.blur()` directly instead of relying on a click target.

While driving this to a real green CI run, found and fixed three more issues surfaced only by actually running the full suite (not visible from a diff read):

- `verify-appshell-i18n-pseudoloc.mjs`'s `button[aria-label]` locator for TreePanel's view-options menu was similarly stale: #2139 added `aria-label` to Toolbar's Back/Forward/BackToHome buttons, which render earlier in the DOM and start disabled — scoped to `#workspace-content` (added by #2141) to disambiguate.
- The same script's `AttributesEditor` header-count assumption ("index 0 is PropertyEditor's own Properties header") broke for the same reason as the original fix — adjusted the expected indices/count.
- The same script's library-verb visibility check (waiting on "drink" from `CoreCommands.aslx`) was hitting a second, deeper level of tree collapsing: `TreePanel.svelte`'s `groupLibraryChildren` folds 20+ consecutive same-library verbs into their own nested collapsed group, so "drink" sits two levels below "Verbs", not one. Now uses the tree node's own "Expand all below" context action instead of a single expand click, so it doesn't depend on the exact nesting depth.
- Discovered (via real rate-limit failures during the above re-runs) that most `verify-appshell-*.mjs` scripts fire an unauthenticated request to `https://api.github.com/repos/textadventures/quest/releases/latest` as a side effect of `HomeHeader`/`DownloadButton` mounting on `/` or `/open` whenever `PUBLIC_SHOW_HOME` is set (which the `appshell_chromium` job's dev server always is) — easily exhausting GitHub's 60-req/hour unauthenticated limit across a full suite run. Added a default mock for that endpoint in `tests/e2e/lib/tracked-chromium.mjs`, the shared `chromium` wrapper every one of those scripts already imports instead of `playwright` directly, so the whole suite is now immune to it. Scripts with their own intentional mocks (including a failure-path test) are unaffected, since Playwright always prefers a page-level `page.route()` over this context-level default.

## Test plan
- [x] `node --check` on every edited script
- [x] `node tests/e2e/check-workflow-manifest.mjs` passes
- [x] Full `e2e` workflow run ([33253531267](https://github.com/textadventures/quest/actions/runs/33253531267)) — all 8 jobs green, including `appshell_chromium` and `electron`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUYjsmoYFAYgTkLtQAhmVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUYjsmoYFAYgTkLtQAhmVX)_