### PR TITLE
fix: friendly error instead of NullReferenceException for unset attributes

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -73,6 +73,12 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     // returns the identifier name as a string rather than trying to resolve it as a variable.
     private bool _evaluatingCastType;
 
+    // Set by __Quest_PropertyAccess__ (see EvaluateAslFunctionAsync) whenever it resolves to null
+    // because the attribute has never been assigned, e.g. "object.unsetattribute". EvaluateBinaryAsync
+    // snapshots this right after evaluating each operand so a null-operand error can name the
+    // actual unset attribute instead of just saying "this value".
+    private string _lastNullPropertyAccessDescription;
+
     private void EvaluateParameter(string name, ParameterEventArgs args)
     {
         var tryMath = EvaluateVariableFromType(typeof(Math), name);
@@ -305,8 +311,13 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
         if (operatorName == null && !isEquality && !isInOperator) return;
 
+        _lastNullPropertyAccessDescription = null;
         var left = await args.LeftValueAsync();
+        var leftNullDescription = left is null ? _lastNullPropertyAccessDescription : null;
+
+        _lastNullPropertyAccessDescription = null;
         var right = await args.RightValueAsync();
+        var rightNullDescription = right is null ? _lastNullPropertyAccessDescription : null;
 
         // NCalc's built-in 'in' operator does a plain foreach over the right-hand IEnumerable,
         // which for IDictionary yields boxed KeyValuePairs rather than keys, so it can never
@@ -323,10 +334,11 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             return;
         }
 
-        HandleBinaryResult(args, isEquality, operatorName, left, right);
+        HandleBinaryResult(args, isEquality, operatorName, left, right, leftNullDescription, rightNullDescription);
     }
 
-    private static void HandleBinaryResult(BinaryEventArgs args, bool isEquality, string operatorName, object left, object right)
+    private static void HandleBinaryResult(BinaryEventArgs args, bool isEquality, string operatorName, object left,
+        object right, string leftNullDescription, string rightNullDescription)
     {
         // NCalc's internal equality logic calls Convert.ChangeType() which requires IConvertible.
         // Element doesn't implement IConvertible, so intercept equality/inequality for non-standard
@@ -357,8 +369,10 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             // (both here and natively in NCalc), so this only needs to guard arithmetic.
             if (!isEquality && (left is null || right is null))
             {
-                throw new Exception(
-                    "Cannot use this value in a calculation because it has not been set - check whether an attribute or variable has been assigned a value before using it.");
+                var description = left is null ? leftNullDescription : rightNullDescription;
+                throw new Exception(description != null
+                    ? $"'{description}' is null (it has not been set) and cannot be used in this calculation."
+                    : "Cannot use this value in a calculation because it has not been set - check whether an attribute or variable has been assigned a value before using it.");
             }
 
             return;
@@ -443,7 +457,16 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             if (receiver is Element element)
             {
                 var fieldName = Utility.ResolveElementName(propertyName);
-                return element.Fields.Exists(fieldName, true) ? element.Fields.Get(fieldName) : null;
+                if (!element.Fields.Exists(fieldName, true))
+                {
+                    // Record what produced this null, so a guard further up the evaluation (e.g.
+                    // arithmetic on a null operand) can name the actual unset attribute in its
+                    // error message instead of just saying "this value".
+                    _lastNullPropertyAccessDescription = $"{element.Name}.{propertyName}";
+                    return null;
+                }
+
+                return element.Fields.Get(fieldName);
             }
 #pragma warning disable IL2075 // script-accessible types are explicitly rooted in ScriptDispatchRoots.cs
             var prop = receiver?.GetType().GetProperty(propertyName,

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -350,7 +350,19 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
         // Let NCalc handle standard numeric/bool/string/null operations natively
         if (IsStandardNCalcType(left) && IsStandardNCalcType(right))
+        {
+            // NCalc's native arithmetic throws a raw NullReferenceException when an operand is
+            // null instead of a proper value - this typically means the operand is an attribute
+            // that has never been assigned. Equality/inequality already handles null cleanly
+            // (both here and natively in NCalc), so this only needs to guard arithmetic.
+            if (!isEquality && (left is null || right is null))
+            {
+                throw new Exception(
+                    "Cannot use this value in a calculation because it has not been set - check whether an attribute or variable has been assigned a value before using it.");
+            }
+
             return;
+        }
 
         var leftType = left?.GetType();
         var rightType = right?.GetType();

--- a/src/Engine/Scripts/ErrorScript.cs
+++ b/src/Engine/Scripts/ErrorScript.cs
@@ -45,7 +45,7 @@ public class ErrorScript : ScriptBase
     public override async Task ExecuteAsync(Context c)
     {
         var result = await m_function.ExecuteAsync(c);
-        throw new Exception(result.ToString());
+        throw new Exception(Utility.ExpressionResultToString(result));
     }
 
     public override string Save()

--- a/src/Engine/Scripts/MsgScript.cs
+++ b/src/Engine/Scripts/MsgScript.cs
@@ -45,7 +45,7 @@ public class MsgScript : ScriptBase
     public override async Task ExecuteAsync(Context c)
     {
         var result = await m_function.ExecuteAsync(c);
-        await m_worldModel.PrintAsync(result.ToString());
+        await m_worldModel.PrintAsync(Utility.ExpressionResultToString(result));
     }
 
     public override string Save()

--- a/src/Engine/Scripts/RequestSpeakScript.cs
+++ b/src/Engine/Scripts/RequestSpeakScript.cs
@@ -51,7 +51,7 @@ public class RequestSpeakScript : ScriptBase
     public override async Task ExecuteAsync(Context c)
     {
         var result = await m_function.ExecuteAsync(c);
-        m_worldModel.PlayerUi.Speak(result.ToString());
+        m_worldModel.PlayerUi.Speak(Utility.ExpressionResultToString(result));
     }
 
     public override string Save()

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -121,7 +121,7 @@ public class SwitchScript : ScriptBase
     {
         var result = await m_expr.ExecuteAsync(c);
         // using .ToString() here as an object comparison of ints won't work
-        var success = await m_cases.ExecuteAsync(c, result.ToString());
+        var success = await m_cases.ExecuteAsync(c, Utility.ExpressionResultToString(result));
 
         if (!success && m_default != null)
         {
@@ -242,7 +242,7 @@ public class SwitchScript : ScriptBase
             {
                 var expr = m_compiledExpressions[switchCase.Key];
 
-                if (result == (await expr.ExecuteAsync(c)).ToString())
+                if (result == Utility.ExpressionResultToString(await expr.ExecuteAsync(c)))
                 {
                     await switchCase.Value.ExecuteAsync(c);
                     return true;

--- a/src/Engine/Utility.cs
+++ b/src/Engine/Utility.cs
@@ -413,6 +413,21 @@ public static partial class Utility
         return input.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
     }
 
+    // A raw "result.ToString()" on a script/expression result throws a raw NullReferenceException
+    // when the result is null - most commonly because it came from an attribute that was never
+    // assigned a value. Use this instead wherever a script command converts an expression result
+    // to a string, so the author gets a clear error rather than a leaked NRE.
+    public static string ExpressionResultToString(object value)
+    {
+        if (value is null)
+        {
+            throw new Exception(
+                "Cannot convert this value to a string because it has not been set - check whether an attribute or variable has been assigned a value before using it.");
+        }
+
+        return value.ToString();
+    }
+
     public static string[] ListSplit(string value)
     {
         return value.Split(s_listSplitDelimiters, StringSplitOptions.None);

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -692,11 +692,11 @@ public class ExpressionTests
         // NullReferenceException all the way up to the player/author instead of a clear message.
         var ex = await Should.ThrowAsync<Exception>(() => RunExpression<int>($"{ObjectName}.unsetattribute + 5"));
         ex.Message.ShouldNotContain("Object reference not set");
-        ex.Message.ShouldContain("has not been set");
+        ex.Message.ShouldContain($"'{ObjectName}.unsetattribute' is null");
 
         var ex2 = await Should.ThrowAsync<Exception>(() => RunExpression<int>($"5 - {ObjectName}.unsetattribute"));
         ex2.Message.ShouldNotContain("Object reference not set");
-        ex2.Message.ShouldContain("has not been set");
+        ex2.Message.ShouldContain($"'{ObjectName}.unsetattribute' is null");
     }
 
     [TestMethod]

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -676,6 +676,30 @@ public class ExpressionTests
     }
 
     [TestMethod]
+    public async Task TestUnsetAttribute_ComparedToNull_ReturnsExpectedBoolean()
+    {
+        // A truly-unset attribute must keep working with null comparisons (unaffected by the
+        // arithmetic guard below).
+        (await RunExpression<bool>($"{ObjectName}.unsetattribute = null")).ShouldBeTrue();
+        (await RunExpression<bool>($"{ObjectName}.unsetattribute <> null")).ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public async Task TestUnsetAttribute_UsedInArithmetic_ThrowsFriendlyErrorInsteadOfNullReferenceException()
+    {
+        // Regression test for https://github.com/textadventures/quest/issues/2096 - using a
+        // truly-unset attribute (never assigned) in arithmetic used to leak a raw
+        // NullReferenceException all the way up to the player/author instead of a clear message.
+        var ex = await Should.ThrowAsync<Exception>(() => RunExpression<int>($"{ObjectName}.unsetattribute + 5"));
+        ex.Message.ShouldNotContain("Object reference not set");
+        ex.Message.ShouldContain("has not been set");
+
+        var ex2 = await Should.ThrowAsync<Exception>(() => RunExpression<int>($"5 - {ObjectName}.unsetattribute"));
+        ex2.Message.ShouldNotContain("Object reference not set");
+        ex2.Message.ShouldContain("has not been set");
+    }
+
+    [TestMethod]
     public async Task TestObjectEqualToStringReturnsFalse()
     {
         // Cross-type equality (Element vs string) must return false, not throw IConvertible.

--- a/tests/EngineTests/UtilityTests.cs
+++ b/tests/EngineTests/UtilityTests.cs
@@ -207,4 +207,21 @@ public class UtilityTests
             "msg(\"end\")" + Environment.NewLine);
     }
 
+    [TestMethod]
+    public void TestExpressionResultToString_NonNullValue_ReturnsToString()
+    {
+        Engine.Utility.ExpressionResultToString(42).ShouldBe("42");
+        Engine.Utility.ExpressionResultToString("hello").ShouldBe("hello");
+    }
+
+    [TestMethod]
+    public void TestExpressionResultToString_NullValue_ThrowsFriendlyErrorInsteadOfNullReferenceException()
+    {
+        // Regression test for https://github.com/textadventures/quest/issues/2096 - msg/error/
+        // switch/requestspeak used to call result.ToString() directly, which throws a raw
+        // NullReferenceException when the result is a truly-unset attribute.
+        var ex = Should.Throw<Exception>(() => Engine.Utility.ExpressionResultToString(null));
+        ex.ShouldNotBeOfType<NullReferenceException>();
+        ex.Message.ShouldContain("has not been set");
+    }
 }


### PR DESCRIPTION
A truly-unset attribute (never assigned) resolves to a clean null via
Fields.Get, but using it directly in arithmetic or passing it to msg/error/
switch/requestspeak called .ToString() or let NCalc's native arithmetic
handle a null operand - both threw a raw NullReferenceException that leaked
the .NET exception message straight to the player/author.

Guard both paths and throw a clear message naming the actual problem
instead.

Fixes #2096