### PR TITLE
fix(Engine): retarget Core.aslx location-bar styling to #qv-status

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -388,6 +388,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-save-slot-title-size.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-location-bar-status-rename.mjs http://localhost:5175
+        working-directory: tests/e2e
 
   # WebPlayer (ASP.NET Core + Blazor Server), Development mode with Dev:Enabled
   # (appsettings.Development.json already sets this — see /dev/open's

--- a/src/Engine/Core/Core.aslx
+++ b/src/Engine/Core/Core.aslx
@@ -107,21 +107,21 @@
         JS.setCss ("#gameBorder", "border-left:1px solid " + game.bordercolour + ";border-right:1px solid " + game.bordercolour)
       }
       if (not game.classiclocation) {
-        JS.setCss ("#status", "background-image:none")
+        JS.setCss ("#qv-status", "background-image:none")
         if (HasString(game, "customlocationcolour")) {
-          JS.setCss ("#status", "background-color:" + game.customlocationcolour)
+          JS.setCss ("#qv-status", "background-color:" + game.customlocationcolour)
         }
         else {
-          JS.setCss ("#status", "background:transparent")
+          JS.setCss ("#qv-status", "background:transparent")
         }
         if (HasString(game, "customlocationtextcolour")) {
-          JS.setCss ("#status", "color:" + game.customlocationtextcolour)
+          JS.setCss ("#qv-status", "color:" + game.customlocationtextcolour)
         }
         if (HasString(game, "customlocationbordercolour")) {
-          JS.setCss ("#status", "border:1px solid " + game.customlocationbordercolour)
+          JS.setCss ("#qv-status", "border:1px solid " + game.customlocationbordercolour)
         }
         else {
-          JS.setCss ("#status", "border:none")
+          JS.setCss ("#qv-status", "border:none")
         }
         if (HasString(game, "locationbarimage")){
           if (not Trim(game.locationbarimage) = ""){
@@ -133,10 +133,9 @@
       //request (Show, "Location")
       if (game.showlocation) {
         JS.uiShow("#location")
-        JS.setCss ("#status", "display:block")
       }
       else {
-        JS.setCss ("#status", "display:none")
+        JS.uiHide("#location")
       }
       if (HasString(game, "marginscolour")) {
         JS.setCss ("body", "background-color:" + game.marginscolour)

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -266,6 +266,11 @@ function initPlayerUI() {
         const newPanelImageMaxHeight = `${(window.innerHeight - 30) * 0.5}px`;
         updatePanelImageMaxHeight(newPanelImageMaxHeight);
 
+        // cmdShowPanes.style.display was just set above - recompute #qv-status's own
+        // visibility now in case resizing past the narrow-window threshold is what
+        // just made (or unmade) the hamburger button #qv-status's only visible child.
+        updateStatusVisibility();
+
         wasWide = isWide;
     }
 
@@ -543,7 +548,12 @@ function uiHide(element) {
 }
 
 function updateStatusVisibility() {
-    var anyVisible = isElementVisible("#location") || isElementVisible("#cmdSave");
+    // #cmdDebug and #cmdShowPanes can each be visible on their own (editor-preview
+    // sessions force Debug on regardless of location/save; #cmdShowPanes only shows
+    // itself up on a narrow window - see doLayout()) - #qv-status must stay up
+    // whenever any of the four buttons/location it hosts is actually showing.
+    var anyVisible = isElementVisible("#location") || isElementVisible("#cmdSave")
+        || isElementVisible("#cmdDebug") || isElementVisible("#cmdShowPanes");
     if (anyVisible) {
         $("#qv-status").show();
         $("#divOutput").css("margin-top", "20px");

--- a/tests/e2e/fixtures/location-bar-custom-colour-test.aslx
+++ b/tests/e2e/fixtures/location-bar-custom-colour-test.aslx
@@ -1,0 +1,19 @@
+<asl version="600">
+
+  <include ref="English.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <game name="LocationBarTest">
+    <showlocation type="boolean">true</showlocation>
+    <classiclocation type="boolean">false</classiclocation>
+    <customlocationcolour>#ff00ff</customlocationcolour>
+    <customlocationtextcolour>#ffffff</customlocationtextcolour>
+    <customlocationbordercolour>#000000</customlocationbordercolour>
+  </game>
+
+  <object name="room">
+    <object name="player">
+    </object>
+  </object>
+
+</asl>

--- a/tests/e2e/fixtures/location-bar-hidden-save-visible-test.aslx
+++ b/tests/e2e/fixtures/location-bar-hidden-save-visible-test.aslx
@@ -1,0 +1,15 @@
+<asl version="600">
+
+  <include ref="English.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <game name="LocationBarHiddenTest">
+    <showlocation type="boolean">false</showlocation>
+  </game>
+
+  <object name="room">
+    <object name="player">
+    </object>
+  </object>
+
+</asl>

--- a/tests/e2e/verify-wasmplayer-location-bar-status-rename.mjs
+++ b/tests/e2e/verify-wasmplayer-location-bar-status-rename.mjs
@@ -3,14 +3,26 @@
 // button's container stays visible regardless of what the location-bar settings do). All 8
 // JS.setCss/display calls driving customlocationcolour/customlocationtextcolour/
 // customlocationbordercolour and the showlocation display toggle were silent no-ops as a
-// result. This verifies both halves of the fix:
+// result. This verifies:
 //   1. The custom colours actually apply to #qv-status.
 //   2. Turning showlocation off hides #location but does NOT hide #qv-status while the Save
 //      button is present - the exact behaviour the 42cdd9b8 rename was protecting.
+//   3. The same holds in an editor-preview session (?source=editor), where Save is hidden
+//      instead (WebPlayer.setCanSave(!isPreview)) and Debug is forced on - a pre-existing
+//      bug in playercore.js's updateStatusVisibility(), found while investigating #2095, only
+//      ever checked #location/#cmdSave, so #qv-status (and the Debug button it hosts, plus
+//      the responsive hamburger menu once resized narrow) collapsed to display:none whenever
+//      both of those happened to be off, regardless of what else was actually showing.
+//   4. Resizing to a narrow window after that reveals the hamburger (#cmdShowPanes) and
+//      #qv-status comes back up with it, rather than staying stuck hidden.
 // Requires the WasmPlayer dev server running locally:
 //   node src/WasmPlayer/dev-server.mjs
 import { chromium } from 'playwright';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const here = dirname(fileURLToPath(import.meta.url));
 const baseUrl = process.argv[2] || 'http://localhost:5175';
 
 const browser = await chromium.launch();
@@ -86,6 +98,61 @@ async function run() {
         throw new Error(`#qv-status should stay visible (Save button present) when showlocation=false, got display:${statusDisplay} - this is the regression 42cdd9b8 was protecting against`);
     }
     console.log('PASS: #qv-status stays visible when showlocation=false because Save button is present');
+
+    // Editor-preview session: source=editor hands the game over via BroadcastChannel
+    // instead of a URL, and flips isPreview - which hides Save and forces Debug on
+    // (see wasm-player.js's initWasmPlayer/WebPlayer.setCanSave|setCanDebug).
+    await page.goto(`${baseUrl}/?source=editor`);
+    await page.waitForTimeout(500);
+    const fixtureBytes = [...readFileSync(join(here, 'fixtures', 'location-bar-hidden-save-visible-test.aslx'))];
+    await page.evaluate(({ bytes, filename }) => {
+        const bc = new BroadcastChannel('quest-preview');
+        bc.postMessage({ type: 'game', bytes: new Uint8Array(bytes), filename });
+    }, { bytes: fixtureBytes, filename: 'location-bar-hidden-save-visible-test.aslx' });
+    await page.waitForSelector('#txtCommand', { timeout: 30000, state: 'attached' });
+    // wasm-player.js's boot order is: WebPlayer.initUI() (which calls
+    // updateStatusVisibility() once, while #cmdSave is still at its pre-setCanSave
+    // default-visible state) -> setCanSave(false)/setCanDebug(true) (neither of which
+    // re-triggers updateStatusVisibility()) -> Bridge.Begin(), which is what actually
+    // runs Core.aslx's InitInterface and its JS.uiHide("#location") call - the first
+    // one that recomputes #qv-status against the real post-setCanSave state. Waiting
+    // on #cmdDebug alone (settled by setCanDebug, before Bridge.Begin()) would read
+    // #qv-status before that recomputation ever happens, so wait on #location's own
+    // inline style instead - jQuery's .hide() sets it directly, unlike the "none" it
+    // already has by default from CSS alone, so this can only become true once
+    // InitInterface has actually run.
+    await page.waitForFunction(
+        () => document.querySelector('#location').style.display === 'none',
+        { timeout: 10000 },
+    );
+
+    const previewDisplays = await page.evaluate(() => ({
+        qvStatus: getComputedStyle(document.querySelector('#qv-status')).display,
+        cmdSave: getComputedStyle(document.querySelector('#cmdSave')).display,
+        cmdDebug: getComputedStyle(document.querySelector('#cmdDebug')).display,
+    }));
+    if (previewDisplays.cmdSave !== 'none') {
+        throw new Error(`Save should be hidden in an editor-preview session, got display:${previewDisplays.cmdSave}`);
+    }
+    if (previewDisplays.qvStatus !== 'block') {
+        throw new Error(`#qv-status should stay visible in editor-preview with showlocation=false (Debug button present), got display:${previewDisplays.qvStatus}`);
+    }
+    console.log('PASS: #qv-status stays visible in editor-preview when showlocation=false because Debug button is present (Save is hidden there)');
+
+    // Resize to a narrow window: the hamburger (#cmdShowPanes) should appear, and
+    // #qv-status must come up with it - doLayout() sets cmdShowPanes' own display on
+    // resize, but only calling updateStatusVisibility() from there makes #qv-status
+    // itself react.
+    await page.setViewportSize({ width: 500, height: 800 });
+    await page.waitForFunction(
+        () => getComputedStyle(document.querySelector('#cmdShowPanes')).display !== 'none',
+        { timeout: 10000 },
+    );
+    const narrowStatusDisplay = await page.$eval('#qv-status', el => getComputedStyle(el).display);
+    if (narrowStatusDisplay !== 'block') {
+        throw new Error(`#qv-status should stay visible after resizing narrow (hamburger now showing), got display:${narrowStatusDisplay}`);
+    }
+    console.log('PASS: #qv-status visible after resize reveals the hamburger menu');
 }
 
 try {

--- a/tests/e2e/verify-wasmplayer-location-bar-status-rename.mjs
+++ b/tests/e2e/verify-wasmplayer-location-bar-status-rename.mjs
@@ -1,0 +1,98 @@
+// Regression test for textadventures/quest#2095: Core.aslx's InitInterface used to target
+// "#status", an element id that was renamed to "#qv-status" in commit 42cdd9b8 (so the Save
+// button's container stays visible regardless of what the location-bar settings do). All 8
+// JS.setCss/display calls driving customlocationcolour/customlocationtextcolour/
+// customlocationbordercolour and the showlocation display toggle were silent no-ops as a
+// result. This verifies both halves of the fix:
+//   1. The custom colours actually apply to #qv-status.
+//   2. Turning showlocation off hides #location but does NOT hide #qv-status while the Save
+//      button is present - the exact behaviour the 42cdd9b8 rename was protecting.
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+async function run() {
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/location-bar-custom-colour-test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000, state: 'attached' });
+    // #txtCommand attaches to the DOM before InitInterface has finished issuing all its
+    // JS.setCss calls (single-threaded WASM interop - see CLAUDE.md), so poll for the
+    // colour to actually land rather than racing it.
+    await page.waitForFunction(
+        () => getComputedStyle(document.querySelector('#qv-status')).backgroundColor === 'rgb(255, 0, 255)',
+        { timeout: 10000 },
+    );
+
+    const style = await page.$eval('#qv-status', el => {
+        const cs = getComputedStyle(el);
+        return { background: cs.backgroundColor, border: cs.borderColor, color: cs.color, display: cs.display };
+    });
+
+    if (style.background !== 'rgb(255, 0, 255)') {
+        throw new Error(`customlocationcolour not applied: expected rgb(255, 0, 255), got ${style.background}`);
+    }
+    console.log('PASS: customlocationcolour applied to #qv-status background');
+
+    if (style.border !== 'rgb(0, 0, 0)') {
+        throw new Error(`customlocationbordercolour not applied: expected rgb(0, 0, 0), got ${style.border}`);
+    }
+    console.log('PASS: customlocationbordercolour applied to #qv-status border');
+
+    if (style.color !== 'rgb(255, 255, 255)') {
+        throw new Error(`customlocationtextcolour not applied: expected rgb(255, 255, 255), got ${style.color}`);
+    }
+    console.log('PASS: customlocationtextcolour applied to #qv-status text colour');
+
+    if (style.display !== 'block') {
+        throw new Error(`#qv-status should be visible when showlocation=true, got display:${style.display}`);
+    }
+    console.log('PASS: #qv-status visible when showlocation=true');
+
+    const locationDisplay = await page.$eval('#location', el => getComputedStyle(el).display);
+    if (locationDisplay !== 'block') {
+        throw new Error(`#location should be visible when showlocation=true, got display:${locationDisplay}`);
+    }
+    console.log('PASS: #location visible when showlocation=true');
+
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/location-bar-hidden-save-visible-test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000, state: 'attached' });
+    // Same InitInterface-hasn't-finished-yet race as above: wait for #qv-status to settle
+    // into "block" (driven by updateStatusVisibility() via the JS.uiHide("#location") call)
+    // before asserting on it or its sibling #location.
+    await page.waitForFunction(
+        () => getComputedStyle(document.querySelector('#qv-status')).display === 'block',
+        { timeout: 10000 },
+    );
+
+    const locationDisplay2 = await page.$eval('#location', el => getComputedStyle(el).display);
+    if (locationDisplay2 !== 'none') {
+        throw new Error(`#location should be hidden when showlocation=false, got display:${locationDisplay2}`);
+    }
+    console.log('PASS: #location hidden when showlocation=false');
+
+    const saveVisible = await page.$eval('#cmdSave', el => getComputedStyle(el).display !== 'none');
+    if (!saveVisible) {
+        throw new Error('#cmdSave should remain visible when showlocation=false');
+    }
+    console.log('PASS: #cmdSave still visible when showlocation=false');
+
+    const statusDisplay = await page.$eval('#qv-status', el => getComputedStyle(el).display);
+    if (statusDisplay !== 'block') {
+        throw new Error(`#qv-status should stay visible (Save button present) when showlocation=false, got display:${statusDisplay} - this is the regression 42cdd9b8 was protecting against`);
+    }
+    console.log('PASS: #qv-status stays visible when showlocation=false because Save button is present');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- `InitInterface`'s 8 `JS.setCss`/display calls in `Core.aslx` still targeted `#status`, which was renamed to `#qv-status` in 42cdd9b8 specifically so the Save button stays visible regardless of location-bar settings — all 8 calls have been silent no-ops since then.
- The 6 appearance calls (background-image, background-color, text color, border) now target `#qv-status` directly.
- The visibility toggle (`game.showlocation`) no longer force-sets `display:block`/`display:none` on the whole `#qv-status` bar, which would reintroduce the exact bug the rename fixed (hiding the Save button whenever the location bar is off). Instead the `else` branch now calls `JS.uiHide("#location")`, mirroring the existing `JS.uiShow("#location")` in the `if` branch — `updateStatusVisibility()` in `playercore.js` already computes `#qv-status`'s own visibility correctly from that.
- **Folded in a related pre-existing bug**, found while manually verifying the above: `updateStatusVisibility()` only ever checked `#location`/`#cmdSave`, so `#qv-status` collapsed to `display:none` whenever both happened to be off — even when the Debug button (forced on in editor-preview sessions, independent of `showlocation`) or the responsive hamburger menu (`#cmdShowPanes`, shown on a narrow window) was still meant to be reachable. Concretely: an editor-preview session (`?source=editor`) with the location bar turned off lost the *entire* status bar — Debug and the hamburger vanished with it — since Save is deliberately hidden in preview sessions (`WebPlayer.setCanSave(!isPreview)`) and nothing else was checked. Now checks all four. Also wired `updateStatusVisibility()` into `doLayout()` (the resize handler) so resizing across the narrow-window breakpoint brings `#qv-status` up/down along with the hamburger, which only recalculates its own visibility there. Confirmed via git-revert-and-rebuild that this is pre-existing on unpatched `main`, not a regression from the first two commits.

Per [CLAUDE.md](../blob/main/CLAUDE.md)'s Core library semantics: the `Core.aslx` half only affects games saved/created after this change lands (Core.aslx is inlined into published `.quest` files at save time). The `playercore.js` half is not inlined and affects every player/session immediately once deployed.

Fixes #2095

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings/errors
- [x] `dotnet test tests/EngineTests` — 315/315 pass
- [x] `dotnet test tests/PlayerCoreTests` — 8/8 pass
- [x] Playwright regression test (`tests/e2e/verify-wasmplayer-location-bar-status-rename.mjs`, wired into `wasmplayer_chromium` in `e2e.yml`) against a real WasmPlayer boot, 10 assertions covering:
  - `customlocationcolour`/`customlocationtextcolour`/`customlocationbordercolour` applying to `#qv-status`
  - `#qv-status` staying visible with the Save button present when `showlocation=false`
  - the same in an editor-preview session, where Debug (not Save) is what keeps it up
  - `#qv-status` reappearing after a resize reveals the hamburger menu
  - Each assertion checked to actually discriminate: reverted the relevant source file, rebuilt, confirmed the specific assertion fails, then restored the fix and confirmed it passes again.

The two doc examples (`ui-custom.md`, `ui-javascript2.md`/`js/index.md`) that also demonstrated the broken `JS.setCss("#status", ...)` call have been fixed on the unmerged `v5-docs-migrate` branch separately; `ui-custom.md`'s 4 embedded screenshots still need regenerating there once this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)