### PR TITLE
fix(Engine): reject play sound wait+loop combination instead of hanging forever

### DIFF
--- a/src/Engine/Scripts/PlaySoundScript.cs
+++ b/src/Engine/Scripts/PlaySoundScript.cs
@@ -52,6 +52,11 @@ public class PlaySoundScript : ScriptBase
         var synchronous = await m_synchronous.ExecuteAsync(c);
         var loop = await m_loop.ExecuteAsync(c);
 
+        if (synchronous && loop)
+        {
+            throw new Exception("play sound: cannot use 'wait' and 'loop' together - this would wait forever for a sound that never finishes");
+        }
+
         if (synchronous)
         {
             var tcs = WorldModel.BeginPrompt(ref m_worldModel._waitTcs);

--- a/tests/EngineTests/AsyncScriptTests.cs
+++ b/tests/EngineTests/AsyncScriptTests.cs
@@ -16,6 +16,7 @@ public class AsyncScriptTests
     public void Setup()
     {
         _worldModel = Helpers.CreateWorldModel();
+        _worldModel.LogError += ex => throw ex;
         _scriptContext = new ScriptContext(_worldModel);
         _scriptFactory = new ScriptFactory(_worldModel);
         _obj = _worldModel.GetElementFactory(ElementType.Object).Create("obj");
@@ -210,5 +211,12 @@ public class AsyncScriptTests
         AddFunction("RunAction", "do (obj, \"action\")");
         await _worldModel.RunProcedureAsync("RunAction", null, false);
         _obj.Fields.GetString("flag").ShouldBe("done");
+    }
+
+    [TestMethod]
+    public async Task TestPlaySoundWaitAndLoopThrowsAsync()
+    {
+        AddFunction("PlaySoundWaitAndLoop", "play sound (\"test.mp3\", true, true)");
+        await Should.ThrowAsync<Exception>(() => CallAsync("PlaySoundWaitAndLoop"));
     }
 }


### PR DESCRIPTION
## Summary
- `play sound`'s `synchronous` (wait) and `loop` options had no cross-validation; setting both together made `ExecuteAsync` await a `TaskCompletionSource` that only completes when the sound finishes naturally — which never happens while looping, hanging the turn forever.
- Now raises a script error (`throw new Exception(...)`, same convention as `ErrorScript`/`AskScript`/etc.) when both are true, before ever touching the wait path. Surfaces to the player as `"Error running script: ..."`, same as any other invalid script call.
- No elegant editor-side fix is available: `CoreEditorScriptsOutput.aslx`'s `play sound` block defines the two checkboxes as fully independent controls, and the XML editor schema has no cross-field constraint primitive (only `onlydisplayif`, which gates on external game state, not sibling attribute values). Execution-time validation is the correct enforcement point here, matching the issue's own recommendation.

Fixes #2098

## Test plan
- [x] Added `TestPlaySoundWaitAndLoopThrowsAsync` (tests/EngineTests/AsyncScriptTests.cs) asserting `play sound ("test.mp3", true, true)` throws
- [x] `dotnet test tests/EngineTests --configuration Release` — 316/316 passed