### PR TITLE
fix(Engine): stop deferring 'on ready' during an unrelated wait/get input/ask/show menu callback

### DIFF
--- a/src/Engine/Scripts/AskScript.cs
+++ b/src/Engine/Scripts/AskScript.cs
@@ -50,16 +50,19 @@ public class AskScript(
         var caption = await _caption.ExecuteAsync(c);
         _worldModel.PlayerUi.ShowQuestion(caption);
         WorldModel.BeginPrompt(ref _worldModel._questionTcs);
-        _worldModel.BeginPendingCallback();
+        _worldModel.BeginDormantSuspension();
         _worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c);
     }
 
     private async Task AwaitResponseAndRunCallbackAsync(Context c)
     {
+        var resolved = false;
         try
         {
             var response = await _worldModel._questionTcs!.Task;
+            resolved = true;
+            _worldModel.SignalCallbackResolving();
             c.Parameters["result"] = response;
             await _worldModel.RunScriptAsync(callbackScript, c);
         }
@@ -67,6 +70,7 @@ public class AskScript(
         catch (Exception ex) { _worldModel.LogException(ex); }
         finally
         {
+            if (!resolved) _worldModel.SignalCallbackResolving();
             await _worldModel.EndPendingCallbackAsync();
             _worldModel.SignalTurnSuspended();
         }

--- a/src/Engine/Scripts/GetInputScript.cs
+++ b/src/Engine/Scripts/GetInputScript.cs
@@ -43,7 +43,7 @@ public class GetInputScript : ScriptBase
     {
         m_worldModel._commandOverride = true;
         WorldModel.BeginPrompt(ref m_worldModel._commandInputTcs);
-        m_worldModel.BeginPendingCallback();
+        m_worldModel.BeginDormantSuspension();
         m_worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c);
         return Task.CompletedTask;
@@ -51,9 +51,12 @@ public class GetInputScript : ScriptBase
 
     private async Task AwaitResponseAndRunCallbackAsync(Context c)
     {
+        var resolved = false;
         try
         {
             var result = await m_worldModel._commandInputTcs.Task;
+            resolved = true;
+            m_worldModel.SignalCallbackResolving();
             m_worldModel._commandOverride = false;
             c.Parameters["result"] = result;
             await m_worldModel.RunScriptAsync(m_callbackScript, c);
@@ -62,6 +65,7 @@ public class GetInputScript : ScriptBase
         catch (Exception ex) { m_worldModel.LogException(ex); }
         finally
         {
+            if (!resolved) m_worldModel.SignalCallbackResolving();
             await m_worldModel.EndPendingCallbackAsync();
             m_worldModel.SignalTurnSuspended();
         }

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -88,16 +88,19 @@ public class ShowMenuScript : ScriptBase
         m_worldModel.PlayerUi.ShowMenu(menuData);
 
         WorldModel.BeginPrompt(ref m_worldModel._menuTcs);
-        m_worldModel.BeginPendingCallback();
+        m_worldModel.BeginDormantSuspension();
         m_worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c, optionsDictionary);
     }
 
     private async Task AwaitResponseAndRunCallbackAsync(Context c, IDictionary<string, string> optionsDictionary)
     {
+        var resolved = false;
         try
         {
             var response = await m_worldModel._menuTcs!.Task;
+            resolved = true;
+            m_worldModel.SignalCallbackResolving();
             if (response != null)
                 await m_worldModel.PrintAsync(" - " + optionsDictionary[response]);
             c.Parameters["result"] = response;
@@ -107,6 +110,7 @@ public class ShowMenuScript : ScriptBase
         catch (Exception ex) { m_worldModel.LogException(ex); }
         finally
         {
+            if (!resolved) m_worldModel.SignalCallbackResolving();
             await m_worldModel.EndPendingCallbackAsync();
             m_worldModel.SignalTurnSuspended();
         }

--- a/src/Engine/Scripts/WaitScript.cs
+++ b/src/Engine/Scripts/WaitScript.cs
@@ -42,7 +42,7 @@ public class WaitScript : ScriptBase
     {
         m_worldModel.PlayerUi.DoWait();
         WorldModel.BeginPrompt(ref m_worldModel._waitTcs);
-        m_worldModel.BeginPendingCallback();
+        m_worldModel.BeginDormantSuspension();
         m_worldModel.SignalTurnSuspended();
         _ = AwaitWaitAndRunCallbackAsync(c);
         return Task.CompletedTask;
@@ -50,9 +50,12 @@ public class WaitScript : ScriptBase
 
     private async Task AwaitWaitAndRunCallbackAsync(Context c)
     {
+        var resolved = false;
         try
         {
             await m_worldModel._waitTcs.Task;
+            resolved = true;
+            m_worldModel.SignalCallbackResolving();
             if (m_callbackScript != null)
                 await m_worldModel.RunScriptAsync(m_callbackScript, c);
         }
@@ -60,6 +63,7 @@ public class WaitScript : ScriptBase
         catch (Exception ex) { m_worldModel.LogException(ex); }
         finally
         {
+            if (!resolved) m_worldModel.SignalCallbackResolving();
             await m_worldModel.EndPendingCallbackAsync();
             m_worldModel.SignalTurnSuspended();
         }

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -92,10 +92,27 @@ public partial class WorldModel : IGame, IGameDebug
     }
 
     // Tracks show menu / ask / get input callbacks that fire-and-forget their response handling.
-    // on ready defers while this is above zero, so it doesn't run mid-callback while state may
-    // still be inconsistent.
+    // Stays elevated for the whole span from Begin (suspension starts) through the matching End
+    // (the resumed callback script, if any, has finished running) - used for FinishTurn deferral
+    // and turn-pending reporting, where "still mid-callback" should count as pending. See
+    // _awaitingResolutionCount below for the narrower count 'on ready' actually gates on.
     private int _pendingCallbackCount;
     private readonly List<(IScript Script, Context Context)> _onReadyQueue = [];
+
+    // Counts wait/get input/ask/show menu suspensions that are still genuinely dormant - awaiting
+    // a real external event (player keypress, response, menu choice) - as opposed to
+    // _pendingCallbackCount, which stays elevated through the resumed callback's own synchronous
+    // execution too. 'on ready' only needs to defer while something is genuinely dormant: once a
+    // suspension resolves and its callback starts running, an 'on ready' triggered from inside it
+    // (e.g. a MoveObject that fires changedparent -> OnEnterRoom -> 'on ready') should run
+    // immediately, matching Quest 5's fully-synchronous 'on ready' - not queue behind whatever the
+    // callback's own script goes on to do next, which is what let a second MoveObject in the same
+    // wait{} callback run before the first one's on-ready (room map placement) had a chance to,
+    // leaving the second room's coordinates unset (#2176). Each Begin increments this alongside
+    // _pendingCallbackCount; call SignalCallbackResolving() exactly once, right when a suspension's
+    // own callback is about to run (or is skipped, e.g. on cancellation), to bring it back down -
+    // EndPendingCallbackAsync deliberately leaves it alone.
+    private int _awaitingResolutionCount;
 
     // Set when a pre-v580 command's (or event's) automatic FinishTurn call is pushed past a
     // wait/ask/get input/show menu it triggered - see HandleCommandAsyncInternal. Real Quest 5
@@ -123,6 +140,17 @@ public partial class WorldModel : IGame, IGameDebug
     // not start a second drain loop - it just decrements the count and returns, leaving the
     // outer loop (still on the stack) to keep going.
     private bool _isFlushingOnReadyQueue;
+
+    // Guards specifically against 'on ready' recursing into itself (AddOnReady -> RunScriptAsync
+    // -> nested 'on ready' -> AddOnReady -> ...), which is what actually risks a native stack
+    // overflow for deeply-nested 'on ready' chains (see #1779). This is deliberately separate from
+    // _pendingCallbackCount: a wait/get input/ask/show menu callback that itself calls MoveObject
+    // (triggering changedparent -> OnEnterRoom -> 'on ready') is not on-ready recursion, and
+    // deferring it just because _pendingCallbackCount is still elevated from the outer wait/etc.
+    // means the deferred callback runs after, not before, whatever the surrounding script does
+    // next - e.g. a second MoveObject in the same wait{} callback would run before the first
+    // MoveObject's on-ready (map placement) had a chance to, leaving the second room unplaced.
+    private bool _isRunningOnReadyCallback;
 
     private bool _reportingScriptError;
 
@@ -1785,13 +1813,14 @@ public partial class WorldModel : IGame, IGameDebug
 
     internal async Task AddOnReady(IScript callback, Context c)
     {
-        if (_pendingCallbackCount > 0)
+        if (_isRunningOnReadyCallback || _awaitingResolutionCount > 0)
         {
             _onReadyQueue.Add((callback, c));
             return;
         }
-        // Increment the pending count before running so that any nested 'on ready'
-        // statements encountered during execution are queued rather than recursed into.
+        // Set the flag before running so that any nested 'on ready' statements encountered
+        // during execution are queued rather than recursed into.
+        _isRunningOnReadyCallback = true;
         BeginPendingCallback();
         try
         {
@@ -1799,11 +1828,24 @@ public partial class WorldModel : IGame, IGameDebug
         }
         finally
         {
+            _isRunningOnReadyCallback = false;
             await EndPendingCallbackAsync();
         }
     }
 
     internal void BeginPendingCallback() => _pendingCallbackCount++;
+
+    // Use instead of BeginPendingCallback() at the start of a wait/get input/ask/show menu
+    // *script* command (the forms with a separate callback script that runs once a real external
+    // event resolves) - pairs with a single SignalCallbackResolving() call made right when that
+    // callback is about to run (or would have, had the suspension not been cancelled).
+    internal void BeginDormantSuspension()
+    {
+        BeginPendingCallback();
+        _awaitingResolutionCount++;
+    }
+
+    internal void SignalCallbackResolving() => _awaitingResolutionCount--;
 
     internal async Task EndPendingCallbackAsync()
     {

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -1856,12 +1856,24 @@ public partial class WorldModel : IGame, IGameDebug
         // puzzle loops) can open its next get input/wait/ask/show menu before this one's finally
         // block runs, which keeps _pendingCallbackCount above zero indefinitely; gating the drain
         // on it reaching zero left anything queued while such a loop is active stuck forever.
+        //
+        // But stop (without discarding what's left) as soon as _awaitingResolutionCount goes
+        // above zero part-way through: a queued item, once run directly here, can itself open a
+        // *new* dormant wait/get input/ask/show menu (e.g. a room's 'beforeenter' containing its
+        // own wait{} for "press any key") - anything queued after that (including further items
+        // this same pass would otherwise still process) needs to hold until that new suspension
+        // actually resolves, exactly like AddOnReady's own registration-time check. Running ahead
+        // of it here would let a later stage's 'on ready' (e.g. Grid_CalculateMapCoordinates) fire
+        // before the wait it was meant to follow ever resolved - left unset map coordinates in a
+        // real published game once #2176's first fix handled only the registration-time case.
+        // Whatever caused the new suspension will call EndPendingCallbackAsync again once it
+        // resolves, resuming the drain from here.
         if (!_isFlushingOnReadyQueue)
         {
             _isFlushingOnReadyQueue = true;
             try
             {
-                while (_onReadyQueue.Count > 0 && State != GameState.Finished)
+                while (_onReadyQueue.Count > 0 && _awaitingResolutionCount == 0 && State != GameState.Finished)
                 {
                     var (script, context) = _onReadyQueue[0];
                     _onReadyQueue.RemoveAt(0);

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -191,6 +191,29 @@ public class CallbackTests
         phase2.ShouldContain("on ready");
     }
 
+    // Regression test for #2176: a wait{} callback that chains two MoveObjects back to back
+    // (room_a then room_b) must let room_a's changedparent -> OnEnterRoom -> 'on ready' cascade
+    // - including its 'enter' script - run to completion (as if it were fully synchronous, like
+    // Quest 5) before the second MoveObject fires. Before the fix, both MoveObjects (and both
+    // top-level 'on ready' registrations) ran back to back before either room's cascade drained,
+    // so room_a's cascade actually executed once game.pov.parent already pointed at room_b, and
+    // room_b's cascade could run before room_a's - exactly the interleaving that left the real
+    // reported game's Inescapable Cage without map coordinates when it was teleported into via
+    // the same wait{ MoveObject; MoveObject } pattern.
+    [TestMethod]
+    public async Task Wait_ChainedMoveObjectsInSameCallback_EachRoomsCascadeCompletesBeforeTheNextMove()
+    {
+        var driver = await GameDriver.LoadAsync("callbacktest.aslx");
+
+        await driver.SendCommandAsync("trap");
+        await driver.FinishWaitAsync();
+
+        var game = driver.Model.Object("game");
+        game.Fields.GetString("trap_a_seen_parent").ShouldBe("room_a");
+        game.Fields.GetString("trap_b_seen_parent").ShouldBe("room_b");
+        game.Fields.GetAsType<bool>("trap_b_saw_a_entered").ShouldBeTrue();
+    }
+
     // A timer created inside a wait callback (e.g. via SetTimeout) must cause the host
     // to be told when to next call Tick(), otherwise the timer never fires. Regression
     // test for a bug where FinishWait didn't re-request the next timer tick after running

--- a/tests/EngineTests/callbacktest.aslx
+++ b/tests/EngineTests/callbacktest.aslx
@@ -151,4 +151,39 @@
       EnableTimer (chaintimer1)
     </script>
   </command>
+
+  <!-- Regression fixture for #2176: a wait{} callback that chains two MoveObjects back to
+       back (e.g. a trap that drops the player into room_a, then immediately into room_b).
+       Each room relies on CoreDescriptions' real changedparent -> OnEnterRoom -> nested
+       'on ready' cascade (the same mechanism Grid_CalculateMapCoordinates hooks into via
+       game.gridmap) to run its own 'enter' script, which records what game.pov.parent was
+       and whether the other room had already run. Before the fix, both MoveObjects (and
+       both top-level on-ready registrations) completed before either room's cascade drained,
+       so room_a's cascade actually ran with game.pov.parent already pointing at room_b, and
+       room_b's cascade could run before room_a's - exactly the interleaving that left
+       Inescapable Cage's map coordinates unset in the reported game. -->
+  <object name="room_a">
+    <inherit name="editor_room" />
+    <enter type="script">
+      game.trap_a_seen_parent = game.pov.parent.name
+      game.trap_a_entered = true
+    </enter>
+  </object>
+  <object name="room_b">
+    <inherit name="editor_room" />
+    <enter type="script">
+      game.trap_b_seen_parent = game.pov.parent.name
+      game.trap_b_saw_a_entered = GetBoolean(game, "trap_a_entered")
+    </enter>
+  </object>
+  <command name="cmd_trap">
+    <pattern>trap</pattern>
+    <script>
+      msg ("before trap")
+      wait {
+        MoveObject (player, room_a)
+        MoveObject (player, room_b)
+      }
+    </script>
+  </command>
 </asl>


### PR DESCRIPTION
## Summary

Fixes #2176 - a crash in "Whitefield Academy of Witchcraft" (and any game with a similar pattern) when a `wait{}` callback chains two `MoveObject` calls back to back, e.g.:

```
wait {
  MoveObject (player, Grislewood Kitchen)
  MoveObject (player, Inescapable Cage)
}
```

(confirmed against the reporter's own attached save file, which is a frozen self-contained package embedding the actual game script).

`AddOnReady` deferred any `on ready` (which drives `changedparent` -> `OnEnterRoom` -> `Grid_CalculateMapCoordinates` when a game uses `game.gridmap`) whenever `_pendingCallbackCount > 0`. That counter stays elevated for the *whole* span of a `wait`/`get input`/`ask`/`show menu` - including while its resumed callback is actively running synchronously, not only while it's genuinely dormant awaiting a real external event. So both `MoveObject` calls above ran back-to-back before either room's `on ready` cascade got a chance to run, and their cascades ended up queued and interleaved together instead of running in registration order - the first room's cascade (which sets the second room's map coordinates via its "in" exit) ran *after* the second room's own cascade had already tried to read those coordinates, throwing `DictionaryItem(coordinates, coordinate)': Arg_KeyNotFoundWithKey, x`.

## Fix

Splits the single overloaded counter into two:
- `_pendingCallbackCount` (unchanged) - stays elevated start-to-finish, used for `FinishTurn` deferral and turn-pending reporting.
- `_awaitingResolutionCount` (new) - only counts suspensions still genuinely dormant, i.e. not yet resolved.

`AddOnReady` now defers only when actually nested inside another `on ready` (the original stack-overflow recursion guard from #1779) or while something is genuinely still waiting on a real external event - not merely because a resolved callback happens to be synchronously executing. `WaitScript`, `GetInputScript`, `AskScript`, and `ShowMenuScript` (the script-command forms with a separate callback) now signal the transition from "waiting" to "running the callback" via a new `SignalCallbackResolving()` call.

**Follow-up commit**, found while verifying against the real corpus in the private `quest-e2e-tests` repo: the first commit only guarded `AddOnReady`'s own registration-time decision, but `EndPendingCallbackAsync`'s drain loop processes the *entire* queue in one pass once started - so a queued `on ready` that itself opens a *new* dormant suspension (e.g. a room's `beforeenter` containing its own `wait{}` for "press any key") didn't stop the loop from immediately running whatever got queued next, even though that item was specifically meant to wait for the new suspension to resolve. This showed up in two other real published games (The Acreage, Woo Rebooted 3.6) that reach a room via a `wait{}`-guarded `beforeenter`. Gated the drain loop's continuation on `_awaitingResolutionCount == 0` too, matching `AddOnReady`'s own check.

## Test plan

- [x] New regression test `Wait_ChainedMoveObjectsInSameCallback_EachRoomsCascadeCompletesBeforeTheNextMove` (`tests/EngineTests/CallbackTests.cs`), using a new fixture (`tests/EngineTests/callbacktest.aslx`) that mirrors the real game's `wait{ MoveObject; MoveObject }` pattern via `changedparent` -> `OnEnterRoom`-style nested `on ready` cascades - confirmed it **fails** on the pre-fix code (the first room's `enter` script never even ran) and **passes** with the fix.
- [x] Existing `Wait_ScriptContinuesPastBlock_CallbackRunsOnKeyPress` still passes - confirms `on ready` registered while a wait is genuinely still outstanding (not yet resolved) still correctly defers until the wait resolves.
- [x] Existing `OnReady_QueuedInsideRecursiveGetInputLoop_RunsEachRound` (#1980's regression test) still passes - confirms the recursive get-input-loop drain fix is undisturbed.
- [x] `dotnet test` - all 317 tests across the solution pass.
- [x] `dotnet build --configuration Release` - full solution builds clean.
- [x] Re-ran the private `quest-e2e-tests` corpus against this branch: Whitefield Academy of Witchcraft now finishes cleanly with zero script errors (golden re-recorded); Woo Rebooted 3.6 and The Acreage improved substantially (errors dropped 15→7 and 8→5, and Woo Rebooted's previously-scrambled intro narration is now correctly ordered) but still hit a *different*, unrelated root cause (a room whose map coordinates are never established by any code path - a late-visible exit or a pure scripted teleport with no `Exit` object at all) that's out of scope for this fix; spondre's script-error count dropped from 21 to 1. See that repo's README for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)