### PR TITLE
fix(Engine): drain the 'on ready' queue once at the turn boundary, not reentrantly

### DIFF
--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -93,11 +93,30 @@ public partial class WorldModel : IGame, IGameDebug
 
     // Tracks show menu / ask / get input callbacks that fire-and-forget their response handling.
     // Stays elevated for the whole span from Begin (suspension starts) through the matching End
-    // (the resumed callback script, if any, has finished running) - used for FinishTurn deferral
-    // and turn-pending reporting, where "still mid-callback" should count as pending. See
-    // _awaitingResolutionCount below for the narrower count 'on ready' actually gates on.
+    // (the resumed callback script, if any, has finished running), so it only returns to zero at
+    // the true end of a turn - which is what makes it the right trigger for turn-pending
+    // reporting, for FinishTurn deferral, and for flushing _deferredOnReadyQueue. See
+    // _awaitingResolutionCount below for the narrower count that decides, at registration time,
+    // whether an 'on ready' has to be deferred in the first place.
     private int _pendingCallbackCount;
-    private readonly List<(IScript Script, Context Context)> _onReadyQueue = [];
+
+    // 'on ready' scripts registered while a wait/get input/ask/show menu was genuinely dormant.
+    // This is the direct equivalent of Quest 5.10.2's CallbackManager.m_onReadyCallbacks: there,
+    // AddOnReady queues whenever m_callbacks.AnyOutstanding(), and the queue is flushed in exactly
+    // one place - TryRunOnFinallyScripts, reached from TryFinishTurn at the end of
+    // RunCallbackAndFinishTurn, i.e. once per resolved suspension, after that suspension's whole
+    // callback script has run. See FlushDeferredOnReadyQueueAsync.
+    private readonly List<(IScript Script, Context Context)> _deferredOnReadyQueue = [];
+
+    // 'on ready' scripts encountered *inside* another 'on ready' callback while nothing was
+    // dormant. Quest 5 simply recursed into these on the spot; Viva queues them instead, to avoid
+    // a native stack overflow on deeply nested chains (#1779) - so they are a trampoline, not a
+    // deferral. They belong to the on-ready chain currently executing and run at the end of it
+    // (see RunNestedOnReadyQueueAsync), long before the turn boundary that flushes
+    // _deferredOnReadyQueue. Keeping the two apart is what stops a stale item queued back when an
+    // older suspension was dormant from being dragged forward into the middle of an unrelated
+    // cascade (#2179).
+    private readonly List<(IScript Script, Context Context)> _nestedOnReadyQueue = [];
 
     // Counts wait/get input/ask/show menu suspensions that are still genuinely dormant - awaiting
     // a real external event (player keypress, response, menu choice) - as opposed to
@@ -133,12 +152,12 @@ public partial class WorldModel : IGame, IGameDebug
         }
     }
 
-    // Guards the on-ready drain loop in EndPendingCallbackAsync against re-entry: a queued
-    // script can itself synchronously await another prompt (e.g. a synchronous "play sound",
-    // or the GetInput()/Ask()/ShowMenu() expression forms), which calls EndPendingCallbackAsync
-    // again from within the drain loop's own call stack. When that happens, the inner call must
-    // not start a second drain loop - it just decrements the count and returns, leaving the
-    // outer loop (still on the stack) to keep going.
+    // Guards FlushDeferredOnReadyQueueAsync against re-entry: a flushed script can itself run a
+    // Begin/EndPendingCallback pair (a directly-run 'on ready', a synchronous "play sound", or the
+    // GetInput()/Ask()/ShowMenu() expression forms), and that inner End can see
+    // _pendingCallbackCount back at zero and try to start a second flush from within the first
+    // one's own call stack. When that happens the inner call must just return, leaving the outer
+    // loop (still on the stack) to keep going.
     private bool _isFlushingOnReadyQueue;
 
     // Guards specifically against 'on ready' recursing into itself (AddOnReady -> RunScriptAsync
@@ -804,7 +823,8 @@ public partial class WorldModel : IGame, IGameDebug
         _questionTcs?.TrySetCanceled();
         _commandInputTcs?.TrySetCanceled();
         _pauseTcs?.TrySetCanceled();
-        _onReadyQueue.Clear();
+        _deferredOnReadyQueue.Clear();
+        _nestedOnReadyQueue.Clear();
 
         RequestNextTimerTick?.Invoke(0);
         Finished?.Invoke();
@@ -1813,23 +1833,74 @@ public partial class WorldModel : IGame, IGameDebug
 
     internal async Task AddOnReady(IScript callback, Context c)
     {
-        if (_isRunningOnReadyCallback || _awaitingResolutionCount > 0)
+        // Check dormancy first: it wins over on-ready nesting, matching Quest 5.10.2's single
+        // AnyOutstanding() test. An 'on ready' registered while a wait/get input/ask/show menu is
+        // dormant belongs to the turn-boundary queue however deeply nested it is - it must not be
+        // treated as part of the chain currently executing, which is free to finish long before
+        // that suspension resolves.
+        if (_awaitingResolutionCount > 0)
         {
-            _onReadyQueue.Add((callback, c));
+            _deferredOnReadyQueue.Add((callback, c));
             return;
         }
+
+        if (_isRunningOnReadyCallback)
+        {
+            _nestedOnReadyQueue.Add((callback, c));
+            return;
+        }
+
         // Set the flag before running so that any nested 'on ready' statements encountered
         // during execution are queued rather than recursed into.
         _isRunningOnReadyCallback = true;
         BeginPendingCallback();
         try
         {
-            await RunScriptAsync(callback, c);
+            try
+            {
+                await RunScriptAsync(callback, c);
+            }
+            finally
+            {
+                // In the finally, so that a script error part-way through the callback still runs
+                // whatever it managed to queue. Leaving items in _nestedOnReadyQueue would strand
+                // them until some unrelated 'on ready' happened along - which, for the OnEnterRoom
+                // cascade, means silently losing the rest of a room's arrival text.
+                await RunNestedOnReadyQueueAsync();
+            }
         }
         finally
         {
             _isRunningOnReadyCallback = false;
             await EndPendingCallbackAsync();
+        }
+    }
+
+    // Trampolined stand-in for Quest 5's native recursion into a nested 'on ready' (see
+    // _nestedOnReadyQueue). Runs the chain the outermost 'on ready' started out to its end, so
+    // that - as in Quest 5 - the whole cascade has finished by the time control returns to the
+    // statement after the 'on ready' block. Nested registrations made while this runs are
+    // appended (_isRunningOnReadyCallback is still set), so the loop naturally follows the chain
+    // however deep it goes, without growing the native stack.
+    private async Task RunNestedOnReadyQueueAsync()
+    {
+        while (_nestedOnReadyQueue.Count > 0 && State != GameState.Finished)
+        {
+            if (_awaitingResolutionCount > 0)
+            {
+                // Something in this chain opened a new dormant wait/get input/ask/show menu (e.g.
+                // a room's 'beforeenter' containing its own "press any key" wait{}). Whatever is
+                // still queued has to hold until that resolves - which is exactly what
+                // _deferredOnReadyQueue means. Hand them over rather than running ahead of the
+                // suspension, or stranding them here where nothing would ever drain them again.
+                _deferredOnReadyQueue.AddRange(_nestedOnReadyQueue);
+                _nestedOnReadyQueue.Clear();
+                return;
+            }
+
+            var (script, context) = _nestedOnReadyQueue[0];
+            _nestedOnReadyQueue.RemoveAt(0);
+            await RunScriptAsync(script, context);
         }
     }
 
@@ -1851,47 +1922,68 @@ public partial class WorldModel : IGame, IGameDebug
     {
         _pendingCallbackCount--;
 
-        // Drain whenever *this* Begin/End pair resolves - not only once every other
-        // outstanding callback has also resolved. A script (e.g. get_partition_sequence-style
-        // puzzle loops) can open its next get input/wait/ask/show menu before this one's finally
-        // block runs, which keeps _pendingCallbackCount above zero indefinitely; gating the drain
-        // on it reaching zero left anything queued while such a loop is active stuck forever.
+        // _pendingCallbackCount returning to zero is Viva's turn boundary: the outermost
+        // wait/get input/ask/show menu of the current chain has now finished running its callback
+        // script *including* everything that script went on to do, because every suspension holds
+        // a count of its own from Begin right through to the end of its callback. That makes this
+        // the counterpart of Quest 5.10.2's one and only flush point - TryFinishTurn ->
+        // TryRunOnFinallyScripts at the end of RunCallbackAndFinishTurn.
         //
-        // But stop (without discarding what's left) as soon as _awaitingResolutionCount goes
-        // above zero part-way through: a queued item, once run directly here, can itself open a
-        // *new* dormant wait/get input/ask/show menu (e.g. a room's 'beforeenter' containing its
-        // own wait{} for "press any key") - anything queued after that (including further items
-        // this same pass would otherwise still process) needs to hold until that new suspension
-        // actually resolves, exactly like AddOnReady's own registration-time check. Running ahead
-        // of it here would let a later stage's 'on ready' (e.g. Grid_CalculateMapCoordinates) fire
-        // before the wait it was meant to follow ever resolved - left unset map coordinates in a
-        // real published game once #2176's first fix handled only the registration-time case.
-        // Whatever caused the new suspension will call EndPendingCallbackAsync again once it
-        // resolves, resuming the drain from here.
-        if (!_isFlushingOnReadyQueue)
-        {
-            _isFlushingOnReadyQueue = true;
-            try
-            {
-                while (_onReadyQueue.Count > 0 && _awaitingResolutionCount == 0 && State != GameState.Finished)
-                {
-                    var (script, context) = _onReadyQueue[0];
-                    _onReadyQueue.RemoveAt(0);
-                    await RunScriptAsync(script, context);
-                }
-            }
-            finally
-            {
-                _isFlushingOnReadyQueue = false;
-            }
-        }
-
-        // Run any FinishTurn a command/event deferred past this callback (see
-        // _finishTurnDeferred), but only once every wait/ask/get input/show menu from that turn -
-        // including ones nested inside this callback's own script - has actually resolved.
+        // Draining from every intermediate Begin/End pair instead (what Viva did up to #2177) ran
+        // items reentrantly, half-way through an unrelated cascade and ahead of statements still
+        // pending higher up the callback's own stack - which silently swallowed a room
+        // description in a real published game (#2179). Gating on _awaitingResolutionCount alone
+        // isn't enough either: it drops to zero the moment a suspension resolves, before its
+        // callback script has run a single statement.
+        //
+        // This also subsumes the old "_awaitingResolutionCount == 0" condition - a dormant
+        // suspension holds a _pendingCallbackCount for at least as long as it is dormant, so the
+        // count can only be zero when nothing is dormant either. And nothing gets stranded by
+        // waiting for it: an item only ever reaches a queue while a suspension is outstanding,
+        // and that suspension's own End is guaranteed to run (callbacks resolve, cancel, or
+        // report an error, all through the same finally block) and to bring the count back down.
         if (_pendingCallbackCount == 0)
         {
+            await FlushDeferredOnReadyQueueAsync();
+
+            // Run any FinishTurn a command/event deferred past this callback (see
+            // _finishTurnDeferred). Quest 5 orders these the same way round: TryFinishTurn flushes
+            // the on-ready queue first, then runs FinishTurn.
             await RunDeferredFinishTurnAsync();
+        }
+    }
+
+    private async Task FlushDeferredOnReadyQueueAsync()
+    {
+        if (_isFlushingOnReadyQueue)
+        {
+            return;
+        }
+
+        _isFlushingOnReadyQueue = true;
+        try
+        {
+            // Stop (without discarding what's left) as soon as _awaitingResolutionCount goes above
+            // zero part-way through: a flushed item can itself open a *new* dormant
+            // wait/get input/ask/show menu (e.g. a room's 'beforeenter' containing its own wait{}
+            // for "press any key"), and anything still queued has to hold until that resolves,
+            // exactly like AddOnReady's registration-time check. Running ahead of it would let a
+            // later stage's 'on ready' (e.g. Grid_CalculateMapCoordinates) fire before the wait it
+            // was meant to follow - which left unset map coordinates in a real published game.
+            // The new suspension's own End reaches the zero-count boundary above once it resolves,
+            // resuming the flush from here. Quest 5's flush is a flat foreach with no such check;
+            // this is a deliberate divergence, and the conservative direction to diverge in.
+            while (_deferredOnReadyQueue.Count > 0 && _awaitingResolutionCount == 0 &&
+                   State != GameState.Finished)
+            {
+                var (script, context) = _deferredOnReadyQueue[0];
+                _deferredOnReadyQueue.RemoveAt(0);
+                await RunScriptAsync(script, context);
+            }
+        }
+        finally
+        {
+            _isFlushingOnReadyQueue = false;
         }
     }
 

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -299,6 +299,53 @@ public class CallbackTests
         phase4.ShouldContain("stopped");
     }
 
+    // Regression test for #2179 (a gap left by #2177). An 'on ready' registered while a wait{}
+    // was still dormant must run at the *end* of that wait's callback script, not part-way
+    // through it. Viva used to attempt a drain from every Begin/End pair that completed, so an
+    // unrelated 'on ready' cascade inside the callback (here, and in the real reported game, a
+    // MoveObject's OnEnterRoom chain) dragged the older queued item forward and ran it before the
+    // statements still pending above it on the callback's own stack - which is how "The Mouse Who
+    // Woke Up For Christmas" lost a room description entirely: the queued callback re-ran
+    // ShowRoomDescription while game.autodescription_* were still zeroed, instead of after the
+    // wait callback had restored them. Quest 5.10.2 flushes its on-ready queue exactly once, from
+    // TryFinishTurn at the end of RunCallbackAndFinishTurn.
+    [TestMethod]
+    public async Task OnReady_QueuedBeforeWait_RunsAfterTheWholeWaitCallback()
+    {
+        var driver = await GameDriver.LoadAsync("callbacktest.aslx");
+
+        var phase1 = await driver.SendCommandAsync("staleonready");
+        phase1.ShouldNotContain("callback end");
+
+        var phase2 = (await driver.FinishWaitAsync()).ToList();
+        phase2.ShouldContain("inner cascade");
+        phase2.ShouldContain("callback end");
+        // The queued 'on ready' must see the state the callback script left behind...
+        phase2.ShouldContain("stale: flag=1");
+        // ...because it ran after the callback finished, not reentrantly inside it.
+        phase2.IndexOf("callback end").ShouldBeLessThan(phase2.IndexOf("stale: flag=1"));
+    }
+
+    // Sibling 'on ready' scripts queued inside one outer 'on ready' are a trampoline for what
+    // Quest 5 did with native recursion, so they normally all run before control returns to the
+    // statement after the block. When one of them opens a wait{}, the rest have to hold until it
+    // resolves - but must not be stranded: they move to the same queue as anything else deferred
+    // by a dormant suspension, and are flushed at the end of the wait's callback.
+    [TestMethod]
+    public async Task OnReady_SiblingQueuedBehindNestedWait_RunsWhenTheWaitResolves()
+    {
+        var driver = await GameDriver.LoadAsync("callbacktest.aslx");
+
+        var phase1 = await driver.SendCommandAsync("nestedwaitsibling");
+        phase1.ShouldContain("sibling1 before");
+        phase1.ShouldNotContain("sibling2");
+
+        var phase2 = (await driver.FinishWaitAsync()).ToList();
+        phase2.ShouldContain("sibling1 wait done");
+        phase2.ShouldContain("sibling2");
+        phase2.IndexOf("sibling1 wait done").ShouldBeLessThan(phase2.IndexOf("sibling2"));
+    }
+
     // Tick() used to call SendNextTimerRequest() right after *starting* (not awaiting)
     // TickAsyncInternal, unlike every other entry point (FinishWait, FinishPause,
     // SetQuestionResponse, SetMenuResponse, HandleCommandAsyncInternal, SendEventCore,

--- a/tests/EngineTests/V5BlockingTests.cs
+++ b/tests/EngineTests/V5BlockingTests.cs
@@ -156,6 +156,37 @@ public class V5BlockingTests
         phase2.ShouldContain("room2 turnscript");
     }
 
+    // #2179, second ordering bug found by the same investigation. A room entered while another
+    // wait{} is still dormant has its whole OnEnterRoom 'on ready' cascade queued, and that
+    // cascade has to run to completion before the turn's deferred FinishTurn. Viva used to
+    // discharge FinishTurn from the Begin/End pair of an *intermediate* stage of the cascade -
+    // the queue was drained by a flat loop that re-entered AddOnReady for each nested stage, and
+    // the innermost stage's End saw the pending count back at zero - so turnscripts ran before
+    // the room's own 'enter' script had. In a real published v550 game that pushed the ending
+    // scene's SetTurnTimeout a whole turn late.
+    [TestMethod]
+    public async Task Wait_RoomEnteredWhileSecondWaitDormant_EnterScriptRunsBeforeTurnScripts()
+    {
+        var driver = await V5BlockingGameDriver.LoadAsync("waitturnscripttest.aslx");
+
+        var phase1 = await driver.SendCommandAsync("movewaitdormant");
+        phase1.ShouldContain("before wait");
+        phase1.ShouldNotContain("entered room3");
+
+        // Resolves the outer wait; the callback opens the inner one and moves the player, so the
+        // room's cascade is queued rather than run.
+        var phase2 = await driver.FinishWaitAsync();
+        phase2.ShouldNotContain("entered room3");
+        phase2.ShouldNotContain("room1 turnscript");
+
+        var phase3 = (await driver.FinishWaitAsync()).ToList();
+        phase3.ShouldContain("entered room3");
+        // The 'enter' script enabled room3's turnscript, so this turn's turnscripts - run by the
+        // FinishTurn deferred from the original command - must see it enabled and fire it.
+        phase3.ShouldContain("room3 turnscript");
+        phase3.IndexOf("entered room3").ShouldBeLessThan(phase3.IndexOf("room3 turnscript"));
+    }
+
     // A wait callback that opens another wait (e.g. a two-beat cutscene) must resolve each
     // key press independently, and FinishTurn/turnscripts must wait for both - not just the
     // first - to resolve. 'wait { }' itself is fire-and-forget regardless of version (matching

--- a/tests/EngineTests/callbacktest.aslx
+++ b/tests/EngineTests/callbacktest.aslx
@@ -176,6 +176,50 @@
       game.trap_b_saw_a_entered = GetBoolean(game, "trap_a_entered")
     </enter>
   </object>
+  <!-- #2179: an 'on ready' registered while a wait{} is dormant must not be run by a
+       reentrant drain triggered from an unrelated 'on ready' cascade inside that wait's own
+       callback - it must wait for the callback script to finish, exactly like Quest 5.10.2's
+       single TryRunOnFinallyScripts flush at the end of RunCallbackAndFinishTurn. So the
+       stale callback must observe stale_flag = 1, and run after "callback end". -->
+  <command name="cmd_stale_on_ready">
+    <pattern>staleonready</pattern>
+    <script>
+      game.stale_flag = 0
+      on ready {
+        wait {
+          on ready {
+            msg ("inner cascade")
+          }
+          game.stale_flag = 1
+          msg ("callback end")
+        }
+        on ready {
+          msg ("stale: flag=" + game.stale_flag)
+        }
+      }
+    </script>
+  </command>
+
+  <!-- Two sibling 'on ready' scripts queued inside the same outer 'on ready', where the first
+       opens a wait{}. The second can't run until that wait resolves, and must not be stranded
+       in the meantime. -->
+  <command name="cmd_nested_wait_sibling">
+    <pattern>nestedwaitsibling</pattern>
+    <script>
+      on ready {
+        on ready {
+          msg ("sibling1 before")
+          wait {
+            msg ("sibling1 wait done")
+          }
+        }
+        on ready {
+          msg ("sibling2")
+        }
+      }
+    </script>
+  </command>
+
   <command name="cmd_trap">
     <pattern>trap</pattern>
     <script>

--- a/tests/EngineTests/waitturnscripttest.aslx
+++ b/tests/EngineTests/waitturnscripttest.aslx
@@ -124,6 +124,22 @@
     </turnscript>
   </object>
 
+  <!-- Entered via a MovePlayer that happens while a second wait{} is still dormant, so the
+       whole OnEnterRoom 'on ready' cascade - including this 'enter' script - is queued and only
+       runs once that inner wait resolves. -->
+  <object name="room3">
+    <enter type="script">
+      msg ("entered room3")
+      EnableTurnScript (room3turn)
+    </enter>
+    <turnscript name="room3turn">
+      <enabled type="boolean">false</enabled>
+      <script>
+        msg ("room3 turnscript")
+      </script>
+    </turnscript>
+  </object>
+
   <!-- The wait callback moves the player to room2, but only once the wait actually
        resolves (key press / FinishWait). FinishTurn/RunTurnScripts must not run until
        after that move, otherwise room1's turnscript incorrectly fires for a turn where
@@ -152,6 +168,23 @@
           msg ("step3")
         }
         msg ("step4")
+      }
+    </script>
+  </command>
+  <!-- Mirrors the shape of a real published v550 game ("Xanadu - The World's Only Hope"):
+       the outer wait's callback opens a second, empty wait{} - fire-and-forget, so it is still
+       dormant - and then moves the player. The move's OnEnterRoom 'on ready' cascade is queued
+       behind that inner wait, and runs only once it resolves. The room's own 'enter' script is
+       part of that cascade, so it must run before the turn's deferred FinishTurn/RunTurnScripts,
+       not half-way through it. -->
+  <command name="cmd_movewait_dormant">
+    <pattern>movewaitdormant</pattern>
+    <script>
+      msg ("before wait")
+      wait {
+        wait {
+        }
+        MovePlayer (room3)
       }
     </script>
   </command>


### PR DESCRIPTION
Fixes #2179.

## Root cause

Viva's single `_onReadyQueue` was conflating two things that Quest 5.10.2 keeps completely separate:

1. **"deferred because a wait/get input/ask/show menu is dormant"** — Quest 5's actual `m_onReadyCallbacks`, flushed at exactly *one* point: `TryFinishTurn` → `TryRunOnFinallyScripts`, at the end of `RunCallbackAndFinishTurn`.
2. **"queued to avoid a native stack overflow on nested `on ready`"** — a Viva-only trampoline (#1779). Quest 5 just recursed into a nested `on ready` on the spot.

Because both lived in one list drained by one loop, an item queued for reason 1 got picked up by a drain triggered for reason 2 — reentrantly, half-way through an unrelated cascade and ahead of statements still pending higher up the wait callback's own stack. That's the "drains reentrant/too-early" behaviour the issue describes.

## Fix

Split the queue in two, with different drain rules:

- **`_deferredOnReadyQueue`** — flushed only when `_pendingCallbackCount` reaches zero in `EndPendingCallbackAsync`. That counter stays elevated from a suspension's `Begin` right through the end of its callback script, so zero *is* the true end of turn — the direct counterpart of Quest 5's single flush point. It also subsumes the old `_awaitingResolutionCount == 0` condition, since a dormant suspension always holds a pending count for at least as long.
- **`_nestedOnReadyQueue`** — a trampoline drained at the end of the outermost `AddOnReady`, standing in for Quest 5's native recursion. If an item there opens a *new* dormant suspension, the remainder is handed to the deferred queue rather than run early or stranded.

Registration now tests dormancy *first*, matching Quest 5's single `AnyOutstanding()` check.

The issue's stated constraint holds: `OnReady_QueuedInsideRecursiveGetInputLoop_RunsEachRound` (#1980) still passes. It turns out #2177's registration-time `_awaitingResolutionCount` fix already handles that loop on its own — the on-ready never gets queued at all, exactly as in Quest 5, where the callback is `Pop`ped before its script runs. That's what makes returning to Quest 5's strict flush condition safe now, where it wasn't pre-#2177.

## A second ordering bug fell out

Comparing golden snapshots across the whole `quest-e2e-tests` corpus surfaced one other deterministic change: **Xanadu - The World's Only Hope**, whose ending scene fired a turn late.

Same root cause. The old flat drain loop re-entered `AddOnReady` for each stage of a room's `OnEnterRoom` cascade, and the innermost stage's `End` saw the pending count back at zero and discharged the turn's deferred `FinishTurn` — *before* the room's own `enter` script (carrying `SetTurnTimeout (2)`) had run. Tracing the Quest 5.10.2 path for that exact shape confirms the new ordering is the correct one: `TryRunOnFinallyScripts` runs the whole cascade inline, *then* `RunProcedure("FinishTurn")`.

## Testing

New regression tests, all of which fail on `main` and pass here:

- `OnReady_QueuedBeforeWait_RunsAfterTheWholeWaitCallback` — the #2179 shape, reduced to a minimal fixture. On `main` it prints `stale: flag=0` *before* `callback end`; now it prints `stale: flag=1` after.
- `OnReady_SiblingQueuedBehindNestedWait_RunsWhenTheWaitResolves` — pins the trampoline hand-off, so a sibling queued behind a nested `wait{}` isn't stranded.
- `Wait_RoomEnteredWhileSecondWaitDormant_EnterScriptRunsBeforeTurnScripts` — the Xanadu shape, in the existing pre-v580 `waitturnscripttest.aslx` fixture.

Full suite green: 320 EngineTests, 0 failures across all projects.

**Real-game corpus** (private `quest-e2e-tests`, 58 games). Note the goldens there are already stale — 18 games fail on clean `main` — and ~15 of the 58 differ run-to-run, so raw FAIL counts are meaningless. I compared three full golden snapshots (main / this branch / this branch again, to measure the noise floor) and isolated **exactly two** deterministic changes, both improvements:

- `dwh6ap1wbkqtujkhgxzrog` (The Mouse Who Woke Up For Christmas) — the missing "Inside A Cage" description returns, as a clean 16-line insertion right where Quest 5.10.2 would put it.
- `sihv9g3rdki50mt9_1v4bq` (Xanadu - The World's Only Hope) — ending fires on the correct turn.

Both goldens need re-baselining in `quest-e2e-tests` once this lands; per the issue, the other 12 goldens from `b799935` are still worth a spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
