### PR TITLE
fix(Engine): don't treat string concatenation with an unset attribute as an error

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -367,7 +367,14 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             // null instead of a proper value - this typically means the operand is an attribute
             // that has never been assigned. Equality/inequality already handles null cleanly
             // (both here and natively in NCalc), so this only needs to guard arithmetic.
-            if (!isEquality && (left is null || right is null))
+            //
+            // "text" + unset is *not* arithmetic: it's string concatenation, where both .NET and
+            // NCalc treat a null operand as an empty string, and real games rely on that. Core's
+            // own FormatStatusAttribute concatenates a status attribute's value with no null check
+            // whenever the attribute has no format string ('CapFirst(attr) + ": " + value'), so
+            // guarding it here turns every status bar listing a not-yet-set attribute into a
+            // script error.
+            if (!isEquality && (left is null || right is null) && !IsStringConcatenation(args, left, right))
             {
                 var description = left is null ? leftNullDescription : rightNullDescription;
                 throw new Exception(description != null
@@ -394,6 +401,11 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             }
         }
     }
+
+    // '+' means concatenation as soon as either side is a string, so a null on the other side is
+    // an empty string rather than an unset number - see the guard in HandleBinaryResult.
+    private static bool IsStringConcatenation(BinaryEventArgs args, object left, object right) =>
+        args.BinaryExpression.Type == BinaryExpressionType.Plus && (left is string || right is string);
 
     private static bool IsStandardNCalcType(object value) =>
         value is null or int or long or double or float or decimal or byte or short or uint or ulong or ushort or sbyte or bool or string;

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -700,6 +700,19 @@ public class ExpressionTests
     }
 
     [TestMethod]
+    public async Task TestUnsetAttribute_ConcatenatedWithString_TreatedAsEmptyString()
+    {
+        // '+' with a string on either side is concatenation, not arithmetic, so an unset attribute
+        // is an empty string here - the arithmetic guard above must not fire. Core's own
+        // FormatStatusAttribute relies on this: with no format string it builds
+        // 'CapFirst(attr) + ": " + value' with no null check, so guarding it would turn any status
+        // bar listing a not-yet-set attribute into a script error.
+        (await RunExpression<string>($"\"prefix\" + {ObjectName}.unsetattribute")).ShouldBe("prefix");
+        (await RunExpression<string>($"{ObjectName}.unsetattribute + \"suffix\"")).ShouldBe("suffix");
+        (await RunExpression<string>($"\"a\" + {ObjectName}.unsetattribute + \"b\"")).ShouldBe("ab");
+    }
+
+    [TestMethod]
     public async Task TestObjectEqualToStringReturnsFalse()
     {
         // Cross-type equality (Element vs string) must return false, not throw IConvertible.


### PR DESCRIPTION
## Problem

#2167 added a guard so that using a never-assigned attribute in arithmetic reports a clear message instead of leaking a raw `NullReferenceException`. The guard in `HandleBinaryResult` fires on *any* null operand of a non-equality binary operator:

```csharp
if (!isEquality && (left is null || right is null))
```

That also catches `+` used for **string concatenation**, where a null operand isn't an unset number — it's an empty string, and both .NET and NCalc already handle it that way.

Quest games rely on that. Core's own `FormatStatusAttribute` (`CoreStatusAttributes.aslx`) builds the status line with no null check whenever a status attribute has no format string:

```
if (LengthOf(format) = 0) {
  return (CapFirst(attr) + ": " + value)
}
```

(only the `else` branch handles `TypeOf(value) = "null"`). So any status bar listing an attribute that hasn't been set yet started reporting a script error on every status update.

## How it was found

The Gift of the Magi, in the private e2e corpus, has a single status attribute with an empty format string. Its transcript went from clean to three errors before the first command:

```
[error] Error evaluating expression 'CapFirst(attr) + ": " + value': Cannot use this value in a
calculation because it has not been set - check whether an attribute or variable has been assigned
a value before using it.
[error] Error evaluating expression 'status + FormatStatusAttribute(attr, GetAttribute(element,
attr), StringDictionaryItem(statusAttributes, attr))': ...
[error] Object reference not set to an instance of an object.
```

Bisected to 7876e1a1 (#2167): the game runs clean at its parent commit, and clean again with this fix.

## Fix

Skip the guard for `Plus` when either operand is a string. Genuine arithmetic is unchanged, and #2167's own regression tests still pass.

## Testing

- Three new cases in `ExpressionTests` covering null-on-the-right, null-on-the-left, and null in the middle of a chain.
- Full `dotnet test` green (394 tests, 5 projects).
- Corpus-wide check via the snapshot-diff method: 16 goldens moved before→after, 15 of them inside the measured run-to-run noise floor. The only game this change affects deterministically is The Gift of the Magi, which now matches its pre-existing golden byte-for-byte with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)