### PR TITLE
perf(WasmPlayer): cache static assets immutably instead of revalidating ~210 per load

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -69,11 +69,72 @@ jobs:
           cp -r src/WasmEditor/bin/Release/net10.0/browser-wasm/AppBundle/. deploy/AppBundle/
           cp -r src/WasmPlayer/bin/Release/net10.0/browser-wasm/AppBundle/. deploy/player/
           cat > deploy/_headers <<'EOF'
-          /player/_framework/*
-            Cache-Control: no-cache
+          # Cloudflare Pages' default for a static asset is
+          # `max-age=0, must-revalidate`, so without these rules a warm reload
+          # of /player spends ~210 conditional requests to move ~90 KB. Every
+          # path listed below is only ever requested with a `?v=<release>`
+          # cache key on it (WasmPlayer: inject-version.mjs stamps the markup,
+          # wasm-player.js the assets it fetches from JS; AppShell: wasm.ts) or
+          # is already content-hashed by Vite (/_app/immutable), so a deploy
+          # always produces a fresh URL and these can be cached indefinitely.
+          #
+          # For _framework/* the version is also what makes this *safe*, and it
+          # replaces the blanket `Cache-Control: no-cache` that used to sit
+          # here: those filenames aren't content-hashed and AOT output isn't
+          # byte-reproducible, so a browser pairing a cached dotnet.boot.js
+          # (the manifest of per-file SHA-256 hashes) with a binary from a
+          # later deploy got an SRI failure. Stamping both with the same
+          # version means they can't come from different deploys.
+          #
+          # Add nothing here that isn't requested with that version — an
+          # `immutable` response to an unversioned URL cannot be busted by any
+          # later deploy, by us or by the visitor. Three things are deliberately
+          # left on the default `must-revalidate` for exactly that reason:
+          # /player/index.html (which is what delivers each new version in the
+          # first place), /player/lib/images/* (referenced by relative URL from
+          # inside jquery-ui.min.css, so never stamped), and
+          # /AppBundle/_framework/dotnet.native.js.symbols (WasmEditor sets
+          # WasmEmitSymbolMap, and the runtime doesn't route that one asset
+          # through the resource loader that stamps all the others) — hence
+          # matching _framework/ by extension below rather than with a blanket
+          # `/*`, so the symbols file falls through to the default.
+          #
+          # Pattern semantics, confirmed against the live deployment rather
+          # than assumed: a `*` spans `/` (the `/*.js` rule below reaches
+          # /player/lib/paper.js), and a match is anchored at both ends (that
+          # same rule does *not* catch dotnet.native.js.symbols).
+          /player/_framework/*.wasm
+            Cache-Control: public, max-age=31536000, immutable
 
-          /AppBundle/_framework/*
-            Cache-Control: no-cache
+          /player/_framework/*.dat
+            Cache-Control: public, max-age=31536000, immutable
+
+          /AppBundle/_framework/*.wasm
+            Cache-Control: public, max-age=31536000, immutable
+
+          /AppBundle/_framework/*.dat
+            Cache-Control: public, max-age=31536000, immutable
+
+          /AppBundle/_framework/*.js
+            Cache-Control: public, max-age=31536000, immutable
+
+          /_app/immutable/*
+            Cache-Control: public, max-age=31536000, immutable
+
+          # Covers /player/lib/* and the four /player/_framework/*.js files too.
+          /player/*.js
+            Cache-Control: public, max-age=31536000, immutable
+
+          /player/*.css
+            Cache-Control: public, max-age=31536000, immutable
+
+          /player/*.svg
+            Cache-Control: public, max-age=31536000, immutable
+
+          # Fetched by wasm-player.js at boot. Spelled out in full rather than
+          # as `*.htm`, so there is no chance of it also catching index.html.
+          /player/playercore.htm
+            Cache-Control: public, max-age=31536000, immutable
 
           /*.js
             Content-Type: application/javascript; charset=utf-8

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -392,6 +392,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-location-bar-status-rename.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-asset-versioning.mjs http://localhost:5175
+        working-directory: tests/e2e
 
   # WebPlayer (ASP.NET Core + Blazor Server), Development mode with Dev:Enabled
   # (appsettings.Development.json already sets this — see /dev/open's

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -1,3 +1,15 @@
+import { PUBLIC_APPSHELL_VERSION } from "$env/static/public";
+
+// Cache key for the WasmEditor AppBundle, mirroring what WasmPlayer's
+// inject-version.mjs/wasm-player.js do for /player — see the _headers block in
+// .github/workflows/deploy-play.yml. Two things need it: the version makes each
+// deploy a distinct URL so /AppBundle/_framework/* can be served `immutable`
+// instead of revalidating ~190 files on every editor load, and it keeps
+// dotnet.boot.js (the manifest of per-file SHA-256 hashes) from ever being
+// paired with a binary from a different deploy, which fails the SRI check.
+// Blank in a dev build, where the assets aren't cached anyway.
+const versionQuery = PUBLIC_APPSHELL_VERSION ? `?v=${encodeURIComponent(PUBLIC_APPSHELL_VERSION)}` : "";
+
 export interface WasmBridge {
   AddAdjacentFile(filename: string, data: Uint8Array): void
   Initialise(bytes: Uint8Array, filename: string): Promise<string>
@@ -157,10 +169,23 @@ export async function loadWasm(): Promise<WasmBridge> {
         // Use new Function to prevent Vite's import-analysis plugin from trying to resolve
         // the URL at build time — it only exists as a runtime-served file.
         const loadModule = new Function("url", "return import(url)");
-        const { dotnet } = (await loadModule("/AppBundle/_framework/dotnet.js")) as { dotnet: any };
+        // dotnet.js reads the query back off its own import.meta.url and
+        // propagates it to the JS modules it imports and to dotnet.boot.js
+        // (`modulesUniqueQuery`), so only the remaining assets — assemblies,
+        // dotnet.native.wasm, ICU data — need stamping in withResourceLoader.
+        const { dotnet } = (await loadModule(`/AppBundle/_framework/dotnet.js${versionQuery}`)) as { dotnet: any };
 
         const { getAssemblyExports, getConfig, runMain } = await dotnet
             .withDiagnosticTracing(false)
+            // Without this the loader fetches every asset with `cache:
+            // "no-cache"`, forcing a conditional request no matter what the CDN
+            // said about freshness — which would make `immutable` pointless.
+            .withConfig({ disableNoCacheFetch: !!versionQuery })
+            // null means "use the default URL" — right for the modules and the
+            // manifest, which modulesUniqueQuery has already stamped; doing it
+            // again here would give them a doubled `?v=...?v=...`.
+            .withResourceLoader((type: string, _name: string, defaultUri: string) =>
+                !versionQuery || type === "manifest" || type === "dotnetjs" ? null : defaultUri + versionQuery)
             .create();
 
         await runMain();

--- a/src/WasmPlayer/scripts/export-embedded.mjs
+++ b/src/WasmPlayer/scripts/export-embedded.mjs
@@ -52,6 +52,27 @@ const cdnBase = `https://cdn.jsdelivr.net/npm/@textadventures/quest-viva-wasmpla
 
 let html = template;
 
+// inject-version.mjs stamps a `?v=<version>` cache key onto every asset URL in
+// generated/index.html (see deploy-play.yml's _headers), so the two tags this
+// script rewrites below no longer match on their bare filenames — hence the
+// optional query in the pattern, which keeps the two scripts from having to
+// agree on its exact shape. (The stamp is harmless in this flavor: the <base
+// href> below already pins a versioned CDN package path, and jsDelivr ignores
+// the extra query.) Matching the whole line, so dropping a tag doesn't leave a
+// blank one behind.
+const scriptLine = (file) => new RegExp(
+    `^[ \\t]*<script type="text/javascript" src="${file.replace(/\./g, '\\.')}(?:\\?[^"]*)?"></script>\\r?\\n`,
+    'm');
+
+// A silently unmatched replace here would produce a plausible-looking export
+// that either leaks the CDN's unused quest-config.js or — far worse — never
+// embeds the game at all, so treat a miss as a build failure.
+function replaceOrFail(haystack, pattern, replacement, what) {
+    const match = pattern.exec(haystack);
+    if (!match) throw new Error(`export-embedded: could not find ${what} in generated/index.html`);
+    return haystack.slice(0, match.index) + replacement(match[0]) + haystack.slice(match.index + match[0].length);
+}
+
 // 1. <html class="qv-booting"> so the file/URL pickers never paint even for a
 //    frame — unlike the ?id=/?url= flavors, this document is exclusively for
 //    an embedded game, so there's no need to detect that at runtime.
@@ -67,7 +88,7 @@ html = html.replace('<head>', `<head>\n    <base href="${cdnBase}" />`);
 // 3. quest-config.js is local-hosting config (API root, defaultGameUrl) —
 //    nothing in this flavor is local, so drop the tag entirely rather than
 //    let it resolve to the CDN's own (unused) copy.
-html = html.replace('    <script type="text/javascript" src="quest-config.js"></script>\n', '');
+html = replaceOrFail(html, scriptLine('quest-config.js'), () => '', 'the quest-config.js tag');
 
 // 4. Embed the game bytes + original filename (its extension selects
 //    .quest vs .aslx vs Legacy .asl/.cas parsing — see
@@ -76,12 +97,12 @@ html = html.replace('    <script type="text/javascript" src="quest-config.js"></
 //    attributes needed on the wasm-player.js tag itself — it resolves its
 //    own absolute URL via document.currentScript to work around a
 //    cross-origin dynamic-import quirk, see the comment there.
-const embedScript = `<script type="text/javascript">\n`
+const embedScript = `    <script type="text/javascript">\n`
     + `        window.QuestVivaEmbeddedGame = ${JSON.stringify(gameBase64)};\n`
     + `        window.QuestVivaEmbeddedGameFilename = ${JSON.stringify(gameFilename)};\n`
-    + `    </script>\n`
-    + `    <script type="text/javascript" src="wasm-player.js"></script>`;
-html = html.replace('<script type="text/javascript" src="wasm-player.js"></script>', embedScript);
+    + `    </script>\n`;
+html = replaceOrFail(html, scriptLine('wasm-player.js'), (line) => embedScript + line,
+    'the wasm-player.js tag');
 
 const outFile = outFileArg
     ? path.resolve(outFileArg)

--- a/src/WasmPlayer/scripts/inject-version.mjs
+++ b/src/WasmPlayer/scripts/inject-version.mjs
@@ -4,6 +4,13 @@
 // print its startup banner immediately on page load — without waiting for the
 // WASM runtime to boot (which only happens once a game starts loading).
 //
+// Also stamps that same version as a `?v=` query onto every relative asset URL
+// in the document. That query is purely a cache key: it changes on every
+// release, so play.questviva.com can serve those assets `immutable` (see the
+// _headers block in .github/workflows/deploy-play.yml) instead of making the
+// browser revalidate ~20 files on every single page load. wasm-player.js does
+// the same for the assets it fetches from JS rather than from the markup.
+//
 // Run via `npm run build`, after build-icons.mjs has produced generated/index.html.
 
 import fs from 'node:fs';
@@ -25,8 +32,21 @@ if (start === -1) throw new Error('generated/index.html is missing the VERSION_S
 const end = html.indexOf('-->', start);
 if (end === -1) throw new Error('VERSION_SCRIPT placeholder comment is not closed with -->');
 
-const output = html.slice(0, start)
+let output = html.slice(0, start)
     + `<script>window.QuestVivaVersion = ${JSON.stringify(version)};</script>`
     + html.slice(end + '-->'.length);
+
+// Only relative paths ending in a static-asset extension, so this can't touch
+// the icon sprite's `<use href="#folder-open">` fragment references or any
+// absolute/data URL. The `[^"?#]+` also makes it idempotent — an already
+// stamped URL contains a `?` and won't match a second time.
+const assetUrl = /\b(src|href)="(?!https?:|\/\/|data:|#)([^"?#]+\.(?:js|css|svg))"/g;
+let stampedCount = 0;
+output = output.replace(assetUrl, (_match, attr, url) => {
+    stampedCount++;
+    return `${attr}="${url}?v=${encodeURIComponent(version)}"`;
+});
+if (stampedCount === 0) throw new Error('generated/index.html has no relative asset URLs to version-stamp');
+
 fs.writeFileSync(target, output);
-console.log(`Wrote generated/index.html with version ${version}`);
+console.log(`Wrote generated/index.html with version ${version} (${stampedCount} asset URLs stamped)`);

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -27,6 +27,28 @@ console.log(
 // relative resolution entirely, so it works either way.
 const wasmPlayerScriptUrl = document.currentScript?.src;
 
+// Cache key for this build's own static assets, matching the `?v=` that
+// scripts/inject-version.mjs stamps onto every asset URL in the markup —
+// window.QuestVivaVersion is spliced in by that same script. This covers the
+// assets fetched from JS instead (playercore.htm, grid.js, and everything
+// under _framework/), so a deploy changes every URL and play.questviva.com can
+// serve them `immutable` rather than revalidating ~210 files on each load.
+//
+// For _framework/ specifically the version is also what makes `immutable`
+// *safe*. None of those filenames are content-hashed and AOT output isn't
+// byte-reproducible, so a browser holding dotnet.boot.js (the manifest of
+// per-file SHA-256 hashes) from one deploy alongside a binary from the next
+// gets an SRI mismatch and the resource is blocked. Stamping manifest and
+// binaries with the same version means they can never come from different
+// deploys — which is what the blanket `Cache-Control: no-cache` on
+// _framework/* used to buy, at the cost of ~190 revalidations per page load.
+//
+// Empty when the version is unknown (which also leaves the runtime's own
+// no-cache fetching alone, below) — nothing then depends on cache keys.
+const assetVersion = window.QuestVivaVersion || '';
+const assetVersionQuery = assetVersion ? `?v=${encodeURIComponent(assetVersion)}` : '';
+const versioned = (url) => (assetVersionQuery && !url.includes('?') ? url + assetVersionQuery : url);
+
 var _audio = null;
 
 const pendingResources = new Map();
@@ -426,7 +448,7 @@ async function setupPaperJs() {
     canvas.style.display = 'none';
     document.body.appendChild(canvas);
     paper.setup(canvas);
-    const code = await fetch('grid.js').then(r => r.text());
+    const code = await fetch(versioned('grid.js')).then(r => r.text());
     paper.PaperScript.evaluate(code, paper);
 }
 
@@ -482,16 +504,37 @@ let currentAllowDebug = false;
 async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null, allowDebug = false) {
     currentIsPreview = isPreview;
     currentAllowDebug = allowDebug;
-    const dotnetJsUrl = wasmPlayerScriptUrl
+    // The version query on dotnet.js is load-bearing beyond its own cache key:
+    // the loader reads it back off its own import.meta.url and propagates it to
+    // the JS modules it imports and to dotnet.boot.js (its `modulesUniqueQuery`),
+    // so those need no further handling in withResourceLoader below.
+    const dotnetJsUrl = versioned(wasmPlayerScriptUrl
         ? new URL('_framework/dotnet.js', wasmPlayerScriptUrl).href
-        : './_framework/dotnet.js';
+        : './_framework/dotnet.js');
     const [htmResponse, { dotnet }] = await Promise.all([
-        fetch('playercore.htm'),
+        fetch(versioned('playercore.htm')),
         import(dotnetJsUrl),
     ]);
     originalPlayerHtml = await htmResponse.text();
 
-    const runtime = await dotnet.create();
+    const runtime = await dotnet
+        // The loader otherwise passes `cache: "no-cache"` on every asset fetch,
+        // which forces a conditional request regardless of how long the CDN
+        // said the response was fresh for — so without this, `immutable` on
+        // _framework/* buys nothing at all. Only safe to turn off because the
+        // URLs are version-stamped (see assetVersionQuery); left alone when
+        // there's no version to stamp with.
+        .withConfig({ disableNoCacheFetch: !!assetVersionQuery })
+        // Stamps the remaining assets — the assemblies, dotnet.native.wasm and
+        // the ICU data. Returning null means "use the default URL", which is
+        // what the JS modules and the manifest want: modulesUniqueQuery has
+        // already appended the same query to those, and doing it here as well
+        // would produce a doubled `?v=...?v=...`.
+        .withResourceLoader((type, name, defaultUri) =>
+            !assetVersionQuery || type === 'manifest' || type === 'dotnetjs'
+                ? null
+                : versioned(defaultUri))
+        .create();
     const { setModuleImports, getAssemblyExports, getConfig } = runtime;
 
     setModuleImports("wasm-player", {

--- a/tests/e2e/verify-wasmplayer-asset-versioning.mjs
+++ b/tests/e2e/verify-wasmplayer-asset-versioning.mjs
@@ -1,0 +1,92 @@
+// Verifies that every static asset WasmPlayer fetches from its own origin
+// carries the `?v=<version>` cache key, exactly once.
+//
+// This is a guard, not a feature test. play.questviva.com serves those paths
+// `Cache-Control: public, max-age=31536000, immutable` (see the _headers block
+// in .github/workflows/deploy-play.yml), which is only sound because the query
+// makes every deploy a distinct cache key. An asset that reaches the browser
+// *without* one gets pinned in every visitor's cache for a year, and no
+// subsequent deploy can recall it — so a new asset added to index.html or
+// fetched from wasm-player.js without going through the stamping needs to fail
+// here rather than in production.
+//
+// The _framework/ half matters twice over: those filenames aren't
+// content-hashed and AOT output isn't byte-reproducible, so pairing a cached
+// dotnet.boot.js (the manifest of per-file SHA-256 hashes) with a binary from a
+// different deploy fails the SRI integrity check and blocks the resource.
+//
+// Run against the WasmPlayer dev server:
+//   node src/WasmPlayer/dev-server.mjs
+//   node tests/e2e/verify-wasmplayer-asset-versioning.mjs http://localhost:5175
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+const browser = await chromium.launch();
+
+try {
+    const page = await browser.newPage();
+    const requested = [];
+    const consoleErrors = [];
+    page.on('request', r => requested.push(r.url()));
+    page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+    page.on('pageerror', e => consoleErrors.push(`pageerror: ${e.message}`));
+
+    await page.goto(`${baseUrl}/?url=/examples/simple.aslx`, { waitUntil: 'load' });
+    await page.waitForFunction(
+        () => document.querySelector('#divOutput')?.textContent?.includes('You are in a room'),
+        { timeout: 120000 });
+
+    const version = await page.evaluate(() => window.QuestVivaVersion);
+    if (!version) throw new Error('window.QuestVivaVersion is not set — scripts/inject-version.mjs did not run, so nothing would be version-stamped');
+    const query = `?v=${encodeURIComponent(version)}`;
+
+    // Same-origin static assets only: the game file itself (/examples/...) is
+    // author content fetched by URL, not part of the deployed bundle.
+    const assets = requested.filter(u => u.startsWith(baseUrl))
+        .filter(u => !u.startsWith(`${baseUrl}/examples/`))
+        .filter(u => new URL(u).pathname !== '/');
+
+    const framework = assets.filter(u => u.includes('/_framework/'));
+    if (framework.length < 100) {
+        throw new Error(`expected the whole runtime to be downloaded, saw only ${framework.length} _framework requests`);
+    }
+
+    // lib/images/* are referenced by relative URL from inside jquery-ui.min.css,
+    // so they can't be stamped and are deliberately excluded from the immutable
+    // rules too — they must stay excluded from both, together.
+    const stampable = assets.filter(u => !new URL(u).pathname.startsWith('/lib/images/'));
+
+    const unstamped = stampable.filter(u => !u.endsWith(query));
+    if (unstamped.length) {
+        throw new Error(`${unstamped.length} of ${stampable.length} same-origin assets were requested without ${query}:\n  `
+            + unstamped.slice(0, 10).join('\n  '));
+    }
+
+    const doubled = stampable.filter(u => (u.match(/[?&]v=/g) || []).length > 1);
+    if (doubled.length) {
+        throw new Error(`${doubled.length} assets carry the version query more than once (the runtime's own modulesUniqueQuery and withResourceLoader are both stamping them):\n  `
+            + doubled.slice(0, 10).join('\n  '));
+    }
+
+    const sriErrors = consoleErrors.filter(e => /integrity|digest/i.test(e));
+    if (sriErrors.length) {
+        throw new Error(`SRI integrity failures — the manifest and the binaries disagree:\n  ${sriErrors.join('\n  ')}`);
+    }
+
+    // The headers are only half the fix: the runtime otherwise fetches every
+    // asset with `cache: "no-cache"`, which forces a conditional request no
+    // matter how long the CDN said the response was fresh for.
+    const noCacheFetch = await page.evaluate(() => globalThis.getDotnetRuntime?.(0)?.getConfig?.()?.disableNoCacheFetch);
+    if (noCacheFetch !== true) {
+        throw new Error(`expected disableNoCacheFetch to be true in the runtime config, got ${JSON.stringify(noCacheFetch)} — `
+            + 'without it the browser revalidates every asset on every load and the immutable headers buy nothing');
+    }
+
+    console.log(`PASS: ${stampable.length} same-origin assets (${framework.length} under _framework/) all carry ${query} exactly once, `
+        + 'no SRI failures, disableNoCacheFetch is on.');
+} catch (e) {
+    process.exitCode = 1;
+    console.error(`FAIL: ${e.message}`);
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Fixes #2185.

## The problem

Refreshing a game on play.questviva.com (cache **enabled**) makes ~213 requests, ~203 of which come back `304 Not Modified` to transfer about 90 KB in total. Measured against the live site: ~870 ms of pure revalidation on a fast connection, ~2.1 s at +100 ms RTT.

Three independent causes, and fixing any one of them alone changes nothing:

1. **Our own `_headers`** set `Cache-Control: no-cache` on `/player/_framework/*` and `/AppBundle/_framework/*`. That came from #1804, to fix SRI integrity failures on redeploy — none of those 190-odd filenames are content-hashed and AOT output isn't byte-reproducible, so a browser could pair a cached `dotnet.boot.js` (the manifest of per-file SHA-256 hashes) with a freshly-fetched binary from a later deploy and get a hash mismatch.
2. **Cloudflare Pages' default** for everything else is `public, max-age=0, must-revalidate` — including SvelteKit's already content-hashed `/_app/immutable/*`.
3. **The .NET loader does it too.** `dotnet.js` passes `cache: "no-cache"` to `fetch()` for every asset unless `disableNoCacheFetch` is set in `MonoConfig`, which bypasses freshness no matter what the CDN said. This one is easy to miss: fixing only the headers leaves the behaviour completely unchanged.

## The fix

Stamp a `?v=<version>` cache key onto every asset, then serve those paths `immutable`.

- `scripts/inject-version.mjs` stamps the 13 relative asset URLs in the markup (it already spliced the version in for the startup banner).
- `wasm-player.js` stamps what it fetches from JS — `playercore.htm`, `grid.js`, and `_framework/dotnet.js`. The runtime propagates that query to the JS modules and `dotnet.boot.js` by itself (`modulesUniqueQuery`), so `withResourceLoader` only needs to cover the assemblies, ICU data and `dotnet.native.wasm`; returning `null` for the rest avoids a doubled `?v=...?v=...`.
- `AppShell/src/lib/wasm.ts` does the same for the editor's AppBundle, off `PUBLIC_APPSHELL_VERSION`.
- `withConfig({ disableNoCacheFetch: true })` on both, without which the headers accomplish nothing.

This also fixes the integrity bug from #1804 properly rather than suppressing it. The version comes from `index.html`, which stays on `max-age=0, must-revalidate`, so manifest and binaries always carry the same version and can never come from different deploys — which is exactly what the blanket `no-cache` was buying, at the cost of ~190 revalidations per load.

## Measured

Warm reload of the Release AppBundle against a local server replicating the new header rules exactly:

| | network requests | from disk cache | 304s | transferred |
|---|---|---|---|---|
| before (live site) | 213 | 0 | 203 | 93 KB |
| after | **8** | 205 | 8 | ~0 |

Nothing under `_framework/` touches the network on a reload. The remaining 8 are `index.html`, the game file, and the six `lib/images/*` — the last referenced by relative URL from inside `jquery-ui.min.css`, so they can't be stamped and are deliberately left off the immutable list.

Isolating cause 3, with versioned URLs and immutable headers already in place but `disableNoCacheFetch: false`: **195 network requests, 195 × 304**. So the header change on its own would have been worth essentially nothing.

## On the safety of `immutable`

An `immutable` response to an *un*versioned URL is pinned in visitors' caches for a year and no later deploy can recall it, so the rules are scoped to paths where every request provably carries a version:

- `_framework/` is matched by extension (`*.wasm`, `*.dat`, `*.js`) rather than a blanket `/*`, so WasmEditor's `dotnet.native.js.symbols` — the one asset the runtime doesn't route through `loadBootResource`, so it can't be stamped — falls through to the default.
- `/player/index.html` and `/player/lib/images/*` are left out for the same reason.
- The `_headers` pattern semantics this relies on were confirmed against the live deployment rather than assumed: a `*` spans `/` (the existing `/*.js` rule demonstrably reaches `/player/lib/paper.js`), and a match is anchored at both ends (that same rule does *not* catch `dotnet.native.js.symbols`, which is served `application/octet-stream`).

`/_app/immutable/*` is a free win regardless — Vite already content-hashes those filenames.

## Test plan

- [x] `dotnet test --configuration Release` — all green
- [x] `npm run lint` and `npm run check` in `src/AppShell`
- [x] All 47 scripts flagged by `find-affected-tests.mjs` for the `wasm.ts` change — 47/47 pass
- [x] New `verify-wasmplayer-asset-versioning.mjs` guards the invariant (210 assets, all stamped exactly once, no SRI errors, `disableNoCacheFetch` on) — negative-tested by unstamping `grid.js`/`chrome.css` and by flipping `disableNoCacheFetch`, both correctly fail
- [x] `export-embedded.mjs` still produces a working single-file export — its two string replacements would otherwise have silently stopped matching once the tags gained a query, so they now tolerate it and throw on a miss
- [x] Dev server, Vite AppBundle middleware and the Electron loopback server all strip the query before resolving a path
- [ ] After merge: confirm `_framework` responses carry `immutable`, and that a redeploy doesn't produce integrity errors for a visitor holding the previous version

🤖 Generated with [Claude Code](https://claude.com/claude-code)