### PR TITLE
perf(WasmPlayer): start the runtime download up front instead of behind the game fetch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -394,6 +394,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-asset-versioning.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-runtime-preload.mjs http://localhost:5175
+        working-directory: tests/e2e
 
   # WebPlayer (ASP.NET Core + Blazor Server), Development mode with Dev:Enabled
   # (appsettings.Development.json already sets this — see /dev/open's

--- a/src/WasmPlayer/index.html
+++ b/src/WasmPlayer/index.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Quest Viva</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <!-- Lets the preload scanner start the runtime loader before the parser has
+         even reached wasm-player.js, which as the last script in this head only
+         executes once jQuery/jQuery UI/paper.js have all downloaded *and* run.
+         It's 37 KB, so it's unconditional rather than gated on a game actually
+         being on its way — the ~10.6 MB the loader then pulls is what's gated,
+         in wasm-player.js's boot IIFE. Stamped with ?v= like every other asset
+         here (scripts/inject-version.mjs), which is also what makes the
+         preload and wasm-player.js's own import() agree on one URL and share a
+         single fetch. -->
+    <link rel="modulepreload" href="_framework/dotnet.js" />
     <script type="text/javascript" src="quest-config.js"></script>
     <script type="text/javascript">
         // Runs before the start screen is parsed, so when a game is specified via the

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -501,23 +501,30 @@ let currentIsPreview = false;
 // must NOT also disable Save or add the Restart button the way isPreview does.
 let currentAllowDebug = false;
 
-async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null, allowDebug = false) {
-    currentIsPreview = isPreview;
-    currentAllowDebug = allowDebug;
-    // The version query on dotnet.js is load-bearing beyond its own cache key:
-    // the loader reads it back off its own import.meta.url and propagates it to
-    // the JS modules it imports and to dotnet.boot.js (its `modulesUniqueQuery`),
+// ── .NET runtime bootstrap ───────────────────────────────────────────────────
+//
+// The runtime is ~10.6 MB spread over ~190 files, and which game is being
+// played has no bearing on any of it. It used to be imported and instantiated
+// inside initWasmPlayer() — i.e. only once the game bytes were already in
+// hand, which for a ?id= link means after a textadventures API round trip and
+// then the game download, neither of which it depends on. Splitting the
+// download away from create() lets the boot IIFE start it up front instead, in
+// parallel with those two fetches. See issue #2186.
+let runtimeBuilderPromise = null;
+
+// Resolves to the configured — but not yet instantiated — host builder.
+function loadRuntimeBuilder() {
+    if (runtimeBuilderPromise) return runtimeBuilderPromise;
+    // A relative specifier fails here when this script is loaded cross-origin
+    // (the CDN-linked single-file export) — see wasmPlayerScriptUrl's comment.
+    // The version query is load-bearing beyond its own cache key too: the
+    // loader reads it back off its own import.meta.url and propagates it to
+    // the JS modules it imports and to dotnet.boot.js (`modulesUniqueQuery`),
     // so those need no further handling in withResourceLoader below.
     const dotnetJsUrl = versioned(wasmPlayerScriptUrl
         ? new URL('_framework/dotnet.js', wasmPlayerScriptUrl).href
         : './_framework/dotnet.js');
-    const [htmResponse, { dotnet }] = await Promise.all([
-        fetch(versioned('playercore.htm')),
-        import(dotnetJsUrl),
-    ]);
-    originalPlayerHtml = await htmResponse.text();
-
-    const runtime = await dotnet
+    runtimeBuilderPromise = import(dotnetJsUrl).then(({ dotnet }) => dotnet
         // The loader otherwise passes `cache: "no-cache"` on every asset fetch,
         // which forces a conditional request regardless of how long the CDN
         // said the response was fresh for — so without this, `immutable` on
@@ -533,8 +540,36 @@ async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, 
         .withResourceLoader((type, name, defaultUri) =>
             !assetVersionQuery || type === 'manifest' || type === 'dotnetjs'
                 ? null
-                : versioned(defaultUri))
-        .create();
+                : versioned(defaultUri)));
+    return runtimeBuilderPromise;
+}
+
+// Pulls every runtime asset into the browser cache without instantiating
+// anything, so the create() in initWasmPlayer has nothing left to fetch.
+// Fire-and-forget by design: it's started before we know the game will even
+// load, and its result is not what anyone waits on. The runtime's own
+// bookkeeping makes create() reuse this exact work rather than repeat it
+// (mono_download_assets is one-shot), and a failure here resurfaces from
+// create() where startGame already turns it into a visible error — so the
+// catch here only exists to keep it from becoming an unhandled rejection.
+//
+// The trade is that a game that turns out not to exist (a bad ?id=) now
+// downloads some of a runtime it won't use. That costs a failed load some
+// bandwidth; not doing it costs every successful load ~1.7s.
+function preloadRuntime() {
+    loadRuntimeBuilder().then(builder => builder.download()).catch(() => {});
+}
+
+async function initWasmPlayer(gameBytes, filename, bc = null, saveBytes = null, isPreview = false, recordWalkthrough = null, runWalkthrough = null, adjacentFiles = null, allowDebug = false) {
+    currentIsPreview = isPreview;
+    currentAllowDebug = allowDebug;
+    const [htmResponse, builder] = await Promise.all([
+        fetch(versioned('playercore.htm')),
+        loadRuntimeBuilder(),
+    ]);
+    originalPlayerHtml = await htmResponse.text();
+
+    const runtime = await builder.create();
     const { setModuleImports, getAssemblyExports, getConfig } = runtime;
 
     setModuleImports("wasm-player", {
@@ -2103,6 +2138,7 @@ async function fetchGameBytes(url) {
     // other boot source converges on. Checked first since, unlike the sources
     // below, an embedded export never carries any of their query params.
     if (window.QuestVivaEmbeddedGame) {
+        preloadRuntime();
         const bytes = Uint8Array.from(atob(window.QuestVivaEmbeddedGame), c => c.charCodeAt(0));
         const filename = window.QuestVivaEmbeddedGameFilename || 'game.quest';
         document.addEventListener('DOMContentLoaded', async () => {
@@ -2115,6 +2151,7 @@ async function fetchGameBytes(url) {
     const params = new URLSearchParams(window.location.search);
 
     if (params.get('source') === 'editor') {
+        preloadRuntime();
         const bc = new BroadcastChannel('quest-preview');
         bc.postMessage({ type: 'ready' });
         bc.onmessage = async ({ data }) => {
@@ -2140,6 +2177,7 @@ async function fetchGameBytes(url) {
     // distinct channel name keeps this from cross-talking with a real
     // editor-preview tab open at the same time.
     if (params.get('source') === 'local') {
+        preloadRuntime();
         const bc = new BroadcastChannel('quest-play-local');
         bc.postMessage({ type: 'ready' });
         // Covers the case where nothing ever answers — see
@@ -2178,7 +2216,10 @@ async function fetchGameBytes(url) {
     const gameUrl = params.get('url') || window.QuestVivaConfig?.defaultGameUrl;
 
     if (id) {
-        // Start API fetch immediately; wire DOM once it's ready.
+        // Start API fetch immediately; wire DOM once it's ready. The runtime
+        // download runs alongside it rather than behind it — the API response
+        // and the game file it points at are what used to gate it.
+        preloadRuntime();
         let resolvedSourceUrl = null;
         const gamePromise = (async () => {
             const apiRoot = window.QuestVivaConfig?.textAdventuresApiRoot
@@ -2210,6 +2251,7 @@ async function fetchGameBytes(url) {
 
     if (gameUrl) {
         // Start fetch immediately; wire DOM once it's ready.
+        preloadRuntime();
         const gamePromise = fetchGameBytes(gameUrl);
 
         document.addEventListener('DOMContentLoaded', async () => {

--- a/tests/e2e/verify-wasmplayer-runtime-preload.mjs
+++ b/tests/e2e/verify-wasmplayer-runtime-preload.mjs
@@ -1,0 +1,99 @@
+// Verifies that the ~10.6 MB .NET runtime download starts up front rather than
+// behind the game fetch, and that it still doesn't start at all when no game is
+// on its way.
+//
+// The runtime has nothing to do with which game is being played, but it used to
+// be imported inside initWasmPlayer() — i.e. only once the game bytes had
+// arrived, which for a ?id= link means after a textadventures API round trip
+// and then the game download. wasm-player.js's boot IIFE now kicks off
+// dotnet.download() before either (issue #2186), and index.html modulepreloads
+// dotnet.js so the preload scanner starts it before the parser even reaches
+// wasm-player.js. Both are invisible when they regress — the player still
+// works, just slower — hence this guard.
+//
+// Run against the WasmPlayer dev server:
+//   node src/WasmPlayer/dev-server.mjs
+//   node tests/e2e/verify-wasmplayer-runtime-preload.mjs http://localhost:5175
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+const GAME_DELAY_MS = 3000;
+
+const browser = await chromium.launch();
+
+try {
+    // ── The runtime download must overlap the game fetch, not follow it ──────
+    {
+        const page = await browser.newPage();
+        const framework = [];
+        let gameDelivered = false;
+        let frameworkRequestsBeforeGame = 0;
+
+        page.on('request', r => { if (r.url().includes('/_framework/')) framework.push(r.url()); });
+
+        // Hold the game file back long enough that a runtime download gated on
+        // it could not possibly have got going by the time we check.
+        await page.route('**/examples/simple.aslx', async route => {
+            await new Promise(resolve => setTimeout(resolve, GAME_DELAY_MS));
+            // Sampled at the end of the delay: whatever is in flight by now got
+            // there without the game bytes, which are still being withheld.
+            frameworkRequestsBeforeGame = framework.length;
+            gameDelivered = true;
+            await route.continue();
+        });
+
+        await page.goto(`${baseUrl}/?url=/examples/simple.aslx`, { waitUntil: 'load' });
+        await page.waitForFunction(
+            () => document.querySelector('#divOutput')?.textContent?.includes('You are in a room'),
+            { timeout: 120000 });
+        if (!gameDelivered) throw new Error('the game route was never hit — the fixture URL must have changed');
+
+        // Measured mid-delay: several dozen assets are already in flight by
+        // then. Anything in single figures means the download is waiting on
+        // something it shouldn't be.
+        if (frameworkRequestsBeforeGame < 20) {
+            throw new Error(`only ${frameworkRequestsBeforeGame} _framework requests had started ${GAME_DELAY_MS}ms into the game fetch `
+                + '— the runtime download looks gated on the game bytes again (see preloadRuntime in wasm-player.js)');
+        }
+
+        // A modulepreload that doesn't match the import()'s URL exactly costs a
+        // second full fetch of every module rather than saving anything.
+        const counts = framework.reduce((acc, u) => (acc[u] = (acc[u] || 0) + 1, acc), {});
+        const repeated = Object.entries(counts).filter(([, n]) => n > 1);
+        if (repeated.length) {
+            throw new Error(`${repeated.length} _framework URLs were fetched more than once (the modulepreload and the import() disagree on a URL):\n  `
+                + repeated.slice(0, 5).map(([u, n]) => `${n}x ${u}`).join('\n  '));
+        }
+
+        console.log(`PASS: ${frameworkRequestsBeforeGame} runtime assets already downloading while the game fetch was still outstanding, no duplicated fetches.`);
+        await page.close();
+    }
+
+    // ── ...but not when there's no game to play ─────────────────────────────
+    {
+        const page = await browser.newPage();
+        const framework = [];
+        page.on('request', r => { if (r.url().includes('/_framework/')) framework.push(r.url()); });
+
+        await page.goto(baseUrl, { waitUntil: 'load' });
+        await page.waitForSelector('#qv-pickers', { state: 'visible', timeout: 30000 });
+        await page.waitForTimeout(4000);
+
+        // dotnet.js itself is modulepreloaded unconditionally — it's 37 KB, and
+        // having it ready is what makes the download start promptly once the
+        // user picks a file. The other ~190 files are the ones that must wait.
+        const beyondLoader = framework.filter(u => !/\/_framework\/dotnet\.js(\?|$)/.test(u));
+        if (beyondLoader.length) {
+            throw new Error(`the start screen pulled ${beyondLoader.length} runtime assets with no game loading — `
+                + `preloadRuntime() must stay off the wireStartScreen path. e.g.\n  ${beyondLoader.slice(0, 5).join('\n  ')}`);
+        }
+
+        console.log(`PASS: start screen with no game fetched only the ${framework.length} modulepreloaded loader file, not the runtime.`);
+        await page.close();
+    }
+} catch (e) {
+    process.exitCode = 1;
+    console.error(`FAIL: ${e.message}`);
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Fixes #2186. Was stacked on #2190; now that's merged, this is rebased straight onto `main` and the diff is just the preload work.

## The problem

The ~10.6 MB runtime, spread over ~190 files, has nothing to do with which game is being played — but it was imported and instantiated inside `initWasmPlayer()`, i.e. only once the game bytes were already in hand. For a `?id=` link that means it waited on a textadventures API round trip *and then* the game download, neither of which it depends on.

Traced against the live site at 5 Mbps / 100 ms:

```
    0ms  /player/?id=…
  184ms  quest-config.js, jquery, playercore.js, wasm-player.js, …
  771ms  textadventures.co.uk/api/game/…
  907ms  playtextadventures.com/…/game.aslx
 1915ms  _framework/dotnet.js   ← the 10.6 MB only starts here
```

## What I did *not* do

#2186 asks for `/player` to query the textadventures API server-side and inline `resourceRoot` into the HTML. play.questviva.com is a static Cloudflare Pages deployment — there's no server to do that, and adding a Pages Function for it would walk back the static/CDN direction. It's also the smaller half: that round trip is ~130 ms of the trace, against ~1.9 s of deferred runtime start.

The rest of the issue needs no server at all, and that's what this does.

## What I did

- Split the download away from instantiation. `loadRuntimeBuilder()` resolves the configured host builder; `preloadRuntime()` calls `download()` on it. `create()` then reuses that exact work rather than repeating it — `mono_download_assets` is one-shot internally.
- The boot IIFE fires `preloadRuntime()` on every branch that leads to a game: embedded single-file export, editor preview, Play-tab handoff, `?id=` and `?url=`.
- `index.html` gains `<link rel="modulepreload" href="_framework/dotnet.js">`. It's 37 KB, so it's unconditional — `wasm-player.js` is the *last* script in that head, so it only executes once jQuery, jQuery UI and paper.js have all downloaded **and** run, whereas the preload scanner can start the loader straight away. `inject-version.mjs` stamps it automatically (it ends in `.js`), which is also what makes the preload and `wasm-player.js`'s own `import()` agree on one URL and share a single fetch.

## Measured

Same throttled conditions (5 Mbps / 100 ms), same game, same local server, preloading toggled off and on:

| | before | after |
|---|---|---|
| `dotnet.js` requested | 3024 ms | **116 ms** |
| runtime fully downloaded | 43575 ms | **32300 ms** |

## Trade-offs

- **The start screen with no game still fetches only the 37 KB loader**, not the runtime — a file the user hasn't picked yet isn't worth 10.6 MB of guessing. (There's a further win available in starting the download when they open the file picker; not doing that here.)
- **A game that turns out not to exist now downloads some of a runtime it won't use.** A bad `?id=` 404s at ~600 ms, by which point maybe 1 MB has been pulled. That costs a failed load some bandwidth, where not doing it costs every successful load ~11 s.
- On a bandwidth-constrained link the runtime download now competes with the game fetch, so the game file itself can land slightly later than before. Total time to playable still improves, because the runtime is much the longer pole.

## Test plan

- [x] `dotnet test --configuration Release` — all green
- [x] `npm run lint` in `src/AppShell`
- [x] All 17 scripts in the `wasmplayer_chromium` job — 17/17 pass, including `verify-game-load-error.mjs` (the bad-game path that now preloads a runtime it won't use)
- [x] All 47 scripts flagged by `find-affected-tests.mjs` — 47/47 pass, which covers the `source=editor` preview and `source=local` Play-tab handoffs
- [x] New `verify-wasmplayer-runtime-preload.mjs` guards both halves — it withholds the game file for 3 s and asserts the runtime is streaming anyway (193 assets in flight), and asserts the start screen stays lean. Negative-tested: commenting out `preloadRuntime()` fails the first, adding it to the `wireStartScreen` path fails the second
- [x] The modulepreload is reused rather than duplicated — exactly one `dotnet.js` request, no repeated `_framework` URLs
- [x] `export-embedded.mjs` still produces a working single-file export, with the preload resolving against the CDN `<base href>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)