### PR TITLE
fix(ElectronApp): set up the macOS signing keychain instead of letting electron-builder do it

### DIFF
--- a/.github/workflows/electron-publish.yml
+++ b/.github/workflows/electron-publish.yml
@@ -86,6 +86,79 @@ jobs:
         shell: bash
         run: echo "${{ secrets.APPLE_API_KEY_P8 }}" | base64 -d > "${{ runner.temp }}/AuthKey.p8"
 
+      - name: Import Developer ID certificate into a signing keychain
+        # Sets the keychain up here and hands electron-builder the finished
+        # article via CSC_KEYCHAIN, instead of letting it do this itself from
+        # CSC_LINK. Its own version of this calls
+        #   security set-key-partition-list ... -k <password> <keychain>
+        # with the .p12 *import* password where `-k` wants the keychain's own
+        # unlock password (electron-userland/electron-builder#10066). That only
+        # ever worked while the keychain happened to still be unlocked from the
+        # preceding `unlock-keychain` — and since those commands race the
+        # certificate download in a Promise.all, it was always luck. The
+        # macos-latest image bump between v6.0.0-beta.57 and v6.0.0-beta.58
+        # (same macos-26-arm64 label, os 25.5.0 -> 25.6.0) tipped it, and every
+        # run since fails with "SecKeychainUnlock: The user name or passphrase
+        # you entered is not correct". The fix is merged upstream but has only
+        # been released in the v27 alphas — 26.16.0 still ships the bug, and
+        # there's no 26.x backport yet (electron-builder#10167).
+        #
+        # With CSC_LINK unset, MacPackager skips that path entirely and just
+        # uses the keychain named by CSC_KEYCHAIN, so this doesn't need
+        # revisiting when the backport eventually lands. Note it also won't
+        # delete this keychain for us the way it would one it created itself —
+        # hence the cleanup step at the end of the job.
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          CERT="$RUNNER_TEMP/certificate.p12"
+          # Random per run and never leaves this job — it only ever unlocks the
+          # throwaway keychain created on the next line.
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          echo "$MAC_CSC_LINK" | base64 -d > "$CERT"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          # Explicit 6h idle timeout, and no -l, so nothing re-locks the
+          # keychain mid-build. Signing plus notarization regularly runs past
+          # the 300s default.
+          security set-keychain-settings -t 21600 -u "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          security import "$CERT" -k "$KEYCHAIN" -P "$MAC_CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild
+          rm -f "$CERT"
+
+          # The line upstream gets wrong: -k is the keychain password, not the
+          # .p12 one. Without it codesign prompts for permission and hangs.
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+
+          # Prepend to the user search list rather than replacing it, so the
+          # login keychain stays available to anything else in the job.
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+
+          # An identity that failed to import would otherwise fail *silently*:
+          # electron-builder would skip signing, the afterSign hook would ad-hoc
+          # sign instead, and we'd ship a DMG that fails notarization. Make it
+          # a loud CI failure instead.
+          # Captured rather than piped: `grep -q` exits on first match, which
+          # under `pipefail` can surface a SIGPIPE from `security` as a failed
+          # pipeline even though the identity was found.
+          IDENTITIES="$(security find-identity -v -p codesigning "$KEYCHAIN")"
+          echo "$IDENTITIES"
+          if ! grep -q "Developer ID Application" <<< "$IDENTITIES"; then
+            echo "::error::No 'Developer ID Application' identity in the keychain after importing MAC_CSC_LINK"
+            exit 1
+          fi
+
+          echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
       - name: Build and package Electron app
         run: npm ci && npm run dist
         working-directory: src/ElectronApp
@@ -95,13 +168,14 @@ jobs:
           # Set via env (not inline `VAR=value` shell syntax) since the
           # windows-latest runner in this matrix defaults to pwsh, not bash.
           WASM_CONFIG: Release
-          # Developer ID signing + notarization, macOS only — ternaries keep
-          # these unset (rather than pointing electron-builder at a macOS
-          # .p12/API key) on the Windows/Linux legs of this matrix, which have
-          # their own unrelated signing story. scripts/adhoc-sign.js already
-          # no-ops itself once CSC_LINK is set, so no change needed there.
-          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.MAC_CSC_KEY_PASSWORD || '' }}
+          # Developer ID signing + notarization, macOS only. CSC_KEYCHAIN comes
+          # from the step above (via GITHUB_ENV, so it's only ever set on the
+          # macOS leg); CSC_LINK/CSC_KEY_PASSWORD are deliberately NOT set —
+          # that's what makes electron-builder use the keychain we prepared
+          # rather than building a broken one of its own. scripts/adhoc-sign.js
+          # keys off CSC_KEYCHAIN too, so it still stands down when real
+          # signing is configured.
+          # The API key is still passed by env: notarization reads it directly.
           APPLE_API_KEY: ${{ matrix.os == 'macos-latest' && format('{0}/AuthKey.p8', runner.temp) || '' }}
           APPLE_API_KEY_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_API_KEY_ID || '' }}
           APPLE_API_ISSUER: ${{ matrix.os == 'macos-latest' && secrets.APPLE_API_ISSUER || '' }}
@@ -129,6 +203,17 @@ jobs:
         run: gh release upload ${{ github.ref_name }} src/ElectronApp/release/${{ matrix.artifact-glob }} --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove the signing keychain
+        # electron-builder only auto-removes a keychain it created itself, and
+        # this one is ours. GitHub's runners are ephemeral so this is belt and
+        # braces, but it also restores the keychain search list for anything
+        # that runs after it. `if: always()` so a failed build still cleans up.
+        if: always() && matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          security delete-keychain "$RUNNER_TEMP/signing.keychain-db" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/certificate.p12" "$RUNNER_TEMP/AuthKey.p8"
 
       # Un-drafting the release once every installer is attached (so
       # releases/latest and public browsing never show one with a missing

--- a/src/ElectronApp/scripts/adhoc-sign.js
+++ b/src/ElectronApp/scripts/adhoc-sign.js
@@ -20,8 +20,13 @@ module.exports = async function adhocSign(context) {
     // codesign doesn't exist there and there's no .app to sign.
     if (context.electronPlatformName !== "darwin") return;
 
-    // A real identity means electron-builder's own signing step already ran.
-    if (process.env.CSC_LINK) return;
+    // A real identity means electron-builder's own signing step already ran,
+    // and ad-hoc signing on top of it would replace the Developer ID signature
+    // with an unusable one — the app would then fail notarization (or fail
+    // Gatekeeper on arrival). CSC_KEYCHAIN is what electron-publish.yml sets
+    // nowadays; CSC_LINK is still honoured for a local build that hands
+    // electron-builder a .p12 directly.
+    if (process.env.CSC_LINK || process.env.CSC_KEYCHAIN) return;
 
     const appPath = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`);
     execFileSync("codesign", ["--force", "--deep", "--sign", "-", appPath], { stdio: "inherit" });


### PR DESCRIPTION
Fixes the `electron-publish` macOS failure that has blocked releases since v6.0.0-beta.58.

## What broke

```
Command failed: /usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -k *** <tmp>.keychain
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

Not caused by beta.58 — that release touched only WasmPlayer/AppShell, nothing under `src/ElectronApp/` or `electron-publish.yml`, and electron-builder is pinned at the same `26.15.3` that worked for beta.57. Windows and Linux packaged fine; only macOS signing failed.

The variable was the runner. Same `macos-latest` label, new image:

| | beta.57 (worked) | beta.58 (failed) |
|---|---|---|
| image | `macos-26-arm64` `20260728.0273.1` | `macos-26-arm64` `20260831.0337.3` |
| electron-builder reports | `os=25.5.0` | `os=25.6.0` |
| electron-builder | 26.15.3 | 26.15.3 |

That exposed a latent electron-builder bug, visible in our own `node_modules`:

```js
const keychainPassword = randomBytes(32).toString("base64");
  ["create-keychain", "-p", keychainPassword, keychainFile],
  ["unlock-keychain", "-p", keychainPassword, keychainFile],

return await importCerts(keychainFile, certPaths, cscPasswords);   // keychainPassword not passed

async function importCerts(keychainFile, paths, keyPasswords) {
    const password = keyPasswords[i];                         // CSC_KEY_PASSWORD
    security import ... -P password                           // correct
    security set-key-partition-list ... -k password ...        // wrong: -k wants the keychain password
```

`-k` is given the `.p12` password. It only ever worked while the keychain was still unlocked from `unlock-keychain`, so `security` never had to check it — and those commands race the certificate download inside a `Promise.all`, so it was always luck.

Upstream: [#10066](https://github.com/electron-userland/electron-builder/issues/10066) is exactly this; [#10167](https://github.com/electron-userland/electron-builder/issues/10167) reports the merged fix missing from 26.16.0, with the maintainer saying it went to `master`/v27 alphas and a v26 backport is still to come. I unpacked both to confirm: `26.16.0` still passes `password`, `27.0.0-alpha.8` passes `keychainPassword`.

## The fix

Do the keychain setup in the workflow and hand electron-builder the finished article via `CSC_KEYCHAIN`. `MacPackager` bails out of `createKeychain` when `CSC_LINK` is null and just uses the keychain named by `CSC_KEYCHAIN`, so this sidesteps the bug entirely — and stops depending on the upstream backport landing at all.

**No secrets change.** The same `MAC_CSC_LINK` / `MAC_CSC_KEY_PASSWORD` are read one step earlier.

Two things that would otherwise have bitten, both handled here:

- **`adhoc-sign.js` stood down only when `CSC_LINK` was set.** With `CSC_LINK` now unset it would have run `codesign --force --deep --sign -` over the real Developer ID signature, giving us a DMG that fails notarization. It keys off `CSC_KEYCHAIN` too now.
- **A cert that failed to import would have failed silently** — electron-builder skips signing, the afterSign hook ad-hoc signs, and the release ships something Gatekeeper rejects. The step now asserts a `Developer ID Application` identity is present and fails the job if not.

Also: a 6h keychain timeout with no `-l`, so nothing re-locks mid-build (signing + notarization runs well past the 300s default); the keychain is *prepended* to the user search list rather than replacing it; and an `if: always()` cleanup step removes the keychain and the decoded secrets, since electron-builder only auto-removes a keychain it created itself.

## Test plan

CI-only code, so I ran what could be run. On this machine — Darwin 25.6.0, the same OS version as the new runner image — I extracted the step's own script text out of the YAML and replayed it against a throwaway self-signed cert and a temp keychain (login keychain and search list untouched):

- [x] `create-keychain` / `set-keychain-settings` / `unlock-keychain` / `import` / `set-key-partition-list` all succeed with the corrected password
- [x] **Negative control**: passing the `.p12` password to `-k` instead reproduces the CI error verbatim — `security: SecKeychainUnlock: The user name or passphrase you entered is not correct.` — which both confirms the diagnosis and shows the OS is now strict about it
- [x] The identity guard trips on an empty keychain and on a non-Developer-ID cert, and passes on the real identity string from the beta.57 run log
- [x] `security list-keychains -d user` unchanged afterwards
- [x] YAML parses; `node --check` on `adhoc-sign.js`

Not verifiable outside CI, and worth watching on the next release: the real `.p12` importing cleanly under this sequence, and notarization succeeding end to end. The identity assertion turns the first of those into a loud failure rather than a silently unsigned DMG.

## Recovering beta.58

Re-running the failed job won't help even with this merged — `workflow_dispatch` and re-runs both take the workflow file from the tagged ref, which has the old version. beta.58 is still a draft (`finalize-release` correctly skipped, `releases/latest` still resolves to beta.57, and textadventures.co.uk never got its dispatch), so nothing is user-visible. Cutting beta.59 once this lands picks up the two perf fixes and produces a complete release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)