### PR TITLE
fix(Engine): remove German enter verb clashing with go command

### DIFF
--- a/src/Engine/Core/Languages/Deutsch.aslx
+++ b/src/Engine/Core/Languages/Deutsch.aslx
@@ -546,7 +546,6 @@
   <template templatetype="command" name="view_transcript_cmd">^(zeige|zeig) (das |)(skript|transkript)$</template>
   <template templatetype="command" name="version_cmd">^(version|info|über)$</template>
   <verbtemplate name="enter">betrete</verbtemplate>
-  <verbtemplate name="enter">gehe</verbtemplate>
   <verbtemplate name="enter">gehe in</verbtemplate>
   <dynamictemplate name="DefaultEnter">"Du kannst " + object.article + " nicht betreten."</dynamictemplate>
 


### PR DESCRIPTION
## Summary
- Removes the bare `<verbtemplate name="enter">gehe</verbtemplate>` from `Deutsch.aslx`, which collided with the `go` command's catch-all pattern `^gehe (?<exit>.*)$` — typing `gehe <object>` was ambiguous between "enter object" and "go to exit named object".
- English's `enter` verbtemplates (`enter`, `go in`, `go into`, `get in`, `get into`) never include a bare `go` for the same reason; German keeps `betrete` and `gehe in` as unambiguous ways to enter.

Fixes #1466

Per this repo's Core-library semantics, this only affects games authored/saved after this change — already-published German-language games carry their own inlined copy of the old templates.

## Test plan
- [x] `dotnet test tests/EngineTests --configuration Release` — 321 passed, 0 failed
- [x] Confirmed `EditorDeutsch.aslx` has no equivalent clashing entry (nothing to change there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)