### PR TITLE
fix(Engine): list carried scenery objects in the INVENTORY command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -398,6 +398,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-sound-timer.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-scenery-inventory.mjs http://localhost:5175
+        working-directory: tests/e2e
 
   # WebPlayer (ASP.NET Core + Blazor Server), Development mode with Dev:Enabled
   # (appsettings.Development.json already sets this — see /dev/open's

--- a/src/Engine/Core/CoreCommands.aslx
+++ b/src/Engine/Core/CoreCommands.aslx
@@ -354,7 +354,7 @@
   </command>
 
   <command name="inventory" pattern="[inventory]">
-    list = FormatObjectList(Template("CarryingListHeader"), game.pov, Template("And"), ".")
+    list = FormatInventoryList(Template("CarryingListHeader"), game.pov, Template("And"), ".")
     if (list = "") {
       msg (Template("NotCarryingAnything"))
     }

--- a/src/Engine/Core/CoreDescriptions.aslx
+++ b/src/Engine/Core/CoreDescriptions.aslx
@@ -208,10 +208,31 @@
   </function>
 
   <function name="FormatObjectList" type="string" parameters="preList, parent, preFinal, postList">
+    return (FormatContentsList(preList, parent, preFinal, postList, false))
+  </function>
+
+  <!--
+    Lists what the player is carrying. Unlike a room or container listing, this
+    includes objects flagged as scenery: "scenery" means "don't clutter the room
+    description with this", not "don't tell the player they are holding it", and
+    the objects pane (fed by ScopeInventory, which has never filtered on scenery)
+    has always shown them. Filtering them here left a carried object invisible to
+    the one command that lists carried objects.
+  -->
+  <function name="FormatInventoryList" type="string" parameters="preList, parent, preFinal, postList">
+    return (FormatContentsList(preList, parent, preFinal, postList, true))
+  </function>
+
+  <function name="FormatContentsList" type="string" parameters="preList, parent, preFinal, postList, includeScenery">
     <![CDATA[
       result = ""
       count = 0
-      list = RemoveSceneryObjects(GetDirectChildren(parent))
+      if (includeScenery) {
+        list = RemoveInvisibleObjects(GetDirectChildren(parent))
+      }
+      else {
+        list = RemoveSceneryObjects(GetDirectChildren(parent))
+      }
       if (CheckDarkness()) {
         list = RemoveDarkObjects(list)
       }
@@ -220,7 +241,9 @@
         if (LengthOf(result) = 0) result = preList + " "
         result = result + GetDisplayNameLink(item, "object")
         if (CanSeeThrough(item)) {
-          result = result + FormatObjectList(" (" + item.contentsprefix, item, preFinal, ")")
+          // Carried scenery stays listed however deep it is - a scenery object
+          // inside a bag the player is carrying is still being carried.
+          result = result + FormatContentsList(" (" + item.contentsprefix, item, preFinal, ")", includeScenery)
         }
         count = count + 1
         if (count = listLength - 1) {
@@ -242,6 +265,18 @@
       result = NewObjectList()
       foreach (obj, list) {
         if (not obj.scenery and obj <> game.pov and obj.visible) {
+          list add (result, obj)
+        }
+      }
+      return (result)
+    ]]>
+  </function>
+
+  <function name="RemoveInvisibleObjects" type="objectlist" parameters="list">
+    <![CDATA[
+      result = NewObjectList()
+      foreach (obj, list) {
+        if (obj <> game.pov and obj.visible) {
           list add (result, obj)
         }
       }

--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -55,6 +55,9 @@
         <None Update="containerlockabletest.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="sceneryinventorytest.aslx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="savetest.aslx">
             <SubType>Designer</SubType>
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/tests/EngineTests/SceneryInventoryTests.cs
+++ b/tests/EngineTests/SceneryInventoryTests.cs
@@ -1,0 +1,44 @@
+using Moq;
+using QuestViva.Common;
+
+namespace QuestViva.EngineTests;
+
+// Regression coverage for issue #905: objects flagged as scenery that the player is
+// carrying. The objects pane (fed by ScopeInventory, which filters on ContainsVisible
+// and has never looked at scenery) listed them; the INVENTORY command, via
+// FormatObjectList -> RemoveSceneryObjects, did not - so a carried object could be
+// invisible to the one command that lists carried objects. The pane is now treated as
+// correct: FormatInventoryList includes carried scenery, at any depth, while room and
+// container listings still exclude it.
+[TestClass]
+public class SceneryInventoryTests
+{
+    [TestMethod]
+    public async Task RunWalkthrough()
+    {
+        var gameDataProvider = new FileGameDataProvider("sceneryinventorytest.aslx");
+        var gameData = await gameDataProvider.GetData();
+        var worldModel = Helpers.CreateWorldModel(gameData);
+
+        worldModel.LogError += ex => throw ex;
+
+        var player = new Mock<IPlayer>();
+        var success = await worldModel.Initialise(player.Object);
+        Assert.IsTrue(success, "Initialisation failed");
+
+        await worldModel.Begin();
+
+        foreach (var cmd in worldModel.Walkthroughs.Walkthroughs["verify"].Steps)
+        {
+            if (cmd.StartsWith("assert:"))
+            {
+                var expr = cmd.Substring(7);
+                Assert.IsTrue(await worldModel.AssertAsync(expr), expr);
+            }
+            else
+            {
+                await worldModel.SendCommand(cmd);
+            }
+        }
+    }
+}

--- a/tests/EngineTests/sceneryinventorytest.aslx
+++ b/tests/EngineTests/sceneryinventorytest.aslx
@@ -1,0 +1,66 @@
+<asl version="600">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="sceneryinventorytest"/>
+  <object name="room">
+    <object name="player">
+      <inherit name="defaultplayer" />
+      <!-- An ordinary carried object: listed by INVENTORY before and after. -->
+      <object name="lamp">
+        <inherit name="editor_object"/>
+      </object>
+      <!--
+        Carried, but flagged as scenery - the objects pane has always listed
+        this (ScopeInventory never filtered on scenery) while the INVENTORY
+        command did not. See issue #905.
+      -->
+      <object name="poster">
+        <inherit name="editor_object"/>
+        <scenery type="boolean">true</scenery>
+      </object>
+      <!-- Carried scenery nested inside a carried open container. -->
+      <object name="bag">
+        <inherit name="editor_object"/>
+        <inherit name="container_open"/>
+        <object name="receipt">
+          <inherit name="editor_object"/>
+          <scenery type="boolean">true</scenery>
+        </object>
+      </object>
+      <!-- Carried but invisible: must stay unlisted either way. -->
+      <object name="ghost">
+        <inherit name="editor_object"/>
+        <visible type="boolean">false</visible>
+      </object>
+    </object>
+    <!-- Scenery in the room, not carried: must stay out of the room listing. -->
+    <object name="mural">
+      <inherit name="editor_object"/>
+      <scenery type="boolean">true</scenery>
+    </object>
+    <object name="rock">
+      <inherit name="editor_object"/>
+    </object>
+  </object>
+
+  <function name="InvList" type="string">
+    return (FormatInventoryList("Carrying:", game.pov, "and", "."))
+  </function>
+
+  <function name="RoomList" type="string">
+    return (FormatObjectList("Here:", room, "and", "."))
+  </function>
+
+  <walkthrough name="verify">
+    <steps>
+      <![CDATA[
+      assert:Instr(InvList(), "lamp") > 0
+      assert:Instr(InvList(), "poster") > 0
+      assert:Instr(InvList(), "receipt") > 0
+      assert:Instr(InvList(), "ghost") = 0
+      assert:Instr(RoomList(), "rock") > 0
+      assert:Instr(RoomList(), "mural") = 0
+      ]]>
+    </steps>
+  </walkthrough>
+</asl>

--- a/tests/e2e/fixtures/scenery-inventory-test.aslx
+++ b/tests/e2e/fixtures/scenery-inventory-test.aslx
@@ -1,0 +1,40 @@
+<asl version="600">
+
+  <include ref="English.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <game name="SceneryInventoryTest">
+  </game>
+
+  <object name="room">
+    <object name="player">
+      <inherit name="defaultplayer"/>
+      <object name="lamp">
+        <inherit name="editor_object"/>
+      </object>
+      <!--
+        Issue #905: carried but flagged as scenery. The objects pane has always
+        listed this (ScopeInventory never filtered on scenery); the INVENTORY
+        command did not. Both should now agree.
+      -->
+      <object name="poster">
+        <inherit name="editor_object"/>
+        <scenery type="boolean">true</scenery>
+      </object>
+      <!-- Carried but invisible: must stay out of both. -->
+      <object name="ghost">
+        <inherit name="editor_object"/>
+        <visible type="boolean">false</visible>
+      </object>
+    </object>
+    <!-- Room scenery: must stay out of the room description. -->
+    <object name="mural">
+      <inherit name="editor_object"/>
+      <scenery type="boolean">true</scenery>
+    </object>
+    <object name="rock">
+      <inherit name="editor_object"/>
+    </object>
+  </object>
+
+</asl>

--- a/tests/e2e/verify-wasmplayer-scenery-inventory.mjs
+++ b/tests/e2e/verify-wasmplayer-scenery-inventory.mjs
@@ -1,0 +1,103 @@
+// Regression coverage for issue #905: an object the player is carrying that is
+// flagged as scenery appeared in the objects pane but not in the INVENTORY
+// command's output, so a carried object could be invisible to the one command
+// that lists carried objects.
+//
+// Settled in favour of the pane: "scenery" means "don't clutter the room
+// description with this", not "don't tell the player they are holding it", so
+// FormatInventoryList now includes carried scenery while room and container
+// listings still exclude it. This asserts the two UIs actually agree, which is
+// the reported symptom and the part a unit test on the formatter alone can't
+// cover.
+//
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('console', msg => console.log('[console]', msg.type(), msg.text()));
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+async function waitUntilCanSendCommand() {
+    await page.waitForFunction(() => window.canSendCommand === true, { timeout: 20000 });
+}
+
+async function sendCommand(command) {
+    await waitUntilCanSendCommand();
+    await page.fill('#txtCommand', command);
+    await page.press('#txtCommand', 'Enter');
+    await waitUntilCanSendCommand();
+}
+
+async function paneItems() {
+    // playercore.js's updateList() renders each held object as an <li> inside
+    // #lstInventory (see the listName == "inventory" branch), not as a link.
+    return await page.$$eval('#lstInventory li',
+        els => els.map(e => e.textContent.trim()).filter(Boolean));
+}
+
+function assertContains(haystack, needle, label) {
+    if (!haystack.includes(needle)) {
+        throw new Error(`${label}: expected to find "${needle}" in:\n${haystack}`);
+    }
+    console.log(`PASS: ${label} lists "${needle}"`);
+}
+
+function assertOmits(haystack, needle, label) {
+    if (haystack.includes(needle)) {
+        throw new Error(`${label}: expected NOT to find "${needle}" in:\n${haystack}`);
+    }
+    console.log(`PASS: ${label} omits "${needle}"`);
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/scenery-inventory-test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 60000, state: 'attached' });
+    await waitUntilCanSendCommand();
+    console.log('PASS: game booted');
+
+    // The objects pane, which was already correct and must not regress.
+    // canSendCommand flips true before the first list update has landed, so
+    // wait for the pane itself rather than reading it straight after boot.
+    await page.waitForSelector('#lstInventory li', { timeout: 20000 });
+    const pane = (await paneItems()).join(', ');
+    if (pane.length === 0) {
+        throw new Error('objects pane is empty - the locator is probably stale, not the engine');
+    }
+    console.log(`objects pane: ${pane}`);
+    assertContains(pane, 'lamp', 'objects pane');
+    assertContains(pane, 'poster', 'objects pane');
+    assertOmits(pane, 'ghost', 'objects pane');
+
+    // The INVENTORY command, which is the half that changed.
+    await page.evaluate(() => { document.querySelector('#divOutput').innerHTML = ''; });
+    await sendCommand('inventory');
+    const inv = (await page.$eval('#divOutput', el => el.innerText)).trim();
+    console.log(`inventory output: ${inv.replace(/\n/g, ' | ')}`);
+    assertContains(inv, 'lamp', 'INVENTORY command');
+    assertContains(inv, 'poster', 'INVENTORY command');
+    assertOmits(inv, 'ghost', 'INVENTORY command');
+
+    // Room listings must be unaffected - scenery still stays out of them.
+    await page.evaluate(() => { document.querySelector('#divOutput').innerHTML = ''; });
+    await sendCommand('look');
+    const look = (await page.$eval('#divOutput', el => el.innerText)).trim();
+    console.log(`look output: ${look.replace(/\n/g, ' | ')}`);
+    assertContains(look, 'rock', 'room description');
+    assertOmits(look, 'mural', 'room description');
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/wasmplayer-scenery-inventory-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Fixes #905.

## The problem

An object the player is carrying that's flagged as `scenery` appeared in the objects pane but *not* in the INVENTORY command's output — so a carried object could be invisible to the one command whose job is to list carried objects.

The two paths were never built from the same parts:

- **The pane** is fed by `ScopeInventory` → `UpdateObjectsListAsync`. It filters on `ContainsVisible` (visibility, darkness, see-through containers) and has never looked at `scenery`.
- **The command** goes `FormatObjectList` → `RemoveSceneryObjects`, which drops it.

## The call

Settled in favour of the pane, so the command now lists carried scenery.

`scenery` means "don't clutter the room description with this", not "don't tell the player they're holding it" — which is also why the take command already clears the flag on pickup (`CoreCommands.aslx:151`). The gaps that partial fix leaves are objects a script moves into the inventory (`obj.parent = player`) and objects authored as scenery that start there.

The opposite call — hide carried scenery in the pane too — was considered and rejected. Hiding a carried object from the only UI that lists carried objects is a worse failure than showing one, and for Quest 2-era games the pane is the *only* inventory. It would also have meant changing what already-published games display.

@ThePix originally wanted the pane to hide them; @KVonGit argued the other way in 2025 and I think has the better of it. Neither appears active, so this is a maintainer call rather than a consensus.

## The change

`FormatObjectList` and the new `FormatInventoryList` both delegate to a shared `FormatContentsList` carrying an `includeScenery` flag — the same shape as the existing `ContainsVisible`/`ContainsReachable` → `ContainsAccessible` trio. Carried scenery stays listed at any depth, so a scenery object inside a bag the player is carrying is still listed. Room and container listings are untouched.

**`ScopeInventory` is deliberately not changed.** It isn't a display function — it's the parser scope, used by `Got()`, the drop and put commands (`CoreCommands.aslx:229` and `:544`), `CoreFunctions`, `CoreWearable` and `CoreParser:777`. Filtering scenery there would stop `DROP <held scenery object>` resolving, turning a cosmetic listing inconsistency into a genuine parser bug.

## Scope of effect

This is a Core library change, so per the inlining rules it affects games saved after it lands — **not** already-published ones, which carry their own frozen copy of Core. Nothing about existing games' panes or inventories changes.

## Tests

- `SceneryInventoryTests` — walkthrough asserting `FormatInventoryList` includes a carried scenery object and one nested inside a carried open container, still omits an invisible carried object, and that room listings still exclude room scenery. Negative-controlled: flipping the new flag back to `false` fails it on the `poster` assertion.
- `verify-wasmplayer-scenery-inventory.mjs` — end-to-end, asserting the pane *and* the command now agree, which is the actual reported symptom and the part a unit test on the formatter alone can't cover. Wired into `e2e.yml`.

Full `dotnet test` green (395 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)