### PR TITLE
fix(PlayerCore): stop the ShowMenu dialog clipping long options

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -372,6 +372,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-showmenu-select-default.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-showmenu-long-options.mjs http://localhost:5175
+        working-directory: tests/e2e
       - run: node verify-game-load-error.mjs http://localhost:5175
         working-directory: tests/e2e
       - run: node verify-wasmplayer-autoscroll.mjs http://localhost:5175

--- a/examples/test.aslx
+++ b/examples/test.aslx
@@ -154,6 +154,10 @@
             options = Split("One,Two,Three,Four", ",")
             msg ("You chose: " + ShowMenu("Please choose one of these...", options, true))
         }
+        else if (command = "menulong") {
+            options = Split("Ask the innkeeper about the strange lights over the northern marshes;Tell the innkeeper you would rather not get involved in any of this;Leave", ";")
+            msg ("You chose: " + ShowMenu("Please choose one of these...", options, true))
+        }
         else if (command = "event") {
             msg ("<a onclick=\"ASLEvent('FromJS','some parameter')\">Click me</a>")
         }

--- a/src/PlayerCore/Resources/player.js
+++ b/src/PlayerCore/Resources/player.js
@@ -41,6 +41,7 @@ var _menuSelection = "";
 function showMenu(title, options, allowCancel) {
     $("#dialogOptions").empty();
     var firstOption = true;
+    var optionCount = 0;
     $.each(options, function (key, value) {
         // Explicitly mark the first <option> selected - a <select> visually
         // shows its first option as selected by default, but jQuery's .val()
@@ -51,13 +52,23 @@ function showMenu(title, options, allowCancel) {
             $("<option/>").attr("value", key).text(value).prop("selected", firstOption)
         );
         firstOption = false;
+        optionCount++;
     });
+
+    // Show every option at once where we can - the markup's fallback size of 3
+    // meant a menu of more than three options was scrolled by default, with no
+    // hint that there was anything below the fold.
+    $("#dialogOptions").attr("size", Math.min(Math.max(optionCount, 3), 10));
 
     $("#dialogCaption").html(title);
 
     var dialogOptions = {
         modal: true,
         autoOpen: false,
+        // Size to the widest option rather than jQuery UI's default 300px,
+        // which clipped longer options. playercore.css caps how far this can
+        // grow so it can't overflow the window.
+        width: "auto",
         buttons: [{
             text: "Select",
             click: function () {

--- a/src/PlayerCore/Resources/playercore.css
+++ b/src/PlayerCore/Resources/playercore.css
@@ -111,6 +111,25 @@ div#controlButtons {
     display: none;
 }
 
+/* showMenu() opens the menu dialog with width: "auto" so that long options
+   aren't clipped, so it's the options themselves that decide how wide the
+   dialog gets. Keep that within the window, keep a long caption wrapping
+   instead of stretching the dialog out on its own, and let the options list
+   shrink rather than overflow once the cap is reached. */
+.ui-dialog {
+    max-width: 95vw;
+}
+
+#dialogCaption {
+    max-width: 60ch;
+}
+
+#dialogOptions {
+    min-width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
 #msgbox {
     display: none;
 }

--- a/tests/e2e/verify-wasmplayer-showmenu-long-options.mjs
+++ b/tests/e2e/verify-wasmplayer-showmenu-long-options.mjs
@@ -1,0 +1,114 @@
+// Ad-hoc manual verification: the ShowMenu dialog (player.js, shared by
+// WasmPlayer and WebPlayer) used jQuery UI's default 300px dialog width, so a
+// menu whose options were wider than that had them silently clipped - the
+// dialog's <select> kept its full intrinsic width and simply overflowed out of
+// sight, with no horizontal scrollbar. Fixed by opening the dialog with
+// width: "auto" (capped in playercore.css so it can't overflow the window) and
+// by sizing the <select> to the number of options instead of always showing
+// three. See https://github.com/alexwarren/quest/issues/1479.
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+
+async function openMenu(page, command) {
+    await page.fill('#txtCommand', command);
+    await page.press('#txtCommand', 'Enter');
+    await page.waitForSelector('#dialogOptions option', { timeout: 10000 });
+    // Let jQuery UI finish sizing/positioning the dialog.
+    await page.waitForTimeout(300);
+    return page.evaluate(() => {
+        const select = document.getElementById('dialogOptions');
+        const content = document.getElementById('dialog');
+        const dialog = document.querySelector('.ui-dialog');
+        const rect = dialog.getBoundingClientRect();
+        return {
+            dialogLeft: rect.left,
+            dialogRight: rect.right,
+            windowWidth: window.innerWidth,
+            // The dialog's content area is what clipped the oversized
+            // <select>, so that's where the overflow shows up - the <select>
+            // itself always reports its full intrinsic width.
+            contentClientWidth: content.clientWidth,
+            contentScrollWidth: content.scrollWidth,
+            selectSize: select.size,
+            optionCount: select.options.length,
+        };
+    });
+}
+
+async function run(viewport, label) {
+    const page = await browser.newPage({ viewport });
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    try {
+        await page.goto(`${baseUrl}/?url=/examples/test.aslx`);
+        await page.waitForSelector('#txtCommand', { timeout: 30000 });
+        console.log(`PASS: [${label}] game booted`);
+
+        // "menulong" shows a menu whose options are far wider than the old
+        // 300px default dialog width.
+        const long = await openMenu(page, 'menulong');
+
+        if (long.dialogRight > long.windowWidth || long.dialogLeft < 0) {
+            throw new Error(
+                `[${label}] Dialog is outside the window: left=${long.dialogLeft}, ` +
+                `right=${long.dialogRight}, windowWidth=${long.windowWidth}`);
+        }
+        console.log(`PASS: [${label}] dialog fits inside the window ` +
+            `(${Math.round(long.dialogLeft)}-${Math.round(long.dialogRight)} of ${long.windowWidth})`);
+
+        // The dialog can only grow to the window's edge, so on a narrow
+        // viewport some clipping is unavoidable - a <select size="n"> listbox
+        // can't wrap its options. Only assert nothing is clipped where there
+        // was room for it.
+        if (viewport.width >= 1024) {
+            if (long.contentScrollWidth > long.contentClientWidth) {
+                throw new Error(
+                    `[${label}] Options are clipped: the dialog's content area is ` +
+                    `${long.contentClientWidth}px wide but needs ${long.contentScrollWidth}px`);
+            }
+            console.log(`PASS: [${label}] no options clipped ` +
+                `(content area ${long.contentClientWidth}px wide, needs ${long.contentScrollWidth}px)`);
+        }
+
+        // The dialog still works: choose the (pre-selected) first option.
+        await page.click('button:has-text("Select")');
+        await page.waitForTimeout(300);
+        const output = await page.$eval('#divOutput', el => el.textContent);
+        if (!output.includes('You chose: Ask the innkeeper about the strange lights')) {
+            throw new Error(
+                `[${label}] Expected the chosen option to be echoed, got tail: ${output.slice(-120)}`);
+        }
+        console.log(`PASS: [${label}] menu choice was submitted`);
+
+        // "menufn" has four options - more than the markup's fallback
+        // size of 3, which used to scroll the last one out of sight with no
+        // hint that it was there.
+        const four = await openMenu(page, 'menufn');
+        if (four.optionCount !== 4) {
+            throw new Error(`[${label}] Expected 4 options from "menufn", got ${four.optionCount}`);
+        }
+        if (four.selectSize < four.optionCount) {
+            throw new Error(
+                `[${label}] Options list shows only ${four.selectSize} of ` +
+                `${four.optionCount} options`);
+        }
+        console.log(`PASS: [${label}] all ${four.optionCount} options visible without scrolling`);
+    } finally {
+        await page.close();
+    }
+}
+
+try {
+    await run({ width: 1280, height: 800 }, 'desktop');
+    await run({ width: 375, height: 700 }, 'mobile');
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Fixes #1479.

The `ShowMenu` dialog opened at jQuery UI's default width of 300px. A `<select>` keeps its full intrinsic width regardless of its container, so any option wider than that simply overflowed the dialog's content area and was clipped — with no horizontal scrollbar to hint there was more text. The markup's `size="3"` separately hid everything past the third option.

The issue points at `src/WebPlayer/wwwroot/player.js`; that file has since moved to `src/PlayerCore/Resources/player.js`, which is an embedded resource served by WebPlayer, WasmPlayer and the Electron app alike — so this fixes all three.

### Changes

- `player.js` — open the dialog with `width: "auto"` so it sizes to its widest option.
- `player.js` — set the `<select>`'s `size` from the option count (clamped to 3–10) instead of always 3, so a menu of four or more options isn't scrolled by default with nothing to indicate there's more below.
- `playercore.css` — cap `.ui-dialog` at `95vw` so `width: auto` can't push the dialog off-screen; `#dialogCaption { max-width: 60ch }` so a long *caption* wraps rather than stretching the dialog on its own; `#dialogOptions { min/max-width: 100% }` so the list fills the dialog and shrinks rather than overflowing once the cap is reached.

The issue also suggests `resizable: true` — that's already jQuery UI's default, so it's left out as a no-op.

### Verification

New `tests/e2e/verify-wasmplayer-showmenu-long-options.mjs` (wired into `e2e.yml`) drives a real `ShowMenu` via a new `menulong` command in `examples/test.aslx`, and asserts the dialog stays inside the window, that nothing is clipped (desktop only — a `<select size=n>` listbox can't wrap, so some clipping is unavoidable on a 375px screen), that every option is visible without scrolling, and that the choice still submits. Confirmed it fails against the unfixed build (`the dialog's content area is 300px wide but needs 622px`) and passes after.

Also checked by hand: 12 options → capped at 10 rows; a 400-character option → dialog stops at 95vw and stays on screen; a very long caption → wraps instead of stretching; 375px viewport → dialog fills the width and stays in-window. The existing `verify-wasmplayer-showmenu-select-default.mjs` still passes, and `dotnet test --configuration Release` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

