### PR TITLE
fix(WebPlayer): stop legacy request(Quit) crashing the quit command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -444,6 +444,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-webplayer-restart-chrome-reset.mjs http://localhost:5099
         working-directory: tests/e2e
+      - run: node verify-webplayer-quit-command.mjs http://localhost:5099
+        working-directory: tests/e2e
 
   # Real, packaged Electron app (Playwright's _electron launcher) — macos-
   # latest, not ubuntu-latest (unlike build_electron in build-and-test.yml,

--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -69,7 +69,6 @@ public interface IPlayer
     void SetForeground(string colour);
     void SetLinkForeground(string colour);
     Task RunScriptAsync(string function, object[]? parameters);
-    void Quit();
     void SetFont(string fontName);
     void SetFontSize(string fontSize);
     void Speak(string text);

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -138,7 +138,6 @@ public class RequestScript : ScriptBase
 
                 break;
             case Request.Quit:
-                m_worldModel.PlayerUi.Quit();
                 m_worldModel.Finish();
                 break;
             case Request.FontName:

--- a/src/PlayerCore/GameQuery.cs
+++ b/src/PlayerCore/GameQuery.cs
@@ -349,10 +349,6 @@ public class GameQuery(string filename, byte[] bytes = null)
             return Task.CompletedTask;
         }
 
-        public void Quit()
-        {
-        }
-
         public void SetFont(string fontName)
         {
         }

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -826,8 +826,6 @@ public partial class WasmPlayerBridge
             _ => JsonSerializer.Serialize(arg.ToString() ?? "", WasmJsonContext.Default.String),
         };
 
-        void IPlayer.Quit() { }
-
         void IPlayer.SetFont(string fontName) => _helper?.SetFont(fontName);
 
         void IPlayer.SetFontSize(string fontSize) => _helper?.SetFontSize(fontSize);

--- a/src/WebPlayer/Player.cs
+++ b/src/WebPlayer/Player.cs
@@ -224,12 +224,6 @@ public class Player : IPlayerHelperUI
         return Task.CompletedTask;
     }
 
-    void IPlayer.Quit()
-    {
-        // TODO
-        throw new NotImplementedException();
-    }
-
     void IPlayer.SetFont(string fontName)
     {
         PlayerHelper.SetFont(fontName);

--- a/tests/LegacyTests/TestPlayer.cs
+++ b/tests/LegacyTests/TestPlayer.cs
@@ -104,10 +104,6 @@ internal class TestPlayer : IPlayer
         return Task.CompletedTask;
     }
 
-    public void Quit()
-    {
-    }
-
     public void SetFont(string fontName)
     {
         FontName = fontName;

--- a/tests/e2e/verify-webplayer-quit-command.mjs
+++ b/tests/e2e/verify-webplayer-quit-command.mjs
@@ -1,0 +1,68 @@
+// Verifies GitHub issue #1530: a legacy Quest 5 game whose "quit" command
+// script calls `request (Quit, "")` (rather than the modern `finish`) used to
+// throw "The method or operation is not implemented." — WebPlayer's
+// IPlayer.Quit() was a bare `throw new NotImplementedException()` stub, which
+// aborted the request script before the WorldModel.Finish() call after it
+// could run. Every IPlayer implementation's Quit() was a no-op anyway (game-
+// over is fully driven by WorldModel.Finish() raising the Finished event), so
+// Quit() was removed from IPlayer entirely and the RequestScript Quit case
+// now just calls Finish(). examples/blank.aslx is a real Quest 5-saved game
+// whose "quit" command still uses `request (Quit, "")`, making it a natural
+// fixture here.
+//
+// Requires WebPlayer running locally in Development mode:
+//   ASPNETCORE_ENVIRONMENT=Development dotnet run --configuration Release \
+//     --no-launch-profile --urls http://localhost:5099 --project src/WebPlayer
+import { chromium } from 'playwright';
+import path from 'node:path';
+
+const baseUrl = process.argv[2] || 'http://localhost:5099';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const bootErrors = [];
+const pageErrors = [];
+let booted = false;
+page.on('pageerror', err => (booted ? pageErrors : bootErrors).push(err.message));
+page.on('console', msg => { if (msg.type() === 'error') (booted ? pageErrors : bootErrors).push(msg.text()); });
+
+try {
+    await page.goto(`${baseUrl}/dev/open`);
+    await page.waitForTimeout(1000);
+    const fileInput = await page.$('input[type=file]');
+    await fileInput.setInputFiles(path.resolve('../../examples/blank.aslx'));
+
+    await page.waitForSelector('#txtCommand', { state: 'visible', timeout: 30000 });
+    await page.waitForTimeout(1000); // let unrelated async boot errors (e.g. grid/PaperScript loading) settle before we start watching
+    booted = true;
+    console.log('Legacy game booted via /dev/open. Pre-existing boot errors ignored:', bootErrors);
+
+    await page.fill('#txtCommand', 'quit');
+    await page.press('#txtCommand', 'Enter');
+    await page.waitForTimeout(1000);
+
+    const finishedPaneVisible = await page.isVisible('#gamePanesFinished');
+    const commandBarVisible = await page.isVisible('#txtCommandDiv');
+    console.log('Finished pane visible after quit (expect true):', finishedPaneVisible);
+    console.log('Command bar visible after quit (expect false):', commandBarVisible);
+    console.log('Page/console errors seen (expect none):', pageErrors);
+
+    if (pageErrors.some(e => e.toLowerCase().includes('not implemented'))) {
+        throw new Error(`FAIL: "not implemented" error was raised by request (Quit, ""): ${JSON.stringify(pageErrors)}`);
+    }
+    if (pageErrors.length > 0) {
+        throw new Error(`FAIL: unexpected page/console error(s) during quit: ${JSON.stringify(pageErrors)}`);
+    }
+    if (!finishedPaneVisible) {
+        throw new Error('FAIL: #gamePanesFinished was not shown after the quit command — game did not reach the finished state.');
+    }
+    if (commandBarVisible) {
+        throw new Error('FAIL: #txtCommandDiv is still visible after the quit command — interface was not disabled.');
+    }
+    console.log('PASS');
+} catch (err) {
+    console.error(err.message || err);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- `IPlayer.Quit()` in WebPlayer was a bare `throw new NotImplementedException()` stub. Legacy Quest 5 games whose `quit` command still uses `request (Quit, "")` (rather than the modern `finish` command) hit this and crashed with "The method or operation is not implemented." — the exception aborted the request script before the `WorldModel.Finish()` call right after it could run.
- Every `IPlayer` implementation's `Quit()` turned out to be a no-op anyway (WasmPlayer, the `GameQuery`/`TestPlayer` test doubles) — game-over is fully driven by `Finish()` raising the `Finished` event. So rather than just fixing WebPlayer's stub, `Quit()` is removed from the `IPlayer` interface entirely, and `RequestScript`'s `Quit` case now just calls `Finish()`.

Fixes #1530.

## Test plan
- [x] Added `tests/e2e/verify-webplayer-quit-command.mjs`, using the existing `examples/blank.aslx` fixture (a real Quest-5-saved game whose `quit` command still uses `request (Quit, "")`). Confirmed it fails against the pre-fix code (reproducing the crash) and passes after the fix.
- [x] `dotnet test --configuration Release` — all 395 tests pass.
- [x] `dotnet build --configuration Release` on the full solution (including WasmPlayer/WasmEditor AOT builds) — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)