### PR TITLE
feat(Engine): add StringListCompact Core library function

### DIFF
--- a/src/Engine/Core/CoreFunctions.aslx
+++ b/src/Engine/Core/CoreFunctions.aslx
@@ -619,6 +619,18 @@
     return (l)
   </function>
 
+  <function name="StringListCompact" parameters="lst" type="stringlist">
+    l = NewStringList()
+    foreach (o, lst) {
+      if (not Equal(o, null)) {
+        if (IndexOf(l, o) = -1) {
+          list add (l, o)
+        }
+      }
+    }
+    return (l)
+  </function>
+
   <function name="AllRooms" type="objectlist">
     return (FilterByAttribute(AllObjects(),"isroom",true))
   </function>


### PR DESCRIPTION
## Summary
- Adds `StringListCompact` to `Engine/Core/CoreFunctions.aslx`, mirroring the existing `ObjectListCompact` pattern (`NewStringList()` instead of `NewList()`/`NewObjectList()`).
- Closes the gap reported in #1639: `ListCompact` dedupes/strips nulls from a list but returns an untyped `list`, so running it on a `stringlist` loses type fidelity (`TypeOf()` no longer reports `"stringlist"`). `StringListCompact` preserves the type, just as `ObjectListCompact` already does for object lists.

Note: per this repo's Core-library semantics, this only affects games authored/saved from now on — a published `.quest` file has its own frozen, inlined copy of Core library functions at save time, so this change can't retroactively affect any existing published game.

## Test plan
- [x] `dotnet build --configuration Release` — succeeds
- [x] `dotnet test --configuration Release tests/EngineTests` — 322/322 passing
- [x] Manually verified via a throwaway test loading a Core-library-included game and calling `StringListCompact` through the expression evaluator: dedupes, strips nulls, and `TypeOf()` correctly reports `"stringlist"` (test removed afterward — no existing test coverage for `ListCompact`/`ObjectListCompact` to extend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)