### PR TITLE
fix(Engine): stop cloned function-call parameters entering the undo log

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -212,6 +212,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-appshell-library-xml-extension.mjs http://localhost:5174
         working-directory: tests/e2e
+      - run: node verify-appshell-make-script-editable-undo.mjs http://localhost:5174
+        working-directory: tests/e2e
       - run: node verify-appshell-multi-control-editors.mjs http://localhost:5174
         working-directory: tests/e2e
       - run: node verify-appshell-object-pickers-exclude-pages.mjs http://localhost:5174

--- a/src/Engine/Scripts/FunctionCallParameters.cs
+++ b/src/Engine/Scripts/FunctionCallParameters.cs
@@ -12,11 +12,6 @@ internal class FunctionCallParameters
 {
     public FunctionCallParameters(WorldModel worldModel, IList<IFunction<object>> parameters)
     {
-        if (worldModel.EditMode)
-        {
-            ParametersAsQuestList.UndoLog = worldModel.UndoLogger;
-        }
-
         Parameters = parameters;
 
         if (parameters != null)
@@ -26,6 +21,16 @@ internal class FunctionCallParameters
                 var paramString = param.Save();
                 ParametersAsQuestList.Add(paramString);
             }
+        }
+
+        // Hook the list up to the undo logger only after populating it. The list doesn't exist
+        // outside this constructor yet, so its initial contents are never something the user could
+        // want to undo - but if a script is cloned while an undo transaction is open (which is what
+        // "Make editable copy" does), every one of those initial Adds would otherwise be logged into
+        // that transaction, and undoing it would strip the parameters back out of the clone again.
+        if (worldModel.EditMode)
+        {
+            ParametersAsQuestList.UndoLog = worldModel.UndoLogger;
         }
     }
 

--- a/src/Engine/Scripts/FunctionCallScript.cs
+++ b/src/Engine/Scripts/FunctionCallScript.cs
@@ -231,13 +231,16 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         m_paramFunction = script;
     }
 
+    // Only an EditableScript wrapper - i.e. a script currently open in the editor - subscribes
+    // to FunctionCallParametersUpdated, so both handlers below have to cope with there being no
+    // subscriber at all.
     private void Parameters_Added(object sender, QuestListUpdatedEventArgs<string> e)
     {
         // the number of parameters in a function call cannot change. So, as QuestList doesn't
         // provide an Updated event (we simulate Updates with a Remove and an Add at the same
         // index), we assume that any Added event is really an update.
 
-        FunctionCallParametersUpdated(this, new ScriptUpdatedEventArgs(e.Index, e.UpdatedItem));
+        FunctionCallParametersUpdated?.Invoke(this, new ScriptUpdatedEventArgs(e.Index, e.UpdatedItem));
     }
 
     private void Parameters_Removed(object sender, QuestListUpdatedEventArgs<string> e)
@@ -247,7 +250,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         // Add above.
         if (e.Index == 0)
         {
-            FunctionCallParametersUpdated(this, new ScriptUpdatedEventArgs(e.Index, string.Empty));
+            FunctionCallParametersUpdated?.Invoke(this, new ScriptUpdatedEventArgs(e.Index, string.Empty));
         }
     }
 

--- a/tests/EditorCoreTests/MakeScriptEditableTests.cs
+++ b/tests/EditorCoreTests/MakeScriptEditableTests.cs
@@ -1,0 +1,90 @@
+using System.Text;
+using QuestViva.Common;
+using QuestViva.EditorCore;
+
+namespace QuestViva.EditorCoreTests;
+
+// Regression coverage for issue #1734: "Make editable copy" on an inherited script attribute took
+// two Undo clicks to revert if the script contained a function call (e.g. defaultobject's
+// changedparent, which calls OnEnterRoom / MergePOVCoordinates), while an otherwise identical
+// script without one (changedisopen, changedlocked) reverted in a single click.
+//
+// Cause: FunctionCallParameters hooked its parameter QuestList up to the undo logger *before*
+// populating it, so cloning such a script inside an open transaction (which is exactly what
+// "Make editable copy" does) logged a spurious UndoListAdd per parameter alongside the real
+// attribute-set action. Undoing then removed those parameters again, and QuestList's Removed
+// handler in FunctionCallScript raised FunctionCallParametersUpdated with no subscriber attached
+// (only a script open in the editor subscribes), throwing a NullReferenceException part-way
+// through the undo. The model had already reverted by then, but the exception propagated out of
+// WasmEditorBridge.Undo, so the AppShell never ran its post-undo refresh and the UI carried on
+// showing the attribute as an owned copy until the next Undo click repainted it.
+[TestClass]
+public class MakeScriptEditableTests
+{
+    // changedparent is the reported case (its body calls OnEnterRoom/MergePOVCoordinates); the
+    // other two are inherited from the same type and contain no function-call statements, so they
+    // were never affected and act as the control.
+    [DataTestMethod]
+    [DataRow("changedparent")]
+    [DataRow("changedisopen")]
+    [DataRow("changedlocked")]
+    public async Task TestMakeInheritedScriptEditableTakesOneUndo(string attribute)
+    {
+        var controller = await LoadTemplateController("English");
+        controller.CreateNewRoom("aRoom", "game", "A Room");
+
+        var undoCountBefore = controller.GetUndoItems().Count();
+        var scripts = (IEditableScripts) controller.GetEditorData("aRoom").GetAttribute(attribute);
+        Assert.AreEqual("defaultobject", scripts.Owner, $"'{attribute}' should start out inherited");
+
+        controller.StartTransaction($"Copy {attribute} script to aRoom");
+        scripts.Clone("aRoom", attribute);
+        controller.EndTransaction();
+
+        Assert.AreEqual(undoCountBefore + 1, controller.GetUndoItems().Count(),
+            "Making the script editable should add exactly one undo entry");
+        Assert.AreEqual("aRoom", GetScriptOwner(controller, attribute),
+            "The script should now be owned by the room");
+
+        await controller.Undo();
+
+        Assert.AreEqual(undoCountBefore, controller.GetUndoItems().Count());
+        Assert.AreEqual("defaultobject", GetScriptOwner(controller, attribute),
+            "A single Undo should put the script back to its inherited state");
+
+        controller.Uninitialise();
+    }
+
+    private static string GetScriptOwner(EditorController controller, string attribute)
+    {
+        return ((IEditableScripts) controller.GetEditorData("aRoom").GetAttribute(attribute)).Owner;
+    }
+
+    // Mirrors IncludedLibraryTests / EditorControllerRoomsAndPagesTests - the shared test.aslx
+    // fixture has its <include> lines commented out, so a real template is needed to get the Core
+    // library's defaultobject type (and its changed* scripts) into the game.
+    private static async Task<EditorController> LoadTemplateController(string templateName)
+    {
+        var templates = EditorController.GetAvailableTemplates();
+        var template = templates.Values.Single(t => t.TemplateName == templateName);
+        var initialFileText = EditorController.CreateNewGameFile(template.ResourceName, "Test");
+        var bytes = Encoding.UTF8.GetBytes(initialFileText);
+
+        var controller = new EditorController();
+        controller.ClearTree += (_, _) => { };
+        controller.BeginTreeUpdate += (_, _) => { };
+        controller.EndTreeUpdate += (_, _) => { };
+        controller.AddedNode += (_, _) => { };
+        controller.RemovedNode += (_, _) => { };
+        controller.RenamedNode += (_, _) => { };
+        controller.RetitledNode += (_, _) => { };
+        controller.ElementsUpdated += (_, _) => { };
+        controller.Dirty += (_, _) => { };
+
+        var ok = await controller.Initialise(new ByteArrayGameDataProvider(bytes, "test.aslx"));
+        Assert.IsTrue(ok, $"Initialisation failed for template '{templateName}'");
+        controller.UpdateTree();
+
+        return controller;
+    }
+}

--- a/tests/e2e/verify-appshell-make-script-editable-undo.mjs
+++ b/tests/e2e/verify-appshell-make-script-editable-undo.mjs
@@ -1,0 +1,87 @@
+// Regression test for issue #1734: in the editor, "Make editable copy" on an
+// inherited script attribute whose body contains a function call (defaultobject's
+// `changedparent`, which calls OnEnterRoom / MergePOVCoordinates) needed *two*
+// Undo clicks to revert, while an inherited script without one (`changedisopen`)
+// needed only one.
+//
+// Cause was engine-side: FunctionCallParameters attached its parameter QuestList
+// to the undo logger before populating it, so cloning such a script inside the
+// "Make editable copy" transaction logged a spurious undo action per parameter.
+// Undoing those raised FunctionCallParametersUpdated on a script with no editor
+// wrapper subscribed, throwing a NullReferenceException part-way through the
+// undo — after the model had already reverted, but before WasmEditorBridge.Undo
+// returned, so editor-store's undo() never ran its post-undo refresh and the UI
+// carried on showing the attribute as an owned copy.
+//
+// This drives the real UI: make the copy, click Undo once, and assert the
+// "This script is inherited — read-only." banner (with its "Make editable copy"
+// button) is back for both attributes.
+import { chromium } from './lib/tracked-chromium.mjs';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+try {
+    const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on('pageerror', err => { pageErrors.push(err.message); console.log('[pageerror]', err.message); });
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Make Editable Undo Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+
+    await page.click('text=room');
+    await page.getByRole('button', { name: /^Attributes$/ }).click();
+    await page.waitForSelector('text=Inherited types', { timeout: 5000 });
+
+    const inheritedBanner = page.getByText('This script is inherited', { exact: false });
+    const makeEditable = page.getByRole('button', { name: 'Make editable copy' });
+    const undoButton = page.getByRole('button', { name: 'Undo' });
+
+    // changedisopen is the control (no function call in its body, was never affected);
+    // changedparent is the reported case.
+    for (const attribute of ['changedisopen', 'changedparent']) {
+        const row = page.locator(`[data-attr="${attribute}"]`);
+        await row.scrollIntoViewIfNeeded();
+        await row.click();
+
+        if (!await inheritedBanner.isVisible()) {
+            throw new Error(`'${attribute}': expected the inherited/read-only banner before making a copy`);
+        }
+
+        await makeEditable.click();
+        await page.waitForTimeout(200);
+        if (await inheritedBanner.isVisible()) {
+            throw new Error(`'${attribute}': banner should be gone once an editable copy has been made`);
+        }
+        console.log(`PASS: '${attribute}' became an editable copy`);
+
+        const errorsBefore = pageErrors.length;
+        if (await undoButton.isDisabled()) {
+            throw new Error(`'${attribute}': Undo button unexpectedly disabled after making the copy`);
+        }
+        await undoButton.click();
+        await page.waitForTimeout(300);
+
+        if (pageErrors.length > errorsBefore) {
+            throw new Error(`'${attribute}': Undo raised an uncaught error: ${pageErrors.slice(errorsBefore).join('; ')}`);
+        }
+        if (!await inheritedBanner.isVisible()) {
+            throw new Error(`'${attribute}': a single Undo should have restored the inherited/read-only state`);
+        }
+        console.log(`PASS: '${attribute}' reverted to inherited after exactly one Undo`);
+    }
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Fixes #1734.

## The bug

"Make editable copy" on an inherited script attribute needed **two** Undo clicks to revert if the script's body contained a function call — `defaultobject`'s `changedparent`, which calls `OnEnterRoom` / `MergePOVCoordinates`. Other inherited `changed*` scripts (`changedisopen`, `changedlocked`) reverted in one click. The desktop Quest 5 editor threw outright on the same operation.

## Cause

`FunctionCallParameters` attached its parameter `QuestList` to the undo logger *before* populating it:

```csharp
if (worldModel.EditMode) ParametersAsQuestList.UndoLog = worldModel.UndoLogger;
Parameters = parameters;
foreach (var param in parameters) ParametersAsQuestList.Add(param.Save());
```

At load time that's harmless — no transaction is open, so `AddUndoAction` no-ops. But "Make editable copy" clones the script *inside* an open transaction, so every cloned `FunctionCallScript`'s constructor logged a spurious `UndoListAdd` per parameter alongside the real attribute-set action.

Undoing those removed the parameters again, firing `Parameters_Removed`, which raised `FunctionCallParametersUpdated` unguarded. Only an `EditableScript` wrapper (a script currently open in the editor) subscribes to that event, and the orphan clone made inside `EditableScripts.Clone` has no wrapper — so `NullReferenceException`.

That explains each symptom in the issue:

- **`changedparent` only** — it's the one `changed*` script on `defaultobject` with function-call *statements*. The others use `do(...)` and expressions, which construct no `FunctionCallParameters`.
- **Desktop Quest 5 throws** — same engine code, exception surfaces directly.
- **Two undo clicks in the web editor** — the model had already reverted (the field-set action runs first), but the NRE propagated out of `WasmEditorBridge.Undo`, so `editor-store.ts`'s `undo()` never reached `refreshSelectedData()` / `refreshUndoRedo()`. The UI kept showing the owned copy until the next Undo click repainted it, silently consuming a real undo step.

## Fix

1. `FunctionCallParameters` — hook up `UndoLog` *after* the initial population. A list that doesn't exist outside its own constructor can't have undoable initial contents.
2. `FunctionCallScript` — null-guard both `FunctionCallParametersUpdated` invocations, as defence in depth. Either change alone clears the symptom.

## Verification

- New `tests/EditorCoreTests/MakeScriptEditableTests.cs` — fails on `changedparent` before the fix, passes after; `changedisopen` / `changedlocked` act as controls.
- New `tests/e2e/verify-appshell-make-script-editable-undo.mjs` drives the real editor UI. Confirmed it fails pre-fix with `[pageerror] Arg_NullReferenceException` and passes post-fix. Wired into `e2e.yml`; `check-workflow-manifest.mjs` passes.
- Full `dotnet test --configuration Release`: 398 passed, 0 failed.
- Manually confirmed in the editor by @alexwarren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)