### PR TITLE
test(Engine): cover status attributes only set in the start script

### DIFF
--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -58,6 +58,9 @@
         <None Update="sceneryinventorytest.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="statusattributetest.aslx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="savetest.aslx">
             <SubType>Designer</SubType>
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/tests/EngineTests/StatusAttributeTests.cs
+++ b/tests/EngineTests/StatusAttributeTests.cs
@@ -1,0 +1,44 @@
+using Moq;
+using QuestViva.Common;
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+// Regression coverage for issue #2178. StartGame calls UpdateStatusAttributes once before
+// running the game's own 'start' script, so a status attribute that is only assigned in
+// 'start' is read while still unset. With no format string, FormatStatusAttribute builds
+// 'CapFirst(attr) + ": " + value' with no null check, which briefly turned into a script
+// error on every affected game's very first turn (fixed engine-side in #2188 - string
+// concatenation with an unset attribute is an empty string, as it was in Quest 5).
+[TestClass]
+public class StatusAttributeTests
+{
+    [TestMethod]
+    public async Task StatusAttributeSetInStartScriptDoesNotError()
+    {
+        var gameDataProvider = new FileGameDataProvider("statusattributetest.aslx");
+        var gameData = await gameDataProvider.GetData();
+        var worldModel = Helpers.CreateWorldModel(gameData);
+
+        var errors = new List<string>();
+        worldModel.LogError += ex => errors.Add(ex.Message);
+
+        var status = new List<string>();
+        var player = new Mock<IPlayer>();
+        player.Setup(p => p.RunScriptAsync("updateStatus", It.IsAny<object[]>()))
+            .Callback<string, object[]>((_, parameters) => status.Add((string)parameters[0]))
+            .Returns(Task.CompletedTask);
+
+        var success = await worldModel.Initialise(player.Object);
+        Assert.IsTrue(success, "Initialisation failed");
+
+        await worldModel.Begin();
+
+        errors.ShouldBeEmpty();
+
+        // The pre-'start' update renders the not-yet-set attributes as empty rather than
+        // failing; the post-'start' one picks up the values the start script assigned.
+        status.First().ShouldBe("Next interaction: <br/>Chapter: ");
+        status.Last().ShouldBe("Next interaction: Della<br/>Chapter: One");
+    }
+}

--- a/tests/EngineTests/statusattributetest.aslx
+++ b/tests/EngineTests/statusattributetest.aslx
@@ -1,0 +1,36 @@
+<asl version="600">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <!--
+    Regression coverage for issue #2178: a status attribute whose value is only
+    assigned in the game's own 'start' script. StartGame calls
+    UpdateStatusAttributes once *before* running 'start', so that first call
+    reads the attribute while it is still unset.
+
+    "Next interaction" has no format string, so FormatStatusAttribute takes the
+    'CapFirst(attr) + ": " + value' branch, concatenating the unset value with a
+    string. "chapter" takes the format-string branch, which has always had its
+    own null check. Neither may log a script error.
+  -->
+  <game name="statusattributetest">
+    <statusattributes type="stringdictionary">
+      <item>
+        <key>Next interaction</key>
+        <value></value>
+      </item>
+      <item>
+        <key>chapter</key>
+        <value>Chapter: !</value>
+      </item>
+    </statusattributes>
+    <start type="script">
+      game.Next interaction = "Della"
+      game.chapter = "One"
+    </start>
+  </game>
+  <object name="room">
+    <object name="player">
+      <inherit name="defaultplayer" />
+    </object>
+  </object>
+</asl>


### PR DESCRIPTION
Regression coverage for #2178.

`StartGame` calls `UpdateStatusAttributes` once *before* running the game's own `start` script, so a status attribute whose value is only assigned in `start` is read while still unset. With no format string, `FormatStatusAttribute` builds `CapFirst(attr) + ": " + value` with no null check.

The arithmetic null-guard added in #2167 fired on that concatenation, turning every affected game's very first turn into three script errors. #2188 fixed it by excluding string concatenation from the guard — but its coverage is expression-level only (`"prefix" + obj.unsetattribute`), and nothing exercised the actual Core status-attribute path end to end.

This adds a small game that assigns its status attributes in `start` and asserts:

- no script error is logged during `Begin()`
- the pre-`start` update renders the not-yet-set values as empty (`Next interaction: <br/>Chapter: `) rather than failing
- the post-`start` update picks up the assigned values (`Next interaction: Della<br/>Chapter: One`)

Both `FormatStatusAttribute` branches are covered: `Next interaction` has no format string (the concatenation branch that broke), `chapter` has one (that branch has always had its own null check).

Verified the test fails with #2188's `IsStringConcatenation` exclusion reverted, and passes with it. Full `EngineTests` suite passes (323 tests).

Test-only change, hence the `test:` prefix — no user-observable behaviour changes here, the fix itself shipped in #2188.

Closes #2178

🤖 Generated with [Claude Code](https://claude.com/claude-code)