### PR TITLE
fix(PlayerCore): size the player chrome for touch on narrow windows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -404,6 +404,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-scenery-inventory.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-mobile-touch-targets.mjs http://localhost:5175
+        working-directory: tests/e2e
 
   # WebPlayer (ASP.NET Core + Blazor Server), Development mode with Dev:Enabled
   # (appsettings.Development.json already sets this — see /dev/open's

--- a/src/PlayerCore/Resources/playercore.css
+++ b/src/PlayerCore/Resources/playercore.css
@@ -80,12 +80,27 @@ div#gamePanes {
 }
 
 div#qv-status {
-    height: 30px;
+    /* A border-box total (box-sizing below): 30px of bar plus
+       .ui-widget-header's 1px border top and bottom. */
+    height: 32px;
     position: fixed;
     top: 0px;
     z-index: 100;
-    width: 100%;
-    max-width: 948px;
+    /* Anchored to the viewport rather than left to its static position inside
+       #gameBorder. It's position: fixed, so a plain "width: 100%" resolved
+       against the viewport while the bar still started at #gameBorder's 1px
+       left border - and with .ui-widget-header's own 1px borders sitting
+       outside a content-box width, the bar overran the window by 3px and
+       clipped its rightmost button on a phone. left/right/margin: auto centres
+       it on the viewport instead, which is where #gameBorder centres too, so
+       the wide layout is unchanged. */
+    left: 0;
+    right: 0;
+    width: auto;
+    /* A border-box total, matching #gameBorder's content width - see
+       setGameWidth() in playercore.js, which caps this at runtime. */
+    box-sizing: border-box;
+    max-width: 950px;
     margin-left: auto;
     margin-right: auto;
     font-size: 14pt;
@@ -335,4 +350,156 @@ div.jj_menu_item_hover {
 
 #cmdShowPanes {
     display: none;
+}
+
+/* ---------------------------------------------------------------------------
+   Narrow-window (phone/tablet) sizing - see issue #2181.
+
+   doLayout() in playercore.js owns the single narrow/wide threshold (the
+   window is narrower than the game width, so the panes have collapsed behind
+   the hamburger button) and publishes it as body.qv-narrow. Keying these rules
+   off that class rather than a media query of their own keeps one source of
+   truth: setGameWidth() can move the threshold at runtime, which a media query
+   couldn't follow.
+
+   The sizes here target WCAG 2.2's 44x44 CSS px pointer target (2.5.5 Target
+   Size (Enhanced)) and lift chrome text to 16px, matching the 12pt default
+   body text rather than sitting well below it.
+   --------------------------------------------------------------------------- */
+
+.qv-narrow {
+    --qv-sidebar-width: min(320px, 85vw);
+}
+
+/* The status bar is a fixed 32px when wide, which can't hold a 44px button.
+   updateStatusVisibility() measures whatever height this ends up being rather
+   than assuming, so #gamePanel/#gridPanel/#gamePanes stay directly below it. */
+.qv-narrow div#qv-status {
+    height: auto;
+    min-height: 50px;
+}
+
+.qv-narrow div#controlButtons {
+    padding-top: 2px;
+}
+
+.qv-narrow div#controlButtons .ui-button {
+    font-size: 16px !important;
+    min-height: 44px;
+    min-width: 44px;
+    /* jQuery UI puts the padding on the inner .ui-button-text span, so the
+       label sits at the top of a min-height-stretched button unless the button
+       itself centres it. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.qv-narrow div#location {
+    padding-top: 12px;
+}
+
+/* Side pane: 12px text in 15px rows, inside a 220px overlay.
+
+   The overlay is anchored between the status bar (updateStatusVisibility()
+   sets its top from the bar's measured height, so it can't end up underneath
+   it) and the bottom of the window. "height: 100%" would instead run the
+   overlay's bottom edge off the screen by however far down its top starts,
+   putting the end of a long pane out of reach. */
+.qv-narrow #sidebar {
+    width: var(--qv-sidebar-width);
+    box-sizing: border-box;
+    height: auto;
+    bottom: 0;
+}
+
+/* In the wide layout #gamePanes is a fixed, floated column positioned against
+   the viewport. Inside the narrow overlay it should simply be the overlay's
+   content: laying it out in flow is what lets #sidebar's own overflow-y scroll
+   it, which a fixed (out-of-flow) child left it unable to do - so a pane taller
+   than the screen had nothing to scroll and its lower half was unreachable.
+   float: none because a float would shrink-wrap instead of filling the width,
+   and min-height: 0 because a 100% of the overlay plus its padding is always
+   fractionally too tall, leaving the overlay permanently scrollable by a few
+   pixels. */
+.qv-narrow div#gamePanes {
+    position: static;
+    float: none;
+    width: auto;
+    min-height: 0;
+}
+
+.qv-narrow #gamePanes .ui-widget {
+    font-size: 16px;
+}
+
+.qv-narrow .ui-accordion-header {
+    font-size: 16px;
+}
+
+.qv-narrow button.accordion-header-text {
+    min-height: 44px;
+}
+
+.qv-narrow .elementList li {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0 6px;
+    box-sizing: border-box;
+}
+
+/* Six 44px rows rather than the ten 15px ones the 200px cap used to hold. */
+.qv-narrow .elementListWrapper {
+    max-height: 264px;
+}
+
+/* The multi-open accordion's expand/collapse arrow is a bare .ui-icon, not the
+   .ui-accordion-header-icon that jQuery UI's own centring rule targets, so it
+   keeps its static position at the top-left of the header's padding box - which
+   left it stranded against the top of a header now 44px tall. Centre it on the
+   header and scale the 16px sprite up to match the rest of the touch chrome
+   (transform rather than background-size, so the sprite's per-icon background
+   position doesn't have to be recomputed). */
+.qv-narrow .ui-accordion-header > .ui-icon {
+    top: 50%;
+    margin-top: -8px;
+    transform: scale(1.5);
+}
+
+/* The compass lives in the same pane, and its buttons are 35px. */
+.qv-narrow .compassbutton {
+    height: 44px;
+    width: 44px;
+}
+
+/* playercore.js pins the direction icon at an inline left: 0.8em, which centres
+   it in a 35px button but not a 44px one - hand centring back to jQuery UI's
+   own rule for it. */
+.qv-narrow .compassbutton span.ui-icon {
+    left: 50% !important;
+    margin-left: -8px;
+}
+
+.qv-narrow #compassTable .ui-button {
+    font-size: 14px !important;
+}
+
+.qv-narrow .verbButtons .ui-button {
+    font-size: 14px !important;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Hyperlink pop-up menu. The font size itself is the game's to choose (see
+   SetMenuFontSize in playercore.js, which applies a floor here rather than
+   overriding it outright), so only the row height is set from CSS. */
+.qv-narrow div.jj_menu_item span {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 4px 10px;
+    box-sizing: border-box;
 }

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -232,6 +232,13 @@ function initPlayerUI() {
     const doLayout = () => {
         let isWide = isWindowWide();
 
+        // Published as a class so playercore.css can hang its larger touch
+        // targets off the same threshold this function already owns, instead
+        // of duplicating it as a media query - which setGameWidth() would then
+        // have no way to move. See issue #2181.
+        document.body.classList.toggle("qv-narrow", !isWide);
+        refreshMenuFontSize();
+
         if (isWide && arePanesVisible) {
             sidebar.style.display = "block";
             sidebar.style.background = "initial";
@@ -263,13 +270,17 @@ function initPlayerUI() {
             if (window.paper && paper.view) paper.view.viewSize.width = Math.min(window.innerWidth, gameWidth);
         }
 
-        const newPanelImageMaxHeight = `${(window.innerHeight - 30) * 0.5}px`;
-        updatePanelImageMaxHeight(newPanelImageMaxHeight);
-
         // cmdShowPanes.style.display was just set above - recompute #qv-status's own
         // visibility now in case resizing past the narrow-window threshold is what
         // just made (or unmade) the hamburger button #qv-status's only visible child.
         updateStatusVisibility();
+
+        // Budget the sticky picture frame against however tall the status bar
+        // actually ended up - it used to subtract a hard-coded 30, which is
+        // neither its narrow-layout height nor right at all when it isn't
+        // showing. updateStatusVisibility() has just settled both, hence the
+        // ordering here.
+        updatePanelImageMaxHeight(`${(window.innerHeight - statusBarHeight()) * 0.5}px`);
 
         wasWide = isWide;
     }
@@ -280,8 +291,12 @@ function initPlayerUI() {
         const gameBorder = document.getElementById("gameBorder");
         gameBorder.style.maxWidth = width + "px";
 
+        // playercore.css gives #qv-status box-sizing: border-box, so this cap is
+        // the bar's whole width including its 1px borders - matching #gameBorder's
+        // content box, which is what "width" is there (it's content-box, with its
+        // own 1px borders outside that).
         const status = document.getElementById("qv-status");
-        status.style.maxWidth = (width - 2) + "px";
+        status.style.maxWidth = width + "px";
 
         gameWidth = width;
         doLayout();
@@ -556,21 +571,59 @@ function updateStatusVisibility() {
         || isElementVisible("#cmdDebug") || isElementVisible("#cmdShowPanes");
     if (anyVisible) {
         $("#qv-status").show();
-        $("#divOutput").css("margin-top", "20px");
-        $("#gamePanes").css("top", "24px");
-        $("#gridPanel").css("top", "32px");
-        $("#gamePanel").css("top", "32px");
+        // #qv-status is no longer a fixed height - on a narrow window it grows
+        // to fit 44px touch targets (see playercore.css's .qv-narrow rules), so
+        // measure its real bottom edge rather than repeating the height as a
+        // constant here. Its 32px on the desktop layout is what the old 24/32
+        // constants were describing: the panels sat flush with the bar's bottom
+        // edge, and #gamePanes deliberately tucked 8px up under it.
+        var statusHeight = statusBarHeight();
+        // #qv-status is position: fixed, so it takes up no space in flow and
+        // this margin is the whole of what holds the game text clear of it.
+        // The 20px it used to be was picked against the 32px desktop bar,
+        // leaving 18px of daylight - which a 50px narrow-layout bar closed to
+        // nothing, running the text right up under it. Tracking the bar keeps
+        // that daylight constant. It's expressed as an offset from the bar's
+        // own height rather than computed from #gameContent's padding, so a
+        // game setting its own custompaddingtop keeps exactly the spacing it
+        // has today.
+        $("#divOutput").css("margin-top", (statusHeight - 12) + "px");
+        $("#gamePanes").css("top", (statusHeight - 8) + "px");
+        $("#gridPanel").css("top", statusHeight + "px");
+        $("#gamePanel").css("top", statusHeight + "px");
+        // The narrow layout's pane overlay, which is opaque and would otherwise
+        // sit over the bottom of the bar it drops down from. (In the wide
+        // layout it's a transparent container and this is the 32px it already
+        // had.) #gamePanes is laid out inside it there rather than positioned,
+        // so this is what actually places the panes on a narrow window - its
+        // own "top" above is only read by the wide layout.
+        $("#sidebar").css("top", statusHeight + "px");
     } else {
         $("#qv-status").hide();
         $("#divOutput").css("margin-top", "0px");
         $("#gamePanes").css("top", "0px");
         $("#gridPanel").css("top", "0px");
         $("#gamePanel").css("top", "0px");
+        $("#sidebar").css("top", "0px");
     }
 }
 
 function isElementVisible(element) {
     return $(element).css("display") != "none";
+}
+
+// doLayout() publishes its narrow/wide threshold as a class on <body> - see
+// playercore.css's .qv-narrow rules.
+function isNarrowLayout() {
+    return document.body.classList.contains("qv-narrow");
+}
+
+// #qv-status's on-screen height, or 0 when it isn't showing at all. 32px on the
+// desktop layout, but it grows to hold 44px touch targets on a narrow one, so
+// nothing downstream should be assuming a number for it.
+function statusBarHeight() {
+    var $status = $("#qv-status");
+    return ($status.length && isElementVisible($status)) ? $status.outerHeight() : 0;
 }
 
 var _animateScroll = true;
@@ -1323,11 +1376,39 @@ function SetMenuFontName(font) {
     css.style.fontFamily = font;
 }
 
+// game.menufontsize defaults to 9pt (12px), and - like every other Core
+// library value - is inlined into each game at publish time, so an already
+// published game calls SetMenuFontSize("9pt") on startup no matter what this
+// stylesheet's own default says. Rather than ignoring the game outright, treat
+// its value as a request with a floor under it on a narrow window: an author
+// who asked for something larger (theme_retro asks for 14pt) still gets
+// exactly what they asked for. max() does the comparison in CSS, so "9pt"
+// doesn't have to be converted to px here; in a browser without support the
+// assignment is simply dropped and the stylesheet's own div.jjmenu size
+// stands, exactly as it did before. See issue #2181.
+function menuFontSizeWithFloor(size) {
+    return isNarrowLayout() ? "max(" + size + ", 16px)" : size;
+}
+
+// The size the game last asked for, before any narrow-window floor, so the
+// floor can be re-evaluated when the window crosses the threshold.
+var _requestedMenuFontSize = null;
+
 function SetMenuFontSize(size) {
     if (_allowMenuFontSizeChange) {
         var css = getCSSRule("div.jjmenu");
-        css.style.fontSize = size;
+        css.style.fontSize = menuFontSizeWithFloor(size);
+        // Recorded only once getCSSRule has actually succeeded, so that
+        // refreshMenuFontSize() stays a no-op rather than throwing on every
+        // resize in the single-file-export case where the rule can't be
+        // reached at all (issue #2192).
+        _requestedMenuFontSize = size;
     }
+}
+
+function refreshMenuFontSize() {
+    if (_requestedMenuFontSize == null) return;
+    getCSSRule("div.jjmenu").style.fontSize = menuFontSizeWithFloor(_requestedMenuFontSize);
 }
 
 function TurnOffHyperlinksUnderline() {

--- a/tests/e2e/fixtures/mobile-touch-targets-large-menu-test.aslx
+++ b/tests/e2e/fixtures/mobile-touch-targets-large-menu-test.aslx
@@ -1,0 +1,25 @@
+<asl version="600">
+
+  <include ref="English.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <!--
+    Companion to mobile-touch-targets-test.aslx: an author who has deliberately
+    chosen a menu font *larger* than the narrow-window floor must keep exactly
+    what they asked for. 20pt is 26.67px, well clear of the 16px floor.
+  -->
+  <game name="Large Menu">
+    <menufontsize type="int">20</menufontsize>
+  </game>
+
+  <object name="room">
+    <object name="player">
+      <inherit name="defaultplayer"/>
+    </object>
+    <object name="rock">
+      <inherit name="editor_object"/>
+      <take/>
+    </object>
+  </object>
+
+</asl>

--- a/tests/e2e/fixtures/mobile-touch-targets-test.aslx
+++ b/tests/e2e/fixtures/mobile-touch-targets-test.aslx
@@ -1,0 +1,31 @@
+<asl version="600">
+
+  <include ref="English.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <!--
+    Fixture for issue #2181 (menu/chrome too small on mobile). Deliberately
+    leaves game.menufontsize at the defaultgame default of 9pt (12px) - the
+    value every already-published game carries inlined - so the narrow-window
+    floor in playercore.js's SetMenuFontSize has something to lift.
+  -->
+  <game name="Touch Targets">
+  </game>
+
+  <object name="room">
+    <object name="player">
+      <inherit name="defaultplayer"/>
+      <!-- Something in the inventory pane, so its rows can be measured. -->
+      <object name="lamp">
+        <inherit name="editor_object"/>
+      </object>
+    </object>
+    <!-- A room object, so the description carries an .elementmenu hyperlink
+         whose verb pop-up (jjmenu) can be opened and measured. -->
+    <object name="rock">
+      <inherit name="editor_object"/>
+      <take/>
+    </object>
+  </object>
+
+</asl>

--- a/tests/e2e/verify-wasmplayer-mobile-touch-targets.mjs
+++ b/tests/e2e/verify-wasmplayer-mobile-touch-targets.mjs
@@ -1,0 +1,337 @@
+// Verifies the narrow-window (phone/tablet) chrome sizing added for issue #2181:
+// the hamburger button was 22px tall, side-pane rows 15px at 12px text, and the
+// hyperlink verb pop-up 12px text in ~22px rows - all well under WCAG 2.2's
+// 44x44 CSS px pointer target (2.5.5) and well under the 16px body text.
+//
+// The threshold itself lives in playercore.js's doLayout(), which publishes it
+// as body.qv-narrow for playercore.css to hang the larger sizes off, so this
+// checks the class actually tracks the window and that the sizes follow it -
+// including back down again when the window widens, since the desktop layout
+// must be untouched.
+//
+// The menu font size is the interesting one: game.menufontsize (9pt = 12px by
+// default) is inlined into every published game, so SetMenuFontSize applies a
+// floor rather than overriding the author. Both halves are checked - a default
+// game gets lifted to 16px, an author asking for 20pt keeps 20pt.
+//
+// Two long-standing bugs in the same chrome are covered here too, since both
+// only really bite once the bar is holding touch-sized controls:
+//   - #qv-status is position: fixed, so its "width: 100%" resolved against the
+//     viewport while the bar still started at #gameBorder's 1px left border -
+//     with its own borders outside a content-box width it overran the window by
+//     3px and clipped its rightmost button on a phone.
+//   - the multi-open accordion's arrow is a bare .ui-icon rather than the
+//     .ui-accordion-header-icon jQuery UI's centring rule targets, so it stayed
+//     pinned to the top-left of a header that is now 44px tall.
+//
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+// Comfortably inside the 950px game width, so doLayout() reports narrow.
+const PHONE = { width: 390, height: 844 };
+// Wider than the 950px game width, so doLayout() reports wide.
+const DESKTOP = { width: 1280, height: 900 };
+
+const MIN_TARGET = 44;
+const MIN_TEXT = 16;
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: PHONE });
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+const box = sel => page.$eval(sel, el => el.getBoundingClientRect().height);
+const font = sel => page.$eval(sel, el => parseFloat(getComputedStyle(el).fontSize));
+
+async function loadGame(fixture) {
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/${fixture}`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000, state: 'attached' });
+    // #txtCommand attaches before InitInterface has finished issuing its interop
+    // calls (single-threaded WASM - see CLAUDE.md), and SetMenuFontSize is one of
+    // them, so poll for the room description rather than racing it.
+    await page.waitForFunction(
+        () => document.querySelectorAll('#divOutput .elementmenu').length > 0,
+        { timeout: 15000 },
+    );
+}
+
+// Opens the verb pop-up on the first object hyperlink in the transcript.
+async function openVerbMenu() {
+    await page.click('#divOutput .elementmenu');
+    await page.waitForSelector('#jjmenu_main .jj_menu_item', { timeout: 5000 });
+}
+
+async function closeVerbMenu() {
+    await page.keyboard.press('Escape');
+    await page.waitForFunction(() => !document.querySelector('#jjmenu_main'), { timeout: 5000 });
+}
+
+async function run() {
+    await loadGame('mobile-touch-targets-test.aslx');
+
+    // --- narrow window ----------------------------------------------------
+    const narrowClass = await page.evaluate(() => document.body.classList.contains('qv-narrow'));
+    if (!narrowClass) {
+        throw new Error(`body.qv-narrow should be set at ${PHONE.width}px (inside the 950px game width), but it is not`);
+    }
+    console.log('PASS: body.qv-narrow set on a phone-width window');
+
+    const hamburgerVisible = await page.$eval('#cmdShowPanes', el => getComputedStyle(el).display !== 'none');
+    if (!hamburgerVisible) {
+        throw new Error('#cmdShowPanes should be visible on a narrow window');
+    }
+
+    const hamburger = await box('#cmdShowPanes');
+    if (hamburger < MIN_TARGET) {
+        throw new Error(`#cmdShowPanes is ${hamburger}px tall, expected at least ${MIN_TARGET}px (issue #2181 reported 22px)`);
+    }
+    console.log(`PASS: hamburger is ${hamburger}px tall (>= ${MIN_TARGET}px)`);
+
+    const save = await box('#cmdSave');
+    if (save < MIN_TARGET) {
+        throw new Error(`#cmdSave is ${save}px tall, expected at least ${MIN_TARGET}px`);
+    }
+    console.log(`PASS: Save / Load button is ${save}px tall (>= ${MIN_TARGET}px)`);
+
+    // ...and it has to fit inside the window, rather than hanging 3px off the
+    // right-hand edge with the hamburger's border clipped off.
+    const overflow = await page.evaluate(() => {
+        const vw = window.innerWidth;
+        return [...document.querySelectorAll('body *')]
+            .filter(e => e.getBoundingClientRect().right > vw + 0.5 && getComputedStyle(e).display !== 'none')
+            .map(e => `${e.tagName}#${e.id || ''} right=${e.getBoundingClientRect().right.toFixed(1)}`);
+    });
+    if (overflow.length > 0) {
+        throw new Error(`nothing should overhang a ${PHONE.width}px window, but these do: ${overflow.join(', ')}`);
+    }
+    console.log('PASS: no chrome overhangs the right-hand edge of a phone-width window');
+
+    // The status bar has to have grown to hold them, and the panels below it
+    // have to follow that measured height rather than the old 30px constant.
+    const statusHeight = await box('#qv-status');
+    if (statusHeight < MIN_TARGET) {
+        throw new Error(`#qv-status is ${statusHeight}px tall, too short to hold a ${MIN_TARGET}px button`);
+    }
+    // #qv-status is fixed, so #divOutput's top margin is the only thing holding
+    // the game text clear of it. That margin used to be a flat 20px chosen
+    // against the 32px desktop bar, so a 50px bar ran the text right up under it.
+    const textGap = async () => page.evaluate(() => {
+        const b = s => document.querySelector(s).getBoundingClientRect();
+        return +(b('#divOutput').top - b('#qv-status').bottom).toFixed(1);
+    });
+    const narrowGap = await textGap();
+    if (Math.abs(narrowGap - 18) > 0.5) {
+        throw new Error(`game text sits ${narrowGap}px below the status bar on a narrow window, expected the same 18px of daylight the desktop layout has (0px would mean it is flush against the bar)`);
+    }
+    console.log(`PASS: game text keeps ${narrowGap}px of daylight below the taller status bar`);
+
+    const sidebarTop = await page.$eval('#sidebar', el => parseFloat(el.style.top));
+    if (sidebarTop !== statusHeight) {
+        throw new Error(`#sidebar top is ${sidebarTop}px, expected the measured #qv-status height of ${statusHeight}px - the pane overlay is still using a hard-coded offset`);
+    }
+    console.log(`PASS: #qv-status grew to ${statusHeight}px and #sidebar tracks it at ${sidebarTop}px`);
+
+    // Side pane.
+    await page.click('#cmdShowPanes');
+    await page.waitForFunction(() => getComputedStyle(document.querySelector('#sidebar')).display === 'block', { timeout: 5000 });
+
+    // Nothing in the opened overlay may overlap the bar it drops down from, and
+    // it has to stop at the bottom of the window rather than running off it.
+    const overlay = await page.evaluate(() => {
+        const b = s => document.querySelector(s).getBoundingClientRect();
+        const sb = document.querySelector('#sidebar');
+        return {
+            barBottom: b('#qv-status').bottom,
+            sidebar: { top: b('#sidebar').top, bottom: b('#sidebar').bottom },
+            panesTop: b('#gamePanes').top,
+            viewportHeight: window.innerHeight,
+            scrollableBy: sb.scrollHeight - sb.clientHeight,
+        };
+    });
+    if (overlay.sidebar.top < overlay.barBottom - 0.5) {
+        throw new Error(`#sidebar starts at ${overlay.sidebar.top}px, overlapping the status bar that ends at ${overlay.barBottom}px`);
+    }
+    if (overlay.panesTop < overlay.barBottom - 0.5) {
+        throw new Error(`#gamePanes starts at ${overlay.panesTop}px, overlapping the status bar that ends at ${overlay.barBottom}px`);
+    }
+    if (overlay.sidebar.bottom > overlay.viewportHeight + 0.5) {
+        throw new Error(`#sidebar runs ${(overlay.sidebar.bottom - overlay.viewportHeight).toFixed(1)}px past the bottom of the window, putting the end of a long pane out of reach`);
+    }
+    console.log(`PASS: pane overlay spans ${overlay.sidebar.top}-${overlay.sidebar.bottom}px, clear of the bar and inside the window`);
+    if (overlay.scrollableBy !== 0) {
+        throw new Error(`#sidebar is scrollable by ${overlay.scrollableBy}px with only two short panes open - its content should fit exactly`);
+    }
+    console.log('PASS: pane overlay has no spurious scroll with short panes');
+
+    // ...but when the panes genuinely are taller than the window, the overlay
+    // must actually scroll them. It couldn't before: #gamePanes was position:
+    // fixed, so it sat outside #sidebar's flow and there was nothing for its
+    // overflow-y to move, leaving the bottom of a long pane unreachable.
+    await page.setViewportSize({ width: PHONE.width, height: 380 });
+    await page.waitForTimeout(300);
+    const scrolled = await page.evaluate(() => {
+        const sb = document.querySelector('#sidebar');
+        const overflow = sb.scrollHeight - sb.clientHeight;
+        sb.scrollTop = sb.scrollHeight;
+        return { overflow, scrollTop: sb.scrollTop };
+    });
+    if (scrolled.overflow <= 0) {
+        throw new Error(`the pane overlay should overflow a ${380}px window, but scrollHeight matches clientHeight - the test can't prove it scrolls`);
+    }
+    if (scrolled.scrollTop <= 0) {
+        throw new Error(`the pane overlay overflows by ${scrolled.overflow}px but will not scroll (scrollTop stayed at 0) - the bottom of a long pane is unreachable`);
+    }
+    console.log(`PASS: pane overlay scrolls when its content overflows (${scrolled.overflow}px of overflow, scrolled to ${scrolled.scrollTop}px)`);
+    await page.setViewportSize(PHONE);
+    await page.waitForTimeout(300);
+
+    const invRow = await box('#lstInventory li');
+    if (invRow < MIN_TARGET) {
+        throw new Error(`inventory row is ${invRow}px tall, expected at least ${MIN_TARGET}px (issue #2181 reported 15px)`);
+    }
+    const invFont = await font('#lstInventory li');
+    if (invFont < MIN_TEXT) {
+        throw new Error(`inventory row text is ${invFont}px, expected at least ${MIN_TEXT}px (issue #2181 reported 12px)`);
+    }
+    console.log(`PASS: inventory rows are ${invRow}px tall at ${invFont}px text`);
+
+    const headerHeight = await box('#inventoryLabel button.accordion-header-text');
+    if (headerHeight < MIN_TARGET) {
+        throw new Error(`accordion header button is ${headerHeight}px tall, expected at least ${MIN_TARGET}px`);
+    }
+    console.log(`PASS: accordion header button is ${headerHeight}px tall`);
+
+    const arrow = await page.evaluate(() => {
+        const h3 = document.querySelector('#inventoryLabel');
+        const i = h3.querySelector('.ui-icon').getBoundingClientRect();
+        const b = h3.querySelector('button.accordion-header-text').getBoundingClientRect();
+        return { iconCentre: i.top + i.height / 2, btnCentre: b.top + b.height / 2, iconHeight: i.height };
+    });
+    if (Math.abs(arrow.iconCentre - arrow.btnCentre) > 1) {
+        throw new Error(`accordion arrow centre is ${arrow.iconCentre.toFixed(1)}px but its header button's is ${arrow.btnCentre.toFixed(1)}px - the arrow is stranded against the top of the header rather than centred on it`);
+    }
+    if (arrow.iconHeight < 20) {
+        throw new Error(`accordion arrow renders at ${arrow.iconHeight}px, expected it scaled up from the 16px sprite to suit touch chrome`);
+    }
+    console.log(`PASS: accordion arrow is centred on its header and renders at ${arrow.iconHeight}px`);
+
+    await page.click('#cmdShowPanes');
+
+    // Hyperlink verb pop-up.
+    await openVerbMenu();
+    const menuFont = await font('#jjmenu_main .jj_menu_item span');
+    if (menuFont < MIN_TEXT) {
+        throw new Error(`verb menu text is ${menuFont}px, expected at least ${MIN_TEXT}px - the game asked for 9pt (12px) and the narrow-window floor should have lifted it`);
+    }
+    const menuRow = await box('#jjmenu_main .jj_menu_item');
+    if (menuRow < MIN_TARGET) {
+        throw new Error(`verb menu row is ${menuRow}px tall, expected at least ${MIN_TARGET}px (issue #2181 reported 22px)`);
+    }
+    console.log(`PASS: verb menu rows are ${menuRow}px tall at ${menuFont}px text (floored up from the game's 9pt)`);
+    await closeVerbMenu();
+
+    // --- widening back out ------------------------------------------------
+    // The desktop layout must be exactly as it was, so everything above has to
+    // come back down again rather than being a one-way change.
+    await page.setViewportSize(DESKTOP);
+    await page.waitForFunction(() => !document.body.classList.contains('qv-narrow'), { timeout: 5000 });
+    console.log('PASS: body.qv-narrow cleared when the window widens past the game width');
+
+    // 32px = the 30px of CSS height plus .ui-widget-header's 1px border top and
+    // bottom, which is exactly what the old hard-coded 24/32 offsets described.
+    const wideStatus = await box('#qv-status');
+    if (wideStatus !== 32) {
+        throw new Error(`#qv-status should be back to its 32px desktop height, got ${wideStatus}px`);
+    }
+    const widePanesTop = await page.$eval('#gamePanes', el => parseFloat(el.style.top));
+    if (widePanesTop !== 24) {
+        throw new Error(`#gamePanes top should be back to the desktop 24px, got ${widePanesTop}px`);
+    }
+    // #gamePanes is positioned again out here, rather than laid out inside the
+    // overlay, so the wide layout's 8px tuck under the bar is real.
+    const widePanesPos = await page.$eval('#gamePanes', el => getComputedStyle(el).position);
+    if (widePanesPos !== 'fixed') {
+        throw new Error(`#gamePanes should be position: fixed on the desktop layout, got ${widePanesPos}`);
+    }
+    const widePanelTop = await page.$eval('#gamePanel', el => parseFloat(el.style.top));
+    if (widePanelTop !== 32) {
+        throw new Error(`#gamePanel top should be back to the desktop 32px, got ${widePanelTop}px`);
+    }
+    const wideMargin = await page.$eval('#divOutput', el => el.style.marginTop);
+    if (wideMargin !== '20px') {
+        throw new Error(`#divOutput margin-top should be back to the desktop 20px, got ${wideMargin}`);
+    }
+    const wideGap = await textGap();
+    if (Math.abs(wideGap - 18) > 0.5) {
+        throw new Error(`game text should sit 18px below the bar on the desktop layout, got ${wideGap}px`);
+    }
+    console.log('PASS: desktop layout unchanged (#gamePanes top 24px, #gamePanel top 32px, text gap 18px)');
+
+    // The bar should span exactly #gameBorder's content box - i.e. inset by its
+    // 1px border on each side - at the default width and at a game-chosen one.
+    const aligned = async label => {
+        const g = await page.evaluate(() => {
+            const b = s => document.querySelector(s).getBoundingClientRect();
+            return { border: b('#gameBorder'), status: b('#qv-status') };
+        });
+        const leftGap = g.status.left - g.border.left;
+        const rightGap = g.border.right - g.status.right;
+        if (Math.abs(leftGap - 1) > 0.5 || Math.abs(rightGap - 1) > 0.5) {
+            throw new Error(`${label}: #qv-status should sit 1px inside #gameBorder on both sides, got ${leftGap.toFixed(1)}px / ${rightGap.toFixed(1)}px`);
+        }
+        console.log(`PASS: ${label} - #qv-status spans #gameBorder's content box exactly`);
+    };
+    await aligned('default width');
+    await page.evaluate(() => window.setGameWidth(700));
+    await page.waitForTimeout(200);
+    await aligned('setGameWidth(700)');
+    await page.evaluate(() => window.setGameWidth(950));
+    await page.waitForTimeout(200);
+
+    // The sticky picture frame's budget should follow the measured bar too,
+    // rather than the 30px constant it used to subtract.
+    const budget = await page.evaluate(() => {
+        const rule = [...document.styleSheets]
+            .flatMap(s => { try { return [...s.cssRules]; } catch { return []; } })
+            .find(r => r.selectorText === 'div#gamePanel img');
+        const bar = document.querySelector('#qv-status').getBoundingClientRect().height;
+        return { maxHeight: rule && rule.style.maxHeight, expected: `${(window.innerHeight - bar) * 0.5}px` };
+    });
+    if (budget.maxHeight !== budget.expected) {
+        throw new Error(`picture frame max-height is ${budget.maxHeight}, expected ${budget.expected} (window height less the measured status bar, halved)`);
+    }
+    console.log(`PASS: picture frame budget follows the measured status bar (${budget.maxHeight})`);
+
+    await openVerbMenu();
+    const wideMenuFont = await font('#jjmenu_main .jj_menu_item span');
+    if (Math.abs(wideMenuFont - 12) > 0.5) {
+        throw new Error(`verb menu on desktop should be the game's own 9pt (12px), got ${wideMenuFont}px - the floor is leaking into the desktop layout`);
+    }
+    console.log(`PASS: verb menu back to the game's own 9pt (${wideMenuFont}px) on desktop`);
+    await closeVerbMenu();
+
+    // --- an author who asked for more keeps it ----------------------------
+    await page.setViewportSize(PHONE);
+    await loadGame('mobile-touch-targets-large-menu-test.aslx');
+    await openVerbMenu();
+    const bigMenuFont = await font('#jjmenu_main .jj_menu_item span');
+    // 20pt = 26.666...px
+    if (Math.abs(bigMenuFont - 80 / 3) > 0.5) {
+        throw new Error(`a game asking for 20pt should still get 20pt (26.67px) on a narrow window, got ${bigMenuFont}px - the floor is clamping instead of flooring`);
+    }
+    console.log(`PASS: a game asking for 20pt still gets ${bigMenuFont}px on a narrow window`);
+    await closeVerbMenu();
+
+    console.log('\nAll checks passed.');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Fixes #2181.

The hamburger button was 22px tall, side-pane rows 15px at 12px text, and the hyperlink verb pop-up 12px text in 22px rows — all well under [WCAG 2.2's 44×44 CSS px pointer target](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html), and well under the 16px body text.

## Approach

`doLayout()` already owns a narrow/wide threshold, so it now publishes it as `body.qv-narrow` for `playercore.css` to hang the larger sizes off. Keying them off the class rather than a media query keeps one source of truth — `setGameWidth()` can move the threshold at runtime, which a media query couldn't follow.

**The verb menu's size is the awkward one.** `game.menufontsize` (9pt) is inlined into every published game, so a stylesheet default can't lift it for games that already shipped. `SetMenuFontSize` therefore applies a *floor* rather than an override: a default game is lifted to 16px, while an author who asked for more (`theme_retro` asks for 14pt) keeps exactly what they asked for. `max()` does the comparison in CSS so `"9pt"` needn't be converted to px; where it isn't supported the assignment is dropped and the old stylesheet value stands.

I also sized the compass buttons (35px → 44px), since they sit in the same pane and fall under the same complaint. That's distinct from #2183, which is about *moving* the compass to the main screen.

## Bugs this turned up

Growing the status bar to hold a 44px button exposed several places with its old height baked in as a constant, plus two long-standing bugs in the same chrome that only really bite once it's holding touch-sized controls:

- `#gamePanel`/`#gridPanel`/`#gamePanes` offsets, `#sidebar`'s top, and the sticky picture frame's height budget are all **measured** from the bar now rather than assuming 30/32px.
- `#divOutput`'s top margin is the only thing holding the game text clear of the fixed bar. At a flat 20px — chosen against the 32px desktop bar — a 50px bar closed the 18px gap to **nothing** and ran the text underneath it.
- `#qv-status` is `position: fixed`, so its `width: 100%` resolved against the viewport while the bar still started at `#gameBorder`'s 1px left border. With its own borders outside a content-box width it overran the window by 3px and clipped its rightmost button on a phone.
- The multi-open accordion's arrow is a bare `.ui-icon`, **not** the `.ui-accordion-header-icon` that jQuery UI's centring rule targets, so it stayed pinned to the top-left of a header now 44px tall.
- `#gamePanes` was `position: fixed` inside the pane overlay, so it sat outside `#sidebar`'s flow and there was nothing for its `overflow-y` to scroll — a pane taller than the screen had its lower half unreachable. Verified: with the old positioning in a 380px window the overlay reports zero overflow and won't scroll, while its content runs to 505px. In the narrow layout it's laid out in flow instead.

## Verification

New `tests/e2e/verify-wasmplayer-mobile-touch-targets.mjs` (21 assertions, two fixtures). It covers both halves of the font floor, that the overlay clears the bar and both *does* scroll when content overflows and *doesn't* when it fits, and that the bar spans `#gameBorder`'s content box at the default and at a `setGameWidth()`-chosen width.

The desktop layout is asserted pixel-identical throughout — bar 32px, `#gamePanes` top 24px, `#gamePanel` top 32px, `#divOutput` margin 20px, verb menu back to the game's own 12px.

Also green: all 399 `dotnet test` tests, and 14 existing player e2e scripts (the five autoscroll ones especially, since this changes both the panel offsets and the picture-frame budget they depend on).

Shared PlayerCore resources, so WebPlayer picks this up too, though I verified through WasmPlayer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)