### PR TITLE
fix(PlayerCore): stop the command bar flickering when a wait or pause ends

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -372,6 +372,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-save-turn-pending.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-wait-pause-input-flicker.mjs http://localhost:5175
+        working-directory: tests/e2e
       - run: node verify-wasmplayer-showmenu-select-default.mjs http://localhost:5175
         working-directory: tests/e2e
       - run: node verify-wasmplayer-showmenu-long-options.mjs http://localhost:5175

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -408,6 +408,13 @@ function setGameName(text) {
 var _waitMode = false;
 var _pauseMode = false;
 
+// True between endPause() and pauseEnded(), i.e. while the command bar is
+// hidden only because a finished pause hasn't been able to restore it yet.
+// Anything that snapshots the command bar's current visibility to restore it
+// later (playSound's synchronous branch) has to count that as visible, or the
+// pause's pending restore is swallowed and the command bar never comes back.
+var _pauseRestorePending = false;
+
 // Mirrors the engine's WorldModel._pendingCallbackCount > 0: true whenever
 // anything is suspended inside a TaskCompletionSource continuation (wait(),
 // get input(), ask, show menu, pause) that a save/reload can't reconstruct -
@@ -437,13 +444,33 @@ function beginPause(ms) {
 }
 
 function endPause() {
+    if (!_pauseMode) return;
     _pauseMode = false;
-    $("#txtCommandDiv").show();
+    // The command bar deliberately stays hidden until pauseEnded() - showing it
+    // here made it flash into view for the length of the round trip whenever the
+    // resumed script went straight into another pause (same bug as endWait()).
+    _pauseRestorePending = true;
 
     // TODO: This is WebPlayer-specific, so shouldn't be in this shared file
     window.setTimeout(async function () {
-        await WebPlayer.uiEndPause();
+        try {
+            await WebPlayer.uiEndPause();
+        } finally {
+            pauseEnded();
+        }
     }, 100);
+}
+
+// Called once the engine has resumed the paused turn and run on to its next
+// stopping point, so anything that turn did to the command bar has already
+// happened: another pause (beginPause), the end of the game (disableInterface)
+// or a synchronous sound (playSound), each of which owns the command bar until
+// it restores it itself.
+function pauseEnded() {
+    _pauseRestorePending = false;
+    if (_pauseMode || _gameFinished || _waitingForSoundToFinish) return;
+    $("#txtCommandDiv").show();
+    focusCommandInput();
 }
 
 function commandKey(e) {
@@ -994,14 +1021,34 @@ function beginWait() {
 
 function endWait() {
     if (!_waitMode) return;
+    // Leave wait mode and hide the Continue link straight away: that's the
+    // click's immediate feedback, and it also stops a second click/keypress
+    // firing a second FinishWait while the engine is resuming. The command
+    // input deliberately stays hidden until waitEnded() - see below.
+    _waitMode = false;
+    $("#endWaitLink").hide();
     sendEndWait();
 }
 
+// Called by the platform's sendEndWait() once the engine has resumed the
+// suspended turn and run on to its next stopping point. If that turn started
+// another wait(), beginWait() has already re-hidden the command input and
+// re-shown the Continue link, so leave both alone: restoring the input
+// unconditionally (as this used to, synchronously at click time) is what made
+// it flash into view for the length of the round trip between chained waits.
 function waitEnded() {
-    _waitMode = false;
-    $("#endWaitLink").hide();
+    if (_waitMode) return;
     $("#txtCommand").show();
     $("#txtCommandPrompt").show();
+    focusCommandInput();
+}
+
+// The command input loses focus while it's hidden (for a wait() or a pause), so
+// put it back once it returns - otherwise the player has to click into it before
+// they can type, and keystrokes meant for the game go nowhere.
+function focusCommandInput() {
+    if (!isElementVisible("#txtCommandDiv") || !isElementVisible("#txtCommand")) return;
+    $("#txtCommand").focus();
 }
 
 function gameFinished() {

--- a/src/WasmPlayer/wasm-player.js
+++ b/src/WasmPlayer/wasm-player.js
@@ -246,10 +246,20 @@ function stageAdjacentFiles(files) {
 function ui_init() { }
 
 function sendEndWait() {
+    // The short delay lets the browser paint endWait()'s hidden Continue link
+    // before the engine resumes and (in the WASM build, which runs it on the
+    // one UI thread) blocks painting for the rest of the turn.
     window.setTimeout(async function () {
-        await WebPlayer.uiEndWait();
+        try {
+            await WebPlayer.uiEndWait();
+        } finally {
+            // uiEndWait only resolves once the resumed turn has reached its
+            // next stopping point and flushed its UI calls, so by now
+            // beginWait() has already run for a chained wait() - which is
+            // exactly what waitEnded() checks before restoring the input.
+            waitEnded();
+        }
     }, 100);
-    waitEnded();
 }
 
 function afterSendCommand() { }
@@ -259,7 +269,10 @@ function playSound(url, synchronous, looped) {
     _audio = new Audio(url);
     if (looped) _audio.loop = true;
     if (synchronous) {
-        var showCmdDiv = isElementVisible("#txtCommandDiv");
+        // Counts a pause whose restore is still pending as visible - see
+        // _pauseRestorePending, otherwise finishSync() below leaves the command
+        // bar hidden for good.
+        var showCmdDiv = isElementVisible("#txtCommandDiv") || _pauseRestorePending;
         _waitingForSoundToFinish = true;
         $("#txtCommandDiv").hide();
         _audio.addEventListener('ended', function () { finishSync(showCmdDiv); });

--- a/src/WebPlayer/wwwroot/playerweb.js
+++ b/src/WebPlayer/wwwroot/playerweb.js
@@ -206,10 +206,19 @@ function ui_init() {
 }
 
 function sendEndWait() {
+    // The short delay lets the browser paint endWait()'s hidden Continue link
+    // before the server round trip that resumes the engine.
     window.setTimeout(async function () {
-        await WebPlayer.uiEndWait();
+        try {
+            await WebPlayer.uiEndWait();
+        } finally {
+            // uiEndWait only resolves once the resumed turn has reached its
+            // next stopping point and flushed its UI calls, so by now
+            // beginWait() has already run for a chained wait() - which is
+            // exactly what waitEnded() checks before restoring the input.
+            waitEnded();
+        }
     }, 100);
-    waitEnded();
 }
 
 function sessionTimeout() {
@@ -228,7 +237,10 @@ function playSound(url, synchronous, looped) {
         _audio.loop = true;
     }
     if (synchronous) {
-        var showCmdDiv = isElementVisible("#txtCommandDiv");
+        // Counts a pause whose restore is still pending as visible - see
+        // _pauseRestorePending, otherwise finishSync() below leaves the command
+        // bar hidden for good.
+        var showCmdDiv = isElementVisible("#txtCommandDiv") || _pauseRestorePending;
         _waitingForSoundToFinish = true;
         $("#txtCommandDiv").hide();
         _audio.addEventListener('ended', function () {

--- a/tests/e2e/fixtures/wait-pause-input-flicker-test.aslx
+++ b/tests/e2e/fixtures/wait-pause-input-flicker-test.aslx
@@ -1,0 +1,32 @@
+<asl version="600">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="WaitPauseInputFlickerTest">
+  </game>
+  <object name="room">
+    <object name="player">
+    </object>
+  </object>
+  <command>
+    <pattern>gowait</pattern>
+    <script><![CDATA[
+      msg("First page of text.")
+      wait {
+        msg("<span id='waitpage2'></span>Second page of text.")
+        wait {
+          msg("<span id='waitpage3'></span>Third page of text.")
+        }
+      }
+    ]]></script>
+  </command>
+  <command>
+    <pattern>gopause</pattern>
+    <script><![CDATA[
+      msg("First paused line.")
+      Pause (1)
+      msg("<span id='pausepage2'></span>Second paused line.")
+      Pause (1)
+      msg("<span id='pausepage3'></span>Third paused line.")
+    ]]></script>
+  </command>
+</asl>

--- a/tests/e2e/verify-wasmplayer-wait-pause-input-flicker.mjs
+++ b/tests/e2e/verify-wasmplayer-wait-pause-input-flicker.mjs
@@ -1,0 +1,164 @@
+// Regression check for issue #2184: clicking a wait()'s "Continue..." link
+// flashed the command input into view for ~100ms before the game's next page
+// of text appeared and hid it again.
+//
+// Cause: sendEndWait() called waitEnded() synchronously at click time, so the
+// input was restored immediately and only re-hidden once the engine had
+// resumed and reached the *next* wait() - i.e. for the whole round trip.
+// endPause() had the same shape (it showed the command bar itself, then told
+// the engine 100ms later), so chained Pause() calls flashed the same way.
+//
+// Both now restore the command bar only after uiEndWait()/uiEndPause()
+// resolves - by which point the resumed turn has reached its next stopping
+// point and flushed its UI calls - and no-op if that turn has meanwhile
+// claimed the command bar itself (another wait/pause, or game over).
+//
+// Also covers the follow-up ask: the command input takes focus again when it
+// comes back, so the player can keep typing without clicking into it first.
+//
+// Fixture: tests/e2e/fixtures/wait-pause-input-flicker-test.aslx
+//   "gowait"  - prints a line, wait()s, prints #waitpage2 and wait()s again,
+//               then prints #waitpage3 and ends the turn.
+//   "gopause" - prints a line, Pause(1)s, prints #pausepage2 and Pause(1)s
+//               again, then prints #pausepage3. (Pause needs asl version 600;
+//               it throws for 550-580.)
+//
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+const isVisible = selector => page.evaluate(sel => {
+    const el = document.querySelector(sel);
+    return !!(el && el.offsetParent !== null);
+}, selector);
+
+const focusedId = () => page.evaluate(() => document.activeElement && document.activeElement.id);
+
+// Samples visibility on every animation frame, so a flash too brief for a
+// Playwright poll to catch still gets recorded.
+async function startSampling(durationMs) {
+    await page.evaluate(ms => {
+        window.__samples = [];
+        const start = performance.now();
+        const vis = sel => {
+            const el = document.querySelector(sel);
+            return !!(el && el.offsetParent !== null);
+        };
+        const tick = () => {
+            window.__samples.push({
+                t: Math.round(performance.now() - start),
+                cmd: vis('#txtCommand'),
+                bar: vis('#txtCommandDiv'),
+                link: vis('#endWaitLink')
+            });
+            if (performance.now() - start < ms) requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+    }, durationMs);
+}
+
+const samples = () => page.evaluate(() => window.__samples);
+
+async function checkWait() {
+    await page.fill('#txtCommand', 'gowait');
+    await page.press('#txtCommand', 'Enter');
+    await page.waitForSelector('#endWaitLink', { state: 'visible', timeout: 10000 });
+
+    if (await isVisible('#txtCommand')) {
+        throw new Error('command input should be hidden while the game is waiting');
+    }
+    console.log('PASS: command input is hidden while the first wait() is pending');
+
+    const samplingMs = 3000;
+    await startSampling(samplingMs);
+    await page.click('#endWaitLink');
+    await page.waitForSelector('#waitpage2', { state: 'attached', timeout: 10000 });
+    await page.waitForTimeout(samplingMs + 200);
+
+    const frames = await samples();
+    if (frames.length < 10) {
+        throw new Error(`expected the frame sampler to collect samples, got ${frames.length}`);
+    }
+    const flashes = frames.filter(s => s.cmd);
+    if (flashes.length > 0) {
+        throw new Error(
+            `command input became visible ${flashes.length} frame(s) between the two chained waits ` +
+            `(first at t=${flashes[0].t}ms)`);
+    }
+    console.log(`PASS: command input never flashed across ${frames.length} frames while the second wait() took over`);
+
+    if (!(await isVisible('#endWaitLink'))) {
+        throw new Error('the second wait()\'s Continue link should be visible');
+    }
+    console.log('PASS: the second wait()\'s Continue link is showing');
+
+    // The other half of the fix: ending the last wait must still bring the
+    // command input back, since nothing else in the player ever re-shows it.
+    await page.click('#endWaitLink');
+    await page.waitForSelector('#waitpage3', { state: 'attached', timeout: 10000 });
+    await page.waitForSelector('#txtCommand', { state: 'visible', timeout: 10000 });
+    if (await isVisible('#endWaitLink')) {
+        throw new Error('the Continue link should be hidden once the last wait() has ended');
+    }
+    console.log('PASS: command input is restored (and the Continue link hidden) after the final wait()');
+
+    const focused = await focusedId();
+    if (focused !== 'txtCommand') {
+        throw new Error(`command input should have focus after the final wait(), but focus is on "${focused}"`);
+    }
+    console.log('PASS: command input has focus again after the final wait()');
+}
+
+async function checkPause() {
+    // Two chained 1s pauses, so 3s of sampling covers both plus the tail.
+    const samplingMs = 3000;
+    await startSampling(samplingMs);
+    await page.fill('#txtCommand', 'gopause');
+    await page.press('#txtCommand', 'Enter');
+    await page.waitForSelector('#pausepage2', { state: 'attached', timeout: 10000 });
+
+    const midway = (await samples()).filter(s => s.t > 300);
+    const shown = midway.filter(s => s.bar);
+    if (shown.length > 0) {
+        throw new Error(
+            `command bar became visible ${shown.length} frame(s) between the two chained pauses ` +
+            `(first at t=${shown[0].t}ms)`);
+    }
+    console.log(`PASS: command bar never flashed across ${midway.length} frames between the two chained pauses`);
+
+    await page.waitForSelector('#pausepage3', { state: 'attached', timeout: 10000 });
+    await page.waitForSelector('#txtCommandDiv', { state: 'visible', timeout: 10000 });
+    console.log('PASS: command bar is restored once the last pause has ended');
+
+    const focused = await focusedId();
+    if (focused !== 'txtCommand') {
+        throw new Error(`command input should have focus after the final pause, but focus is on "${focused}"`);
+    }
+    console.log('PASS: command input has focus again after the final pause');
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/wait-pause-input-flicker-test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000, state: 'visible' });
+
+    await checkWait();
+    await checkPause();
+
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/wasmplayer-wait-pause-input-flicker-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Fixes #2184.

Clicking a `wait()`'s "Continue..." link flashed the command input into view for ~100ms before the game's next page of text appeared and hid it again.

## Cause

`sendEndWait()` called `waitEnded()` **synchronously at click time**, which unconditionally re-showed `#txtCommand`/`#txtCommandPrompt`. The engine was only told to resume 100ms later, and only when it reached the *next* `wait()` did `beginWait()` hide the input again — so the input was visible for the whole round trip.

`endPause()` had the identical shape (it showed `#txtCommandDiv` itself, then told the engine 100ms later), so chained `Pause()` calls flashed the same way.

Measured on a per-animation-frame sampler against the WasmPlayer, before the fix:

```
t=3ms   cmd=false link=true  page2=false   <- waiting
t=60ms  cmd=true  link=false page2=false   <- input flashes in
t=157ms cmd=false link=true  page2=true    <- second page + Continue, input gone
```

## Fix

- `endWait()` now clears wait mode and hides the Continue link itself — instant click feedback, and a second click/keypress can't fire a second `FinishWait` while the engine is resuming.
- `waitEnded()` / the new `pauseEnded()` restore the command bar only after `uiEndWait()`/`uiEndPause()` resolves. That promise settles once `WorldModel`'s `_turnSuspendedTcs` has resolved and the buffered UI calls have flushed, so anything the resumed turn did to the command bar has already happened. The restore no-ops if that turn claimed it (another wait/pause, or game over).
- `playSound()`'s synchronous branch snapshots the command bar's visibility to restore it when the sound ends, so it now counts a pause's outstanding restore as visible (`_pauseRestorePending`) — otherwise a `Pause()` followed immediately by a synchronous sound would leave the bar hidden for good.
- Follow-up ask from testing: the command input takes focus again whenever it comes back, so the player can keep typing without clicking into it first.

## Testing

New `tests/e2e/verify-wasmplayer-wait-pause-input-flicker.mjs` + fixture, wired into `e2e.yml`. It samples visibility every animation frame (a ~100ms flash is too brief for a Playwright poll) and checks, for both paths: no flash, correct Continue-link state, command bar restored on the last one, and focus back on the input.

Each half fails on the unfixed code and passes on the fixed code — the pause half was run in isolation against a stashed build to confirm it isn't just riding on the wait failure:

```
FAIL: command input became visible 10 frame(s) between the two chained waits (first at t=66ms)
FAIL: command bar became visible 12 frame(s) between the two chained pauses (first at t=1210ms)
```

The fixture is `version="600"` because `request(Pause)` throws for WorldModel versions 550-580.

WebPlayer verified by hand against the same fixture via `/dev/open`: 0 flash frames on both paths, focus back on `#txtCommand` after each.

Also re-ran `verify-wasmplayer-sound-timer`, `save-turn-pending`, `save-disabled-during-wait-input`, `autoscroll`, `autoscroll-clearscreen-after-wait`, `dialogue-pages` and `onready-recursive-getinput` (all pass), plus a full `dotnet test` (388 tests, green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)