### PR TITLE
fix(WasmPlayer): add crossorigin to single-file export's CDN stylesheets

### DIFF
--- a/src/WasmPlayer/scripts/export-embedded.mjs
+++ b/src/WasmPlayer/scripts/export-embedded.mjs
@@ -104,6 +104,22 @@ const embedScript = `    <script type="text/javascript">\n`
 html = replaceOrFail(html, scriptLine('wasm-player.js'), (line) => embedScript + line,
     'the wasm-player.js tag');
 
+// 5. The <base href> above makes these three stylesheets load cross-origin
+//    from jsDelivr. Without `crossorigin`, the browser won't expose their
+//    cssRules to script (SecurityError), which breaks getCSSRule and every
+//    caller that depends on it (SetMenuBackground, etc — see issue #2192).
+//    jsDelivr sends `Access-Control-Allow-Origin: *`, so anonymous mode is
+//    enough; harmless (if pointless) on the same-origin deployments that
+//    share this template, so it's added here rather than in index.html.
+const styleLine = (file) => new RegExp(
+    `^[ \\t]*<link rel="stylesheet" type="text/css" href="${file.replace(/\./g, '\\.')}(?:\\?[^"]*)?" />\\r?\\n`,
+    'm');
+for (const file of ['lib/jquery-ui.min.css', 'playercore.css', 'chrome.css']) {
+    html = replaceOrFail(html, styleLine(file),
+        (line) => line.replace(/ \/>(\r?\n)$/, ' crossorigin="anonymous" />$1'),
+        `the ${file} stylesheet link`);
+}
+
 const outFile = outFileArg
     ? path.resolve(outFileArg)
     : path.join(path.dirname(gameFile), path.basename(gameFile, path.extname(gameFile)) + '.html');


### PR DESCRIPTION
## Summary
- The single-file export (`scripts/export-embedded.mjs`) loads `playercore.css`, `chrome.css`, and `lib/jquery-ui.min.css` cross-origin from jsDelivr via `<base href>`, and none of those `<link>` tags carried `crossorigin`
- Without it, the browser throws `SecurityError` on `document.styleSheets[i].cssRules`, which `getCSSRule` silently swallows and returns `false` for — every caller (`SetMenuBackground`, `SetMenuForeground`, `SetMenuFontName`, `TurnOffHyperlinksUnderline`, etc.) then throws a `TypeError` dereferencing it
- Added `crossorigin="anonymous"` to the three stylesheet `<link>` tags in `export-embedded.mjs` (not `index.html`, which is shared with the same-origin deployments that don't need it) — jsDelivr already sends `Access-Control-Allow-Origin: *`

Fixes #2192

## Test plan
- [x] Ran `node scripts/export-embedded.mjs ../../examples/simple.aslx "" <out>.html` and confirmed all three stylesheet links now carry `crossorigin="anonymous"`
- [x] Confirmed the game-embedding and other existing transforms in the script still succeed (output size/structure otherwise unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)