### PR TITLE
fix(PlayerCore): fall back to inserting a CSS rule when a selector isn't found

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -408,6 +408,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-mobile-touch-targets.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-getcssrule-fallback.mjs http://localhost:5175
+        working-directory: tests/e2e
 
   # WebPlayer (ASP.NET Core + Blazor Server), Development mode with Dev:Enabled
   # (appsettings.Development.json already sets this — see /dev/open's

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -1399,27 +1399,27 @@ function AddVimeo(id) {
 }
 
 function SetMenuBackground(color) {
-    var css = getCSSRule("div.jj_menu_item");
+    var css = addCSSRule("div.jj_menu_item");
     css.style.backgroundColor = color;
 }
 
 function SetMenuForeground(color) {
-    var css = getCSSRule("div.jj_menu_item");
+    var css = addCSSRule("div.jj_menu_item");
     css.style.color = color;
 }
 
 function SetMenuHoverBackground(color) {
-    var css = getCSSRule("div.jj_menu_item_hover");
+    var css = addCSSRule("div.jj_menu_item_hover");
     css.style.backgroundColor = color;
 }
 
 function SetMenuHoverForeground(color) {
-    var css = getCSSRule("div.jj_menu_item_hover");
+    var css = addCSSRule("div.jj_menu_item_hover");
     css.style.color = color;
 }
 
 function SetMenuFontName(font) {
-    var css = getCSSRule("div.jjmenu");
+    var css = addCSSRule("div.jjmenu");
     css.style.fontFamily = font;
 }
 
@@ -1443,23 +1443,19 @@ var _requestedMenuFontSize = null;
 
 function SetMenuFontSize(size) {
     if (_allowMenuFontSizeChange) {
-        var css = getCSSRule("div.jjmenu");
+        var css = addCSSRule("div.jjmenu");
         css.style.fontSize = menuFontSizeWithFloor(size);
-        // Recorded only once getCSSRule has actually succeeded, so that
-        // refreshMenuFontSize() stays a no-op rather than throwing on every
-        // resize in the single-file-export case where the rule can't be
-        // reached at all (issue #2192).
         _requestedMenuFontSize = size;
     }
 }
 
 function refreshMenuFontSize() {
     if (_requestedMenuFontSize == null) return;
-    getCSSRule("div.jjmenu").style.fontSize = menuFontSizeWithFloor(_requestedMenuFontSize);
+    addCSSRule("div.jjmenu").style.fontSize = menuFontSizeWithFloor(_requestedMenuFontSize);
 }
 
 function TurnOffHyperlinksUnderline() {
-    var css = getCSSRule("a.cmdlink");
+    var css = addCSSRule("a.cmdlink");
     css.style.textDecoration = "none";
 }
 

--- a/tests/e2e/verify-getcssrule-fallback.mjs
+++ b/tests/e2e/verify-getcssrule-fallback.mjs
@@ -3,9 +3,13 @@
 // caller (SetMenuBackground etc.) dereferenced that unchecked, throwing
 // TypeError. Fixed by having those setters call addCSSRule instead, which
 // inserts the rule if missing and never returns false.
+//
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
 import { chromium } from 'playwright';
 
-const url = 'http://localhost:5175/?url=/examples/simple.aslx';
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+const url = `${baseUrl}/?url=/examples/simple.aslx`;
 let browser;
 try {
     browser = await chromium.launch();

--- a/tests/e2e/verify-getcssrule-fallback.mjs
+++ b/tests/e2e/verify-getcssrule-fallback.mjs
@@ -1,0 +1,90 @@
+// Issue #2192's second concern: getCSSRule returns `false` when a selector
+// isn't found (including cross-origin stylesheets it can't read), and every
+// caller (SetMenuBackground etc.) dereferenced that unchecked, throwing
+// TypeError. Fixed by having those setters call addCSSRule instead, which
+// inserts the rule if missing and never returns false.
+import { chromium } from 'playwright';
+
+const url = 'http://localhost:5175/?url=/examples/simple.aslx';
+let browser;
+try {
+    browser = await chromium.launch();
+    const page = await browser.newPage();
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+        if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => consoleErrors.push(String(err)));
+
+    await page.goto(url, { waitUntil: 'load' });
+    // playercore.js is a plain <script> tag, so these are on window as soon
+    // as it parses - no need to wait for the WASM game itself to boot.
+    await page.waitForFunction(() => typeof window.SetMenuBackground === 'function');
+
+    const result = await page.evaluate(() => {
+        const out = {};
+
+        // 1. Existing selectors that ship in playercore.css/chrome.css - the
+        //    original bug's repro path (getCSSRule finding a real rule).
+        try {
+            window.SetMenuBackground('rgb(1, 2, 3)');
+            out.setMenuBackgroundOk = true;
+        } catch (e) {
+            out.setMenuBackgroundOk = false;
+            out.setMenuBackgroundError = String(e);
+        }
+        const jjMenuItem = window.getCSSRule('div.jj_menu_item');
+        out.menuBackgroundApplied = jjMenuItem && jjMenuItem.style.backgroundColor;
+
+        try {
+            window.TurnOffHyperlinksUnderline();
+            out.turnOffHyperlinksOk = true;
+        } catch (e) {
+            out.turnOffHyperlinksOk = false;
+            out.turnOffHyperlinksError = String(e);
+        }
+
+        // 2. A selector that genuinely doesn't exist in any stylesheet.
+        //    Before this change, getCSSRule would return false and the
+        //    caller's unchecked .style dereference would throw; addCSSRule
+        //    must insert an empty rule and return it instead.
+        const fakeSelector = 'div.qv-test-nonexistent-rule-2192';
+        out.fakeRuleMissingBeforehand = window.getCSSRule(fakeSelector) === false;
+        try {
+            const created = window.addCSSRule(fakeSelector);
+            out.addCSSRuleOk = !!created && typeof created.style === 'object';
+            if (created) {
+                created.style.color = 'rgb(9, 9, 9)';
+                out.fakeRuleStyleSettable = created.style.color === 'rgb(9, 9, 9)';
+            }
+        } catch (e) {
+            out.addCSSRuleOk = false;
+            out.addCSSRuleError = String(e);
+        }
+        out.fakeRuleFoundAfterInsert = window.getCSSRule(fakeSelector) !== false;
+
+        return out;
+    });
+
+    console.log(JSON.stringify(result, null, 2));
+    console.log('console/page errors captured:', consoleErrors);
+
+    const failures = [];
+    if (!result.setMenuBackgroundOk) failures.push('SetMenuBackground threw');
+    if (result.menuBackgroundApplied !== 'rgb(1, 2, 3)') failures.push(`menu background not applied: ${result.menuBackgroundApplied}`);
+    if (!result.turnOffHyperlinksOk) failures.push('TurnOffHyperlinksUnderline threw');
+    if (!result.fakeRuleMissingBeforehand) failures.push('test selector unexpectedly pre-existed');
+    if (!result.addCSSRuleOk) failures.push('addCSSRule threw or returned no rule for a missing selector');
+    if (!result.fakeRuleStyleSettable) failures.push('inserted rule style was not settable/readable');
+    if (!result.fakeRuleFoundAfterInsert) failures.push('getCSSRule still cannot find the rule after addCSSRule inserted it');
+
+    if (failures.length) {
+        throw new Error('Verification failed:\n' + failures.join('\n'));
+    }
+    console.log('PASS');
+} catch (err) {
+    console.error('FAIL:', err);
+    process.exitCode = 1;
+} finally {
+    if (browser) await browser.close();
+}


### PR DESCRIPTION
## Summary
- `getCSSRule` returns `false` whenever it can't find a matching selector — including when a stylesheet throws `SecurityError` on read (the cross-origin single-file-export case fixed in #2209) but also, regardless of origin, when a selector genuinely isn't defined anywhere
- Every caller (`SetMenuBackground`, `SetMenuForeground`, `SetMenuHoverBackground`, `SetMenuHoverForeground`, `SetMenuFontName`, `SetMenuFontSize`, `refreshMenuFontSize`, `TurnOffHyperlinksUnderline`) dereferenced that return value unchecked (`.style....`), throwing `TypeError` on `false`
- Switched those callers from `getCSSRule` to `addCSSRule`, which already existed for exactly this purpose: it inserts an empty rule into `document.styleSheets[0]` (always the inline `<style>` block shipped in `index.html`, so always same-origin/readable) when the selector isn't found, then returns it — guaranteeing a real `CSSStyleRule`
- Dropped the now-stale comment on `SetMenuFontSize`/`refreshMenuFontSize` describing the old single-file-export throwing behavior, since `addCSSRule` no longer throws there either

This is the second, origin-independent concern the issue called out separately from the `crossorigin` fix in #2209.

Related to #2192

## Test plan
- [x] Added `tests/e2e/verify-getcssrule-fallback.mjs`, run against a local `dev-server.mjs` (Debug build): confirms `SetMenuBackground`/`TurnOffHyperlinksUnderline` still apply correctly for real selectors, and that a selector with no matching rule anywhere — previously `getCSSRule() === false` and a throw on dereference — now gets created on demand via `addCSSRule` with no error and a settable `.style`
- [x] `dotnet build src/WasmPlayer/WasmPlayer.csproj` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)