### PR TITLE
fix(PlayerCore): merge duplicate focusCommandInput definitions

### DIFF
--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -773,7 +773,12 @@ function scrollToTurnStart(turnStart, allowBackward) {
 // jumped straight to the document's bottom, undoing every calculation above.
 // {preventScroll: true} keeps the input usable (typing still works
 // immediately) without fighting the scroll position we just computed.
+//
+// Also guards against focusing the input while it's genuinely hidden (mid
+// wait()/pause()) — needed by waitEnded()/pauseEnded(), which share this
+// same function to restore focus once the command bar comes back.
 function focusCommandInput() {
+    if (!isElementVisible("#txtCommandDiv") || !isElementVisible("#txtCommand")) return;
     document.getElementById("txtCommand")?.focus({preventScroll: true});
 }
 
@@ -1041,14 +1046,6 @@ function waitEnded() {
     $("#txtCommand").show();
     $("#txtCommandPrompt").show();
     focusCommandInput();
-}
-
-// The command input loses focus while it's hidden (for a wait() or a pause), so
-// put it back once it returns - otherwise the player has to click into it before
-// they can type, and keystrokes meant for the game go nowhere.
-function focusCommandInput() {
-    if (!isElementVisible("#txtCommandDiv") || !isElementVisible("#txtCommand")) return;
-    $("#txtCommand").focus();
 }
 
 function gameFinished() {


### PR DESCRIPTION
## Summary
- The nightly/manual e2e run (`wasmplayer_chromium` job, run [34048736970](https://github.com/textadventures/quest/actions/runs/34048736970)) failed on `verify-wasmplayer-autoscroll-frame-load-race.mjs`
- Root cause: PR #2208 added a second `focusCommandInput()` function declaration later in `playercore.js`, not noticing one already existed (added for the picture-frame autoscroll fix, using `{preventScroll: true}`). JS hoists function declarations, so the *later* one in source order wins for the whole file — silently reinstating the native focus-triggered scroll-into-view jump that the first version exists to prevent.
- Fix: merge both into a single `focusCommandInput()` that keeps the visibility guard (needed by `waitEnded()`/`pauseEnded()`) and the `preventScroll: true` (needed by `scrollToTurnStart()`), and delete the duplicate.

## Test plan
- [x] `dotnet build src/WasmPlayer/WasmPlayer.csproj` (Debug)
- [x] `node verify-wasmplayer-autoscroll-frame-load-race.mjs` — now passes locally
- [x] Re-ran `verify-wasmplayer-wait-pause-input-flicker.mjs`, `verify-wasmplayer-save-disabled-during-wait-input.mjs`, and the other autoscroll scripts (`verify-wasmplayer-autoscroll.mjs`, `-clearscreen-after-wait`, `-clearscreen-frame`, `-frame`) — all pass, no regression to the #2208 wait/pause fix
- [x] `dotnet test tests/PlayerCoreTests --configuration Release` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)