### PR TITLE
docs(Site): point homepage hero at Create, add a Play games action

### DIFF
--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -10,9 +10,18 @@ hero:
     file: ../../assets/quest-viva.svg
   actions:
     - text: Start creating
-      link: https://play.questviva.com/
+      link: https://play.questviva.com/open
       icon: right-arrow
       variant: primary
+    - text: Play games
+      link: https://play.questviva.com/
+      # Lucide's "play" glyph, inlined: Starlight's built-in icon set has no
+      # play icon, but a hero action's `icon` falls back to treating the string
+      # as raw HTML when it doesn't match a built-in name (schemas/hero.ts).
+      # Filled rather than Lucide's usual stroke, to match the built-in icons
+      # sitting next to it; sized to the 1.5rem those get from LinkButton.
+      icon: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" style="width:1.5rem;height:1.5rem"><path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"/></svg>'
+      variant: secondary
     - text: Documentation
       link: /intro
       icon: open-book


### PR DESCRIPTION
## What

The homepage hero's primary action, **Start creating**, linked to `https://play.questviva.com/` — which is unconditionally the Play catalog, never the editor (root always means the Play tab when `PUBLIC_SHOW_HOME` is true, see `src/AppShell/src/routes/+page.svelte`). The label promised the editor and delivered a game browser.

- **Start creating** now points at `/open`, the Create tab.
- Added a separate secondary **Play games** action for root, so the browse-games path stays reachable deliberately rather than by accident — before this, the hero had no play entry point at all, and browsing was only reachable via textadventures.co.uk links buried in the second card.

## The inline SVG

Starlight's built-in icon set has ~50 general-purpose glyphs (the rest of its 129 are social/brand and tech logos) and no play icon. A hero action's `icon` falls back to treating the string as raw HTML when it doesn't match a built-in name (`schemas/hero.ts`), so **Play games** inlines Lucide's `play` path — the same glyph `@lucide/svelte` draws in AppShell.

Two deliberate deviations from how Lucide normally renders it, both noted in a comment in the file:

- **Filled, not stroked**, so it sits consistently beside Starlight's solid `right-arrow` and `open-book`, and inherits the button's text colour in both themes.
- **Explicit `1.5rem`**, because raw SVG bypasses the `size` prop `LinkButton.astro` gives built-in icons and only picks up `flex-shrink: 0`.

## Verification

- `npm run build` in `site/` completes clean (168 pages), SVG survives into `dist/index.html`.
- Checked in the browser: all five hero icons render at exactly 24×24, hrefs resolve as intended, correct in light and dark, and the layout holds on mobile (wraps 2 + 1 + 2 with no overflow).
- `https://play.questviva.com/open` returns 200 live, with and without a trailing slash.

`docs:` rather than `fix:` since it's a website change with nothing user-observable in a release — keeps it out of the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)