### PR TITLE
feat(AppShell): link to the documentation site from the editor and Home

### DIFF
--- a/src/AppShell/src/components/HomeHeader.svelte
+++ b/src/AppShell/src/components/HomeHeader.svelte
@@ -7,6 +7,8 @@
     import GithubIcon from "$components/GithubIcon.svelte";
     import DownloadButton from "$components/DownloadButton.svelte";
     import SettingsIcon from "@lucide/svelte/icons/settings";
+    import BookOpen from "@lucide/svelte/icons/book-open";
+    import { DOCS_URL } from "$lib/docs-links";
 
     let { forceDark = false }: { forceDark?: boolean } = $props();
 
@@ -23,6 +25,16 @@
                 <DownloadButton compact />
             </div>
         {/if}
+        <a
+            href={DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="home-header-link"
+            title={t("homeHeader.documentation")}
+            aria-label={t("homeHeader.documentation")}
+        >
+            <BookOpen size={18} />
+        </a>
         <a
             href="https://textadventures.co.uk/community/discord"
             target="_blank"

--- a/src/AppShell/src/components/Toolbar.svelte
+++ b/src/AppShell/src/components/Toolbar.svelte
@@ -43,11 +43,13 @@
     import Ellipsis from "@lucide/svelte/icons/ellipsis";
     import FileCode from "@lucide/svelte/icons/file-code";
     import SettingsIcon from "@lucide/svelte/icons/settings";
+    import BookOpen from "@lucide/svelte/icons/book-open";
     import DiscordIcon from "$components/DiscordIcon.svelte";
     import GithubIcon from "$components/GithubIcon.svelte";
     import DropdownMenu from "$components/DropdownMenu.svelte";
     import type { DropdownMenuItem } from "$components/DropdownMenu.svelte";
     import { isNarrow } from "$lib/layout.svelte";
+    import { DOCS_URL } from "$lib/docs-links";
 
     const DISCORD_URL = "https://textadventures.co.uk/community/discord";
     const GITHUB_URL = "https://github.com/textadventures/quest";
@@ -191,6 +193,7 @@
     // as visible icon-only buttons.
     let overflowItems = $derived.by((): DropdownMenuItem[] => {
         const links: DropdownMenuItem[] = [
+            { label: t("toolbar.documentation"), action: () => openLink(DOCS_URL), icon: BookOpen },
             { label: t("toolbar.discord"), action: () => openLink(DISCORD_URL), icon: DiscordIcon },
             { label: t("toolbar.github"), action: () => openLink(GITHUB_URL), icon: GithubIcon },
             { label: t("common.settings"), action: () => settingsModalOpen.set(true), icon: SettingsIcon },

--- a/src/AppShell/src/lib/docs-links.ts
+++ b/src/AppShell/src/lib/docs-links.ts
@@ -1,0 +1,26 @@
+// Single source of truth for links out to the documentation site
+// (questviva.com — the Astro/Starlight project in site/).
+//
+// questviva.com's root is a marketing splash (site/src/content/docs/index.mdx,
+// template: splash), so it's the wrong landing spot for someone who clicked
+// "Documentation" from inside the app — that page's own Documentation action
+// points at /intro, and so do we.
+//
+// Sibling hard-coded link: src/ElectronApp/src/main.ts's Help menu. It's a
+// separate build (Electron main process) with no import path into AppShell, so
+// it stays duplicated rather than shared.
+
+const DOCS_BASE_URL = "https://questviva.com";
+
+// Trailing slashes are deliberate: the site builds to directory-style routes,
+// so questviva.com/intro answers 308 -> /intro/. Linking to the canonical form
+// saves every click a redirect hop.
+function docsUrl(path: string): string {
+    return `${DOCS_BASE_URL}${path}/`;
+}
+
+/** Documentation home — the reference/guide entry point, not the splash page. */
+export const DOCS_URL = docsUrl("/intro");
+
+/** Step-by-step "build your first game" walkthrough, for first-time authors. */
+export const DOCS_TUTORIAL_URL = docsUrl("/tutorial/tutorial-introduction");

--- a/src/AppShell/src/routes/open/+page.svelte
+++ b/src/AppShell/src/routes/open/+page.svelte
@@ -29,6 +29,7 @@
     import Trash2 from "@lucide/svelte/icons/trash-2";
     import Download from "@lucide/svelte/icons/download";
     import { t, locale } from "$lib/i18n";
+    import { DOCS_TUTORIAL_URL } from "$lib/docs-links";
 
     const hasServer = PUBLIC_HAS_SERVER === "true";
 
@@ -771,5 +772,17 @@
             {/if}
 
         </div>
+    {/if}
+
+    {#if !loading}
+        <!-- Deliberately the tutorial rather than the docs home: everyone who
+             reaches this page is about to author a game, and HomeHeader's
+             Documentation link already covers the general case. -->
+        <p class="text-sm text-surface-600-400 text-center">
+            {t("openPage.newToQuestViva")}
+            <a class="anchor" href={DOCS_TUTORIAL_URL} target="_blank" rel="noopener noreferrer">
+                {t("openPage.readTheTutorial")}
+            </a>
+        </p>
     {/if}
 </main>

--- a/src/AppShell/static/locales/de.json
+++ b/src/AppShell/static/locales/de.json
@@ -28,6 +28,7 @@
     "toolbar.more": "Mehr",
     "toolbar.discord": "Discord",
     "toolbar.github": "GitHub",
+    "toolbar.documentation": "Dokumentation",
     "toolbar.addPage": "Neue Seite",
     "toolbar.addRoom": "Neuer Raum",
     "toolbar.addObjectIn": "Neues Objekt in \"{name}\"",
@@ -377,6 +378,7 @@
 
     "homeHeader.joinDiscord": "Tritt uns auf Discord bei",
     "homeHeader.viewGithub": "Auf GitHub ansehen",
+    "homeHeader.documentation": "Dokumentation",
 
     "homeTabs.play": "Spielen",
     "homeTabs.create": "Erstellen",
@@ -453,5 +455,7 @@
     "openPage.enterGameName": "Bitte gib einen Spielnamen ein.",
     "openPage.selectTemplate": "Bitte wähle eine Vorlage aus.",
     "openPage.missingGameId": "Dem neuen Spiel fehlt eine Spiel-ID.",
-    "openPage.failedToLoadNewGame": "Neues Spiel konnte nicht geladen werden."
+    "openPage.failedToLoadNewGame": "Neues Spiel konnte nicht geladen werden.",
+    "openPage.newToQuestViva": "Neu bei Quest Viva?",
+    "openPage.readTheTutorial": "Lies das Tutorial"
 }

--- a/src/AppShell/static/locales/en.json
+++ b/src/AppShell/static/locales/en.json
@@ -28,6 +28,7 @@
     "toolbar.more": "More",
     "toolbar.discord": "Discord",
     "toolbar.github": "GitHub",
+    "toolbar.documentation": "Documentation",
     "toolbar.addPage": "Add Page",
     "toolbar.addRoom": "Add Room",
     "toolbar.addObjectIn": "Add Object in \"{name}\"",
@@ -377,6 +378,7 @@
 
     "homeHeader.joinDiscord": "Join us on Discord",
     "homeHeader.viewGithub": "View on GitHub",
+    "homeHeader.documentation": "Documentation",
 
     "homeTabs.play": "Play",
     "homeTabs.create": "Create",
@@ -453,5 +455,7 @@
     "openPage.enterGameName": "Please enter a game name.",
     "openPage.selectTemplate": "Please select a template.",
     "openPage.missingGameId": "New game is missing a gameid.",
-    "openPage.failedToLoadNewGame": "Failed to load new game."
+    "openPage.failedToLoadNewGame": "Failed to load new game.",
+    "openPage.newToQuestViva": "New to Quest Viva?",
+    "openPage.readTheTutorial": "Read the tutorial"
 }

--- a/src/AppShell/static/locales/es.json
+++ b/src/AppShell/static/locales/es.json
@@ -28,6 +28,7 @@
     "toolbar.more": "Más",
     "toolbar.discord": "Discord",
     "toolbar.github": "GitHub",
+    "toolbar.documentation": "Documentación",
     "toolbar.addPage": "Añadir página",
     "toolbar.addRoom": "Añadir lugar",
     "toolbar.addObjectIn": "Añadir objeto en \"{name}\"",
@@ -377,6 +378,7 @@
 
     "homeHeader.joinDiscord": "Únete a nosotros en Discord",
     "homeHeader.viewGithub": "Ver en GitHub",
+    "homeHeader.documentation": "Documentación",
 
     "homeTabs.play": "Jugar",
     "homeTabs.create": "Crear",
@@ -453,5 +455,7 @@
     "openPage.enterGameName": "Por favor ingresa un nombre para el juego.",
     "openPage.selectTemplate": "Por favor selecciona una plantilla.",
     "openPage.missingGameId": "Al juego nuevo le falta un gameid.",
-    "openPage.failedToLoadNewGame": "Error al cargar el juego nuevo."
+    "openPage.failedToLoadNewGame": "Error al cargar el juego nuevo.",
+    "openPage.newToQuestViva": "¿Nuevo en Quest Viva?",
+    "openPage.readTheTutorial": "Lee el tutorial"
 }

--- a/src/AppShell/static/locales/xx.json
+++ b/src/AppShell/static/locales/xx.json
@@ -27,6 +27,7 @@
     "toolbar.more": "[Móré]",
     "toolbar.discord": "[Díscórd]",
     "toolbar.github": "[GítHúb]",
+    "toolbar.documentation": "[Dócúméntátíón]",
     "toolbar.addPage": "[Ádd Págé]",
     "toolbar.addRoom": "[Ádd Róóm]",
     "toolbar.addObjectIn": "[Ádd Óbjéct ín \"{name}\"]",
@@ -315,6 +316,7 @@
     "common.textAdventure": "[Téxt Ádvéntúré]",
     "homeHeader.joinDiscord": "[Jóín ús ón Díscórd]",
     "homeHeader.viewGithub": "[Víéw ón GítHúb]",
+    "homeHeader.documentation": "[Dócúméntátíón]",
     "homeTabs.play": "[Pláy]",
     "homeTabs.create": "[Créáté]",
     "gameCard.byAuthor": "[by {author}]",
@@ -381,5 +383,7 @@
     "openPage.enterGameName": "[Pléásé éntér á gámé námé.]",
     "openPage.selectTemplate": "[Pléásé séléct á témpláté.]",
     "openPage.missingGameId": "[Néw gámé ís míssíng á gáméíd.]",
-    "openPage.failedToLoadNewGame": "[Fáíléd tó lóád néw gámé.]"
+    "openPage.failedToLoadNewGame": "[Fáíléd tó lóád néw gámé.]",
+    "openPage.newToQuestViva": "[Néw tó Qúést Vívá?]",
+    "openPage.readTheTutorial": "[Réád thé tútóríál]"
 }

--- a/tests/e2e/verify-appshell-home-header-links.mjs
+++ b/tests/e2e/verify-appshell-home-header-links.mjs
@@ -1,14 +1,19 @@
-// Verifies the Discord/GitHub links (DiscordIcon.svelte / GithubIcon.svelte)
-// appear in both places they're wired up:
-//   - HomeHeader.svelte, top-right, on the Play (/) and Create (/open) tabs
-//     — only rendered when PUBLIC_SHOW_HOME=true, so this script needs it set
-//   - Toolbar.svelte, end of the trailing button cluster, in the editor
-//     (/edit) — shown unconditionally, regardless of PUBLIC_SHOW_HOME
+// Verifies the Documentation/Discord/GitHub links appear in both places
+// they're wired up:
+//   - HomeHeader.svelte, top-right, on the Play (/) and Create (/open) tabs,
+//     as plain <a> elements — only rendered when PUBLIC_SHOW_HOME=true, so
+//     this script needs it set
+//   - Toolbar.svelte, in the editor (/edit), as items inside the overflow
+//     ("...") DropdownMenu — shown unconditionally, regardless of
+//     PUBLIC_SHOW_HOME. These are <button role="menuitem"> elements that call
+//     window.open(), NOT anchors, so they're checked by intercepting the popup
+//     rather than by reading an href.
 // Run against a dev server started with:
 //   PUBLIC_SHOW_HOME=true npm --prefix src/AppShell run dev -- --port 5180
 import { chromium } from './lib/tracked-chromium.mjs';
 
 const baseUrl = process.argv[2] || 'http://localhost:5180';
+const expectedDocsHref = 'https://questviva.com/intro/';
 const expectedDiscordHref = 'https://textadventures.co.uk/community/discord';
 const expectedGithubHref = 'https://github.com/textadventures/quest';
 
@@ -16,29 +21,69 @@ const browser = await chromium.launch();
 const page = await browser.newPage({ viewport: { width: 1200, height: 500 } });
 page.on('pageerror', err => console.log('[pageerror]', err.message));
 
-async function checkLinks(label) {
+async function checkHeaderLinks(label) {
     await page.waitForSelector('a[title="Join us on Discord"]', { timeout: 30000 });
-    const discordHref = await page.getAttribute('a[title="Join us on Discord"]', 'href');
-    const githubHref = await page.getAttribute('a[title="View on GitHub"]', 'href');
-    if (discordHref !== expectedDiscordHref) throw new Error(`[${label}] unexpected Discord href: ${discordHref}`);
-    if (githubHref !== expectedGithubHref) throw new Error(`[${label}] unexpected GitHub href: ${githubHref}`);
-    console.log(`PASS: [${label}] Discord and GitHub links present with correct hrefs`);
+    const expected = {
+        Documentation: [expectedDocsHref, 'a[title="Documentation"]'],
+        Discord: [expectedDiscordHref, 'a[title="Join us on Discord"]'],
+        GitHub: [expectedGithubHref, 'a[title="View on GitHub"]'],
+    };
+    for (const [name, [href, selector]] of Object.entries(expected)) {
+        if (await page.locator(selector).count() !== 1) {
+            throw new Error(`[${label}] expected exactly one ${name} link matching ${selector}`);
+        }
+        const actual = await page.getAttribute(selector, 'href');
+        if (actual !== href) throw new Error(`[${label}] unexpected ${name} href: ${actual} (expected ${href})`);
+    }
+    console.log(`PASS: [${label}] Documentation, Discord and GitHub links present with correct hrefs`);
+}
+
+// The toolbar items call openLink() -> window.open(), so the URL only shows up
+// as a popup request. Asserting on it is the only way to check the target;
+// there is no href to read.
+async function checkToolbarMenuItem(label, itemLabel, expectedUrl) {
+    await page.click('button[aria-label="More"]');
+    const menuItem = page.locator(`[role="menu"] button[role="menuitem"]:has-text("${itemLabel}")`);
+    if (await menuItem.count() !== 1) {
+        throw new Error(`[${label}] expected exactly one "${itemLabel}" item in the overflow menu`);
+    }
+    const [popup] = await Promise.all([
+        page.waitForEvent('popup', { timeout: 10000 }),
+        menuItem.click(),
+    ]);
+    const actual = popup.url();
+    await popup.close();
+    if (actual !== expectedUrl) {
+        throw new Error(`[${label}] "${itemLabel}" opened ${actual} (expected ${expectedUrl})`);
+    }
+    console.log(`PASS: [${label}] "${itemLabel}" opens ${expectedUrl}`);
 }
 
 async function run() {
     // HomeHeader — Play tab (root) and Create tab (/open)
     await page.goto(`${baseUrl}/`);
-    await checkLinks('Play tab (HomeHeader)');
+    await checkHeaderLinks('Play tab (HomeHeader)');
 
     await page.goto(`${baseUrl}/open`);
-    await checkLinks('Create tab (HomeHeader)');
+    await checkHeaderLinks('Create tab (HomeHeader)');
 
-    // Toolbar — inside the editor (/edit), reached by creating a local draft
+    // Toolbar — inside the editor (/edit), reached by creating a local draft.
+    // waitForURL matters: without it the assertions below race the SPA
+    // navigation and can run against /open's HomeHeader instead.
     await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
     await page.fill('input[placeholder="Game name"]', 'Toolbar Icons Test');
     await page.waitForSelector('text=Text adventure', { timeout: 10000 });
     await page.click('button:has-text("Create local draft")');
-    await checkLinks('Editor toolbar (/edit)');
+    await page.waitForURL('**/edit', { timeout: 30000 });
+    await page.waitForSelector('button[aria-label="More"]', { timeout: 30000 });
+
+    if (await page.locator('a[title="Join us on Discord"]').count() !== 0) {
+        throw new Error('[Editor toolbar (/edit)] HomeHeader is unexpectedly rendered here — the checks below would be testing the wrong surface');
+    }
+
+    await checkToolbarMenuItem('Editor toolbar (/edit)', 'Documentation', expectedDocsHref);
+    await checkToolbarMenuItem('Editor toolbar (/edit)', 'Discord', expectedDiscordHref);
+    await checkToolbarMenuItem('Editor toolbar (/edit)', 'GitHub', expectedGithubHref);
 
     console.log('PASS');
 }


### PR DESCRIPTION
Until now the only clickable link to questviva.com anywhere in the product was the Electron Help menu (`src/ElectronApp/src/main.ts:397`) — the web AppShell had none at all.

## What this adds

Three entry points, all sharing a new `src/AppShell/src/lib/docs-links.ts`:

- **HomeHeader** — a book icon alongside the existing Discord/GitHub links, on the Play and Create tabs
- **Toolbar** — "Documentation" as the first item in the overflow (⋯) menu, in the editor
- **/open** — a "New to Quest Viva? Read the tutorial" footer, pointing at the tutorial rather than the docs home, since everyone reaching that page is about to author a game

Strings added to all four locale files (en/de/es + the `xx` pseudo-locale).

## Why `/intro/` and not `questviva.com`

questviva.com's root is a `template: splash` marketing page (`site/src/content/docs/index.mdx`) — the wrong landing spot for someone who just clicked "Documentation" inside the app. That page's own Documentation action goes to `/intro`, so these do too.

The trailing slash is deliberate: the site builds to directory-style routes, so `/intro` answers `308 → /intro/`. Linking to the canonical form saves a redirect hop on every click.

The Electron Help menu is left as-is — separate build, no import path into AppShell — but `docs-links.ts` cross-references it.

## Test fix folded in

`verify-appshell-home-header-links.mjs` had a **false PASS**. Its "Editor toolbar (/edit)" assertion looked for `a[title="Join us on Discord"]`, but those links moved into the overflow `DropdownMenu` and became `<button role="menuitem">` elements — there are *zero* `a[title]` elements on `/edit`. It passed only by racing the SPA navigation and re-checking `/open`'s HomeHeader, so that surface had been effectively untested.

It now waits for the `/edit` URL, asserts HomeHeader is absent (so a future regression can't silently re-check the wrong surface), and checks each menu item by intercepting the `window.open` popup. That rewrite is what caught the trailing-slash redirect above.

## Verification

- `npm run lint` and `npm run check` clean
- All 50 scripts flagged by `node tests/e2e/find-affected-tests.mjs` pass
- `verify-appshell-i18n-pseudoloc.mjs` passes (covers the locale edits, which the coverage map doesn't track)

🤖 Generated with [Claude Code](https://claude.com/claude-code)