### PR TITLE
feat: add numeric `<versioncode>` field for games

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -200,6 +200,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-appshell-verbs-editor.mjs http://localhost:5174
         working-directory: tests/e2e
+      - run: node verify-appshell-versioncode.mjs http://localhost:5174
+        working-directory: tests/e2e
       - run: node verify-rename-invalid-name.mjs http://localhost:5174
         working-directory: tests/e2e
       - run: node verify-update-banner-web.mjs http://localhost:5174

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -200,6 +200,20 @@
         return { main: controls.filter(c => !c.advanced), advanced };
     }
 
+    // <samerow/> - pack consecutive controls onto one horizontal flex row. A control with
+    // sameRow joins the previous row; one without starts a new row.
+    function groupControlRows(controls: ControlInfo[]): ControlInfo[][] {
+        const rows: ControlInfo[][] = [];
+        for (const ctrl of controls) {
+            if (ctrl.sameRow && rows.length > 0) {
+                rows[rows.length - 1].push(ctrl);
+            } else {
+                rows.push([ctrl]);
+            }
+        }
+        return rows;
+    }
+
     function attrValue(attribute: string): string | null {
         return $selectedData?.attributes[attribute] ?? null;
     }
@@ -475,8 +489,16 @@
             <div class="flex-1 overflow-hidden flex flex-col min-h-0 {readOnly ? "pointer-events-none opacity-60" : ""}">
                 <AttributesEditor>
                     {#snippet extraControls()}
-                        {#each main as ctrl, i (i)}
-                            {@render controlRow(ctrl)}
+                        {#each groupControlRows(main) as row, ri (ri)}
+                            {#if row.length === 1}
+                                {@render controlRow(row[0])}
+                            {:else}
+                                <div class="flex flex-wrap items-start gap-x-2">
+                                    {#each row as ctrl, ci (ci)}
+                                        {@render controlRow(ctrl)}
+                                    {/each}
+                                </div>
+                            {/if}
                         {/each}
                         {@render advancedExpander(advanced)}
                     {/snippet}
@@ -485,8 +507,16 @@
         {:else}
             {@const { main, advanced } = partitionControls(viewControls)}
             <div class="flex-1 overflow-y-auto {readOnly ? "pointer-events-none opacity-60" : ""}">
-                {#each main as ctrl, i (i)}
-                    {@render controlRow(ctrl)}
+                {#each groupControlRows(main) as row, ri (ri)}
+                    {#if row.length === 1}
+                        {@render controlRow(row[0])}
+                    {:else}
+                        <div class="flex flex-wrap items-start gap-x-2">
+                            {#each row as ctrl, ci (ci)}
+                                {@render controlRow(ctrl)}
+                            {/each}
+                        </div>
+                    {/if}
                 {/each}
                 {@render advancedExpander(advanced)}
             </div>
@@ -967,8 +997,16 @@
             <summary class="px-3 pt-2.5 pb-1.5 text-xs font-semibold uppercase text-surface-600-400 cursor-pointer select-none">
                 {t("common.advanced")}
             </summary>
-            {#each controls as ctrl, i (i)}
-                {@render controlRow(ctrl)}
+            {#each groupControlRows(controls) as row, ri (ri)}
+                {#if row.length === 1}
+                    {@render controlRow(row[0])}
+                {:else}
+                    <div class="flex flex-wrap items-start gap-x-2">
+                        {#each row as ctrl, ci (ci)}
+                            {@render controlRow(ctrl)}
+                        {/each}
+                    </div>
+                {/if}
             {/each}
         </details>
     {/if}

--- a/src/AppShell/src/lib/types.ts
+++ b/src/AppShell/src/lib/types.ts
@@ -78,6 +78,8 @@ export interface ControlInfo {
   width?: number | null
   // <bold/> - renders a "label" control's caption in bold.
   bold?: boolean
+  // <samerow/> - pack this control onto the same horizontal row as the previous control.
+  sameRow?: boolean
 }
 
 export interface TabInfo {

--- a/src/Engine/Core/CoreCommands.aslx
+++ b/src/Engine/Core/CoreCommands.aslx
@@ -938,7 +938,11 @@
         if (HasAttribute (game, "author")) {
           s = s + "<b>AUTHOR: </b>" + game.author + "<br/>"
         }
-        s = s + "<b>VERSION: </b>" + game.version + "<br/>"
+        s = s + "<b>VERSION: </b>" + game.version
+        if (HasInt (game, "versioncode")) {
+          s = s + " (" + game.versioncode + ")"
+        }
+        s = s + "<br/>"
         s = s + "<b>IFID: </b>" + game.gameid + "<br/>"
         s = s + "<br/>"
         msg (s)

--- a/src/Engine/Core/CoreEditorGame.aslx
+++ b/src/Engine/Core/CoreEditorGame.aslx
@@ -32,6 +32,16 @@
         <controltype>textbox</controltype>
         <caption>[EditorGameVersion]</caption>
         <attribute>version</attribute>
+        <width>120</width>
+      </control>
+
+      <control>
+        <controltype>number</controltype>
+        <caption>[EditorGameVersionCode]</caption>
+        <attribute>versioncode</attribute>
+        <width>80</width>
+        <minimum>0</minimum>
+        <samerow/>
       </control>
 
       <control>

--- a/src/Engine/Core/CoreTypes.aslx
+++ b/src/Engine/Core/CoreTypes.aslx
@@ -75,6 +75,7 @@
     <command_newline type="boolean">false</command_newline>
     <description type="string"></description>
     <languageid>[LanguageId]</languageid>
+    <versioncode type="int">1</versioncode>
     <gridmap type="boolean">false</gridmap>
     <mapscale type="int">30</mapscale>
     <mapsize type="int">300</mapsize>

--- a/src/Engine/Core/GamebookCore.aslx
+++ b/src/Engine/Core/GamebookCore.aslx
@@ -42,6 +42,7 @@
     <menuhoverforeground>Black</menuhoverforeground>
     <description type="string"></description>
     <languageid>[LanguageId]</languageid>
+    <versioncode type="int">1</versioncode>
     <setcustomwidth type="boolean">true</setcustomwidth>
     <customwidth type="int">700</customwidth>
     <setcustompadding type="boolean">false</setcustompadding>

--- a/src/Engine/Core/GamebookCoreEditor.aslx
+++ b/src/Engine/Core/GamebookCoreEditor.aslx
@@ -217,6 +217,16 @@
         <controltype>textbox</controltype>
         <caption>[EditorGameVersion]</caption>
         <attribute>version</attribute>
+        <width>120</width>
+      </control>
+
+      <control>
+        <controltype>number</controltype>
+        <caption>[EditorGameVersionCode]</caption>
+        <attribute>versioncode</attribute>
+        <width>80</width>
+        <minimum>0</minimum>
+        <samerow/>
       </control>
 
       <control>

--- a/src/Engine/Core/Languages/Deutsch.aslx
+++ b/src/Engine/Core/Languages/Deutsch.aslx
@@ -555,7 +555,7 @@
   <template name="TranscriptAlreadyDisabled">Das Tanskript ist schon deaktiviert.</template>
   <template name="TranscriptEnterFilename">Please enter a transcript name.</template>
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Gib </i>" + Template("TranscriptOffAllCaps") + "<i> ein um das Transkript zu beenden.  ]</i></b>"]]></dynamictemplate>
-  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start des Transkripts:<br/><b>TITEL: </b>" + game.gamename + "<br/><b>AUTOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
+  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start des Transkripts:<br/><b>TITEL: </b>" + game.gamename + "<br/><b>AUTOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + (HasInt(game, "versioncode") ? (" (" + game.versioncode + ")") : "") + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSKRIPT AUS</template>
   <template name="TranscriptViewerMessage">Deine Transkripte werden im localStorage deines Browsers gespeichert. Du kannst sie hier ansehen, herunterladen oder löschen:</template>
   <template name="TranscriptViewerLinkText">Deine Transkripte</template>

--- a/src/Engine/Core/Languages/EditorDeutsch.aslx
+++ b/src/Engine/Core/Languages/EditorDeutsch.aslx
@@ -135,6 +135,7 @@
   <template name="EditorGameAuthor">Autor</template>
   <template name="EditorGameDisplaytitle">Titel und Autor anzeigen, wenn das Spiel beginnt</template>
   <template name="EditorGameVersion">Version</template>
+  <template name="EditorGameVersionCode">Versionscode</template>
   <template name="EditorGameTheGameIDbelow">Die Spiel-ID wird verwendet, um dein Spiel eindeutig zu identifizieren. Du solltest nur eine neue ID generieren, wenn du ein Spiel kopiert hast, um ein neues zu erstellen.</template>
   <template name="EditorGameGameID">Spiel-ID</template>
   <template name="EditorGameCategory">Kategorie</template>

--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -134,6 +134,7 @@
   <template name="EditorGameAuthor">Author</template>
   <template name="EditorGameDisplaytitle">Display title and author when the game begins</template>
   <template name="EditorGameVersion">Version</template>
+  <template name="EditorGameVersionCode">Version Code</template>
   <template name="EditorGameTheGameIDbelow">The Game ID below is used to uniquely identify your game. You should only generate a new ID if you have copied a game to create a new one.</template>
   <template name="EditorGameGameID">Game ID</template>
   <template name="EditorGameCategory">Category</template>

--- a/src/Engine/Core/Languages/EditorEspanol.aslx
+++ b/src/Engine/Core/Languages/EditorEspanol.aslx
@@ -133,6 +133,7 @@
   <template name="EditorGameAuthor">Autor</template>
   <template name="EditorGameDisplaytitle">Mostrar título y autor cuando el juego comienza</template>
   <template name="EditorGameVersion">Versión</template>
+  <template name="EditorGameVersionCode">Código de versión</template>
   <template name="EditorGameTheGameIDbelow">El código del juego de más abajo sirve para identificar tu juego de forma única. Solo deberías generar otro si has clonado un juego como base para crear uno nuevo.</template>
   <template name="EditorGameGameID">Código del Juego</template>
   <template name="EditorGameCategory">Categoría</template>

--- a/src/Engine/Core/Languages/English.aslx
+++ b/src/Engine/Core/Languages/English.aslx
@@ -500,7 +500,7 @@
   <template name="TranscriptAlreadyDisabled">The transcript is already disabled.</template>
   <template name="TranscriptEnterFilename">Please enter a transcript name.</template>
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Enter </i>" + Template("TranscriptOffAllCaps") + "<i> to disable the transcript.  ]</i></b>"]]></dynamictemplate>
-  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start of a transcript of:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
+  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Start of a transcript of:<br/><b>TITLE: </b>" + game.gamename + "<br/><b>AUTHOR: </b>" + game.author + "<br/><b>VERSION: </b>" + game.version + (HasInt(game, "versioncode") ? (" (" + game.versioncode + ")") : "") + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSCRIPT OFF</template>
   <template name="TranscriptViewerMessage">Your transcripts are saved to the localStorage in your browser. You can view, download, or delete them here:</template>
   <template name="TranscriptViewerLinkText">Your Transcripts</template>

--- a/src/Engine/Core/Languages/Espanol.aslx
+++ b/src/Engine/Core/Languages/Espanol.aslx
@@ -711,7 +711,7 @@
   <template name="TranscriptAlreadyDisabled">La transcripción ya está desactivada.</template>
   <template name="TranscriptEnterFilename">Por favor ingresa un nombre para la transcripción.</template>
   <dynamictemplate name="ToDisableTranscript"><![CDATA["<b><i>[  Escribe </i>" + Template("TranscriptOffAllCaps") + "<i> para desactivar la transcripción.  ]</i></b>"]]></dynamictemplate>
-  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Inicio de la transcripción de:<br/><b>TÍTULO: </b>" + game.gamename + "<br/><b>AUTOR: </b>" + game.author + "<br/><b>VERSIÓN: </b>" + game.version + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
+  <dynamictemplate name="TranscriptEnabledMessage"><![CDATA["<hr/>Inicio de la transcripción de:<br/><b>TÍTULO: </b>" + game.gamename + "<br/><b>AUTOR: </b>" + game.author + "<br/><b>VERSIÓN: </b>" + game.version + (HasInt(game, "versioncode") ? (" (" + game.versioncode + ")") : "") + "<br/><b>IFID: </b>" + game.gameid]]></dynamictemplate>
   <template name="TranscriptOffAllCaps">TRANSCRIPCIÓN APAGADA</template>
   <template name="TranscriptViewerMessage">Tus transcripciones se guardan en el localStorage de tu navegador. Puedes verlas, descargarlas o eliminarlas aquí:</template>
   <template name="TranscriptViewerLinkText">Tus transcripciones</template>

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -62,7 +62,10 @@ internal record ControlInfo(
     int? Width = null,
     // <bold/> - renders a "label" control's caption in bold, e.g. to draw attention to a
     // warning-style label (a locked exit's "to unlock this" note, a disabled-feature notice).
-    bool Bold = false);
+    bool Bold = false,
+    // <samerow/> - pack this control onto the same horizontal row as the previous control
+    // in the property editor (e.g. Version + Version Code on the Setup tab).
+    bool SameRow = false);
 
 internal record TabInfo(string? Caption, List<ControlInfo> Controls, string? HelpUrl = null);
 
@@ -4352,6 +4355,7 @@ public partial class WasmEditorBridge
         // number, ...) - the dictionary/list/multi controltypes above return early and never
         // reach here, so this can't misfire on something with no single value to clear.
         var nullable = ctrl.GetBool("nullable");
+        var sameRow = ctrl.GetBool("samerow");
 
         return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
             null, null, textProcessorCommands, addPrompt, Source: source,
@@ -4362,7 +4366,8 @@ public partial class WasmEditorBridge
             Minimum: minimum, Maximum: maximum, Increment: increment,
             Nullable: nullable,
             Width: ctrl.Width,
-            Bold: bold);
+            Bold: bold,
+            SameRow: sameRow);
     }
 
     // <minimum>/<maximum>/<increment> can be authored as either an int or a double literal in

--- a/tests/EngineTests/VersionCodeTests.cs
+++ b/tests/EngineTests/VersionCodeTests.cs
@@ -1,0 +1,31 @@
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+[TestClass]
+public class VersionCodeTests
+{
+    [TestMethod]
+    public async Task VersionCommand_IncludesVersionCodeWhenPresent()
+    {
+        var driver = await GameDriver.LoadAsync("savetest.aslx");
+        driver.Model.Game.Fields.Set("version", "1.0");
+        driver.Model.Game.Fields.Set("versioncode", 42);
+
+        var output = string.Join("\n", await driver.SendCommandAsync("version"));
+        output.ShouldContain("VERSION:");
+        output.ShouldContain("1.0");
+        output.ShouldContain("(42)");
+    }
+
+    [TestMethod]
+    public async Task VersionCommand_UsesDefaultVersionCodeFromType()
+    {
+        var driver = await GameDriver.LoadAsync("savetest.aslx");
+        driver.Model.Game.Fields.Set("version", "1.0");
+
+        var output = string.Join("\n", await driver.SendCommandAsync("version"));
+        output.ShouldContain("VERSION:");
+        output.ShouldContain("1.0 (1)");
+    }
+}

--- a/tests/e2e/verify-appshell-versioncode.mjs
+++ b/tests/e2e/verify-appshell-versioncode.mjs
@@ -1,0 +1,83 @@
+// Verifies the Setup-tab Version Code field (<versioncode>): number input on the
+// same horizontal row as Version, default 1 from defaultgame, and
+// persisted as an int in the game XML.
+//
+// Run against a dev server started with:
+//   PUBLIC_SHOW_HOME=true npm --prefix src/AppShell run dev -- --port 5180
+import { chromium } from './lib/tracked-chromium.mjs';
+
+const baseUrl = process.argv[2] || 'http://localhost:5180';
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+page.on('pageerror', err => console.log('[pageerror]', err.message));
+
+function check(label, actual, expected) {
+    if (actual !== expected) throw new Error(`[${label}] got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`);
+    console.log(`PASS: ${label}`);
+}
+
+const tabStrip = () => page.locator('.flex.border-b.border-surface-200-800.overflow-x-auto.flex-shrink-0');
+
+async function selectTab(name) {
+    const tab = tabStrip().getByRole('button', { name: new RegExp(`^${name}$`) });
+    await tab.waitFor({ state: 'visible', timeout: 10000 });
+    await tab.click();
+    await page.waitForTimeout(150);
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Version Code ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 60000 });
+
+    await page.locator('[data-value="game"][data-part="branch-control"]').click();
+    await selectTab('Setup');
+
+    const versionCaption = page.locator('span', { hasText: /^Version:$/ });
+    const versionCodeCaption = page.locator('span', { hasText: /^Version Code:$/ });
+    await versionCaption.waitFor({ state: 'visible', timeout: 10000 });
+    await versionCodeCaption.waitFor({ state: 'visible', timeout: 10000 });
+
+    const sharedParent = await versionCaption.evaluate((el) => {
+        const versionOuter = el.closest('.flex.flex-col.gap-1');
+        const codeOuter = [...document.querySelectorAll('span')]
+            .find(s => /^Version Code:$/.test(s.textContent.trim()))
+            ?.closest('.flex.flex-col.gap-1');
+        return !!(versionOuter && codeOuter && versionOuter.parentElement === codeOuter.parentElement
+            && [...(versionOuter.parentElement?.classList ?? [])].some(c => c === 'flex'));
+    });
+    check('Version and Version Code share a horizontal flex row', sharedParent, true);
+
+    const versionCodeField = versionCodeCaption.locator('xpath=ancestor::label[1]//input[@type="number"]');
+    check('Version Code uses a number input', await versionCodeField.count(), 1);
+    check('Version Code min is 0', await versionCodeField.getAttribute('min'), '0');
+    check('default Version Code is 1', await versionCodeField.inputValue(), '1');
+
+    await versionCodeField.fill('42');
+    await versionCodeField.dispatchEvent('change');
+    await page.waitForTimeout(300);
+
+    await page.click('button[title="Raw XML code view"]');
+    await page.waitForSelector('.cm-editor', { timeout: 5000 });
+    const xmlText = await page.locator('.cm-content').first().innerText();
+    if (!xmlText.includes('<versioncode type="int">42</versioncode>')) {
+        throw new Error(`Expected <versioncode type="int">42</versioncode> in raw XML; got:\n${xmlText.slice(0, 800)}`);
+    }
+    console.log('PASS: versioncode 42 persisted in game XML');
+
+    console.log('PASS');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    await page.screenshot({ path: '/tmp/appshell-versioncode-failure.png' });
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Introducs a Babel-friendly integer version code alongside the freeform Version string, with Setup-tab editing, VERSION command output, and templates/i18n support.

* Apropos #2227

<img width="1392" height="972" alt="image" src="https://github.com/user-attachments/assets/e733cd6f-0eb3-4f26-b97c-ea784a9d668c" />

<img width="1162" height="962" alt="image" src="https://github.com/user-attachments/assets/78a2b745-e779-461e-b54a-de0d98822ed0" />
