### PR TITLE
feat: embed `metadata.iFiction` in published `.quest` packages

### DIFF
--- a/src/Engine/GameLoader/IFictionWriter.cs
+++ b/src/Engine/GameLoader/IFictionWriter.cs
@@ -1,0 +1,425 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+using QuestViva.Common;
+
+namespace QuestViva.Engine.GameLoader;
+
+/// <summary>
+///     Builds a Treaty of Babel iFiction record from a WorldModel's bibliographic fields,
+///     for embedding as <c>metadata.iFiction</c> inside a published <c>.quest</c> package.
+/// </summary>
+internal static class IFictionWriter
+{
+    private static readonly Regex Whitespace = new(@"\s+", RegexOptions.Compiled);
+    private static readonly Regex HtmlTag = new(@"<[^>]+>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex BrTag = new(@"<br\s*/?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex ClosePTag = new(@"</p\s*>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex OpenPTag = new(@"<p\b[^>]*>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex FirstPublishedYear = new(@"^\d{4}$", RegexOptions.Compiled);
+    private static readonly Regex FirstPublishedDate = new(@"^\d{4}-\d{2}-\d{2}$", RegexOptions.Compiled);
+
+    public static string Write(WorldModel worldModel,
+        IEnumerable<WorldModel.PackageIncludeFile>? includeFiles)
+    {
+        var game = worldModel.Game.Fields;
+        var gameId = game.GetString("gameid");
+        if (string.IsNullOrWhiteSpace(gameId))
+        {
+            throw new InvalidOperationException(
+                "Cannot publish without a gameid (IFID). Generate one in the game's Setup tab.");
+        }
+
+        var ifid = gameId.Trim().ToUpperInvariant();
+        var title = NormalizeText(game.GetString("gamename")) ?? "An Interactive Fiction";
+        var author = NormalizeText(game.GetString("author")) ?? "Anonymous";
+        var headline = NormalizeText(game.GetString("subtitle"));
+        var genre = NormalizeText(game.GetString("category"));
+        var firstPublished = NormalizeFirstPublished(game.GetString("firstpublished"));
+        var description = ToIFictionDescription(game.GetString("description"));
+        var language = NormalizeLanguage(worldModel.LanguageId);
+        var cover = TryGetCoverInfo(game.GetString("cover"), includeFiles);
+
+        var settings = new XmlWriterSettings
+        {
+            Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            Indent = true,
+            IndentChars = "  ",
+            OmitXmlDeclaration = false,
+            NewLineChars = "\n",
+            NewLineHandling = NewLineHandling.Replace
+        };
+
+        using var stringWriter = new StringWriter(CultureInfo.InvariantCulture) { NewLine = "\n" };
+        using (var writer = XmlWriter.Create(stringWriter, settings))
+        {
+            writer.WriteStartDocument();
+            writer.WriteStartElement("ifindex", "http://babel.ifarchive.org/protocol/iFiction/");
+            writer.WriteAttributeString("version", "1.0");
+
+            writer.WriteStartElement("story");
+
+            writer.WriteStartElement("identification");
+            writer.WriteElementString("ifid", ifid);
+            writer.WriteElementString("format", "quest");
+            writer.WriteEndElement(); // identification
+
+            writer.WriteStartElement("bibliographic");
+            writer.WriteElementString("title", title);
+            writer.WriteElementString("author", author);
+            if (headline != null)
+            {
+                writer.WriteElementString("headline", headline);
+            }
+
+            if (genre != null)
+            {
+                writer.WriteElementString("genre", genre);
+            }
+
+            if (firstPublished != null)
+            {
+                writer.WriteElementString("firstpublished", firstPublished);
+            }
+
+            if (description != null)
+            {
+                WriteDescription(writer, description);
+            }
+
+            if (language != null)
+            {
+                writer.WriteElementString("language", language);
+            }
+
+            writer.WriteEndElement(); // bibliographic
+
+            if (cover != null)
+            {
+                writer.WriteStartElement("cover");
+                writer.WriteElementString("format", cover.Format);
+                writer.WriteElementString("height", cover.Height.ToString(CultureInfo.InvariantCulture));
+                writer.WriteElementString("width", cover.Width.ToString(CultureInfo.InvariantCulture));
+                writer.WriteEndElement(); // cover
+            }
+
+            // Format-specific section
+            var questVersion = NormalizeText(game.GetString("version"));
+            var coverLeafname = cover != null
+                ? Path.GetFileName(NormalizeText(game.GetString("cover")))
+                : null;
+            var questStyle = worldModel.IsGamebook ? "Gamebook" : "Text Adventure";
+            writer.WriteStartElement("quest");
+            writer.WriteElementString("style", questStyle);
+            if (questVersion != null)
+            {
+                writer.WriteElementString("version", questVersion);
+            }
+
+            if (coverLeafname != null)
+            {
+                writer.WriteElementString("coverleafname", coverLeafname);
+            }
+
+            writer.WriteEndElement(); // quest
+
+            var releaseDate = DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var releaseVersion = FormatReleaseVersion(game);
+            writer.WriteStartElement("releases");
+            writer.WriteStartElement("attached");
+            writer.WriteStartElement("release");
+            if (releaseVersion != null)
+            {
+                writer.WriteElementString("version", releaseVersion);
+            }
+
+            writer.WriteElementString("releasedate", releaseDate);
+            writer.WriteElementString("compiler", "Quest Viva");
+            writer.WriteElementString("compilerversion", VersionInfo.Version);
+            writer.WriteEndElement(); // release
+            writer.WriteEndElement(); // attached
+            writer.WriteEndElement(); // releases
+
+            writer.WriteStartElement("colophon");
+            writer.WriteElementString("generator", "Quest Viva");
+            writer.WriteElementString("generatorversion", VersionInfo.Version);
+            writer.WriteElementString("originated", releaseDate);
+            writer.WriteEndElement(); // colophon
+
+            writer.WriteEndElement(); // story
+            writer.WriteEndElement(); // ifindex
+            writer.WriteEndDocument();
+        }
+
+        // XmlWriter emits a UTF-8 declaration claiming encoding="utf-16" when writing to
+        // StringWriter; rewrite the declaration to match the UTF-8 bytes we actually store.
+        var xml = stringWriter.ToString();
+        if (xml.StartsWith("<?xml", StringComparison.Ordinal))
+        {
+            var end = xml.IndexOf("?>", StringComparison.Ordinal);
+            if (end >= 0)
+            {
+                xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + xml[(end + 2)..];
+            }
+        }
+
+        return xml.EndsWith('\n') ? xml : xml + "\n";
+    }
+
+    private static string? NormalizeText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return Whitespace.Replace(value.Trim(), " ");
+    }
+
+    private static string? NormalizeFirstPublished(string? value)
+    {
+        var normalized = NormalizeText(value);
+        if (normalized == null)
+        {
+            return null;
+        }
+
+        return FirstPublishedYear.IsMatch(normalized) || FirstPublishedDate.IsMatch(normalized)
+            ? normalized
+            : null;
+    }
+
+    /// <summary>
+    ///     Babel requires <c>&lt;release&gt;/&lt;version&gt;</c> to be a non-negative integer.
+    ///     Quest stores that as <c>versioncode</c>; the freeform display <c>version</c> string
+    ///     is not used here.
+    /// </summary>
+    private static string? FormatReleaseVersion(Fields game)
+    {
+        if (!game.HasType<int>("versioncode"))
+        {
+            return null;
+        }
+
+        var code = game.GetAsType<int>("versioncode");
+        return code < 0 ? null : code.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string? NormalizeLanguage(string? languageId)
+    {
+        return NormalizeText(languageId);
+    }
+
+    /// <summary>
+    ///     Convert Quest richtext HTML into Babel plain text with literal <c>&lt;br/&gt;</c>
+    ///     paragraph breaks. Returns null when nothing usable remains.
+    /// </summary>
+    private static string? ToIFictionDescription(string? html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return null;
+        }
+
+        var text = ClosePTag.Replace(html, "\n");
+        text = OpenPTag.Replace(text, "");
+        text = BrTag.Replace(text, "\n");
+        text = HtmlTag.Replace(text, "");
+        text = WebUtility.HtmlDecode(text);
+
+        var parts = text.Split('\n')
+            .Select(part => Whitespace.Replace(part, " ").Trim())
+            .Where(part => part.Length > 0)
+            .ToArray();
+
+        if (parts.Length == 0)
+        {
+            return null;
+        }
+
+        return string.Join("<br/>", parts);
+    }
+
+    private static void WriteDescription(XmlWriter writer, string description)
+    {
+        writer.WriteStartElement("description");
+        var parts = description.Split("<br/>");
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WriteRaw("<br/>");
+            }
+
+            writer.WriteString(parts[i]);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static CoverInfo? TryGetCoverInfo(string? coverName,
+        IEnumerable<WorldModel.PackageIncludeFile>? includeFiles)
+    {
+        if (string.IsNullOrWhiteSpace(coverName) || includeFiles == null)
+        {
+            return null;
+        }
+
+        var file = includeFiles.FirstOrDefault(f =>
+            string.Equals(f.Filename, coverName, StringComparison.OrdinalIgnoreCase));
+        if (file?.Content == null || !file.Content.CanSeek)
+        {
+            // Non-seekable streams can't be rewound after we peek at the header;
+            // omit cover metadata rather than truncate the image in WriteZip.
+            return null;
+        }
+
+        var format = CoverFormatFromFilename(coverName);
+        if (format == null)
+        {
+            return null;
+        }
+
+        var position = file.Content.Position;
+        try
+        {
+            file.Content.Position = 0;
+
+            if (!TryReadImageSize(file.Content, format, out var width, out var height))
+            {
+                return null;
+            }
+
+            return new CoverInfo(format, width, height);
+        }
+        finally
+        {
+            file.Content.Position = position;
+        }
+    }
+
+    private static string? CoverFormatFromFilename(string filename)
+    {
+        var ext = Path.GetExtension(filename).ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" => "jpg",
+            ".png" => "png",
+            _ => null
+        };
+    }
+
+    private static bool TryReadImageSize(Stream stream, string format, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        return format switch
+        {
+            "png" => TryReadPngSize(stream, out width, out height),
+            "jpg" => TryReadJpegSize(stream, out width, out height),
+            _ => false
+        };
+    }
+
+    private static bool TryReadPngSize(Stream stream, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        Span<byte> header = stackalloc byte[24];
+        if (stream.ReadAtLeast(header, 24, throwOnEndOfStream: false) < 24)
+        {
+            return false;
+        }
+
+        // PNG signature + IHDR length/type
+        ReadOnlySpan<byte> signature = [137, 80, 78, 71, 13, 10, 26, 10];
+        if (!header[..8].SequenceEqual(signature) ||
+            header[12] != (byte)'I' || header[13] != (byte)'H' ||
+            header[14] != (byte)'D' || header[15] != (byte)'R')
+        {
+            return false;
+        }
+
+        width = (header[16] << 24) | (header[17] << 16) | (header[18] << 8) | header[19];
+        height = (header[20] << 24) | (header[21] << 16) | (header[22] << 8) | header[23];
+        return width > 0 && height > 0;
+    }
+
+    private static bool TryReadJpegSize(Stream stream, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+        if (stream.ReadByte() != 0xFF || stream.ReadByte() != 0xD8)
+        {
+            return false;
+        }
+
+        while (true)
+        {
+            int b;
+            do
+            {
+                b = stream.ReadByte();
+                if (b < 0)
+                {
+                    return false;
+                }
+            } while (b != 0xFF);
+
+            do
+            {
+                b = stream.ReadByte();
+                if (b < 0)
+                {
+                    return false;
+                }
+            } while (b == 0xFF);
+
+            // SOF0..SOF3, SOF5..SOF7, SOF9..SOF11, SOF13..SOF15 (skip DHT/JPG/DAC)
+            if ((b & 0xF0) == 0xC0 && b != 0xC4 && b != 0xC8 && b != 0xCC)
+            {
+                if (stream.ReadByte() < 0 || stream.ReadByte() < 0 || stream.ReadByte() < 0)
+                {
+                    return false;
+                }
+
+                var h1 = stream.ReadByte();
+                var h2 = stream.ReadByte();
+                var w1 = stream.ReadByte();
+                var w2 = stream.ReadByte();
+                if (h1 < 0 || h2 < 0 || w1 < 0 || w2 < 0)
+                {
+                    return false;
+                }
+
+                height = (h1 << 8) | h2;
+                width = (w1 << 8) | w2;
+                return width > 0 && height > 0;
+            }
+
+            if (b is 0xD8 or 0xD9)
+            {
+                return false;
+            }
+
+            var l1 = stream.ReadByte();
+            var l2 = stream.ReadByte();
+            if (l1 < 0 || l2 < 0)
+            {
+                return false;
+            }
+
+            var length = ((l1 << 8) | l2) - 2;
+            if (length < 0)
+            {
+                return false;
+            }
+
+            stream.Position += length;
+        }
+    }
+
+    private sealed record CoverInfo(string Format, int Width, int Height);
+}

--- a/src/Engine/GameLoader/PackageReader.cs
+++ b/src/Engine/GameLoader/PackageReader.cs
@@ -31,6 +31,12 @@ internal class PackageReader
             foreach (var entry in zip.Entries)
             {
                 var entryName = entry.FullName;
+                // Bibliographic sidecar for Babel / IF Archive — not a game resource.
+                if (string.Equals(entryName, "metadata.iFiction", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 var memoryStream = new MemoryStream();
                 entry.Open().CopyTo(memoryStream);
                 _files.TryAdd(entryName, memoryStream.ToArray());

--- a/src/Engine/GameLoader/Packager.cs
+++ b/src/Engine/GameLoader/Packager.cs
@@ -27,15 +27,18 @@ internal class Packager(WorldModel worldModel)
             var ifid = _worldModel.Game.Fields.GetString("gameid")!.Trim().ToUpperInvariant();
             var ifidBrand = $"UUID://{ifid}//\n";
 
+            var includeFileList = includeFiles?.ToList() ?? [];
+            var ifiction = IFictionWriter.Write(_worldModel, includeFileList);
+
             if (filename != null)
             {
                 using var fileStream = File.Create(filename);
-                WriteZip(fileStream, data, ifidBrand, includeFiles);
+                WriteZip(fileStream, data, ifidBrand, ifiction, includeFileList);
             }
             else
             {
                 // Caller owns outputStream — do not dispose it.
-                WriteZip(outputStream, data, ifidBrand, includeFiles);
+                WriteZip(outputStream, data, ifidBrand, ifiction, includeFileList);
             }
         }
         catch (Exception ex)
@@ -47,8 +50,8 @@ internal class Packager(WorldModel worldModel)
         return true;
     }
 
-    private static void WriteZip(Stream stream, string data, string ifidBrand,
-        IEnumerable<WorldModel.PackageIncludeFile> includeFiles)
+    private static void WriteZip(Stream stream, string data, string ifidBrand, string ifiction,
+        List<WorldModel.PackageIncludeFile> includeFileList)
     {
         using var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
         zip.Comment = ifidBrand;
@@ -60,7 +63,14 @@ internal class Packager(WorldModel worldModel)
             writer.Write(data);
         }
 
-        foreach (var file in includeFiles)
+        var ifictionEntry = zip.CreateEntry("metadata.iFiction", CompressionLevel.Optimal);
+        using (var entryStream = ifictionEntry.Open())
+        using (var writer = new StreamWriter(entryStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+        {
+            writer.Write(ifiction);
+        }
+
+        foreach (var file in includeFileList)
         {
             var fileEntry = zip.CreateEntry(file.Filename, CompressionLevel.Optimal);
             using var fileEntryStream = fileEntry.Open();

--- a/tests/EngineTests/PackagerTests.cs
+++ b/tests/EngineTests/PackagerTests.cs
@@ -20,6 +20,9 @@ public class PackagerTests
         var player = new Mock<IPlayer>();
         Assert.IsTrue(await worldModel.Initialise(player.Object), "Initialisation failed");
 
+        // savetest.aslx has no gameid; publish requires an IFID for metadata.iFiction.
+        worldModel.Game.Fields.Set("gameid", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
         var assetBytes = "asset contents"u8.ToArray();
         var includeFiles = new[]
         {
@@ -82,5 +85,85 @@ public class PackagerTests
         packageStream.Position = 0;
         using var zip = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
         Assert.AreEqual(expected, zip.Comment);
+    }
+
+    [TestMethod]
+    public async Task CreatePackage_EmbedsMetadataIFiction()
+    {
+        var gameDataProvider = new FileGameDataProvider("savetest.aslx");
+        var gameData = await gameDataProvider.GetData();
+        var worldModel = Helpers.CreateWorldModel(gameData);
+        worldModel.LogError += ex => throw ex;
+
+        var player = new Mock<IPlayer>();
+        Assert.IsTrue(await worldModel.Initialise(player.Object), "Initialisation failed");
+
+        worldModel.Game.Fields.Set("gameid", "1652e7ec-2d7d-4b59-95ed-e65d79edf257");
+        worldModel.Game.Fields.Set("author", "Test Author");
+        worldModel.Game.Fields.Set("subtitle", "An Interactive Test");
+        worldModel.Game.Fields.Set("category", "Fantasy");
+        worldModel.Game.Fields.Set("firstpublished", "2026");
+        worldModel.Game.Fields.Set("version", "1.0");
+        worldModel.Game.Fields.Set("versioncode", 3);
+        worldModel.Game.Fields.Set("description", "Line one.<br/>Line two.");
+        worldModel.Game.Fields.Set("cover", "cover.png");
+
+        // Minimal 1x1 PNG
+        var png = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
+        var includeFiles = new[]
+        {
+            new WorldModel.PackageIncludeFile
+            {
+                Filename = "cover.png",
+                Content = new MemoryStream(png)
+            }
+        };
+
+        using var packageStream = new MemoryStream();
+        var success = worldModel.CreatePackage(null, includeWalkthrough: false, out var error, includeFiles, packageStream);
+        Assert.IsTrue(success, error);
+
+        packageStream.Position = 0;
+        using var zip = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
+        var entry = zip.GetEntry("metadata.iFiction");
+        Assert.IsNotNull(entry, "Published .quest should contain metadata.iFiction");
+
+        using var entryStream = entry.Open();
+        using var reader = new StreamReader(entryStream, Encoding.UTF8);
+        var ifiction = await reader.ReadToEndAsync();
+
+        StringAssert.Contains(ifiction, "<ifid>1652E7EC-2D7D-4B59-95ED-E65D79EDF257</ifid>");
+        StringAssert.Contains(ifiction, "<format>quest</format>");
+        StringAssert.Contains(ifiction, "<title>savetest</title>");
+        StringAssert.Contains(ifiction, "<author>Test Author</author>");
+        StringAssert.Contains(ifiction, "<headline>An Interactive Test</headline>");
+        StringAssert.Contains(ifiction, "<genre>Fantasy</genre>");
+        StringAssert.Contains(ifiction, "<firstpublished>2026</firstpublished>");
+        StringAssert.Contains(ifiction, "<description>Line one.<br/>Line two.</description>");
+        StringAssert.Contains(ifiction, "<language>en</language>");
+        StringAssert.Contains(ifiction, "<cover>");
+        StringAssert.Contains(ifiction, "<format>png</format>");
+        StringAssert.Contains(ifiction, "<height>1</height>");
+        StringAssert.Contains(ifiction, "<width>1</width>");
+        StringAssert.Contains(ifiction, "<generator>Quest Viva</generator>");
+        StringAssert.Contains(ifiction, "<quest>");
+        StringAssert.Contains(ifiction, "<style>Text Adventure</style>");
+        StringAssert.Contains(ifiction, "<version>1.0</version>");
+        StringAssert.Contains(ifiction, "<coverleafname>cover.png</coverleafname>");
+        StringAssert.Contains(ifiction, "<releases>");
+        StringAssert.Contains(ifiction, "<attached>");
+        StringAssert.Contains(ifiction, "<version>3</version>");
+        StringAssert.Contains(ifiction, "<compiler>Quest Viva</compiler>");
+        StringAssert.Contains(ifiction, $"<compilerversion>{VersionInfo.Version}</compilerversion>");
+        StringAssert.Contains(ifiction, "<releasedate>");
+
+        // metadata.iFiction is a bibliographic sidecar, not a playable game resource
+        var packageProvider = new ByteArrayGameDataProvider(packageStream.ToArray(), "game.quest");
+        var packageGameData = await packageProvider.GetData();
+        var reloaded = Helpers.CreateWorldModel(packageGameData);
+        Assert.IsTrue(await reloaded.Initialise(player.Object), "Reloaded package failed to initialise");
+        CollectionAssert.DoesNotContain(((IGame)reloaded).GetResourceNames().ToList(), "metadata.iFiction");
+        CollectionAssert.Contains(((IGame)reloaded).GetResourceNames().ToList(), "cover.png");
     }
 }


### PR DESCRIPTION
* Apropos #2227 
* Apropos https://github.com/iftechfoundation/ifarchive-if-specs/pull/29
* Apropos https://github.com/iftechfoundation/babel-tool/pull/45

Here's an example output file.

* It's using a new `<format>quest</format>`
* And we've defined a new `<quest>` format-specific tag, per [Treaty of Babel section 5.10](https://babel.ifarchive.org/babel.html#the-format-specific-tags). Within the `<quest>` element:
    * `<style>` can be "Text Adventure" or "Gamebook"
    * `<coverleafname>` is the name of the cover art file in the `.quest` ZIP archive. (Strangely, Babel has no standardized way of identifying the actual file name of the cover art!)
    * `<version>` is the `<version>` version string from the ASLX.
* The `releases/attached/release/version` is the ASLX `<versioncode>`, introduced in PR 2229.

```
<?xml version="1.0" encoding="UTF-8"?>
<ifindex version="1.0" xmlns="http://babel.ifarchive.org/protocol/iFiction/">
  <story>
    <identification>
      <ifid>1652E7EC-2D7D-4B59-95ED-E65D79EDF257</ifid>
      <format>quest</format>
    </identification>
    <bibliographic>
      <title>Test</title>
      <author>Dan Fabulich</author>
      <headline>subtitle</headline>
      <genre>Educational</genre>
      <firstpublished>2026</firstpublished>
      <description>This is a test. &lt;3<br/>multiple paragraphs<br/>line 1<br/>line 2 with no paragraph break</description>
      <language>en</language>
    </bibliographic>
    <cover>
      <format>png</format>
      <height>512</height>
      <width>512</width>
    </cover>
    <quest>
      <style>Text Adventure</style>
      <version>1.0</version>
      <coverleafname>black-cover.png</coverleafname>
    </quest>
    <releases>
      <attached>
        <release>
          <version>1</version>
          <releasedate>2026-09-09</releasedate>
          <compiler>Quest Viva</compiler>
          <compilerversion>6.0.0-beta.59</compilerversion>
        </release>
      </attached>
    </releases>
    <colophon>
      <generator>Quest Viva</generator>
      <generatorversion>6.0.0-beta.59</generatorversion>
      <originated>2026-09-09</originated>
    </colophon>
  </story>
</ifindex>
```