### PR TITLE
feat: add `UUID://...//` zip comment when publishing `.quest` file

### DIFF
--- a/src/Engine/GameLoader/Packager.cs
+++ b/src/Engine/GameLoader/Packager.cs
@@ -14,24 +14,28 @@ internal class Packager(WorldModel worldModel)
 
         try
         {
-            var data = _worldModel.Save(SaveMode.Package, includeWalkthrough);
-
-            using var stream = filename != null ? File.Create(filename) : outputStream;
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            // Editor normally assigns gameid on open; ensure publish never ships without an IFID.
+            if (string.IsNullOrWhiteSpace(_worldModel.Game.Fields.GetString("gameid")))
             {
-                var gameEntry = zip.CreateEntry("game.aslx", CompressionLevel.Optimal);
-                using (var entryStream = gameEntry.Open())
-                using (var writer = new StreamWriter(entryStream, Encoding.UTF8))
-                {
-                    writer.Write(data);
-                }
+                _worldModel.Game.Fields.Set("gameid", Guid.NewGuid().ToString());
+            }
 
-                foreach (var file in includeFiles)
-                {
-                    var fileEntry = zip.CreateEntry(file.Filename, CompressionLevel.Optimal);
-                    using var fileEntryStream = fileEntry.Open();
-                    file.Content.CopyTo(fileEntryStream);
-                }
+            var data = _worldModel.Save(SaveMode.Package, includeWalkthrough);
+            // Babel "other file formats": literal ASCII UUID://…// somewhere in the file.
+            // ZIP archive comment is written at the end of the archive as raw bytes.
+            // Trailing newline to workaround https://github.com/iftechfoundation/babel-tool/issues/43
+            var ifid = _worldModel.Game.Fields.GetString("gameid")!.Trim().ToUpperInvariant();
+            var ifidBrand = $"UUID://{ifid}//\n";
+
+            if (filename != null)
+            {
+                using var fileStream = File.Create(filename);
+                WriteZip(fileStream, data, ifidBrand, includeFiles);
+            }
+            else
+            {
+                // Caller owns outputStream — do not dispose it.
+                WriteZip(outputStream, data, ifidBrand, includeFiles);
             }
         }
         catch (Exception ex)
@@ -41,5 +45,26 @@ internal class Packager(WorldModel worldModel)
         }
 
         return true;
+    }
+
+    private static void WriteZip(Stream stream, string data, string ifidBrand,
+        IEnumerable<WorldModel.PackageIncludeFile> includeFiles)
+    {
+        using var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
+        zip.Comment = ifidBrand;
+
+        var gameEntry = zip.CreateEntry("game.aslx", CompressionLevel.Optimal);
+        using (var entryStream = gameEntry.Open())
+        using (var writer = new StreamWriter(entryStream, Encoding.UTF8))
+        {
+            writer.Write(data);
+        }
+
+        foreach (var file in includeFiles)
+        {
+            var fileEntry = zip.CreateEntry(file.Filename, CompressionLevel.Optimal);
+            using var fileEntryStream = fileEntry.Open();
+            file.Content.CopyTo(fileEntryStream);
+        }
     }
 }

--- a/tests/EngineTests/PackagerTests.cs
+++ b/tests/EngineTests/PackagerTests.cs
@@ -1,3 +1,5 @@
+using System.IO.Compression;
+using System.Text;
 using Moq;
 using QuestViva.Common;
 using QuestViva.Engine;
@@ -53,5 +55,32 @@ public class PackagerTests
         // full save/reload round trip, not just the initial parse.
         var reloadedFunction = reloadedWorldModel.Elements.Get("VerifyCreatedExit");
         Assert.AreEqual("Verification", reloadedFunction.Fields[FieldDefinitions.EditorFolder]);
+    }
+
+    [TestMethod]
+    public async Task CreatePackage_EmbedsIfidAsZipArchiveComment()
+    {
+        var gameDataProvider = new FileGameDataProvider("savetest.aslx");
+        var gameData = await gameDataProvider.GetData();
+        var worldModel = Helpers.CreateWorldModel(gameData);
+        worldModel.LogError += ex => throw ex;
+
+        var player = new Mock<IPlayer>();
+        Assert.IsTrue(await worldModel.Initialise(player.Object), "Initialisation failed");
+
+        worldModel.Game.Fields.Set("gameid", "1974a053-7db0-4103-93a1-767c1382c0b7");
+
+        using var packageStream = new MemoryStream();
+        var success = worldModel.CreatePackage(null, includeWalkthrough: false, out var error,
+            Array.Empty<WorldModel.PackageIncludeFile>(), packageStream);
+        Assert.IsTrue(success, error);
+
+        var packageBytes = packageStream.ToArray();
+        const string expected = "UUID://1974A053-7DB0-4103-93A1-767C1382C0B7//\n";
+        StringAssert.Contains(Encoding.ASCII.GetString(packageBytes), expected);
+
+        packageStream.Position = 0;
+        using var zip = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
+        Assert.AreEqual(expected, zip.Comment);
     }
 }


### PR DESCRIPTION
* Apropos #2227 

This complies with the Treaty of Babel section 2.2.2 https://babel.ifarchive.org/babel.html#embed-formats

```
% babel -identify /tmp/Test.quest
Warning: Story format could not be positively identified. Guessing executable
No bibliographic data
IFID: 1652E7EC-2D7D-4B59-95ED-E65D79EDF257
executable, 46k, no cover
```