### PR TITLE
chore: adopt Rider naming conventions for fields and enforce at build time

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,45 @@
 root = true
 
+[*.cs]
+# Naming conventions, matching Rider's defaults. Enforced at build time via
+# EnforceCodeStyleInBuild (Directory.Build.props) + TreatWarningsAsErrors.
+dotnet_diagnostic.IDE1006.severity = warning
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case.capitalization = camel_case
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+
+dotnet_naming_symbols.private_constants.applicable_kinds = field
+dotnet_naming_symbols.private_constants.applicable_accessibilities = private
+dotnet_naming_symbols.private_constants.required_modifiers = const
+
+dotnet_naming_symbols.private_static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_readonly_fields.required_modifiers = static, readonly
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_symbols.local_constants.applicable_kinds = local
+dotnet_naming_symbols.local_constants.required_modifiers = const
+
+dotnet_naming_rule.private_constants_are_pascal_case.symbols = private_constants
+dotnet_naming_rule.private_constants_are_pascal_case.style = pascal_case
+dotnet_naming_rule.private_constants_are_pascal_case.severity = warning
+
+dotnet_naming_rule.private_static_readonly_fields_are_pascal_case.symbols = private_static_readonly_fields
+dotnet_naming_rule.private_static_readonly_fields_are_pascal_case.style = pascal_case
+dotnet_naming_rule.private_static_readonly_fields_are_pascal_case.severity = warning
+
+dotnet_naming_rule.private_fields_are_underscore_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_are_underscore_camel_case.style = underscore_camel_case
+dotnet_naming_rule.private_fields_are_underscore_camel_case.severity = warning
+
+dotnet_naming_rule.local_constants_are_camel_case.symbols = local_constants
+dotnet_naming_rule.local_constants_are_camel_case.style = camel_case
+dotnet_naming_rule.local_constants_are_camel_case.severity = warning
+
 [src/Engine/Core/**.aslx]
 charset = utf-8
 end_of_line = lf

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Enforces the naming rules in .editorconfig at build time -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 </Project>

--- a/docs/editor-progressive-disclosure.md
+++ b/docs/editor-progressive-disclosure.md
@@ -42,7 +42,7 @@ Two conventions for the flags themselves, established by the audit:
 ## Dormant EditorCore plumbing — keep it
 
 EditorCore still carries the full v5 Simple Mode plumbing, all deliberately dormant:
-`SimpleMode` / `SimpleModeChanged` on `EditorController`, the `m_advancedTypes` tree
+`SimpleMode` / `SimpleModeChanged` on `EditorController`, the `_advancedTypes` tree
 filtering, `IsTabVisibleInSimpleMode` (`EditorTab.cs`), `IsControlVisibleInSimpleMode`
 (`EditorControl.cs` — this one *is* consulted, inverted, by `WasmEditorBridge` to
 populate the `Advanced` flags above), `IsVisibleInSimpleMode`

--- a/src/AppShell/src/components/PropertyEditor.svelte
+++ b/src/AppShell/src/components/PropertyEditor.svelte
@@ -69,7 +69,7 @@
     ];
     // Gamebook mode only supports Function/Library/JavaScript — Timer/Walkthrough
     // don't apply to a flat page-based game, and Template/Object Type are in
-    // EditorController's m_ignoredTypes for gamebook (adding one would create an
+    // EditorController's _ignoredTypes for gamebook (adding one would create an
     // invisible, orphaned element).
     let ADVANCED_ADDERS = $derived(ALL_ADVANCED_ADDERS.filter(a => !$isGamebook || a.gamebook));
 

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -1768,7 +1768,7 @@ export async function deleteAssetAndOwner(key: string): Promise<void> {
 function performDeleteElement(key: string) {
     if (!_bridge) return;
     // Same staleness as adding one (see createIncludedLibrary above): a removed library's
-    // <editor> panes stay registered in m_editorDefinitions until Initialise() re-runs, so a
+    // <editor> panes stay registered in _editorDefinitions until Initialise() re-runs, so a
     // deleted library can leave the editor showing panes for elements that no longer exist.
     if (get(treeNodes).find(n => n.key === key)?.nodeType === "include") showLibraryReloadBanner.set(true);
     _bridge.DeleteElement(key);
@@ -1909,7 +1909,7 @@ export const clipboardVersion = writable(0);
 
 // Keys currently staged by Cut (not yet pasted) — TreePanel dims these rows so
 // a cut element doesn't look untouched. Mirrors EditorController's own
-// m_lastelementscutout flag: cleared by Copy (a fresh copy isn't a cut) and by
+// _lastelementscutout flag: cleared by Copy (a fresh copy isn't a cut) and by
 // a completed Paste (the element has landed at its new parent), set by Cut.
 export const cutElementKeys = writable<Set<string>>(new Set());
 

--- a/src/AppShell/src/lib/filesystem/electron-adapter.ts
+++ b/src/AppShell/src/lib/filesystem/electron-adapter.ts
@@ -2,7 +2,7 @@ import { isJunkAssetName, isLibraryFilename, type AssetInfo, type FileAdapter } 
 
 const ASLX_FILTER = [{ name: "Quest game files", extensions: ["aslx"] }];
 
-// Mirrors PlayerHelper.cs's s_mimeTypes. window.electronApp.fs.readFile returns
+// Mirrors PlayerHelper.cs's MimeTypes. window.electronApp.fs.readFile returns
 // raw bytes with no type info (unlike FSA's FileSystemFileHandle.getFile(),
 // which browsers auto-type from the OS) — without this, getAsset()'s Blob has
 // an empty type, WasmPlayer's data-URL resource protocol produces an untyped

--- a/src/EditorCore/EditableCommandPattern.cs
+++ b/src/EditorCore/EditableCommandPattern.cs
@@ -5,18 +5,18 @@ namespace QuestViva.EditorCore;
 
 public class EditableCommandPattern : IEditableCommandPattern
 {
-    private readonly string m_attribute;
-    private readonly Element m_parent;
-    private readonly EditorCommandPattern m_pattern;
-    private EditorController m_controller;
+    private readonly string _attribute;
+    private readonly Element _parent;
+    private readonly EditorCommandPattern _pattern;
+    private EditorController _controller;
 
     public EditableCommandPattern(EditorController controller, EditorCommandPattern pattern, Element parent,
         string attribute)
     {
-        m_pattern = pattern;
-        m_controller = controller;
-        m_parent = parent;
-        m_attribute = attribute;
+        _pattern = pattern;
+        _controller = controller;
+        _parent = parent;
+        _attribute = attribute;
     }
 
     public event EventHandler<DataWrapperUpdatedEventArgs> UnderlyingValueUpdated
@@ -27,17 +27,17 @@ public class EditableCommandPattern : IEditableCommandPattern
 
     public object GetUnderlyingValue()
     {
-        return m_pattern;
+        return _pattern;
     }
 
     public string DisplayString()
     {
-        return m_pattern.Pattern;
+        return _pattern.Pattern;
     }
 
     public string Pattern
     {
-        get => m_pattern.Pattern;
-        set => m_parent.Fields.Set(m_attribute, new EditorCommandPattern(value));
+        get => _pattern.Pattern;
+        set => _parent.Fields.Set(_attribute, new EditorCommandPattern(value));
     }
 }

--- a/src/EditorCore/EditableDataWrapper.cs
+++ b/src/EditorCore/EditableDataWrapper.cs
@@ -2,29 +2,29 @@
 
 internal class EditableDataWrapper<TSource, TWrapped>
 {
-    private readonly Func<EditorController, TSource, TWrapped> GetNewWrappedInstance;
-    private readonly Dictionary<TSource, TWrapped> s_instances = new();
+    private readonly Func<EditorController, TSource, TWrapped> _getNewWrappedInstance;
+    private readonly Dictionary<TSource, TWrapped> _instances = new();
 
     public EditableDataWrapper(Func<EditorController, TSource, TWrapped> instanceCreator)
     {
-        GetNewWrappedInstance = instanceCreator;
+        _getNewWrappedInstance = instanceCreator;
     }
 
     public TWrapped GetInstance(EditorController controller, TSource source)
     {
         TWrapped instance;
-        if (s_instances.TryGetValue(source, out instance))
+        if (_instances.TryGetValue(source, out instance))
         {
             return instance;
         }
 
-        instance = GetNewWrappedInstance(controller, source);
-        s_instances.Add(source, instance);
+        instance = _getNewWrappedInstance(controller, source);
+        _instances.Add(source, instance);
         return instance;
     }
 
     internal void Clear()
     {
-        s_instances.Clear();
+        _instances.Clear();
     }
 }

--- a/src/EditorCore/EditableDictionary.cs
+++ b/src/EditorCore/EditableDictionary.cs
@@ -4,21 +4,21 @@ namespace QuestViva.EditorCore;
 
 public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
 {
-    private static int s_count;
-    private readonly EditorController m_controller;
+    private static int _count;
+    private readonly EditorController _controller;
 
-    private readonly QuestDictionary<T> m_source;
-    private readonly Dictionary<string, IEditableListItem<T>> m_wrappedItems = new();
+    private readonly QuestDictionary<T> _source;
+    private readonly Dictionary<string, IEditableListItem<T>> _wrappedItems = new();
 
     public EditableDictionary(EditorController controller, QuestDictionary<T> source)
     {
-        s_count++;
-        Id = "dictionary" + s_count;
+        _count++;
+        Id = "dictionary" + _count;
 
-        m_controller = controller;
-        m_source = source;
-        m_source.Added += m_source_Added;
-        m_source.Removed += m_source_Removed;
+        _controller = controller;
+        _source = source;
+        _source.Added += OnSourceAdded;
+        _source.Removed += OnSourceRemoved;
         PopulateWrappedItems();
     }
 
@@ -31,7 +31,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
 
     public object GetUnderlyingValue()
     {
-        return m_source;
+        return _source;
     }
 
     public string DisplayString()
@@ -50,7 +50,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
         remove { }
     }
 
-    public IDictionary<string, IEditableListItem<T>> Items => m_wrappedItems;
+    public IDictionary<string, IEditableListItem<T>> Items => _wrappedItems;
 
     public IEnumerable<KeyValuePair<string, string>> DisplayItems
     {
@@ -58,7 +58,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
         {
             var result = new Dictionary<string, string>();
 
-            foreach (var item in m_wrappedItems)
+            foreach (var item in _wrappedItems)
             {
                 // TO DO: We will need some kind of projection function for non-string T's
                 result.Add(item.Key, item.Value.Value as string);
@@ -81,9 +81,9 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
             throw new InvalidOperationException("Unknown dictionary type");
         }
 
-        m_controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
-        m_source.Add(key, value, UpdateSource.User);
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
+        _source.Add(key, value, UpdateSource.User);
+        _controller.WorldModel.UndoLogger.EndTransaction();
     }
 
     public void Remove(params string[] keys)
@@ -99,18 +99,18 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
             throw new InvalidOperationException("Unknown list type");
         }
 
-        m_controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
+        _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
         foreach (var key in keys)
         {
-            m_source.Remove(key, UpdateSource.User);
+            _source.Remove(key, UpdateSource.User);
         }
 
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.EndTransaction();
     }
 
     public ValidationResult CanAdd(string key)
     {
-        if (m_source.ContainsKey(key))
+        if (_source.ContainsKey(key))
         {
             return new ValidationResult {Valid = false, Message = ValidationMessage.ItemAlreadyExists};
         }
@@ -118,23 +118,23 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
         return new ValidationResult {Valid = true};
     }
 
-    public T this[string key] => m_source[key];
+    public T this[string key] => _source[key];
 
     public void Update(string key, T value)
     {
-        var index = m_source.IndexOfKey(key);
-        m_source.Remove(key, UpdateSource.User);
-        m_source.Add(key, value, UpdateSource.User, index);
+        var index = _source.IndexOfKey(key);
+        _source.Remove(key, UpdateSource.User);
+        _source.Add(key, value, UpdateSource.User, index);
     }
 
-    public bool Locked => m_source.Locked;
+    public bool Locked => _source.Locked;
 
     public IEditableDictionary<T> Clone(string parent, string attribute)
     {
         IEditableDictionary<T> result;
-        m_controller.WorldModel.UndoLogger.StartTransaction(string.Format("Copy '{0}' {1}", parent, attribute));
-        result = CloneInternal(m_controller.WorldModel.Elements.Get(parent), attribute);
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.StartTransaction(string.Format("Copy '{0}' {1}", parent, attribute));
+        result = CloneInternal(_controller.WorldModel.Elements.Get(parent), attribute);
+        _controller.WorldModel.UndoLogger.EndTransaction();
         return result;
     }
 
@@ -142,31 +142,31 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
     {
         get
         {
-            if (m_source.Owner == null)
+            if (_source.Owner == null)
             {
                 return null;
             }
 
-            return m_source.Owner.Name;
+            return _source.Owner.Name;
         }
     }
 
     public void ChangeKey(string oldKey, string newKey)
     {
-        var index = m_source.IndexOfKey(oldKey);
-        var value = m_source[oldKey];
-        m_source.Remove(oldKey, UpdateSource.User);
-        m_source.Add(newKey, value, UpdateSource.User, index);
+        var index = _source.IndexOfKey(oldKey);
+        var value = _source[oldKey];
+        _source.Remove(oldKey, UpdateSource.User);
+        _source.Add(newKey, value, UpdateSource.User, index);
     }
 
     public string Id { get; }
 
     private void PopulateWrappedItems()
     {
-        m_wrappedItems.Clear();
+        _wrappedItems.Clear();
         var index = 0;
 
-        foreach (var item in m_source)
+        foreach (var item in _source)
         {
             AddWrappedItem(item.Key, item.Value, EditorUpdateSource.System, index);
             index++;
@@ -176,7 +176,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
     private void AddWrappedItem(string key, T value, EditorUpdateSource source, int index)
     {
         IEditableListItem<T> wrappedValue = new EditableListItem<T>(key, value);
-        m_wrappedItems.Add(key, wrappedValue);
+        _wrappedItems.Add(key, wrappedValue);
 
         if (Added != null)
         {
@@ -187,44 +187,44 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
 
     private void RemoveWrappedItem(IEditableListItem<T> item, EditorUpdateSource source, int index)
     {
-        m_wrappedItems.Remove(item.Key);
+        _wrappedItems.Remove(item.Key);
         if (Removed != null)
         {
             Removed(this, new EditableListUpdatedEventArgs<T> {UpdatedItem = item, Index = index, Source = source});
         }
     }
 
-    private void m_source_Added(object sender, QuestDictionaryUpdatedEventArgs<T> e)
+    private void OnSourceAdded(object sender, QuestDictionaryUpdatedEventArgs<T> e)
     {
         AddWrappedItem(e.Key, e.Item, (EditorUpdateSource) e.Source, e.Index);
     }
 
-    private void m_source_Removed(object sender, QuestDictionaryUpdatedEventArgs<T> e)
+    private void OnSourceRemoved(object sender, QuestDictionaryUpdatedEventArgs<T> e)
     {
-        RemoveWrappedItem(m_wrappedItems[e.Key], (EditorUpdateSource) e.Source, e.Index);
+        RemoveWrappedItem(_wrappedItems[e.Key], (EditorUpdateSource) e.Source, e.Index);
     }
 
     private IEditableDictionary<T> CloneInternal(Element parent, string attribute)
     {
-        var newSource = (QuestDictionary<T>) m_source.Clone();
+        var newSource = (QuestDictionary<T>) _source.Clone();
         newSource.Locked = false;
         parent.Fields.Set(attribute, newSource);
         newSource = (QuestDictionary<T>) parent.Fields.Get(attribute);
-        return GetNewInstance(m_controller, newSource);
+        return GetNewInstance(_controller, newSource);
     }
 
     #region Static DataWrapper
 
-    private static readonly EditableDataWrapper<QuestDictionary<T>, EditableDictionary<T>> s_wrapper;
+    private static readonly EditableDataWrapper<QuestDictionary<T>, EditableDictionary<T>> Wrapper;
 
     static EditableDictionary()
     {
-        s_wrapper = new EditableDataWrapper<QuestDictionary<T>, EditableDictionary<T>>(GetNewInstance);
+        Wrapper = new EditableDataWrapper<QuestDictionary<T>, EditableDictionary<T>>(GetNewInstance);
     }
 
     public static EditableDictionary<T> GetInstance(EditorController controller, QuestDictionary<T> list)
     {
-        return s_wrapper.GetInstance(controller, list);
+        return Wrapper.GetInstance(controller, list);
     }
 
     private static EditableDictionary<T> GetNewInstance(EditorController controller, QuestDictionary<T> list)
@@ -234,7 +234,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
 
     public static void Clear()
     {
-        s_wrapper.Clear();
+        Wrapper.Clear();
     }
 
     #endregion

--- a/src/EditorCore/EditableIfScript.cs
+++ b/src/EditorCore/EditableIfScript.cs
@@ -5,48 +5,48 @@ namespace QuestViva.EditorCore;
 
 public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 {
-    private readonly Dictionary<IScript, EditableElseIf> m_elseIfScripts = new();
+    private readonly Dictionary<IScript, EditableElseIf> _elseIfScripts = new();
 
-    private readonly IIfScript m_ifScript;
-    private readonly EditableScripts m_thenScript;
-    private EditableScripts m_elseScript;
+    private readonly IIfScript _ifScript;
+    private readonly EditableScripts _thenScript;
+    private EditableScripts _elseScript;
 
     internal EditableIfScript(EditorController controller, IIfScript script, UndoLogger undoLogger)
         : base(controller, script, undoLogger)
     {
-        m_ifScript = script;
+        _ifScript = script;
 
-        m_ifScript.IfScriptUpdated += m_ifScript_IfScriptUpdated;
+        _ifScript.IfScriptUpdated += OnIfScriptUpdated;
 
-        if (m_ifScript.ThenScript == null)
+        if (_ifScript.ThenScript == null)
         {
-            m_ifScript.ThenScript = new MultiScript(Controller.WorldModel);
+            _ifScript.ThenScript = new MultiScript(Controller.WorldModel);
         }
 
-        m_thenScript = EditableScripts.GetInstance(Controller, m_ifScript.ThenScript);
-        m_thenScript.Updated += nestedScript_Updated;
+        _thenScript = EditableScripts.GetInstance(Controller, _ifScript.ThenScript);
+        _thenScript.Updated += nestedScript_Updated;
 
-        foreach (var elseIfScript in m_ifScript.ElseIfScripts)
+        foreach (var elseIfScript in _ifScript.ElseIfScripts)
         {
             var newEditableElseIf = new EditableElseIf(elseIfScript, this);
-            m_elseIfScripts.Add(elseIfScript.Script, newEditableElseIf);
+            _elseIfScripts.Add(elseIfScript.Script, newEditableElseIf);
             newEditableElseIf.EditableScripts.Updated += nestedScript_Updated;
         }
 
-        if (m_ifScript.ElseScript != null)
+        if (_ifScript.ElseScript != null)
         {
-            m_elseScript = EditableScripts.GetInstance(Controller, m_ifScript.ElseScript);
-            m_elseScript.Updated += nestedScript_Updated;
+            _elseScript = EditableScripts.GetInstance(Controller, _ifScript.ElseScript);
+            _elseScript.Updated += nestedScript_Updated;
         }
     }
 
-    public string IfExpression => m_ifScript.ExpressionString;
+    public string IfExpression => _ifScript.ExpressionString;
 
-    public IEditableScripts ThenScript => m_thenScript;
+    public IEditableScripts ThenScript => _thenScript;
 
-    public IEditableScripts ElseScript => m_elseScript;
+    public IEditableScripts ElseScript => _elseScript;
 
-    public IEnumerable<EditableElseIf> ElseIfScripts => m_elseIfScripts.Values;
+    public IEnumerable<EditableElseIf> ElseIfScripts => _elseIfScripts.Values;
 
     public override string DisplayString(int index, object newValue)
     {
@@ -91,7 +91,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
     {
         if (attribute == "expression")
         {
-            return m_ifScript.ExpressionString;
+            return _ifScript.ExpressionString;
         }
 
         throw new ArgumentOutOfRangeException("attribute", "Unrecognised 'if' attribute");
@@ -101,7 +101,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
     {
         if (attribute == "expression")
         {
-            m_ifScript.ExpressionString = (string) value;
+            _ifScript.ExpressionString = (string) value;
         }
         else
         {
@@ -134,13 +134,13 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
     public event EventHandler<ElseIfEventArgs> AddedElseIf;
     public event EventHandler<ElseIfEventArgs> RemovedElseIf;
 
-    private void m_ifScript_IfScriptUpdated(object sender, IfScriptUpdatedEventArgs e)
+    private void OnIfScriptUpdated(object sender, IfScriptUpdatedEventArgs e)
     {
         switch (e.EventType)
         {
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.AddedElse:
-                m_elseScript = EditableScripts.GetInstance(Controller, m_ifScript.ElseScript);
-                m_elseScript.Updated += nestedScript_Updated;
+                _elseScript = EditableScripts.GetInstance(Controller, _ifScript.ElseScript);
+                _elseScript.Updated += nestedScript_Updated;
                 if (AddedElse != null)
                 {
                     AddedElse(this, new EventArgs());
@@ -148,8 +148,8 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
                 break;
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.RemovedElse:
-                m_elseScript.Updated -= nestedScript_Updated;
-                m_elseScript = null;
+                _elseScript.Updated -= nestedScript_Updated;
+                _elseScript = null;
                 if (RemovedElse != null)
                 {
                     RemovedElse(this, new EventArgs());
@@ -162,7 +162,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
                 // Wrap the newly created elseif in an EditableElseIf and add it to our internal dictionary
                 var newEditableElseIf = new EditableElseIf(e.Data, this);
-                m_elseIfScripts.Add(e.Data.Script, newEditableElseIf);
+                _elseIfScripts.Add(e.Data.Script, newEditableElseIf);
 
                 // Raise the update to display in the UI
                 if (AddedElseIf != null)
@@ -175,10 +175,10 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
                 EditableScripts.GetInstance(Controller, e.Data.Script).Updated -= nestedScript_Updated;
                 if (RemovedElseIf != null)
                 {
-                    RemovedElseIf(this, new ElseIfEventArgs(m_elseIfScripts[e.Data.Script]));
+                    RemovedElseIf(this, new ElseIfEventArgs(_elseIfScripts[e.Data.Script]));
                 }
 
-                m_elseIfScripts.Remove(e.Data.Script);
+                _elseIfScripts.Remove(e.Data.Script);
                 break;
             default:
                 throw new Exception("Unhandled event");
@@ -199,7 +199,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
             ? ThenDisplayStringFragment(index, newValue)
             : ThenDisplayStringFragment(-1, string.Empty);
 
-        foreach (var elseIf in m_elseIfScripts.Values)
+        foreach (var elseIf in _elseIfScripts.Values)
         {
             result += modifiedSection == elseIf.EditableScripts
                 ? ElseIfDisplayStringFragment(elseIf, index, newValue)
@@ -238,23 +238,23 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
     public void AddElse()
     {
         IScript newScript = new MultiScript(Controller.WorldModel);
-        m_ifScript.SetElse(newScript);
+        _ifScript.SetElse(newScript);
     }
 
     public void AddElseIf()
     {
         IScript newScript = new MultiScript(Controller.WorldModel);
-        var newElseIf = m_ifScript.AddElseIf(string.Empty, newScript);
+        var newElseIf = _ifScript.AddElseIf(string.Empty, newScript);
     }
 
     public void RemoveElseIf(EditableElseIf removeElseIf)
     {
-        m_ifScript.RemoveElseIf(removeElseIf.ElseIfScript);
+        _ifScript.RemoveElseIf(removeElseIf.ElseIfScript);
     }
 
     public void RemoveElse()
     {
-        m_ifScript.SetElse(null);
+        _ifScript.SetElse(null);
     }
 
     public class ElseIfEventArgs : EventArgs
@@ -269,12 +269,12 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
     public class EditableElseIf : IEditorData
     {
-        private readonly EditableIfScript m_parent;
+        private readonly EditableIfScript _parent;
 
         internal EditableElseIf(IElseIfScript elseIfScript, EditableIfScript parent)
         {
             ElseIfScript = elseIfScript;
-            m_parent = parent;
+            _parent = parent;
             EditableScripts = EditorCore.EditableScripts.GetInstance(parent.Controller, elseIfScript.Script);
         }
 
@@ -340,7 +340,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
         public IEnumerable<string> GetVariablesInScope()
         {
-            return m_parent.GetVariablesInScope();
+            return _parent.GetVariablesInScope();
         }
 
         public bool IsDirectlySaveable => true;

--- a/src/EditorCore/EditableList.cs
+++ b/src/EditorCore/EditableList.cs
@@ -6,20 +6,20 @@ namespace QuestViva.EditorCore;
 
 public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollectionChanged
 {
-    private readonly EditorController m_controller;
+    private readonly EditorController _controller;
 
-    private readonly QuestList<T> m_source;
-    private readonly List<string> m_wrappedItemKeys = new();
-    private readonly Dictionary<string, IEditableListItem<T>> m_wrappedItems = new();
-    private readonly List<IEditableListItem<T>> m_wrappedItemsList = new();
-    private int m_nextId;
+    private readonly QuestList<T> _source;
+    private readonly List<string> _wrappedItemKeys = new();
+    private readonly Dictionary<string, IEditableListItem<T>> _wrappedItems = new();
+    private readonly List<IEditableListItem<T>> _wrappedItemsList = new();
+    private int _nextId;
 
     public EditableList(EditorController controller, QuestList<T> source)
     {
-        m_controller = controller;
-        m_source = source;
-        m_source.Added += m_source_Added;
-        m_source.Removed += m_source_Removed;
+        _controller = controller;
+        _source = source;
+        _source.Added += OnSourceAdded;
+        _source.Removed += OnSourceRemoved;
         PopulateWrappedItems();
     }
 
@@ -32,7 +32,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
 
     public object GetUnderlyingValue()
     {
-        return m_source;
+        return _source;
     }
 
     public string DisplayString()
@@ -43,7 +43,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
     public event EventHandler<EditableListUpdatedEventArgs<T>> Added;
     public event EventHandler<EditableListUpdatedEventArgs<T>> Removed;
 
-    public IDictionary<string, IEditableListItem<T>> Items => m_wrappedItems;
+    public IDictionary<string, IEditableListItem<T>> Items => _wrappedItems;
 
     public void Add(T item)
     {
@@ -58,9 +58,9 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
             throw new InvalidOperationException("Unknown list type");
         }
 
-        m_controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
+        _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
         AddInternal(item);
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.EndTransaction();
     }
 
     public void Remove(params string[] keys)
@@ -76,14 +76,14 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
             throw new InvalidOperationException("Unknown list type");
         }
 
-        m_controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
+        _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
 
         foreach (var key in keys)
         {
-            m_source.RemoveByIndex(m_wrappedItemKeys.IndexOf(key), UpdateSource.User);
+            _source.RemoveByIndex(_wrappedItemKeys.IndexOf(key), UpdateSource.User);
         }
 
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.EndTransaction();
     }
 
     public void Update(int index, T item)
@@ -99,15 +99,15 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
             throw new InvalidOperationException("Unknown list type");
         }
 
-        m_controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
-        m_source.Remove(m_source[index], UpdateSource.User, index);
-        m_source.Add(item, UpdateSource.User, index);
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
+        _source.Remove(_source[index], UpdateSource.User, index);
+        _source.Add(item, UpdateSource.User, index);
+        _controller.WorldModel.UndoLogger.EndTransaction();
     }
 
     public void Update(string key, T item)
     {
-        Update(m_wrappedItemKeys.IndexOf(key), item);
+        Update(_wrappedItemKeys.IndexOf(key), item);
     }
 
     public IEnumerable<KeyValuePair<string, string>> DisplayItems
@@ -116,7 +116,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         {
             var result = new Dictionary<string, string>();
 
-            foreach (var item in m_wrappedItems)
+            foreach (var item in _wrappedItems)
             {
                 // TO DO: We will need some kind of projection function for non-string T's
                 result.Add(item.Key, item.Value.Value as string);
@@ -130,7 +130,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
     {
         // Commented this section out as it is valid to have the same item multiple times in a list,
         // for example for walkthroughs.
-        //if (m_source.Contains(item))
+        //if (_source.Contains(item))
         //{
         //    return new ValidationResult { Valid = false, Message = ValidationMessage.ItemAlreadyExists };
         //}
@@ -138,46 +138,46 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         return new ValidationResult {Valid = true};
     }
 
-    public bool Locked => m_source.Locked;
+    public bool Locked => _source.Locked;
 
     public IEditableList<T> Clone(string parent, string attribute)
     {
         IEditableList<T> result;
-        m_controller.WorldModel.UndoLogger.StartTransaction(string.Format("Copy '{0}' {1}", parent, attribute));
-        result = CloneInternal(m_controller.WorldModel.Elements.Get(parent), attribute);
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.StartTransaction(string.Format("Copy '{0}' {1}", parent, attribute));
+        result = CloneInternal(_controller.WorldModel.Elements.Get(parent), attribute);
+        _controller.WorldModel.UndoLogger.EndTransaction();
         return result;
     }
 
     public IEnumerator GetEnumerator()
     {
-        return m_wrappedItemsList.GetEnumerator();
+        return _wrappedItemsList.GetEnumerator();
     }
 
     public string Owner
     {
         get
         {
-            if (m_source.Owner == null)
+            if (_source.Owner == null)
             {
                 return null;
             }
 
-            return m_source.Owner.Name;
+            return _source.Owner.Name;
         }
     }
 
-    public IEnumerable<IEditableListItem<T>> ItemsList => m_wrappedItemsList;
+    public IEnumerable<IEditableListItem<T>> ItemsList => _wrappedItemsList;
     public event NotifyCollectionChangedEventHandler CollectionChanged;
 
     private void PopulateWrappedItems()
     {
-        m_wrappedItems.Clear();
-        m_wrappedItemsList.Clear();
-        m_wrappedItemKeys.Clear();
+        _wrappedItems.Clear();
+        _wrappedItemsList.Clear();
+        _wrappedItemKeys.Clear();
         var index = 0;
 
-        foreach (var item in m_source)
+        foreach (var item in _source)
         {
             AddWrappedItem(item, EditorUpdateSource.System, index);
             index++;
@@ -186,16 +186,16 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
 
     internal void AddInternal(T item)
     {
-        m_source.Add(item, UpdateSource.User);
+        _source.Add(item, UpdateSource.User);
     }
 
     private void AddWrappedItem(T item, EditorUpdateSource source, int index)
     {
         var key = GetUniqueId();
         IEditableListItem<T> wrappedValue = new EditableListItem<T>(key, item);
-        m_wrappedItems.Add(key, wrappedValue);
-        m_wrappedItemsList.Insert(index, wrappedValue);
-        m_wrappedItemKeys.Insert(index, key);
+        _wrappedItems.Add(key, wrappedValue);
+        _wrappedItemsList.Insert(index, wrappedValue);
+        _wrappedItemKeys.Insert(index, key);
 
         if (Added != null)
         {
@@ -212,15 +212,15 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
 
     private string GetUniqueId()
     {
-        m_nextId++;
-        return "k" + m_nextId;
+        _nextId++;
+        return "k" + _nextId;
     }
 
     private void RemoveWrappedItem(IEditableListItem<T> item, EditorUpdateSource source, int index)
     {
-        m_wrappedItems.Remove(item.Key);
-        m_wrappedItemsList.Remove(item);
-        m_wrappedItemKeys.Remove(item.Key);
+        _wrappedItems.Remove(item.Key);
+        _wrappedItemsList.Remove(item);
+        _wrappedItemKeys.Remove(item.Key);
         if (Removed != null)
         {
             Removed(this, new EditableListUpdatedEventArgs<T> {UpdatedItem = item, Index = index, Source = source});
@@ -233,37 +233,37 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         }
     }
 
-    private void m_source_Added(object sender, QuestListUpdatedEventArgs<T> e)
+    private void OnSourceAdded(object sender, QuestListUpdatedEventArgs<T> e)
     {
         AddWrappedItem(e.UpdatedItem, (EditorUpdateSource) e.Source, e.Index);
     }
 
-    private void m_source_Removed(object sender, QuestListUpdatedEventArgs<T> e)
+    private void OnSourceRemoved(object sender, QuestListUpdatedEventArgs<T> e)
     {
-        RemoveWrappedItem(m_wrappedItems[m_wrappedItemKeys[e.Index]], (EditorUpdateSource) e.Source, e.Index);
+        RemoveWrappedItem(_wrappedItems[_wrappedItemKeys[e.Index]], (EditorUpdateSource) e.Source, e.Index);
     }
 
     private IEditableList<T> CloneInternal(Element parent, string attribute)
     {
-        var newSource = (QuestList<T>) m_source.Clone();
+        var newSource = (QuestList<T>) _source.Clone();
         newSource.Locked = false;
         parent.Fields.Set(attribute, newSource);
         newSource = (QuestList<T>) parent.Fields.Get(attribute);
-        return GetNewInstance(m_controller, newSource);
+        return GetNewInstance(_controller, newSource);
     }
 
     #region Static DataWrapper
 
-    private static readonly EditableDataWrapper<QuestList<T>, EditableList<T>> s_wrapper;
+    private static readonly EditableDataWrapper<QuestList<T>, EditableList<T>> Wrapper;
 
     static EditableList()
     {
-        s_wrapper = new EditableDataWrapper<QuestList<T>, EditableList<T>>(GetNewInstance);
+        Wrapper = new EditableDataWrapper<QuestList<T>, EditableList<T>>(GetNewInstance);
     }
 
     public static EditableList<T> GetInstance(EditorController controller, QuestList<T> list)
     {
-        return s_wrapper.GetInstance(controller, list);
+        return Wrapper.GetInstance(controller, list);
     }
 
     private static EditableList<T> GetNewInstance(EditorController controller, QuestList<T> list)
@@ -273,7 +273,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
 
     public static void Clear()
     {
-        s_wrapper.Clear();
+        Wrapper.Clear();
     }
 
     #endregion

--- a/src/EditorCore/EditableObjectReference.cs
+++ b/src/EditorCore/EditableObjectReference.cs
@@ -4,17 +4,17 @@ namespace QuestViva.EditorCore;
 
 public class EditableObjectReference : IEditableObjectReference
 {
-    private readonly string m_attribute;
-    private readonly EditorController m_controller;
-    private readonly Element m_parent;
-    private Element m_object;
+    private readonly string _attribute;
+    private readonly EditorController _controller;
+    private readonly Element _parent;
+    private Element _object;
 
     public EditableObjectReference(EditorController controller, Element obj, Element parent, string attribute)
     {
-        m_object = obj;
-        m_controller = controller;
-        m_parent = parent;
-        m_attribute = attribute;
+        _object = obj;
+        _controller = controller;
+        _parent = parent;
+        _attribute = attribute;
     }
 
     public event EventHandler<DataWrapperUpdatedEventArgs> UnderlyingValueUpdated
@@ -25,21 +25,21 @@ public class EditableObjectReference : IEditableObjectReference
 
     public object GetUnderlyingValue()
     {
-        return m_object;
+        return _object;
     }
 
     public string DisplayString()
     {
-        return "Object: " + m_object.Name;
+        return "Object: " + _object.Name;
     }
 
     public string Reference
     {
-        get => m_object.Name;
+        get => _object.Name;
         set
         {
-            m_object = string.IsNullOrEmpty(value) ? null : m_controller.WorldModel.Elements.Get(value);
-            m_parent.Fields.Set(m_attribute, m_object);
+            _object = string.IsNullOrEmpty(value) ? null : _controller.WorldModel.Elements.Get(value);
+            _parent.Fields.Set(_attribute, _object);
         }
     }
 }

--- a/src/EditorCore/EditableScript.cs
+++ b/src/EditorCore/EditableScript.cs
@@ -8,14 +8,14 @@ namespace QuestViva.EditorCore;
 
 public class EditableScript : EditableScriptBase, IEditableScript
 {
-    private static readonly Regex s_regex = new("#(?<attribute>\\d+)");
-    private readonly List<EditableScripts> m_watchedNestedScripts = new();
-    private string m_editorName;
+    private static readonly Regex AttributeRegex = new("#(?<attribute>\\d+)");
+    private readonly List<EditableScripts> _watchedNestedScripts = new();
+    private string _editorName;
 
     internal EditableScript(EditorController controller, IScript script, UndoLogger undoLogger)
         : base(controller, script, undoLogger)
     {
-        m_editorName = Script.Keyword;
+        _editorName = Script.Keyword;
     }
 
     internal string DisplayTemplate { get; set; }
@@ -33,9 +33,9 @@ public class EditableScript : EditableScriptBase, IEditableScript
         var result = DisplayTemplate;
         var startAt = 1;
 
-        while (startAt < result.Length && s_regex.IsMatch(result, startAt))
+        while (startAt < result.Length && AttributeRegex.IsMatch(result, startAt))
         {
-            var m = s_regex.Match(result);
+            var m = AttributeRegex.Match(result);
             var attributeNum = int.Parse(m.Groups["attribute"].Value);
             string attributeValue;
 
@@ -82,7 +82,7 @@ public class EditableScript : EditableScriptBase, IEditableScript
                 attributeValue = "<unknown>";
             }
 
-            result = s_regex.Replace(result, attributeValue, 1, startAt);
+            result = AttributeRegex.Replace(result, attributeValue, 1, startAt);
             startAt = m.Groups["attribute"].Index + attributeValue.Length;
         }
 
@@ -91,8 +91,8 @@ public class EditableScript : EditableScriptBase, IEditableScript
 
     public override string EditorName
     {
-        get => m_editorName;
-        set => m_editorName = value;
+        get => _editorName;
+        set => _editorName = value;
     }
 
     public override object GetParameter(string index)
@@ -139,10 +139,10 @@ public class EditableScript : EditableScriptBase, IEditableScript
 
     private void RegisterNestedScriptForUpdates(EditableScripts script)
     {
-        if (!m_watchedNestedScripts.Contains(script))
+        if (!_watchedNestedScripts.Contains(script))
         {
             script.Updated += nestedScript_Updated;
-            m_watchedNestedScripts.Add(script);
+            _watchedNestedScripts.Add(script);
         }
     }
 

--- a/src/EditorCore/EditableScriptBase.cs
+++ b/src/EditorCore/EditableScriptBase.cs
@@ -5,9 +5,9 @@ namespace QuestViva.EditorCore;
 
 public abstract class EditableScriptBase : IEditableScript
 {
-    private static int s_count;
+    private static int _count;
 
-    private IScript m_script;
+    private IScript _script;
 
     public EditableScriptBase(EditorController controller, IScript script, UndoLogger undoLogger)
     {
@@ -18,28 +18,28 @@ public abstract class EditableScriptBase : IEditableScript
             script.UndoLog = undoLogger;
         }
 
-        s_count++;
-        Id = "script" + s_count;
+        _count++;
+        Id = "script" + _count;
     }
 
     internal IScript Script
     {
-        get => m_script;
+        get => _script;
         set
         {
-            if (m_script != null)
+            if (_script != null)
             {
-                m_script.ScriptUpdated -= ScriptUpdated;
+                _script.ScriptUpdated -= ScriptUpdated;
                 if (FunctionCallScript != null)
                 {
                     FunctionCallScript.FunctionCallParametersUpdated -= FunctionCallParametersUpdated;
                 }
             }
 
-            m_script = value;
-            if (m_script != null)
+            _script = value;
+            if (_script != null)
             {
-                m_script.ScriptUpdated += ScriptUpdated;
+                _script.ScriptUpdated += ScriptUpdated;
                 if (FunctionCallScript != null)
                 {
                     FunctionCallScript.FunctionCallParametersUpdated += FunctionCallParametersUpdated;
@@ -48,7 +48,7 @@ public abstract class EditableScriptBase : IEditableScript
         }
     }
 
-    internal IFunctionCallScript FunctionCallScript => m_script as IFunctionCallScript;
+    internal IFunctionCallScript FunctionCallScript => _script as IFunctionCallScript;
 
     protected EditorController Controller { get; }
 

--- a/src/EditorCore/EditableScriptFactory.cs
+++ b/src/EditorCore/EditableScriptFactory.cs
@@ -6,7 +6,7 @@ namespace QuestViva.EditorCore;
 
 public class EditableScriptData
 {
-    private readonly Expression<bool> m_visibilityExpression;
+    private readonly Expression<bool> _visibilityExpression;
 
     public EditableScriptData(Element editor, WorldModel worldModel, int order)
     {
@@ -20,7 +20,7 @@ public class EditableScriptData
         var expression = editor.Fields.GetString("onlydisplayif");
         if (expression != null)
         {
-            m_visibilityExpression = new Expression<bool>(Engine.Utility.EncodeIdentifierSpaces(expression),
+            _visibilityExpression = new Expression<bool>(Engine.Utility.EncodeIdentifierSpaces(expression),
                 new ScriptContext(worldModel, true));
         }
     }
@@ -35,22 +35,22 @@ public class EditableScriptData
 
     public async Task<bool> IsVisible()
     {
-        return m_visibilityExpression == null || await m_visibilityExpression.ExecuteAsync(new Context());
+        return _visibilityExpression == null || await _visibilityExpression.ExecuteAsync(new Context());
     }
 }
 
 internal class EditableScriptFactory
 {
-    private readonly Dictionary<IScript, EditableScriptBase> m_cache = new();
-    private readonly EditorController m_controller;
-    private readonly ScriptFactory m_scriptFactory;
-    private readonly WorldModel m_worldModel;
+    private readonly Dictionary<IScript, EditableScriptBase> _cache = new();
+    private readonly EditorController _controller;
+    private readonly ScriptFactory _scriptFactory;
+    private readonly WorldModel _worldModel;
 
     internal EditableScriptFactory(EditorController controller, ScriptFactory factory, WorldModel worldModel)
     {
-        m_controller = controller;
-        m_scriptFactory = factory;
-        m_worldModel = worldModel;
+        _controller = controller;
+        _scriptFactory = factory;
+        _worldModel = worldModel;
 
         var order = 0;
         foreach (var editor in worldModel.Elements.GetElements(ElementType.Editor).Where(IsScriptEditor))
@@ -69,7 +69,7 @@ internal class EditableScriptFactory
 
     internal EditableScriptBase CreateEditableScript(string keyword)
     {
-        var script = m_scriptFactory.CreateSimpleScript(keyword);
+        var script = _scriptFactory.CreateSimpleScript(keyword);
         return CreateEditableScript(script);
     }
 
@@ -77,18 +77,18 @@ internal class EditableScriptFactory
     {
         EditableScriptBase newScript;
 
-        if (m_cache.TryGetValue(script, out newScript))
+        if (_cache.TryGetValue(script, out newScript))
         {
             return newScript;
         }
 
         if (script.Keyword == "if")
         {
-            newScript = new EditableIfScript(m_controller, (IIfScript) script, m_worldModel.UndoLogger);
+            newScript = new EditableIfScript(_controller, (IIfScript) script, _worldModel.UndoLogger);
         }
         else
         {
-            var newEditableScript = new EditableScript(m_controller, script, m_worldModel.UndoLogger);
+            var newEditableScript = new EditableScript(_controller, script, _worldModel.UndoLogger);
             if (ScriptData.ContainsKey(script.Keyword))
             {
                 newEditableScript.DisplayTemplate = ScriptData[script.Keyword].DisplayString;
@@ -97,13 +97,13 @@ internal class EditableScriptFactory
             newScript = newEditableScript;
         }
 
-        m_cache.Add(script, newScript);
+        _cache.Add(script, newScript);
         return newScript;
     }
 
     internal EditableScriptBase CreateEditableFunctionCallScript()
     {
-        var script = m_scriptFactory.CreateBlankFunctionCallScript();
+        var script = _scriptFactory.CreateBlankFunctionCallScript();
         return CreateEditableScript(script);
     }
 
@@ -134,6 +134,6 @@ internal class EditableScriptFactory
 
     internal IScript Clone(IScript script)
     {
-        return m_scriptFactory.CreateSimpleScript(script.Save());
+        return _scriptFactory.CreateSimpleScript(script.Save());
     }
 }

--- a/src/EditorCore/EditableScripts.cs
+++ b/src/EditorCore/EditableScripts.cs
@@ -6,22 +6,22 @@ namespace QuestViva.EditorCore;
 
 public class EditableScripts : IEditableScripts, IDataWrapper
 {
-    private static readonly EditableDataWrapper<IScript, EditableScripts> s_wrapper;
-    private readonly EditorController m_controller;
+    private static readonly EditableDataWrapper<IScript, EditableScripts> Wrapper;
+    private readonly EditorController _controller;
 
-    private readonly List<IEditableScript> m_scripts;
-    private bool m_replacingScripts;
-    private IMultiScript m_underlyingScript;
+    private readonly List<IEditableScript> _scripts;
+    private bool _replacingScripts;
+    private IMultiScript _underlyingScript;
 
     static EditableScripts()
     {
-        s_wrapper = new EditableDataWrapper<IScript, EditableScripts>(GetNewInstance);
+        Wrapper = new EditableDataWrapper<IScript, EditableScripts>(GetNewInstance);
     }
 
     private EditableScripts(EditorController controller)
     {
-        m_controller = controller;
-        m_scripts = new List<IEditableScript>();
+        _controller = controller;
+        _scripts = new List<IEditableScript>();
     }
 
     private EditableScripts(EditorController controller, IScript script)
@@ -37,8 +37,8 @@ public class EditableScripts : IEditableScripts, IDataWrapper
 
     public object GetUnderlyingValue()
     {
-        Debug.Assert(m_underlyingScript.Scripts.Count() == m_scripts.Count);
-        return m_underlyingScript;
+        Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
+        return _underlyingScript;
     }
 
     #endregion
@@ -50,11 +50,11 @@ public class EditableScripts : IEditableScripts, IDataWrapper
 
     public string DisplayString(int index, string newValue)
     {
-        Debug.Assert(m_underlyingScript.Scripts.Count() == m_scripts.Count);
+        Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
 
         var count = 0;
         var result = new StringBuilder();
-        foreach (var script in m_scripts)
+        foreach (var script in _scripts)
         {
             if (result.Length > 0)
             {
@@ -78,7 +78,7 @@ public class EditableScripts : IEditableScripts, IDataWrapper
 
     public void Swap(int index1, int index2)
     {
-        m_underlyingScript.Swap(index1, index2);
+        _underlyingScript.Swap(index1, index2);
     }
 
     public void Cut(int[] indexes)
@@ -92,38 +92,38 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         var scripts = new List<IScript>();
         foreach (var index in indexes)
         {
-            scripts.Add(m_underlyingScript.Scripts.ElementAt(index));
+            scripts.Add(_underlyingScript.Scripts.ElementAt(index));
         }
 
-        m_controller.SetClipboardScript(scripts);
+        _controller.SetClipboardScript(scripts);
     }
 
     public void Paste(int index, bool useTransaction)
     {
         if (useTransaction)
         {
-            m_controller.StartTransaction("Paste script");
+            _controller.StartTransaction("Paste script");
         }
 
-        foreach (var script in m_controller.GetClipboardScript())
+        foreach (var script in _controller.GetClipboardScript())
         {
-            m_underlyingScript.Insert(index, m_controller.ScriptFactory.Clone(script));
+            _underlyingScript.Insert(index, _controller.ScriptFactory.Clone(script));
             index++;
         }
 
         if (useTransaction)
         {
-            m_controller.EndTransaction();
+            _controller.EndTransaction();
         }
     }
 
     public IEditableScripts Clone(string parent, string attribute)
     {
-        var clonedScript = (IScript) m_underlyingScript.Clone();
-        var parentElement = m_controller.WorldModel.Elements.Get(parent);
+        var clonedScript = (IScript) _underlyingScript.Clone();
+        var parentElement = _controller.WorldModel.Elements.Get(parent);
         parentElement.Fields.Set(attribute, clonedScript);
         clonedScript = (IScript) parentElement.Fields.Get(attribute);
-        var result = new EditableScripts(m_controller, clonedScript);
+        var result = new EditableScripts(_controller, clonedScript);
 
         return result;
     }
@@ -132,17 +132,17 @@ public class EditableScripts : IEditableScripts, IDataWrapper
     {
         get
         {
-            if (m_underlyingScript == null)
+            if (_underlyingScript == null)
             {
                 return null;
             }
 
-            if (m_underlyingScript.Owner == null)
+            if (_underlyingScript.Owner == null)
             {
                 return null;
             }
 
-            return m_underlyingScript.Owner.Name;
+            return _underlyingScript.Owner.Name;
         }
     }
 
@@ -150,12 +150,12 @@ public class EditableScripts : IEditableScripts, IDataWrapper
     {
         get
         {
-            if (m_underlyingScript == null)
+            if (_underlyingScript == null)
             {
                 return string.Empty;
             }
 
-            var result = Engine.Utility.IndentScript(m_underlyingScript.Save(), 0, "  ");
+            var result = Engine.Utility.IndentScript(_underlyingScript.Save(), 0, "  ");
             if (result.StartsWith(Environment.NewLine))
             {
                 result = result.Substring(Environment.NewLine.Length);
@@ -170,17 +170,17 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         }
         set
         {
-            m_controller.StartTransaction("Editing script in code view");
-            m_underlyingScript.LoadCode(value);
+            _controller.StartTransaction("Editing script in code view");
+            _underlyingScript.LoadCode(value);
             ClearScripts();
-            InitialiseScript(m_underlyingScript);
-            m_controller.EndTransaction();
+            InitialiseScript(_underlyingScript);
+            _controller.EndTransaction();
         }
     }
 
     public static EditableScripts GetInstance(EditorController controller, IScript script)
     {
-        return s_wrapper.GetInstance(controller, script);
+        return Wrapper.GetInstance(controller, script);
     }
 
     private static EditableScripts GetNewInstance(EditorController controller, IScript script)
@@ -190,41 +190,41 @@ public class EditableScripts : IEditableScripts, IDataWrapper
 
     public static void Clear()
     {
-        s_wrapper.Clear();
+        Wrapper.Clear();
     }
 
     private void InitialiseScript(IScript script)
     {
         InitialiseMultiScript((IMultiScript) script);
 
-        foreach (var scriptItem in m_underlyingScript.Scripts)
+        foreach (var scriptItem in _underlyingScript.Scripts)
         {
-            m_scripts.Add(m_controller.ScriptFactory.CreateEditableScript(scriptItem));
+            _scripts.Add(_controller.ScriptFactory.CreateEditableScript(scriptItem));
         }
 
-        foreach (var editableScript in m_scripts)
+        foreach (var editableScript in _scripts)
         {
             editableScript.Updated += script_Updated;
         }
 
-        Debug.Assert(m_underlyingScript.Scripts.Count() == m_scripts.Count);
+        Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
     }
 
     private void InitialiseMultiScript(IMultiScript script)
     {
-        if (m_underlyingScript != null)
+        if (_underlyingScript != null)
         {
-            m_underlyingScript.ScriptUpdated -= multiScript_ScriptUpdated;
+            _underlyingScript.ScriptUpdated -= multiScript_ScriptUpdated;
         }
 
-        m_underlyingScript = script;
-        m_underlyingScript.ScriptUpdated += multiScript_ScriptUpdated;
-        m_underlyingScript.UndoLog = m_controller.WorldModel.UndoLogger;
+        _underlyingScript = script;
+        _underlyingScript.ScriptUpdated += multiScript_ScriptUpdated;
+        _underlyingScript.UndoLog = _controller.WorldModel.UndoLogger;
     }
 
     private void multiScript_ScriptUpdated(object sender, ScriptUpdatedEventArgs e)
     {
-        if (m_adding)
+        if (_adding)
         {
             return;
         }
@@ -233,36 +233,36 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         // to remove it from this wrapper too.
         if (e.RemovedScript != null)
         {
-            foreach (var es in m_scripts.ToArray())
+            foreach (var es in _scripts.ToArray())
             {
                 var s = (EditableScriptBase) es;
                 if (s.Script == e.RemovedScript)
                 {
-                    m_scripts.Remove(es);
+                    _scripts.Remove(es);
                 }
             }
         }
 
         if (e.AddedScript != null)
         {
-            Add(m_controller.ScriptFactory.CreateEditableScript(e.AddedScript), true);
+            Add(_controller.ScriptFactory.CreateEditableScript(e.AddedScript), true);
         }
 
         if (e.InsertedScript != null)
         {
-            Add(m_controller.ScriptFactory.CreateEditableScript(e.InsertedScript), e.Index, true);
+            Add(_controller.ScriptFactory.CreateEditableScript(e.InsertedScript), e.Index, true);
         }
 
         if (e.ScriptsReplaced)
         {
-            m_replacingScripts = true;
-            m_scripts.Clear();
+            _replacingScripts = true;
+            _scripts.Clear();
             foreach (var script in ((MultiScript) sender).Scripts)
             {
-                Add(m_controller.ScriptFactory.CreateEditableScript(script), true);
+                Add(_controller.ScriptFactory.CreateEditableScript(script), true);
             }
 
-            m_replacingScripts = false;
+            _replacingScripts = false;
         }
 
         if (Updated != null)
@@ -275,7 +275,7 @@ public class EditableScripts : IEditableScripts, IDataWrapper
             UnderlyingValueUpdated(this, new DataWrapperUpdatedEventArgs());
         }
 
-        Debug.Assert(m_underlyingScript.Scripts.Count() == m_scripts.Count);
+        Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
     }
 
     private void script_Updated(object sender, EditableScriptUpdatedEventArgs e)
@@ -290,22 +290,22 @@ public class EditableScripts : IEditableScripts, IDataWrapper
             UnderlyingValueUpdated(this, new DataWrapperUpdatedEventArgs());
         }
 
-        Debug.Assert(m_underlyingScript.Scripts.Count() == m_scripts.Count);
+        Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
     }
 
     private void ClearScripts()
     {
-        foreach (var script in m_scripts)
+        foreach (var script in _scripts)
         {
             script.Updated -= script_Updated;
         }
 
-        m_scripts.Clear();
+        _scripts.Clear();
     }
 
     #region IEditableScripts Members
 
-    public IEnumerable<IEditableScript> Scripts => m_scripts.AsReadOnly();
+    public IEnumerable<IEditableScript> Scripts => _scripts.AsReadOnly();
 
     private void Add(EditableScriptBase script, bool fromUpdate)
     {
@@ -317,16 +317,16 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         script.Updated += script_Updated;
         if (index.HasValue)
         {
-            m_scripts.Insert(index.Value, script);
+            _scripts.Insert(index.Value, script);
         }
         else
         {
-            m_scripts.Add(script);
+            _scripts.Add(script);
         }
 
-        if (m_underlyingScript == null)
+        if (_underlyingScript == null)
         {
-            InitialiseMultiScript(new MultiScript(m_controller.WorldModel));
+            InitialiseMultiScript(new MultiScript(_controller.WorldModel));
         }
 
         if (!fromUpdate)
@@ -336,25 +336,25 @@ public class EditableScripts : IEditableScripts, IDataWrapper
             // to a multiscript update in the first place so no point adding the same
             // script again!
 
-            m_adding = true;
-            m_underlyingScript.Add(script.Script);
-            m_adding = false;
+            _adding = true;
+            _underlyingScript.Add(script.Script);
+            _adding = false;
         }
 
-        Debug.Assert(m_replacingScripts || m_underlyingScript.Scripts.Count() == m_scripts.Count);
+        Debug.Assert(_replacingScripts || _underlyingScript.Scripts.Count() == _scripts.Count);
     }
 
     // TO DO: This is a temporary hacky flag to prevent re-entrant updates. What we should be doing instead is
-    // never adding to our own wrapped m_scripts collection unless we receive an update from the underlying
+    // never adding to our own wrapped _scripts collection unless we receive an update from the underlying
     // MultiScript.
-    private bool m_adding;
+    private bool _adding;
 
     public void AddNew(string keyword, string elementName)
     {
-        m_controller.WorldModel.UndoLogger.StartTransaction(string.Format("Add '{0}' script to '{1}'", keyword,
+        _controller.WorldModel.UndoLogger.StartTransaction(string.Format("Add '{0}' script to '{1}'", keyword,
             elementName));
         AddNewInternal(keyword);
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.EndTransaction();
     }
 
     internal void AddNewInternal(string keyword)
@@ -362,25 +362,25 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         EditableScriptBase script;
         if (!string.IsNullOrEmpty(keyword))
         {
-            script = m_controller.ScriptFactory.CreateEditableScript(keyword);
+            script = _controller.ScriptFactory.CreateEditableScript(keyword);
         }
         else
         {
-            script = m_controller.ScriptFactory.CreateEditableFunctionCallScript();
+            script = _controller.ScriptFactory.CreateEditableFunctionCallScript();
         }
 
         Add(script, false);
     }
 
-    public IEditableScript this[int index] => m_scripts[index];
+    public IEditableScript this[int index] => _scripts[index];
 
     public void Remove(int[] indexes)
     {
         var desc = indexes.Length == 0
-            ? string.Format("Remove '{0}' script", m_scripts[indexes[0]].DisplayString())
+            ? string.Format("Remove '{0}' script", _scripts[indexes[0]].DisplayString())
             : string.Format("Remove {0} scripts", indexes.Length);
 
-        m_controller.WorldModel.UndoLogger.StartTransaction(desc);
+        _controller.WorldModel.UndoLogger.StartTransaction(desc);
 
         var indexesDescending = from index in indexes
             orderby index descending
@@ -388,16 +388,16 @@ public class EditableScripts : IEditableScripts, IDataWrapper
 
         foreach (var index in indexesDescending)
         {
-            m_scripts.Remove(m_scripts[index]);
-            m_underlyingScript.Remove(index);
+            _scripts.Remove(_scripts[index]);
+            _underlyingScript.Remove(index);
         }
 
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.EndTransaction();
 
-        Debug.Assert(m_underlyingScript.Scripts.Count() == m_scripts.Count);
+        Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
     }
 
-    public int Count => m_scripts.Count;
+    public int Count => _scripts.Count;
 
     #endregion
 }

--- a/src/EditorCore/EditableWrappedItemDictionary.cs
+++ b/src/EditorCore/EditableWrappedItemDictionary.cs
@@ -10,22 +10,22 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
     where TWrapped : IDataWrapper
     where TSource : class
 {
-    private static int s_count;
-    private readonly EditorController m_controller;
+    private static int _count;
+    private readonly EditorController _controller;
 
-    private readonly QuestDictionary<TSource> m_source;
-    private readonly Dictionary<string, IEditableListItem<TWrapped>> m_wrappedItems = new();
-    private readonly Dictionary<TWrapped, IEditableListItem<TWrapped>> m_wrappedItemsLookup = new();
+    private readonly QuestDictionary<TSource> _source;
+    private readonly Dictionary<string, IEditableListItem<TWrapped>> _wrappedItems = new();
+    private readonly Dictionary<TWrapped, IEditableListItem<TWrapped>> _wrappedItemsLookup = new();
 
     public EditableWrappedItemDictionary(EditorController controller, QuestDictionary<TSource> source)
     {
-        s_count++;
-        Id = "wrapdictionary" + s_count;
+        _count++;
+        Id = "wrapdictionary" + _count;
 
-        m_controller = controller;
-        m_source = source;
-        m_source.Added += m_source_Added;
-        m_source.Removed += m_source_Removed;
+        _controller = controller;
+        _source = source;
+        _source.Added += OnSourceAdded;
+        _source.Removed += OnSourceRemoved;
         PopulateWrappedItems();
     }
 
@@ -38,12 +38,12 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     public object GetUnderlyingValue()
     {
-        return m_source;
+        return _source;
     }
 
     public string DisplayString()
     {
-        return string.Format("(Script Dictionary: {0} items)", m_source.Count);
+        return string.Format("(Script Dictionary: {0} items)", _source.Count);
     }
 
     public event EventHandler<EditableListUpdatedEventArgs<TWrapped>> Added;
@@ -51,7 +51,7 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     public event EventHandler<EditableListUpdatedEventArgs<TWrapped>> Updated;
 
-    public IDictionary<string, IEditableListItem<TWrapped>> Items => m_wrappedItems;
+    public IDictionary<string, IEditableListItem<TWrapped>> Items => _wrappedItems;
 
     public IEnumerable<KeyValuePair<string, string>> DisplayItems
     {
@@ -59,7 +59,7 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         {
             var result = new Dictionary<string, string>();
 
-            foreach (var item in m_wrappedItems)
+            foreach (var item in _wrappedItems)
             {
                 result.Add(item.Key, item.Value.Value.DisplayString());
             }
@@ -75,9 +75,9 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         string undoEntry = null;
         undoEntry = string.Format("Add '{0}={1}'", key, value == null ? string.Empty : value.DisplayString());
 
-        m_controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
-        m_source.Add(key, UnwrapValue(value), UpdateSource.User);
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
+        _source.Add(key, UnwrapValue(value), UpdateSource.User);
+        _controller.WorldModel.UndoLogger.EndTransaction();
     }
 
     public void Remove(params string[] keys)
@@ -85,18 +85,18 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         string undoEntry = null;
         undoEntry = string.Format("Remove '{0}'", string.Join(",", keys));
 
-        m_controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
+        _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
         foreach (var key in keys)
         {
-            m_source.Remove(key, UpdateSource.User);
+            _source.Remove(key, UpdateSource.User);
         }
 
-        m_controller.WorldModel.UndoLogger.EndTransaction();
+        _controller.WorldModel.UndoLogger.EndTransaction();
     }
 
     public ValidationResult CanAdd(string key)
     {
-        if (m_source.ContainsKey(key))
+        if (_source.ContainsKey(key))
         {
             return new ValidationResult {Valid = false, Message = ValidationMessage.ItemAlreadyExists};
         }
@@ -104,13 +104,13 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         return new ValidationResult {Valid = true};
     }
 
-    public TWrapped this[string key] => WrapValue(m_source[key]);
+    public TWrapped this[string key] => WrapValue(_source[key]);
 
     public void Update(string key, TWrapped value)
     {
-        var index = m_source.IndexOfKey(key);
-        m_source.Remove(key, UpdateSource.User);
-        m_source.Add(key, UnwrapValue(value), UpdateSource.User, index);
+        var index = _source.IndexOfKey(key);
+        _source.Remove(key, UpdateSource.User);
+        _source.Add(key, UnwrapValue(value), UpdateSource.User, index);
     }
 
     // it is up to the caller of this method to start/end a transaction (this should also be the case eventually
@@ -118,15 +118,15 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     public void ChangeKey(string oldKey, string newKey)
     {
-        //m_controller.WorldModel.UndoLogger.StartTransaction(string.Format("Update key '{0}' to '{1}'", oldKey, newKey));
-        var index = m_source.IndexOfKey(oldKey);
-        var value = m_source[oldKey];
-        m_source.Remove(oldKey, UpdateSource.User);
-        m_source.Add(newKey, value, UpdateSource.User, index);
-        //m_controller.WorldModel.UndoLogger.EndTransaction();
+        //_controller.WorldModel.UndoLogger.StartTransaction(string.Format("Update key '{0}' to '{1}'", oldKey, newKey));
+        var index = _source.IndexOfKey(oldKey);
+        var value = _source[oldKey];
+        _source.Remove(oldKey, UpdateSource.User);
+        _source.Add(newKey, value, UpdateSource.User, index);
+        //_controller.WorldModel.UndoLogger.EndTransaction();
     }
 
-    public bool Locked => m_source.Locked;
+    public bool Locked => _source.Locked;
 
     public IEditableDictionary<TWrapped> Clone(string parent, string attribute)
     {
@@ -134,31 +134,31 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         throw new NotImplementedException();
 
         //IEditableDictionary<TWrapped> result;
-        //m_controller.WorldModel.UndoLogger.StartTransaction(string.Format("Copy '{0}' {1}", parent, attribute));
-        //result = CloneInternal(m_controller.WorldModel.Elements.Get(parent), attribute);
-        //m_controller.WorldModel.UndoLogger.EndTransaction();
+        //_controller.WorldModel.UndoLogger.StartTransaction(string.Format("Copy '{0}' {1}", parent, attribute));
+        //result = CloneInternal(_controller.WorldModel.Elements.Get(parent), attribute);
+        //_controller.WorldModel.UndoLogger.EndTransaction();
         //return result;
     }
 
     //private IEditableDictionary<TWrapped> CloneInternal(Element parent, string attribute)
     //{
-    //    QuestDictionary<TSource> newSource = (QuestDictionary<TSource>)m_source.Clone();
+    //    QuestDictionary<TSource> newSource = (QuestDictionary<TSource>)_source.Clone();
     //    newSource.Locked = false;
     //    parent.Fields.Set(attribute, newSource);
     //    newSource = (QuestDictionary<TSource>)parent.Fields.Get(attribute);
-    //    return EditableWrappedItemDictionary<TSource, TWrapped>.GetNewInstance(m_controller, newSource);
+    //    return EditableWrappedItemDictionary<TSource, TWrapped>.GetNewInstance(_controller, newSource);
     //}
 
     public string Owner
     {
         get
         {
-            if (m_source.Owner == null)
+            if (_source.Owner == null)
             {
                 return null;
             }
 
-            return m_source.Owner.Name;
+            return _source.Owner.Name;
         }
     }
 
@@ -166,10 +166,10 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     private void PopulateWrappedItems()
     {
-        m_wrappedItems.Clear();
+        _wrappedItems.Clear();
         var index = 0;
 
-        foreach (var item in m_source)
+        foreach (var item in _source)
         {
             AddWrappedItem(item.Key, WrapValue(item.Value), EditorUpdateSource.System, index);
             index++;
@@ -178,7 +178,7 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     private TWrapped WrapValue(TSource source)
     {
-        return (TWrapped) m_controller.WrapValue(source);
+        return (TWrapped) _controller.WrapValue(source);
     }
 
     private TSource UnwrapValue(TWrapped wrapped)
@@ -194,8 +194,8 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
     private void AddWrappedItem(string key, TWrapped value, EditorUpdateSource source, int index)
     {
         IEditableListItem<TWrapped> wrappedValue = new EditableListItem<TWrapped>(key, value);
-        m_wrappedItems.Add(key, wrappedValue);
-        m_wrappedItemsLookup.Add(value, wrappedValue);
+        _wrappedItems.Add(key, wrappedValue);
+        _wrappedItemsLookup.Add(value, wrappedValue);
         value.UnderlyingValueUpdated += WrappedUnderlyingValueUpdated;
 
         if (Added != null)
@@ -208,9 +208,9 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     private void RemoveWrappedItem(IEditableListItem<TWrapped> item, EditorUpdateSource source, int index)
     {
-        m_wrappedItems[item.Key].Value.UnderlyingValueUpdated -= WrappedUnderlyingValueUpdated;
-        m_wrappedItemsLookup.Remove(m_wrappedItems[item.Key].Value);
-        m_wrappedItems.Remove(item.Key);
+        _wrappedItems[item.Key].Value.UnderlyingValueUpdated -= WrappedUnderlyingValueUpdated;
+        _wrappedItemsLookup.Remove(_wrappedItems[item.Key].Value);
+        _wrappedItems.Remove(item.Key);
         if (Removed != null)
         {
             Removed(this,
@@ -227,30 +227,30 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
             Updated(this, new EditableListUpdatedEventArgs<TWrapped>
             {
-                UpdatedItem = m_wrappedItemsLookup[updatedItem],
-                Index = m_source.IndexOfKey(m_wrappedItemsLookup[updatedItem].Key)
+                UpdatedItem = _wrappedItemsLookup[updatedItem],
+                Index = _source.IndexOfKey(_wrappedItemsLookup[updatedItem].Key)
             });
         }
     }
 
-    private void m_source_Added(object sender, QuestDictionaryUpdatedEventArgs<TSource> e)
+    private void OnSourceAdded(object sender, QuestDictionaryUpdatedEventArgs<TSource> e)
     {
         AddWrappedItem(e.Key, WrapValue(e.Item), (EditorUpdateSource) e.Source, e.Index);
     }
 
-    private void m_source_Removed(object sender, QuestDictionaryUpdatedEventArgs<TSource> e)
+    private void OnSourceRemoved(object sender, QuestDictionaryUpdatedEventArgs<TSource> e)
     {
-        RemoveWrappedItem(m_wrappedItems[e.Key], (EditorUpdateSource) e.Source, e.Index);
+        RemoveWrappedItem(_wrappedItems[e.Key], (EditorUpdateSource) e.Source, e.Index);
     }
 
     #region Static DataWrapper
 
     private static readonly
-        EditableDataWrapper<QuestDictionary<TSource>, EditableWrappedItemDictionary<TSource, TWrapped>> s_wrapper;
+        EditableDataWrapper<QuestDictionary<TSource>, EditableWrappedItemDictionary<TSource, TWrapped>> Wrapper;
 
     static EditableWrappedItemDictionary()
     {
-        s_wrapper =
+        Wrapper =
             new EditableDataWrapper<QuestDictionary<TSource>, EditableWrappedItemDictionary<TSource, TWrapped>>(
                 GetNewInstance);
     }
@@ -258,7 +258,7 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
     public static EditableWrappedItemDictionary<TSource, TWrapped> GetInstance(EditorController controller,
         QuestDictionary<TSource> list)
     {
-        return s_wrapper.GetInstance(controller, list);
+        return Wrapper.GetInstance(controller, list);
     }
 
     private static EditableWrappedItemDictionary<TSource, TWrapped> GetNewInstance(EditorController controller,
@@ -269,7 +269,7 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     public static void Clear()
     {
-        s_wrapper.Clear();
+        Wrapper.Clear();
     }
 
     #endregion

--- a/src/EditorCore/EditorControl.cs
+++ b/src/EditorCore/EditorControl.cs
@@ -4,16 +4,16 @@ namespace QuestViva.EditorCore;
 
 internal class EditorControl : IEditorControl
 {
-    private readonly EditorDefinition m_parent;
-    private readonly Element m_source;
-    private readonly EditorVisibilityHelper m_visibilityHelper;
-    private WorldModel m_worldModel;
+    private readonly EditorDefinition _parent;
+    private readonly Element _source;
+    private readonly EditorVisibilityHelper _visibilityHelper;
+    private WorldModel _worldModel;
 
     public EditorControl(EditorDefinition parent, WorldModel worldModel, Element source)
     {
-        m_parent = parent;
-        m_worldModel = worldModel;
-        m_source = source;
+        _parent = parent;
+        _worldModel = worldModel;
+        _source = source;
         ControlType = source.Fields.GetString("controltype");
         Caption = source.Fields.GetString("caption");
         Attribute = source.Fields.GetString("attribute");
@@ -32,7 +32,7 @@ internal class EditorControl : IEditorControl
             Expand = source.Fields.GetAsType<bool>("expand");
         }
 
-        m_visibilityHelper = new EditorVisibilityHelper(parent, worldModel, source);
+        _visibilityHelper = new EditorVisibilityHelper(parent, worldModel, source);
         IsControlVisibleInSimpleMode = !source.Fields.GetAsType<bool>("advanced");
         Id = source.Name;
 
@@ -56,55 +56,55 @@ internal class EditorControl : IEditorControl
 
     public string GetString(string tag)
     {
-        return m_source.Fields.GetString(tag);
+        return _source.Fields.GetString(tag);
     }
 
     public IEnumerable<string> GetListString(string tag)
     {
-        return m_source.Fields.GetAsType<QuestList<string>>(tag);
+        return _source.Fields.GetAsType<QuestList<string>>(tag);
     }
 
     public IDictionary<string, string> GetDictionary(string tag)
     {
-        return m_source.Fields.GetAsType<QuestDictionary<string>>(tag);
+        return _source.Fields.GetAsType<QuestDictionary<string>>(tag);
     }
 
     public bool GetBool(string tag)
     {
-        return m_source.Fields.GetAsType<bool>(tag);
+        return _source.Fields.GetAsType<bool>(tag);
     }
 
     public int? GetInt(string tag)
     {
-        if (!m_source.Fields.HasType<int>(tag))
+        if (!_source.Fields.HasType<int>(tag))
         {
             return null;
         }
 
-        return m_source.Fields.GetAsType<int>(tag);
+        return _source.Fields.GetAsType<int>(tag);
     }
 
     public double? GetDouble(string tag)
     {
-        if (!m_source.Fields.HasType<double>(tag))
+        if (!_source.Fields.HasType<double>(tag))
         {
             return null;
         }
 
-        return m_source.Fields.GetAsType<double>(tag);
+        return _source.Fields.GetAsType<double>(tag);
     }
 
     public Task<bool> IsControlVisible(IEditorData data)
     {
-        return m_visibilityHelper.IsVisible(data);
+        return _visibilityHelper.IsVisible(data);
     }
 
     public bool IsControlVisibleSync(IEditorData data)
     {
-        return m_visibilityHelper.IsVisibleIgnoringExpression(data);
+        return _visibilityHelper.IsVisibleIgnoringExpression(data);
     }
 
-    public IEditorDefinition Parent => m_parent;
+    public IEditorDefinition Parent => _parent;
 
     public bool IsControlVisibleInSimpleMode { get; }
 

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -58,10 +58,10 @@ public class TemplateData
 
 public sealed class EditorController : IDisposable
 {
-    private const string k_commands = "_gameCommands";
-    private const string k_verbs = "_gameVerbs";
+    private const string Commands = "_gameCommands";
+    private const string Verbs = "_gameVerbs";
 
-    private static readonly Dictionary<ValidationMessage, string> s_validationMessages = new()
+    private static readonly Dictionary<ValidationMessage, string> ValidationMessages = new()
     {
         {ValidationMessage.OK, "No error"},
         {ValidationMessage.ItemAlreadyExists, "Item '{0}' already exists in the list"},
@@ -94,9 +94,9 @@ public sealed class EditorController : IDisposable
         {ValidationMessage.MismatchingQuotes, "Missing quote character (\")"}
     };
 
-    private static readonly List<string> s_invalidChars = new() {"\\", "/", ":", "*", "?", "\"", "<", ">", "|"};
+    private static readonly List<string> InvalidChars = new() {"\\", "/", ":", "*", "?", "\"", "<", ">", "|"};
 
-    private readonly List<ElementType> m_advancedTypes = new()
+    private readonly List<ElementType> _advancedTypes = new()
     {
         ElementType.DynamicTemplate,
         ElementType.Function,
@@ -108,11 +108,11 @@ public sealed class EditorController : IDisposable
         ElementType.Walkthrough
     };
 
-    private readonly Dictionary<string, Type> m_controlTypes = new();
-    private readonly Dictionary<string, EditorDefinition> m_editorDefinitions = new();
-    private readonly Dictionary<string, EditorDefinition> m_expressionDefinitions = new();
+    private readonly Dictionary<string, Type> _controlTypes = new();
+    private readonly Dictionary<string, EditorDefinition> _editorDefinitions = new();
+    private readonly Dictionary<string, EditorDefinition> _expressionDefinitions = new();
 
-    private readonly List<ElementType> m_ignoredTypes = new()
+    private readonly List<ElementType> _ignoredTypes = new()
     {
         ElementType.ImpliedType,
         ElementType.Delegate,
@@ -122,20 +122,20 @@ public sealed class EditorController : IDisposable
         ElementType.Resource
     };
 
-    private readonly Regex s_startsWithNumberRegex = new(@"^\d");
+    private readonly Regex _startsWithNumberRegex = new(@"^\d");
 
-    private readonly Regex s_validNameRegex = new(@"^[\w ]+$");
-    private List<Element> m_clipboardElements;
-    private ElementType m_clipboardElementType;
-    private List<IScript> m_clipboardScripts;
-    private Dictionary<ElementType, TreeHeader> m_elementTreeStructure;
-    private FilterOptions m_filterOptions;
-    private FontsManager m_fontsManager;
-    private bool m_initialised;
-    private bool m_lastelementscutout;
-    private ScriptFactory m_scriptFactory;
-    private bool m_simpleMode;
-    private Dictionary<string, string> m_treeTitles;
+    private readonly Regex _validNameRegex = new(@"^[\w ]+$");
+    private List<Element> _clipboardElements;
+    private ElementType _clipboardElementType;
+    private List<IScript> _clipboardScripts;
+    private Dictionary<ElementType, TreeHeader> _elementTreeStructure;
+    private FilterOptions _filterOptions;
+    private FontsManager _fontsManager;
+    private bool _initialised;
+    private bool _lastelementscutout;
+    private ScriptFactory _scriptFactory;
+    private bool _simpleMode;
+    private Dictionary<string, string> _treeTitles;
 
     public EditorController()
     {
@@ -143,7 +143,7 @@ public sealed class EditorController : IDisposable
         AvailableFilters.Add("libraries", "Show Library Elements");
         // m_availableFilters.Add("libraries", L.T("EditorFilterShowLibraryElements"));
 
-        m_filterOptions = new FilterOptions();
+        _filterOptions = new FilterOptions();
         // set default filters here
 
         // FontsManager is initialized lazily to avoid firing the Google Fonts network request
@@ -166,12 +166,12 @@ public sealed class EditorController : IDisposable
 
     public bool SimpleMode
     {
-        get => m_simpleMode;
+        get => _simpleMode;
         set
         {
-            if (m_simpleMode != value)
+            if (_simpleMode != value)
             {
-                m_simpleMode = value;
+                _simpleMode = value;
                 UpdateTree();
                 if (SimpleModeChanged != null)
                 {
@@ -238,18 +238,18 @@ public sealed class EditorController : IDisposable
 
     public async Task<bool> Initialise(IGameDataProvider gameDataProvider, bool partialInit = false)
     {
-        m_lastelementscutout = false;
+        _lastelementscutout = false;
         var gameData = await gameDataProvider.GetData();
         Filename = gameData?.Filename ?? string.Empty;
         WorldModel = new WorldModel(gameData, null);
-        m_scriptFactory = new ScriptFactory(WorldModel);
-        WorldModel.ElementFieldUpdated += m_worldModel_ElementFieldUpdated;
-        WorldModel.ElementRefreshed += m_worldModel_ElementRefreshed;
-        WorldModel.ElementMetaFieldUpdated += m_worldModel_ElementMetaFieldUpdated;
+        _scriptFactory = new ScriptFactory(WorldModel);
+        WorldModel.ElementFieldUpdated += OnWorldModelElementFieldUpdated;
+        WorldModel.ElementRefreshed += OnWorldModelElementRefreshed;
+        WorldModel.ElementMetaFieldUpdated += OnWorldModelElementMetaFieldUpdated;
         WorldModel.UndoLogger.TransactionsUpdated += UndoLogger_TransactionsUpdated;
         WorldModel.UndoLogger.TransactionCommitted += (_, _) => Dirty?.Invoke(this, EventArgs.Empty);
         WorldModel.Elements.ElementRenamed += Elements_ElementRenamed;
-        WorldModel.LoadStatus += m_worldModel_LoadStatus;
+        WorldModel.LoadStatus += OnWorldModelLoadStatus;
 
         var ok = await WorldModel.InitialiseEdit();
 
@@ -261,17 +261,17 @@ public sealed class EditorController : IDisposable
                 if (WorldModel.IsGamebook)
                 {
                     EditorStyle = EditorStyle.GameBook;
-                    m_ignoredTypes.Add(ElementType.Template);
-                    m_ignoredTypes.Add(ElementType.ObjectType);
+                    _ignoredTypes.Add(ElementType.Template);
+                    _ignoredTypes.Add(ElementType.ObjectType);
                 }
 
                 // need to initialise the EditableScriptFactory after we've loaded the game XML above,
                 // as the editor definitions contain the "friendly" templates for script commands.
-                ScriptFactory = new EditableScriptFactory(this, m_scriptFactory, WorldModel);
+                ScriptFactory = new EditableScriptFactory(this, _scriptFactory, WorldModel);
 
-                m_initialised = true;
+                _initialised = true;
 
-                WorldModel.ObjectsUpdated += m_worldModel_ObjectsUpdated;
+                WorldModel.ObjectsUpdated += OnWorldModelObjectsUpdated;
 
                 foreach (var e in WorldModel.Elements.GetElements(ElementType.Editor))
                 {
@@ -279,12 +279,12 @@ public sealed class EditorController : IDisposable
                     if (def.AppliesTo != null)
                     {
                         // Normal editor definition for editing an element or a script command
-                        m_editorDefinitions.Add(def.AppliesTo, def);
+                        _editorDefinitions.Add(def.AppliesTo, def);
                     }
                     else if (def.Pattern != null)
                     {
                         // Editor definition for an expression template in the "if" editor
-                        m_expressionDefinitions.Add(def.Pattern, def);
+                        _expressionDefinitions.Add(def.Pattern, def);
                     }
                 }
 
@@ -308,7 +308,7 @@ public sealed class EditorController : IDisposable
         return ok;
     }
 
-    private void m_worldModel_LoadStatus(object sender, Engine.LoadStatusEventArgs e)
+    private void OnWorldModelLoadStatus(object sender, Engine.LoadStatusEventArgs e)
     {
         if (LoadStatus != null)
         {
@@ -341,9 +341,9 @@ public sealed class EditorController : IDisposable
         }
     }
 
-    private void m_worldModel_ElementFieldUpdated(object sender, ElementFieldUpdatedEventArgs e)
+    private void OnWorldModelElementFieldUpdated(object sender, ElementFieldUpdatedEventArgs e)
     {
-        if (!m_initialised)
+        if (!_initialised)
         {
             return;
         }
@@ -412,9 +412,9 @@ public sealed class EditorController : IDisposable
         }
     }
 
-    private void m_worldModel_ElementMetaFieldUpdated(object sender, ElementFieldUpdatedEventArgs e)
+    private void OnWorldModelElementMetaFieldUpdated(object sender, ElementFieldUpdatedEventArgs e)
     {
-        if (!m_initialised)
+        if (!_initialised)
         {
             return;
         }
@@ -484,9 +484,9 @@ public sealed class EditorController : IDisposable
         RemovedNode(this, new RemovedNodeEventArgs {Key = e.Name});
     }
 
-    private void m_worldModel_ElementRefreshed(object sender, ElementRefreshEventArgs e)
+    private void OnWorldModelElementRefreshed(object sender, ElementRefreshEventArgs e)
     {
-        if (m_initialised)
+        if (_initialised)
         {
             if (ElementRefreshed != null)
             {
@@ -495,7 +495,7 @@ public sealed class EditorController : IDisposable
         }
     }
 
-    private void m_worldModel_ObjectsUpdated(object sender, ObjectsUpdatedEventArgs args)
+    private void OnWorldModelObjectsUpdated(object sender, ObjectsUpdatedEventArgs args)
     {
         if (args.Added != null)
         {
@@ -516,8 +516,8 @@ public sealed class EditorController : IDisposable
 
     private void InitialiseTreeStructure()
     {
-        m_treeTitles = new Dictionary<string, string> {{k_commands, "Commands"}, {k_verbs, "Verbs"}};
-        m_elementTreeStructure = new Dictionary<ElementType, TreeHeader>();
+        _treeTitles = new Dictionary<string, string> {{Commands, "Commands"}, {Verbs, "Verbs"}};
+        _elementTreeStructure = new Dictionary<ElementType, TreeHeader>();
 
         AddTreeHeader(EditorStyle.TextAdventure, ElementType.Object, "_objects", "Objects", null, false);
         AddTreeHeader(EditorStyle.GameBook, ElementType.Object, "_objects", "Pages", null, false);
@@ -545,11 +545,11 @@ public sealed class EditorController : IDisposable
 
         if (simple || !SimpleMode)
         {
-            m_treeTitles.Add(key, title);
+            _treeTitles.Add(key, title);
             var header = new TreeHeader {Key = key, Title = title};
             if (type != null)
             {
-                m_elementTreeStructure.Add(type.Value, header);
+                _elementTreeStructure.Add(type.Value, header);
             }
 
             AddedNode(this,
@@ -580,7 +580,7 @@ public sealed class EditorController : IDisposable
             // redistribution), but a full rebuild like this one must sort explicitly or a
             // reordered element's new tree position silently reverts to its old, pre-reorder spot
             // the next time anything triggers a full UpdateTree() rather than an incremental
-            // single-element reposition (see m_worldModel_ElementMetaFieldUpdated's own
+            // single-element reposition (see OnWorldModelElementMetaFieldUpdated's own
             // GetElementPosition, which already gets this right for that path).
             foreach (var o in WorldModel.Elements.GetElements(type).Where(e => e.Parent == null)
                          .OrderBy(e => e.MetaFields[MetaFieldDefinitions.SortIndex]))
@@ -619,7 +619,7 @@ public sealed class EditorController : IDisposable
         var display = true;
         var isLibrary = o.MetaFields.GetAsType<bool>("library");
 
-        if (isLibrary && !m_filterOptions.IsSet("libraries"))
+        if (isLibrary && !_filterOptions.IsSet("libraries"))
         {
             display = false;
         }
@@ -642,13 +642,13 @@ public sealed class EditorController : IDisposable
                 AddedNode(this,
                     new AddedNodeEventArgs
                     {
-                        Key = k_verbs, Text = "Verbs", Parent = "game", IsLibraryNode = false, Position = null,
+                        Key = Verbs, Text = "Verbs", Parent = "game", IsLibraryNode = false, Position = null,
                         NodeType = "header"
                     });
                 AddedNode(this,
                     new AddedNodeEventArgs
                     {
-                        Key = k_commands, Text = "Commands", Parent = "game", IsLibraryNode = false, Position = null,
+                        Key = Commands, Text = "Commands", Parent = "game", IsLibraryNode = false, Position = null,
                         NodeType = "header"
                     });
             }
@@ -658,12 +658,12 @@ public sealed class EditorController : IDisposable
     private bool IsElementVisible(Element e)
     {
         // Don't display implied types, editor elements etc.
-        if (m_ignoredTypes.Contains(e.ElemType))
+        if (_ignoredTypes.Contains(e.ElemType))
         {
             return false;
         }
 
-        if (SimpleMode && m_advancedTypes.Contains(e.ElemType))
+        if (SimpleMode && _advancedTypes.Contains(e.ElemType))
         {
             return false;
         }
@@ -710,10 +710,10 @@ public sealed class EditorController : IDisposable
 
         if (o.ElemType == ElementType.Object && o.Type == ObjectType.Command)
         {
-            return o.Fields.GetAsType<bool>("isverb") ? k_verbs : k_commands;
+            return o.Fields.GetAsType<bool>("isverb") ? Verbs : Commands;
         }
 
-        return m_elementTreeStructure[o.ElemType].Key;
+        return _elementTreeStructure[o.ElemType].Key;
     }
 
     private string GetDisplayName(Element e)
@@ -772,9 +772,9 @@ public sealed class EditorController : IDisposable
 
     public string GetDisplayName(string element)
     {
-        if (m_treeTitles.ContainsKey(element))
+        if (_treeTitles.ContainsKey(element))
         {
-            return m_treeTitles[element];
+            return _treeTitles[element];
         }
 
         if (!WorldModel.Elements.ContainsKey(element))
@@ -828,7 +828,7 @@ public sealed class EditorController : IDisposable
 
     public void UpdateFilterOptions(FilterOptions options)
     {
-        m_filterOptions = options;
+        _filterOptions = options;
         UpdateTree();
     }
 
@@ -863,12 +863,12 @@ public sealed class EditorController : IDisposable
                 }
             }
 
-            if (m_editorDefinitions.ContainsKey(type))
+            if (_editorDefinitions.ContainsKey(type))
             {
                 return type;
             }
         }
-        else if (m_editorDefinitions.ContainsKey(elementKey))
+        else if (_editorDefinitions.ContainsKey(elementKey))
         {
             return elementKey;
         }
@@ -878,7 +878,7 @@ public sealed class EditorController : IDisposable
 
     public IEnumerable<string> GetAllEditorNames()
     {
-        return m_editorDefinitions.Keys;
+        return _editorDefinitions.Keys;
     }
 
     public Dictionary<string, EditableScriptData> GetScriptEditorData()
@@ -897,7 +897,7 @@ public sealed class EditorController : IDisposable
         {
             // see if we have a specific editor definition for this function
             EditorDefinition result;
-            if (m_editorDefinitions.TryGetValue(script.EditorName, out result))
+            if (_editorDefinitions.TryGetValue(script.EditorName, out result))
             {
                 return result;
             }
@@ -908,12 +908,12 @@ public sealed class EditorController : IDisposable
             script.EditorName = "()";
         }
 
-        return m_editorDefinitions[script.EditorName];
+        return _editorDefinitions[script.EditorName];
     }
 
     public IEditorDefinition GetEditorDefinition(string editorName)
     {
-        return m_editorDefinitions[editorName];
+        return _editorDefinitions[editorName];
     }
 
     public IEditorData GetEditorData(string elementKey)
@@ -1292,13 +1292,13 @@ public sealed class EditorController : IDisposable
 
     public void AddControlType(string name, Type type)
     {
-        m_controlTypes.Add(name, type);
+        _controlTypes.Add(name, type);
     }
 
     public Type GetControlType(string name)
     {
         Type controlType;
-        m_controlTypes.TryGetValue(name, out controlType);
+        _controlTypes.TryGetValue(name, out controlType);
         return controlType;
     }
 
@@ -1929,7 +1929,7 @@ public sealed class EditorController : IDisposable
             return new ValidationResult {Valid = false, Message = ValidationMessage.InvalidElementNameEmpty};
         }
 
-        if (!s_validNameRegex.IsMatch(name))
+        if (!_validNameRegex.IsMatch(name))
         {
             var invalidChars = Regex.Matches(name, "[^\\w ]").Select(m => m.Value).Distinct().ToList();
             return new ValidationResult
@@ -1944,7 +1944,7 @@ public sealed class EditorController : IDisposable
             return new ValidationResult {Valid = false, Message = ValidationMessage.InvalidElementNameMultipleSpaces};
         }
 
-        if (s_startsWithNumberRegex.IsMatch(name))
+        if (_startsWithNumberRegex.IsMatch(name))
         {
             return new ValidationResult {Valid = false, Message = ValidationMessage.InvalidElementNameStartsWithNumber};
         }
@@ -2051,27 +2051,27 @@ public sealed class EditorController : IDisposable
 
     public void CopyElements(IEnumerable<string> elementNames)
     {
-        m_clipboardElements = (from name in elementNames select WorldModel.Elements.Get(name)).ToList();
+        _clipboardElements = (from name in elementNames select WorldModel.Elements.Get(name)).ToList();
 
         var first = true;
 
-        foreach (var e in m_clipboardElements)
+        foreach (var e in _clipboardElements)
         {
             if (first)
             {
-                m_clipboardElementType = e.ElemType;
+                _clipboardElementType = e.ElemType;
                 first = false;
             }
             else
             {
-                if (m_clipboardElementType != e.ElemType)
+                if (_clipboardElementType != e.ElemType)
                 {
                     throw new InvalidOperationException("Cannot mix element types in the clipboard");
                 }
             }
         }
 
-        m_lastelementscutout = false;
+        _lastelementscutout = false;
     }
 
     public string PasteElements(string parentName)
@@ -2087,16 +2087,16 @@ public sealed class EditorController : IDisposable
 
         WorldModel.UndoLogger.StartTransaction("Paste");
 
-        foreach (var e in m_clipboardElements)
+        foreach (var e in _clipboardElements)
         {
             Element newElement;
             if (EditorStyle == EditorStyle.TextAdventure)
             {
-                newElement = e.Clone(el => true, m_lastelementscutout);
+                newElement = e.Clone(el => true, _lastelementscutout);
             }
             else if (EditorStyle == EditorStyle.GameBook)
             {
-                newElement = e.Clone(el => el.Name != "player", m_lastelementscutout);
+                newElement = e.Clone(el => el.Name != "player", _lastelementscutout);
             }
             else
             {
@@ -2109,7 +2109,7 @@ public sealed class EditorController : IDisposable
 
         WorldModel.UndoLogger.EndTransaction();
 
-        m_lastelementscutout = false;
+        _lastelementscutout = false;
 
         return lastPastedElement;
     }
@@ -2118,7 +2118,7 @@ public sealed class EditorController : IDisposable
     {
         WorldModel.UndoLogger.StartTransaction("Cut");
         CopyElements(elementNames);
-        m_lastelementscutout = true;
+        _lastelementscutout = true;
 
         /*
          * The cut out elements should be displayed in gray.
@@ -2137,7 +2137,7 @@ public sealed class EditorController : IDisposable
 
     public bool CanPaste(string parentName)
     {
-        if (m_clipboardElements == null || m_clipboardElements.Count == 0)
+        if (_clipboardElements == null || _clipboardElements.Count == 0)
         {
             return false;
         }
@@ -2153,7 +2153,7 @@ public sealed class EditorController : IDisposable
             return false;
         }
 
-        return parent.ElemType == m_clipboardElementType;
+        return parent.ElemType == _clipboardElementType;
     }
 
     private Element GetPasteParent(string parentName)
@@ -2175,7 +2175,7 @@ public sealed class EditorController : IDisposable
             {
                 // But don't paste a copy of an object inside itself
 
-                if (m_clipboardElements.Any(clipboardElement => clipboardElement == e))
+                if (_clipboardElements.Any(clipboardElement => clipboardElement == e))
                 {
                     return e.Parent;
                 }
@@ -2264,21 +2264,21 @@ public sealed class EditorController : IDisposable
 
     public bool CanPasteScript()
     {
-        return m_clipboardScripts != null && m_clipboardScripts.Count > 0;
+        return _clipboardScripts != null && _clipboardScripts.Count > 0;
     }
 
     internal void SetClipboardScript(IEnumerable<IScript> script)
     {
-        m_clipboardScripts = new List<IScript>(script);
+        _clipboardScripts = new List<IScript>(script);
         if (ScriptClipboardUpdated != null)
         {
-            ScriptClipboardUpdated(this, new ScriptClipboardUpdateEventArgs {HasScript = m_clipboardScripts.Count > 0});
+            ScriptClipboardUpdated(this, new ScriptClipboardUpdateEventArgs {HasScript = _clipboardScripts.Count > 0});
         }
     }
 
     internal IEnumerable<IScript> GetClipboardScript()
     {
-        return m_clipboardScripts.AsReadOnly();
+        return _clipboardScripts.AsReadOnly();
     }
 
     public IEnumerable<string> GetPropertyNames()
@@ -2288,7 +2288,7 @@ public sealed class EditorController : IDisposable
 
     public IEnumerable<string> GetExpressionEditorNames(string expressionType)
     {
-        return m_expressionDefinitions.Values.Where(d => d.ExpressionType == expressionType).Select(d => d.Description);
+        return _expressionDefinitions.Values.Where(d => d.ExpressionType == expressionType).Select(d => d.Description);
     }
 
     public string GetExpressionEditorDefinitionName(string expression, string expressionType)
@@ -2308,7 +2308,7 @@ public sealed class EditorController : IDisposable
         // Definition which corresponds to "(Got(#object#))" [note: this is turned into a
         // regex by the SimplePattern attribute loader]
 
-        var candidates = from def in m_expressionDefinitions.Values
+        var candidates = from def in _expressionDefinitions.Values
             where def.ExpressionType == expressionType
             where Engine.Utility.IsRegexMatch(def.Pattern, expression)
             select def;
@@ -2333,7 +2333,7 @@ public sealed class EditorController : IDisposable
 
     public string GetNewExpression(string templateName)
     {
-        var definitions = from def in m_expressionDefinitions.Values
+        var definitions = from def in _expressionDefinitions.Values
             where def.Description == templateName
             select def;
 
@@ -2866,39 +2866,39 @@ public sealed class EditorController : IDisposable
 
     public void Uninitialise()
     {
-        if (m_editorDefinitions != null)
+        if (_editorDefinitions != null)
         {
-            m_editorDefinitions.Clear();
+            _editorDefinitions.Clear();
         }
 
-        if (m_expressionDefinitions != null)
+        if (_expressionDefinitions != null)
         {
-            m_expressionDefinitions.Clear();
+            _expressionDefinitions.Clear();
         }
 
-        if (m_elementTreeStructure != null)
+        if (_elementTreeStructure != null)
         {
-            m_elementTreeStructure.Clear();
+            _elementTreeStructure.Clear();
         }
 
-        if (m_clipboardElements != null)
+        if (_clipboardElements != null)
         {
-            m_clipboardElements.Clear();
+            _clipboardElements.Clear();
         }
 
-        if (m_clipboardScripts != null)
+        if (_clipboardScripts != null)
         {
-            m_clipboardScripts.Clear();
+            _clipboardScripts.Clear();
         }
 
         if (WorldModel != null)
         {
-            WorldModel.ElementFieldUpdated -= m_worldModel_ElementFieldUpdated;
-            WorldModel.ElementRefreshed -= m_worldModel_ElementRefreshed;
-            WorldModel.ElementMetaFieldUpdated -= m_worldModel_ElementMetaFieldUpdated;
+            WorldModel.ElementFieldUpdated -= OnWorldModelElementFieldUpdated;
+            WorldModel.ElementRefreshed -= OnWorldModelElementRefreshed;
+            WorldModel.ElementMetaFieldUpdated -= OnWorldModelElementMetaFieldUpdated;
             WorldModel.UndoLogger.TransactionsUpdated -= UndoLogger_TransactionsUpdated;
             WorldModel.Elements.ElementRenamed -= Elements_ElementRenamed;
-            WorldModel.ObjectsUpdated -= m_worldModel_ObjectsUpdated;
+            WorldModel.ObjectsUpdated -= OnWorldModelObjectsUpdated;
         }
 
         EditableScripts.Clear();
@@ -2919,7 +2919,7 @@ public sealed class EditorController : IDisposable
 
     public string GetSelectedDropDownType(IEditorControl ctl, string element)
     {
-        const string k_noType = "*";
+        const string noType = "*";
 
         var types = ctl.GetDictionary("types");
         var inheritedTypes = new List<string>();
@@ -2929,7 +2929,7 @@ public sealed class EditorController : IDisposable
 
         // Find out which of the handled types are inherited by the object
 
-        foreach (var item in types.Where(i => i.Key != k_noType))
+        foreach (var item in types.Where(i => i.Key != noType))
         {
             if (DoesElementInheritType(element, item.Key))
             {
@@ -2941,7 +2941,7 @@ public sealed class EditorController : IDisposable
         {
             case 0:
                 // Default - no types inherited
-                return k_noType;
+                return noType;
             case 1:
                 return inheritedTypes[0];
             default:
@@ -3000,7 +3000,7 @@ public sealed class EditorController : IDisposable
     public static string GenerateSafeFilename(string gameName)
     {
         var result = gameName;
-        foreach (var invalidChar in s_invalidChars)
+        foreach (var invalidChar in InvalidChars)
         {
             result = result.Replace(invalidChar, "");
         }
@@ -3035,7 +3035,7 @@ public sealed class EditorController : IDisposable
         // string/script dictionaries (determined by their corresponding control having a source of "object",
         // and update keys if necessary
 
-        var objectEditor = m_editorDefinitions["object"];
+        var objectEditor = _editorDefinitions["object"];
         foreach (var tab in objectEditor.Tabs.Values)
         {
             foreach (var ctl in tab.Controls.Where(c => c.GetString("source") == "object"))
@@ -3103,27 +3103,27 @@ public sealed class EditorController : IDisposable
 
     public static string GetValidationError(ValidationResult result, object input)
     {
-        return string.Format(s_validationMessages[result.Message], input, result.MessageData);
+        return string.Format(ValidationMessages[result.Message], input, result.MessageData);
     }
 
     public List<string> AvailableBaseFonts()
     {
-        if (m_fontsManager == null)
+        if (_fontsManager == null)
         {
-            m_fontsManager = new FontsManager();
+            _fontsManager = new FontsManager();
         }
 
-        return m_fontsManager.GetBaseFonts();
+        return _fontsManager.GetBaseFonts();
     }
 
     public List<string> AvailableWebFonts()
     {
-        if (m_fontsManager == null)
+        if (_fontsManager == null)
         {
-            m_fontsManager = new FontsManager();
+            _fontsManager = new FontsManager();
         }
 
-        return m_fontsManager.GetWebFonts();
+        return _fontsManager.GetWebFonts();
     }
 
     public class AddedNodeEventArgs : EventArgs

--- a/src/EditorCore/EditorData.cs
+++ b/src/EditorCore/EditorData.cs
@@ -24,14 +24,14 @@ internal class EditorAttributeData : IEditorAttributeData
 
 internal class EditorData : IEditorDataExtendedAttributeInfo
 {
-    private readonly EditorController m_controller;
-    private readonly Element m_element;
-    private readonly Dictionary<string, string> m_filters = new();
+    private readonly EditorController _controller;
+    private readonly Element _element;
+    private readonly Dictionary<string, string> _filters = new();
 
     public EditorData(Element element, EditorController controller)
     {
-        m_element = element;
-        m_controller = controller;
+        _element = element;
+        _controller = controller;
 
         element.Fields.AttributeChanged += Fields_AttributeChanged;
         element.Fields.AttributeChangedSilent += Fields_AttributeChanged;
@@ -39,16 +39,16 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
 
     public event EventHandler Changed;
 
-    public string Name => m_element.Name;
+    public string Name => _element.Name;
 
     public object GetAttribute(string attribute)
     {
-        if (attribute == "name" && m_element.Fields[FieldDefinitions.Anonymous])
+        if (attribute == "name" && _element.Fields[FieldDefinitions.Anonymous])
         {
             return string.Empty;
         }
 
-        return m_controller.WrapValue(m_element.Fields.Get(attribute), m_element, attribute);
+        return _controller.WrapValue(_element.Fields.Get(attribute), _element, attribute);
     }
 
     public ValidationResult SetAttribute(string attribute, object value)
@@ -62,15 +62,15 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
 
             ValidationResult result;
 
-            result = m_controller.CanRename(m_element, (string) value);
+            result = _controller.CanRename(_element, (string) value);
             if (!result.Valid)
             {
                 return result;
             }
 
-            if (m_element.Fields[FieldDefinitions.Anonymous])
+            if (_element.Fields[FieldDefinitions.Anonymous])
             {
-                m_element.Fields[FieldDefinitions.Anonymous] = false;
+                _element.Fields[FieldDefinitions.Anonymous] = false;
             }
         }
 
@@ -88,14 +88,14 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
         string oldName = null;
         if (attribute == "name")
         {
-            oldName = m_element.Name;
+            oldName = _element.Name;
         }
 
-        m_element.Fields.Set(attribute, value);
+        _element.Fields.Set(attribute, value);
 
         if (attribute == "name")
         {
-            m_controller.UpdateDictionariesReferencingRenamedObject(oldName, (string) value);
+            _controller.UpdateDictionariesReferencingRenamedObject(oldName, (string) value);
         }
 
         return new ValidationResult {Valid = true};
@@ -116,13 +116,13 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
     public string GetSelectedFilter(string filterGroup)
     {
         string result;
-        m_filters.TryGetValue(filterGroup, out result);
+        _filters.TryGetValue(filterGroup, out result);
         return result;
     }
 
     public void SetSelectedFilter(string filterGroup, string filter)
     {
-        m_filters[filterGroup] = filter;
+        _filters[filterGroup] = filter;
         if (Changed != null)
         {
             Changed(this, new EventArgs());
@@ -131,30 +131,30 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
 
     public IEnumerable<IEditorAttributeData> GetAttributeData()
     {
-        var data = m_controller.WorldModel.GetDebugData(m_element.Name);
+        var data = _controller.WorldModel.GetDebugData(_element.Name);
         return ConvertDebugDataToEditorAttributeData(data);
     }
 
     public IEditorAttributeData GetAttributeData(string attribute)
     {
-        var data = m_controller.WorldModel.GetDebugDataItem(m_element.Name, attribute);
+        var data = _controller.WorldModel.GetDebugDataItem(_element.Name, attribute);
         return new EditorAttributeData(attribute, data.IsInherited, data.Source, data.IsDefaultType);
     }
 
     public void RemoveAttribute(string attribute)
     {
-        m_element.Fields.RemoveField(attribute);
+        _element.Fields.RemoveField(attribute);
     }
 
     public IEnumerable<IEditorAttributeData> GetInheritedTypes()
     {
-        var data = m_controller.WorldModel.GetInheritedTypesDebugData(m_element.Name);
+        var data = _controller.WorldModel.GetInheritedTypesDebugData(_element.Name);
         return ConvertDebugDataToEditorAttributeData(data);
     }
 
-    public bool IsLibraryElement => m_element.MetaFields[MetaFieldDefinitions.Library];
+    public bool IsLibraryElement => _element.MetaFields[MetaFieldDefinitions.Library];
 
-    public string Filename => m_element.MetaFields[MetaFieldDefinitions.Filename];
+    public string Filename => _element.MetaFields[MetaFieldDefinitions.Filename];
 
     public void MakeElementLocal()
     {
@@ -163,8 +163,8 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
             throw new InvalidOperationException("Element is not defined in a library");
         }
 
-        m_element.MetaFields[MetaFieldDefinitions.Library] = false;
-        m_element.MetaFields[MetaFieldDefinitions.Filename] = null;
+        _element.MetaFields[MetaFieldDefinitions.Library] = false;
+        _element.MetaFields[MetaFieldDefinitions.Filename] = null;
     }
 
     public bool ReadOnly

--- a/src/EditorCore/EditorDefinition.cs
+++ b/src/EditorCore/EditorDefinition.cs
@@ -4,15 +4,15 @@ namespace QuestViva.EditorCore;
 
 internal class EditorDefinition : IEditorDefinition
 {
-    private readonly Dictionary<string, IEditorControl> m_controls;
-    private readonly Dictionary<string, FilterGroup> m_filterGroups = new();
+    private readonly Dictionary<string, IEditorControl> _controls;
+    private readonly Dictionary<string, FilterGroup> _filterGroups = new();
 
-    private readonly Dictionary<string, IEditorTab> m_tabs;
+    private readonly Dictionary<string, IEditorTab> _tabs;
 
     public EditorDefinition(WorldModel worldModel, Element source)
     {
-        m_tabs = new Dictionary<string, IEditorTab>();
-        m_controls = new Dictionary<string, IEditorControl>();
+        _tabs = new Dictionary<string, IEditorTab>();
+        _controls = new Dictionary<string, IEditorControl>();
         AppliesTo = source.Fields.GetString("appliesto");
         Pattern = source.Fields.GetString("pattern");
         OriginalPattern = source.Fields.GetString(FieldDefinitions.OriginalPattern.Property);
@@ -24,7 +24,7 @@ internal class EditorDefinition : IEditorDefinition
         {
             if (e.Parent == source)
             {
-                m_tabs.Add(e.Name, new EditorTab(this, worldModel, e));
+                _tabs.Add(e.Name, new EditorTab(this, worldModel, e));
             }
         }
 
@@ -32,7 +32,7 @@ internal class EditorDefinition : IEditorDefinition
         {
             if (e.Parent == source)
             {
-                m_controls.Add(e.Name, new EditorControl(this, worldModel, e));
+                _controls.Add(e.Name, new EditorControl(this, worldModel, e));
             }
         }
     }
@@ -49,13 +49,13 @@ internal class EditorDefinition : IEditorDefinition
 
     public string Description { get; }
 
-    public IDictionary<string, IEditorTab> Tabs => m_tabs;
+    public IDictionary<string, IEditorTab> Tabs => _tabs;
 
-    public IEnumerable<IEditorControl> Controls => m_controls.Values;
+    public IEnumerable<IEditorControl> Controls => _controls.Values;
 
     public string GetDefaultFilterName(string filterGroupName, IEditorData data)
     {
-        var filterGroup = m_filterGroups[filterGroupName];
+        var filterGroup = _filterGroups[filterGroupName];
         var candidates = new List<Filter>();
 
         foreach (var filter in filterGroup.Filters.Values)
@@ -82,12 +82,12 @@ internal class EditorDefinition : IEditorDefinition
 
     internal void RegisterFilter(string filterGroupName, string filterName, string attribute)
     {
-        if (!m_filterGroups.ContainsKey(filterGroupName))
+        if (!_filterGroups.ContainsKey(filterGroupName))
         {
-            m_filterGroups.Add(filterGroupName, new FilterGroup(filterGroupName));
+            _filterGroups.Add(filterGroupName, new FilterGroup(filterGroupName));
         }
 
-        var filterGroup = m_filterGroups[filterGroupName];
+        var filterGroup = _filterGroups[filterGroupName];
 
         if (!filterGroup.Filters.ContainsKey(filterName))
         {

--- a/src/EditorCore/EditorTab.cs
+++ b/src/EditorCore/EditorTab.cs
@@ -4,13 +4,13 @@ namespace QuestViva.EditorCore;
 
 internal class EditorTab : IEditorTab
 {
-    private readonly Dictionary<string, IEditorControl> m_controls;
-    private readonly Element m_source;
-    private readonly EditorVisibilityHelper m_visibilityHelper;
+    private readonly Dictionary<string, IEditorControl> _controls;
+    private readonly Element _source;
+    private readonly EditorVisibilityHelper _visibilityHelper;
 
     public EditorTab(EditorDefinition parent, WorldModel worldModel, Element source)
     {
-        m_controls = new Dictionary<string, IEditorControl>();
+        _controls = new Dictionary<string, IEditorControl>();
         Caption = source.Fields.GetString("caption");
         // Editor definitions live in <library type="editor">, which GameSaver
         // excludes from both package and editor saves - so unlike Core.aslx
@@ -25,29 +25,29 @@ internal class EditorTab : IEditorTab
         {
             if (e.Parent == source)
             {
-                m_controls.Add(e.Name, new EditorControl(parent, worldModel, e));
+                _controls.Add(e.Name, new EditorControl(parent, worldModel, e));
             }
         }
 
-        m_visibilityHelper = new EditorVisibilityHelper(parent, worldModel, source);
-        m_source = source;
+        _visibilityHelper = new EditorVisibilityHelper(parent, worldModel, source);
+        _source = source;
     }
 
     public string Caption { get; }
 
     public string HelpUrl { get; }
 
-    public IEnumerable<IEditorControl> Controls => m_controls.Values;
+    public IEnumerable<IEditorControl> Controls => _controls.Values;
 
     public Task<bool> IsTabVisible(IEditorData data)
     {
-        return m_visibilityHelper.IsVisible(data);
+        return _visibilityHelper.IsVisible(data);
     }
 
     public bool IsTabVisibleInSimpleMode { get; }
 
     public bool GetBool(string tag)
     {
-        return m_source.Fields.GetAsType<bool>(tag);
+        return _source.Fields.GetAsType<bool>(tag);
     }
 }

--- a/src/EditorCore/EditorVisibilityHelper.cs
+++ b/src/EditorCore/EditorVisibilityHelper.cs
@@ -6,71 +6,71 @@ namespace QuestViva.EditorCore;
 
 internal class EditorVisibilityHelper
 {
-    private readonly bool m_alwaysVisible = true;
-    private readonly string m_filter;
-    private readonly string m_filterGroup;
-    private readonly IList<string> m_notVisibleIfElementInheritsType;
-    private readonly EditorDefinition m_parent;
-    private readonly string m_relatedAttribute;
-    private readonly bool m_relatedAttributeNegate;
-    private readonly Expression<bool> m_visibilityExpression;
-    private readonly IList<string> m_visibleIfElementInheritsType;
-    private readonly string m_visibleIfRelatedAttributeIsType;
-    private readonly WorldModel m_worldModel;
-    private List<Element> m_notVisibleIfElementInheritsTypeElement;
-    private List<Element> m_visibleIfElementInheritsTypeElement;
+    private readonly bool _alwaysVisible = true;
+    private readonly string _filter;
+    private readonly string _filterGroup;
+    private readonly IList<string> _notVisibleIfElementInheritsType;
+    private readonly EditorDefinition _parent;
+    private readonly string _relatedAttribute;
+    private readonly bool _relatedAttributeNegate;
+    private readonly Expression<bool> _visibilityExpression;
+    private readonly IList<string> _visibleIfElementInheritsType;
+    private readonly string _visibleIfRelatedAttributeIsType;
+    private readonly WorldModel _worldModel;
+    private List<Element> _notVisibleIfElementInheritsTypeElement;
+    private List<Element> _visibleIfElementInheritsTypeElement;
 
     public EditorVisibilityHelper(EditorDefinition parent, WorldModel worldModel, Element source)
     {
-        m_parent = parent;
-        m_worldModel = worldModel;
-        m_relatedAttribute = source.Fields.GetString("relatedattribute");
-        if (m_relatedAttribute != null)
+        _parent = parent;
+        _worldModel = worldModel;
+        _relatedAttribute = source.Fields.GetString("relatedattribute");
+        if (_relatedAttribute != null)
         {
-            m_alwaysVisible = false;
+            _alwaysVisible = false;
         }
 
-        m_relatedAttributeNegate = source.Fields.GetAsType<bool>("relatedattributenegate");
-        m_visibleIfRelatedAttributeIsType = source.Fields.GetString("relatedattributedisplaytype");
-        m_visibleIfElementInheritsType = source.Fields.GetAsType<QuestList<string>>("mustinherit");
-        m_notVisibleIfElementInheritsType = source.Fields.GetAsType<QuestList<string>>("mustnotinherit");
-        if (m_visibleIfElementInheritsType != null || m_notVisibleIfElementInheritsType != null)
+        _relatedAttributeNegate = source.Fields.GetAsType<bool>("relatedattributenegate");
+        _visibleIfRelatedAttributeIsType = source.Fields.GetString("relatedattributedisplaytype");
+        _visibleIfElementInheritsType = source.Fields.GetAsType<QuestList<string>>("mustinherit");
+        _notVisibleIfElementInheritsType = source.Fields.GetAsType<QuestList<string>>("mustnotinherit");
+        if (_visibleIfElementInheritsType != null || _notVisibleIfElementInheritsType != null)
         {
-            m_alwaysVisible = false;
+            _alwaysVisible = false;
         }
 
-        m_filterGroup = source.Fields.GetString("filtergroup");
-        m_filter = source.Fields.GetString("filter");
-        if (m_filter != null)
+        _filterGroup = source.Fields.GetString("filtergroup");
+        _filter = source.Fields.GetString("filter");
+        if (_filter != null)
         {
-            m_alwaysVisible = false;
+            _alwaysVisible = false;
         }
 
         var expression = source.Fields.GetString("onlydisplayif");
         if (expression != null)
         {
-            m_visibilityExpression = new Expression<bool>(Engine.Utility.EncodeIdentifierSpaces(expression),
+            _visibilityExpression = new Expression<bool>(Engine.Utility.EncodeIdentifierSpaces(expression),
                 new ScriptContext(worldModel, true));
-            m_alwaysVisible = false;
+            _alwaysVisible = false;
         }
     }
 
     public async Task<bool> IsVisible(IEditorData data)
     {
-        if (m_alwaysVisible)
+        if (_alwaysVisible)
         {
             return true;
         }
 
-        if (m_visibilityExpression != null)
+        if (_visibilityExpression != null)
         {
             // evaluate <onlydisplayif> expression, with "this" as the current element
             var context = new Context();
-            context.Parameters = new Parameters("this", m_worldModel.Elements.Get(data.Name));
+            context.Parameters = new Parameters("this", _worldModel.Elements.Get(data.Name));
             var result = false;
             try
             {
-                result = await m_visibilityExpression.ExecuteAsync(context);
+                result = await _visibilityExpression.ExecuteAsync(context);
             }
             catch
             {
@@ -93,7 +93,7 @@ internal class EditorVisibilityHelper
     // evaluated synchronously.
     public bool IsVisibleIgnoringExpression(IEditorData data)
     {
-        if (m_alwaysVisible)
+        if (_alwaysVisible)
         {
             return true;
         }
@@ -103,21 +103,21 @@ internal class EditorVisibilityHelper
 
     private bool IsVisibleSyncCore(IEditorData data)
     {
-        if (m_notVisibleIfElementInheritsType != null)
+        if (_notVisibleIfElementInheritsType != null)
         {
-            if (m_notVisibleIfElementInheritsTypeElement == null)
+            if (_notVisibleIfElementInheritsTypeElement == null)
             {
                 // convert "mustnotinherit" type names list into a list of type elements
-                m_notVisibleIfElementInheritsTypeElement = new List<Element>(
-                    m_notVisibleIfElementInheritsType.Select(t => m_worldModel.Elements.Get(ElementType.ObjectType, t))
+                _notVisibleIfElementInheritsTypeElement = new List<Element>(
+                    _notVisibleIfElementInheritsType.Select(t => _worldModel.Elements.Get(ElementType.ObjectType, t))
                 );
             }
 
             // if the element does inherit any of the "forbidden" types, then this control is not visible
 
-            var element = m_worldModel.Elements.Get(data.Name);
+            var element = _worldModel.Elements.Get(data.Name);
 
-            foreach (var forbiddenType in m_notVisibleIfElementInheritsTypeElement)
+            foreach (var forbiddenType in _notVisibleIfElementInheritsTypeElement)
             {
                 if (element.Fields.InheritsTypeRecursive(forbiddenType))
                 {
@@ -126,9 +126,9 @@ internal class EditorVisibilityHelper
             }
         }
 
-        if (m_relatedAttribute != null)
+        if (_relatedAttribute != null)
         {
-            var relatedAttributeValue = data.GetAttribute(m_relatedAttribute);
+            var relatedAttributeValue = data.GetAttribute(_relatedAttribute);
             if (relatedAttributeValue is IDataWrapper)
             {
                 relatedAttributeValue = ((IDataWrapper) relatedAttributeValue).GetUnderlyingValue();
@@ -146,24 +146,24 @@ internal class EditorVisibilityHelper
             var relatedAttributeType = relatedAttributeValue == null
                 ? "null"
                 : WorldModel.ConvertTypeToTypeName(relatedAttributeValue.GetType());
-            return (relatedAttributeType == m_visibleIfRelatedAttributeIsType) != m_relatedAttributeNegate;
+            return (relatedAttributeType == _visibleIfRelatedAttributeIsType) != _relatedAttributeNegate;
         }
 
-        if (m_visibleIfElementInheritsType != null)
+        if (_visibleIfElementInheritsType != null)
         {
-            if (m_visibleIfElementInheritsTypeElement == null)
+            if (_visibleIfElementInheritsTypeElement == null)
             {
                 // convert "mustinherit" type names list into a list of type elements
-                m_visibleIfElementInheritsTypeElement = new List<Element>(
-                    m_visibleIfElementInheritsType.Select(t => m_worldModel.Elements.Get(ElementType.ObjectType, t))
+                _visibleIfElementInheritsTypeElement = new List<Element>(
+                    _visibleIfElementInheritsType.Select(t => _worldModel.Elements.Get(ElementType.ObjectType, t))
                 );
             }
 
             // if the element does inherit any of the types, then this control is visible
 
-            var element = m_worldModel.Elements.Get(data.Name);
+            var element = _worldModel.Elements.Get(data.Name);
 
-            foreach (var type in m_visibleIfElementInheritsTypeElement)
+            foreach (var type in _visibleIfElementInheritsTypeElement)
             {
                 if (element.Fields.InheritsTypeRecursive(type))
                 {
@@ -174,19 +174,19 @@ internal class EditorVisibilityHelper
             return false;
         }
 
-        if (m_filterGroup != null)
+        if (_filterGroup != null)
         {
             // This control is visible if the named filtergroup's current filter selection is this control's filter.
-            var selectedFilter = data.GetSelectedFilter(m_filterGroup);
+            var selectedFilter = data.GetSelectedFilter(_filterGroup);
 
             // Or, if the named filtergroup's current filter selection is not set, infer the current filter value
             // based on which attribute is populated for this data.
             if (selectedFilter == null)
             {
-                selectedFilter = m_parent.GetDefaultFilterName(m_filterGroup, data);
+                selectedFilter = _parent.GetDefaultFilterName(_filterGroup, data);
             }
 
-            return selectedFilter == m_filter;
+            return selectedFilter == _filter;
         }
 
         return true;

--- a/src/EditorCore/ExpressionTemplateEditorData.cs
+++ b/src/EditorCore/ExpressionTemplateEditorData.cs
@@ -2,9 +2,9 @@
 
 internal class ExpressionTemplateEditorData : IEditorData
 {
-    private readonly string m_originalPattern;
-    private readonly IDictionary<string, string> m_parameters;
-    private readonly IEditorData m_parentData;
+    private readonly string _originalPattern;
+    private readonly IDictionary<string, string> _parameters;
+    private readonly IEditorData _parentData;
 
     public ExpressionTemplateEditorData(string expression, EditorDefinition definition, IEditorData parentData)
     {
@@ -13,9 +13,9 @@ internal class ExpressionTemplateEditorData : IEditorData
         // We create the parameter dictionary in the same way as the command parser, so
         // we end up with a dictionary like "object=myobject".
 
-        m_parameters = Engine.Utility.Populate(definition.Pattern, expression);
-        m_originalPattern = definition.OriginalPattern;
-        m_parentData = parentData;
+        _parameters = Engine.Utility.Populate(definition.Pattern, expression);
+        _originalPattern = definition.OriginalPattern;
+        _parentData = parentData;
     }
 
     public event EventHandler Changed;
@@ -24,12 +24,12 @@ internal class ExpressionTemplateEditorData : IEditorData
 
     public object GetAttribute(string attribute)
     {
-        return m_parameters[attribute];
+        return _parameters[attribute];
     }
 
     public ValidationResult SetAttribute(string attribute, object value)
     {
-        m_parameters[attribute] = (string) value;
+        _parameters[attribute] = (string) value;
         if (Changed != null)
         {
             Changed(this, new EventArgs());
@@ -57,7 +57,7 @@ internal class ExpressionTemplateEditorData : IEditorData
 
     public IEnumerable<string> GetVariablesInScope()
     {
-        return m_parentData.GetVariablesInScope();
+        return _parentData.GetVariablesInScope();
     }
 
     public bool IsDirectlySaveable => false;
@@ -68,8 +68,8 @@ internal class ExpressionTemplateEditorData : IEditorData
         // names with their values. If changedAttribute and changedValue are set, then
         // we're in the middle of editing, so use the specified change in place of the
         // currently saved values.
-        var result = m_originalPattern;
-        foreach (var parameter in m_parameters)
+        var result = _originalPattern;
+        foreach (var parameter in _parameters)
         {
             var value = parameter.Key == changedAttribute ? changedValue : parameter.Value;
             result = result.Replace(string.Format("#{0}#", parameter.Key), value);

--- a/src/EditorCore/FilterOptions.cs
+++ b/src/EditorCore/FilterOptions.cs
@@ -2,40 +2,40 @@
 
 public class FilterOptions
 {
-    private readonly List<string> m_filters = new();
+    private readonly List<string> _filters = new();
 
     public void Set(string filter, bool value)
     {
-        if (value && !m_filters.Contains(filter))
+        if (value && !_filters.Contains(filter))
         {
-            m_filters.Add(filter);
+            _filters.Add(filter);
         }
 
-        if (!value && m_filters.Contains(filter))
+        if (!value && _filters.Contains(filter))
         {
-            m_filters.Remove(filter);
+            _filters.Remove(filter);
         }
     }
 
     public bool IsSet(string filter)
     {
-        return m_filters.Contains(filter);
+        return _filters.Contains(filter);
     }
 }
 
 public class AvailableFilters
 {
-    private readonly Dictionary<string, string> m_filterDefs = new();
+    private readonly Dictionary<string, string> _filterDefs = new();
 
-    public IEnumerable<string> AllFilters => m_filterDefs.Keys;
+    public IEnumerable<string> AllFilters => _filterDefs.Keys;
 
     internal void Add(string key, string desc)
     {
-        m_filterDefs.Add(key, desc);
+        _filterDefs.Add(key, desc);
     }
 
     public string Get(string key)
     {
-        return m_filterDefs[key];
+        return _filterDefs[key];
     }
 }

--- a/src/EditorCore/FontsManager.cs
+++ b/src/EditorCore/FontsManager.cs
@@ -9,7 +9,7 @@ internal partial class FontsManagerJsonContext : JsonSerializerContext { }
 
 internal class FontsManager
 {
-    private static readonly HttpClient s_client = new();
+    private static readonly HttpClient Client = new();
 
     private readonly List<string> _basefonts = new()
     {
@@ -39,7 +39,7 @@ internal class FontsManager
     {
         try
         {
-            var json = await s_client.GetStringAsync(
+            var json = await Client.GetStringAsync(
                 "https://www.googleapis.com/webfonts/v1/webfonts?key=AIzaSyDs93IH2UgudQK5IyNSdvKnm1N8TIYzlcM");
             var result = JsonSerializer.Deserialize(json, FontsManagerJsonContext.Default.WebFontsResult);
             if (result?.items != null)

--- a/src/EditorCore/ScriptCommandEditorData.cs
+++ b/src/EditorCore/ScriptCommandEditorData.cs
@@ -2,15 +2,15 @@
 
 public class ScriptCommandEditorData : IEditorData
 {
-    private readonly EditorController m_controller;
-    private readonly IEditableScript m_script;
+    private readonly EditorController _controller;
+    private readonly IEditableScript _script;
 
     public ScriptCommandEditorData(EditorController controller, IEditableScript script)
     {
-        m_controller = controller;
-        m_script = script;
+        _controller = controller;
+        _script = script;
 
-        m_script.Updated += m_script_Updated;
+        _script.Updated += OnScriptUpdated;
     }
 
     public event EventHandler Changed;
@@ -19,12 +19,12 @@ public class ScriptCommandEditorData : IEditorData
 
     public object GetAttribute(string attribute)
     {
-        return m_controller.WrapValue(m_script.GetParameter(attribute));
+        return _controller.WrapValue(_script.GetParameter(attribute));
     }
 
     public ValidationResult SetAttribute(string attribute, object value)
     {
-        m_script.SetParameter(attribute, value);
+        _script.SetParameter(attribute, value);
 
         return new ValidationResult {Valid = true};
     }
@@ -47,12 +47,12 @@ public class ScriptCommandEditorData : IEditorData
 
     public IEnumerable<string> GetVariablesInScope()
     {
-        return m_script.GetVariablesInScope();
+        return _script.GetVariablesInScope();
     }
 
     public bool IsDirectlySaveable => true;
 
-    private void m_script_Updated(object sender, EditableScriptUpdatedEventArgs e)
+    private void OnScriptUpdated(object sender, EditableScriptUpdatedEventArgs e)
     {
         if (Changed != null)
         {

--- a/src/EditorCore/SubEditorControlData.cs
+++ b/src/EditorCore/SubEditorControlData.cs
@@ -2,7 +2,7 @@
 
 public class AttributeSubEditorControlData : IEditorControl
 {
-    private static readonly Dictionary<string, string> s_allTypes = new()
+    private static readonly Dictionary<string, string> AllTypes = new()
     {
         {"string", "String"},
         {"boolean", "Boolean"},
@@ -22,7 +22,7 @@ public class AttributeSubEditorControlData : IEditorControl
         Attribute = attribute;
     }
 
-    protected virtual Dictionary<string, string> AllowedTypes => s_allTypes;
+    protected virtual Dictionary<string, string> AllowedTypes => AllTypes;
 
     public string Attribute { get; }
 

--- a/src/EditorCore/Utility.cs
+++ b/src/EditorCore/Utility.cs
@@ -4,7 +4,7 @@ namespace QuestViva.EditorCore;
 
 public static class EditorUtility
 {
-    private static readonly Regex s_containsUnescapedQuote = new("^\"|[^\\\\]\\\"");
+    private static readonly Regex ContainsUnescapedQuote = new("^\"|[^\\\\]\\\"");
 
     public static string FormatAsOneLine(string input)
     {
@@ -32,7 +32,7 @@ public static class EditorUtility
         var inner = expression.Substring(1, expression.Length - 2);
 
         // must not contain an unescaped quote character
-        return !s_containsUnescapedQuote.IsMatch(inner);
+        return !ContainsUnescapedQuote.IsMatch(inner);
     }
 
     public static string ConvertToSimpleStringExpression(string expression)

--- a/src/Engine/Element.cs
+++ b/src/Engine/Element.cs
@@ -48,48 +48,48 @@ public enum ObjectType
 // TODO: IComparable was needed for NCalc - this should be added to other types too.
 public class Element : IComparable
 {
-    private static readonly Dictionary<ObjectType, string> s_typeStrings;
-    private static readonly Dictionary<string, ObjectType> s_mapObjectTypeStringsToElementType;
-    private static readonly Dictionary<ElementType, string> s_elemTypeStrings;
-    private static readonly Dictionary<string, ElementType> s_mapElemTypeStringsToElementType;
+    private static readonly Dictionary<ObjectType, string> TypeStrings;
+    private static readonly Dictionary<string, ObjectType> MapObjectTypeStringsToElementType;
+    private static readonly Dictionary<ElementType, string> ElemTypeStrings;
+    private static readonly Dictionary<string, ElementType> MapElemTypeStringsToElementType;
 
     private string _name;
 
     private Element _parent;
 
     private string _text;
-    private ElementType m_elemType;
+    private ElementType _elemType;
 
-    private ObjectType m_type;
-    internal WorldModel m_worldModel;
+    private ObjectType _type;
+    internal WorldModel _worldModel;
 
     static Element()
     {
-        s_typeStrings = new Dictionary<ObjectType, string>();
-        s_typeStrings.Add(ObjectType.Object, "object");
-        s_typeStrings.Add(ObjectType.Exit, "exit");
-        s_typeStrings.Add(ObjectType.Command, "command");
-        s_typeStrings.Add(ObjectType.Game, "game");
-        s_typeStrings.Add(ObjectType.TurnScript, "turnscript");
+        TypeStrings = new Dictionary<ObjectType, string>();
+        TypeStrings.Add(ObjectType.Object, "object");
+        TypeStrings.Add(ObjectType.Exit, "exit");
+        TypeStrings.Add(ObjectType.Command, "command");
+        TypeStrings.Add(ObjectType.Game, "game");
+        TypeStrings.Add(ObjectType.TurnScript, "turnscript");
 
-        s_mapObjectTypeStringsToElementType = new Dictionary<string, ObjectType>();
-        foreach (var item in s_typeStrings)
+        MapObjectTypeStringsToElementType = new Dictionary<string, ObjectType>();
+        foreach (var item in TypeStrings)
         {
-            s_mapObjectTypeStringsToElementType.Add(item.Value, item.Key);
+            MapObjectTypeStringsToElementType.Add(item.Value, item.Key);
         }
 
-        s_elemTypeStrings = new Dictionary<ElementType, string>();
+        ElemTypeStrings = new Dictionary<ElementType, string>();
         foreach (ElementType t in Enum.GetValues<ElementType>())
         {
-            s_elemTypeStrings.Add(t,
+            ElemTypeStrings.Add(t,
                 ((ElementTypeInfo) typeof(ElementType).GetField(t.ToString())
                     .GetCustomAttributes(typeof(ElementTypeInfo), false)[0]).Name);
         }
 
-        s_mapElemTypeStringsToElementType = new Dictionary<string, ElementType>();
-        foreach (var item in s_elemTypeStrings)
+        MapElemTypeStringsToElementType = new Dictionary<string, ElementType>();
+        foreach (var item in ElemTypeStrings)
         {
-            s_mapElemTypeStringsToElementType.Add(item.Value, item.Key);
+            MapElemTypeStringsToElementType.Add(item.Value, item.Key);
         }
     }
 
@@ -100,7 +100,7 @@ public class Element : IComparable
 
     internal Element(WorldModel worldModel, Element element)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
 
         if (element == null)
         {
@@ -145,31 +145,31 @@ public class Element : IComparable
 
     public ObjectType Type
     {
-        get => m_type;
+        get => _type;
         set
         {
-            m_type = value;
+            _type = value;
             Fields.Set("type", TypeString);
         }
     }
 
     public ElementType ElemType
     {
-        get => m_elemType;
+        get => _elemType;
         set
         {
-            m_elemType = value;
+            _elemType = value;
             Fields.Set("elementtype", ElementTypeString);
         }
     }
 
-    internal string TypeString => s_typeStrings[m_type];
+    internal string TypeString => TypeStrings[_type];
 
-    internal string ElementTypeString => s_elemTypeStrings[m_elemType];
+    internal string ElementTypeString => ElemTypeStrings[_elemType];
 
     internal bool Initialised { get; private set; }
 
-    internal WorldModel WorldModel => m_worldModel;
+    internal WorldModel WorldModel => _worldModel;
 
     public int CompareTo(object obj)
     {
@@ -178,22 +178,22 @@ public class Element : IComparable
 
     internal static ElementType GetElementTypeForTypeString(string typeString)
     {
-        return s_mapElemTypeStringsToElementType[typeString];
+        return MapElemTypeStringsToElementType[typeString];
     }
 
     internal static ObjectType GetObjectTypeForTypeString(string typeString)
     {
-        return s_mapObjectTypeStringsToElementType[typeString];
+        return MapObjectTypeStringsToElementType[typeString];
     }
 
     internal static string GetTypeStringForElementType(ElementType type)
     {
-        return s_elemTypeStrings[type];
+        return ElemTypeStrings[type];
     }
 
     internal static string GetTypeStringForObjectType(ObjectType type)
     {
-        return s_typeStrings[type];
+        return TypeStrings[type];
     }
 
     private void Fields_AttributeChangedSilent(object sender, AttributeChangedEventArgs e)
@@ -201,17 +201,17 @@ public class Element : IComparable
         // used by the Editor to receive notifications of updates when undoing
         if (e.InheritedTypesSet)
         {
-            m_worldModel.NotifyElementRefreshed(this);
+            _worldModel.NotifyElementRefreshed(this);
         }
         else
         {
-            m_worldModel.NotifyElementFieldUpdate(this, e.Property, e.Value, true);
+            _worldModel.NotifyElementFieldUpdate(this, e.Property, e.Value, true);
         }
     }
 
     private void Fields_AttributeChanged(object sender, AttributeChangedEventArgs e)
     {
-        m_worldModel.NotifyElementFieldUpdate(this, e.Property, e.Value, false);
+        _worldModel.NotifyElementFieldUpdate(this, e.Property, e.Value, false);
     }
 
     internal async Task SetFieldAsync(string fieldName, object value)
@@ -219,25 +219,25 @@ public class Element : IComparable
         var oldValue = Fields.Get(fieldName);
         var changed = value == null ? oldValue != null : !value.Equals(oldValue);
         Fields.Set(fieldName, value);
-        if (changed && !m_worldModel.EditMode)
+        if (changed && !_worldModel.EditMode)
         {
             var changedScriptName = "changed" + fieldName;
             if (Fields.HasType<IScript>(changedScriptName))
             {
                 var parameters = new Parameters("oldvalue", oldValue);
-                await m_worldModel.RunScriptAsync(Fields.GetAsType<IScript>(changedScriptName), parameters, this);
+                await _worldModel.RunScriptAsync(Fields.GetAsType<IScript>(changedScriptName), parameters, this);
             }
         }
     }
 
     private void MetaFields_AttributeChanged(object sender, AttributeChangedEventArgs e)
     {
-        m_worldModel.NotifyElementMetaFieldUpdate(this, e.Property, e.Value, false);
+        _worldModel.NotifyElementMetaFieldUpdate(this, e.Property, e.Value, false);
     }
 
     private void MetaFields_AttributeChangedSilent(object sender, AttributeChangedEventArgs e)
     {
-        m_worldModel.NotifyElementMetaFieldUpdate(this, e.Property, e.Value, true);
+        _worldModel.NotifyElementMetaFieldUpdate(this, e.Property, e.Value, true);
     }
 
     public IScript GetAction(string action)
@@ -257,7 +257,7 @@ public class Element : IComparable
             throw new ArgumentException($"Parent of element '{Name}' cannot be set to itself");
         }
 
-        m_worldModel.Elements.UpdateParentIndex(this, _parent, parent);
+        _worldModel.Elements.UpdateParentIndex(this, _parent, parent);
         _parent = parent;
     }
 
@@ -298,8 +298,8 @@ public class Element : IComparable
 
     public Element Clone(Func<Element, bool> canCloneChild, bool lastelementscutout = false)
     {
-        var newElement = m_worldModel.GetElementFactory(m_elemType)
-            .CloneElement(this, lastelementscutout ? Name : m_worldModel.GetUniqueElementName(Name));
+        var newElement = _worldModel.GetElementFactory(_elemType)
+            .CloneElement(this, lastelementscutout ? Name : _worldModel.GetUniqueElementName(Name));
 
         if (MetaFields[MetaFieldDefinitions.Library])
         {
@@ -308,7 +308,7 @@ public class Element : IComparable
         }
 
         // Pre-fetch all children of this element
-        var children = m_worldModel.Elements.GetDirectChildren(this).ToList();
+        var children = _worldModel.Elements.GetDirectChildren(this).ToList();
 
         foreach (var child in children.Where(e => canCloneChild(e)))
         {

--- a/src/Engine/Elements.cs
+++ b/src/Engine/Elements.cs
@@ -3,35 +3,35 @@ namespace QuestViva.Engine;
 
 public class Elements
 {
-    private readonly Dictionary<string, Element> m_allElements = new();
-    private readonly Dictionary<ElementType, Dictionary<string, Element>> m_elements = new();
-    private readonly Dictionary<ElementType, List<Element>> m_elementsLists = new();
+    private readonly Dictionary<string, Element> _allElements = new();
+    private readonly Dictionary<ElementType, Dictionary<string, Element>> _elements = new();
+    private readonly Dictionary<ElementType, List<Element>> _elementsLists = new();
 
     // Index of parent -> direct children, kept in sync by Add/Remove/UpdateParentIndex so that
     // GetDirectChildren doesn't need to do a full scan of every element in the game.
-    private readonly List<Element> m_rootElements = new();
-    private readonly Dictionary<Element, List<Element>> m_childrenByParent = new();
+    private readonly List<Element> _rootElements = new();
+    private readonly Dictionary<Element, List<Element>> _childrenByParent = new();
 
     // Elements that have completed at least one Add() call, and so are eligible to have their
     // parent-index entry moved by UpdateParentIndex. Elements being cloned have "parent" copied
     // onto them (via Fields.Clone) before they've been added, so that early parent assignment
     // must not touch the index - Add() below performs the baseline registration instead.
-    private readonly HashSet<Element> m_indexedElements = new();
+    private readonly HashSet<Element> _indexedElements = new();
 
     // Per-parent counters backing UpdateElementSortOrder, so assigning a new child's SortIndex
     // doesn't need to scan all existing siblings to find the current max. SortIndex is only ever
     // used for relative ordering (OrderBy) or pairwise swapping of two already-issued values, so
     // a monotonically increasing counter per parent is safe even though it doesn't reclaim gaps
     // left by removed elements.
-    private readonly Dictionary<Element, int> m_nextSortIndexByParent = new();
-    private int m_nextRootSortIndex;
+    private readonly Dictionary<Element, int> _nextSortIndexByParent = new();
+    private int _nextRootSortIndex;
 
     internal Elements()
     {
         foreach (ElementType t in Enum.GetValues<ElementType>())
         {
-            m_elements.Add(t, new Dictionary<string, Element>());
-            m_elementsLists.Add(t, new List<Element>());
+            _elements.Add(t, new Dictionary<string, Element>());
+            _elementsLists.Add(t, new List<Element>());
         }
     }
 
@@ -46,41 +46,41 @@ public class Elements
             throw new ArgumentException("Invalid object name");
         }
 
-        if (m_allElements.ContainsKey(key))
+        if (_allElements.ContainsKey(key))
         {
             // An element with this name already exists. This is OK if the new element
             // is of the same type - then it will just override the previous element.
 
-            if (!m_elements[t].ContainsKey(key))
+            if (!_elements[t].ContainsKey(key))
             {
                 throw new Exception(string.Format(
                     "Element '{0}' of type '{1}' cannot override the existing element of type '{2}'",
                     key,
                     t,
-                    m_allElements[key].ElemType));
+                    _allElements[key].ElemType));
             }
 
             // element is being overridden, so detach the event handler
-            var oldElement = m_allElements[key];
+            var oldElement = _allElements[key];
             oldElement.Fields.NameChanged -= ElementNameChanged;
 
             // remove old element from ordered elements list
-            m_elementsLists[t].Remove(m_elements[t][key]);
+            _elementsLists[t].Remove(_elements[t][key]);
 
             // and from the parent index, since it's being displaced from the live element graph
             RemoveFromParentIndex(oldElement, oldElement.Parent);
-            m_indexedElements.Remove(oldElement);
+            _indexedElements.Remove(oldElement);
         }
 
-        m_allElements[key] = e;
-        m_elements[t][key] = e;
-        m_elementsLists[t].Add(e);
+        _allElements[key] = e;
+        _elements[t][key] = e;
+        _elementsLists[t].Add(e);
 
         // Baseline parent-index registration. Covers both fresh elements (Parent is still null
         // at this point) and clones (Parent may already be set, copied from the clone source by
         // Fields.Clone before Add() ran) and undo/redo re-creation of a previously-removed element.
         AddToParentIndex(e, e.Parent);
-        m_indexedElements.Add(e);
+        _indexedElements.Add(e);
 
         e.Fields.NameChanged += ElementNameChanged;
     }
@@ -92,11 +92,11 @@ public class Elements
             throw new ArgumentException("Invalid object name");
         }
 
-        m_allElements.Remove(e.OldName);
-        m_elements[e.Element.ElemType].Remove(e.OldName);
+        _allElements.Remove(e.OldName);
+        _elements[e.Element.ElemType].Remove(e.OldName);
 
-        m_allElements.Add(e.Element.Name, e.Element);
-        m_elements[e.Element.ElemType].Add(e.Element.Name, e.Element);
+        _allElements.Add(e.Element.Name, e.Element);
+        _elements[e.Element.ElemType].Add(e.Element.Name, e.Element);
 
         if (ElementRenamed != null)
         {
@@ -106,22 +106,22 @@ public class Elements
 
     internal void Remove(ElementType t, string key)
     {
-        if (m_allElements.TryGetValue(key, out var element))
+        if (_allElements.TryGetValue(key, out var element))
         {
             RemoveFromParentIndex(element, element.Parent);
-            m_indexedElements.Remove(element);
+            _indexedElements.Remove(element);
         }
 
-        m_allElements.Remove(key);
-        m_elementsLists[t].Remove(m_elements[t][key]);
-        m_elements[t].Remove(key);
+        _allElements.Remove(key);
+        _elementsLists[t].Remove(_elements[t][key]);
+        _elements[t].Remove(key);
     }
 
     // Called by Element.SetParentFromFields whenever an element's parent changes, so the
     // parent -> children index stays in sync without needing a full rescan of all elements.
     internal void UpdateParentIndex(Element child, Element oldParent, Element newParent)
     {
-        if (!m_indexedElements.Contains(child))
+        if (!_indexedElements.Contains(child))
         {
             // Still under construction (e.g. Fields.Clone copying "parent" before the clone has
             // been added) - Add() will perform the baseline registration once it's added.
@@ -136,14 +136,14 @@ public class Elements
     {
         if (parent == null)
         {
-            m_rootElements.Add(child);
+            _rootElements.Add(child);
             return;
         }
 
-        if (!m_childrenByParent.TryGetValue(parent, out var children))
+        if (!_childrenByParent.TryGetValue(parent, out var children))
         {
             children = new List<Element>();
-            m_childrenByParent[parent] = children;
+            _childrenByParent[parent] = children;
         }
 
         children.Add(child);
@@ -153,11 +153,11 @@ public class Elements
     {
         if (parent == null)
         {
-            m_rootElements.Remove(child);
+            _rootElements.Remove(child);
             return;
         }
 
-        if (m_childrenByParent.TryGetValue(parent, out var children))
+        if (_childrenByParent.TryGetValue(parent, out var children))
         {
             children.Remove(child);
         }
@@ -167,7 +167,7 @@ public class Elements
     {
         try
         {
-            return m_allElements[key];
+            return _allElements[key];
         }
         catch (KeyNotFoundException ex)
         {
@@ -182,7 +182,7 @@ public class Elements
 
     public IEnumerable<Element> GetElements(ElementType t)
     {
-        foreach (var e in m_elementsLists[t])
+        foreach (var e in _elementsLists[t])
         {
             yield return e;
         }
@@ -190,7 +190,7 @@ public class Elements
 
     public IEnumerable<Element> GetElements()
     {
-        foreach (var e in m_allElements.Values)
+        foreach (var e in _allElements.Values)
         {
             yield return e;
         }
@@ -198,19 +198,19 @@ public class Elements
 
     public bool ContainsKey(ElementType t, string key)
     {
-        return m_elements[t].ContainsKey(key);
+        return _elements[t].ContainsKey(key);
     }
 
     public bool ContainsKey(string key)
     {
-        return m_allElements.ContainsKey(key);
+        return _allElements.ContainsKey(key);
     }
 
     public Element Get(ElementType t, string key)
     {
         try
         {
-            return m_elements[t][key];
+            return _elements[t][key];
         }
         catch (KeyNotFoundException ex)
         {
@@ -220,22 +220,22 @@ public class Elements
 
     public bool TryGetValue(ElementType t, string key, out Element element)
     {
-        return m_elements[t].TryGetValue(key, out element);
+        return _elements[t].TryGetValue(key, out element);
     }
 
     public int Count(ElementType t)
     {
-        return m_elements[t].Count;
+        return _elements[t].Count;
     }
 
     public int Count()
     {
-        return m_allElements.Count;
+        return _allElements.Count;
     }
 
     public Element GetSingle(ElementType t)
     {
-        foreach (var e in m_elements[t].Values)
+        foreach (var e in _elements[t].Values)
         {
             return e;
         }
@@ -266,21 +266,21 @@ public class Elements
     {
         if (parent == null)
         {
-            return m_rootElements;
+            return _rootElements;
         }
 
-        return m_childrenByParent.TryGetValue(parent, out var children) ? children : [];
+        return _childrenByParent.TryGetValue(parent, out var children) ? children : [];
     }
 
     internal int GetNextSortIndex(Element parent)
     {
         if (parent == null)
         {
-            return m_nextRootSortIndex++;
+            return _nextRootSortIndex++;
         }
 
-        var next = m_nextSortIndexByParent.GetValueOrDefault(parent);
-        m_nextSortIndexByParent[parent] = next + 1;
+        var next = _nextSortIndexByParent.GetValueOrDefault(parent);
+        _nextSortIndexByParent[parent] = next + 1;
         return next;
     }
 }

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -166,19 +166,19 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         return (handled, result);
     }
 
-    private static readonly Dictionary<(Type, string), MethodBase[]?> s_methodCache = new();
+    private static readonly Dictionary<(Type, string), MethodBase[]?> MethodCache = new();
 
     private static MethodBase[]? GetPublicMethodsByName([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string name)
     {
         var key = (type, name);
-        if (s_methodCache.TryGetValue(key, out var cached))
+        if (MethodCache.TryGetValue(key, out var cached))
             return cached;
 
         var methods = type.GetMethods()
             .Where(m => m.IsPublic && m.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
             .ToArray<MethodBase>();
         var result = methods.Length == 0 ? null : methods;
-        s_methodCache[key] = result;
+        MethodCache[key] = result;
         return result;
     }
 

--- a/src/Engine/Fields.cs
+++ b/src/Engine/Fields.cs
@@ -132,13 +132,13 @@ public static class MetaFieldDefinitions
 
 public class Fields
 {
-    private static readonly Dictionary<Type, DebugFormatDelegate> s_formatters = new()
+    private static readonly Dictionary<Type, DebugFormatDelegate> Formatters = new()
     {
         {typeof(List<string>), ListFormatter}
     };
 
     // Debugger attribute-override pre-fill (see WasmPlayerBridge's debugger):
-    // unlike s_formatters above (a human-readable *display* string — an
+    // unlike Formatters above (a human-readable *display* string — an
     // Element shows as "Object: kitchen", a string has no quotes, a bool
     // reads "True"), this produces a value already written as valid script
     // syntax, ready to feed straight into ScriptFactory.CreateScript for
@@ -146,7 +146,7 @@ public class Fields
     // scripts, ...) fall back to the same display string, which isn't
     // generally re-enterable — there's no simple literal syntax for those,
     // so the debugger's override hint still covers that residual case.
-    private static readonly Dictionary<Type, DebugFormatDelegate> s_editFormatters = new()
+    private static readonly Dictionary<Type, DebugFormatDelegate> EditFormatters = new()
     {
         {typeof(bool), v => (bool) v ? "true" : "false"},
         {typeof(string), v => "\"" + ((string) v).Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""},
@@ -154,13 +154,13 @@ public class Fields
     };
 
     // Which value kinds the debugger's override control should even offer —
-    // the types above (their ToString() already needs the s_editFormatters
+    // the types above (their ToString() already needs the EditFormatters
     // rewrite to become valid script syntax) plus plain numeric types (whose
     // ToString() already *is* valid script syntax, no rewrite needed). Lists,
     // dictionaries, scripts etc. have no simple literal syntax to write back,
     // so there's deliberately no entry for them here — an override textbox
     // for those would just be a dead end.
-    private static readonly HashSet<Type> s_overridableValueTypes = new()
+    private static readonly HashSet<Type> OverridableValueTypes = new()
     {
         typeof(bool), typeof(string), typeof(Element),
         typeof(int), typeof(double), typeof(long), typeof(float), typeof(decimal), typeof(short)
@@ -168,37 +168,37 @@ public class Fields
 
     private static bool CanOverrideValue(object value)
     {
-        return value == null || s_overridableValueTypes.Contains(value.GetType());
+        return value == null || OverridableValueTypes.Contains(value.GetType());
     }
 
-    private readonly Dictionary<string, object> m_attributes = new();
-    private readonly Element m_element;
-    private readonly Dictionary<string, IExtendableField> m_extendableFields = new();
-    private readonly bool m_isMeta;
-    private readonly WorldModel m_worldModel;
-    private Stack<Element> m_types = new();
+    private readonly Dictionary<string, object> _attributes = new();
+    private readonly Element _element;
+    private readonly Dictionary<string, IExtendableField> _extendableFields = new();
+    private readonly bool _isMeta;
+    private readonly WorldModel _worldModel;
+    private Stack<Element> _types = new();
 
     public Fields(WorldModel worldModel, Element element, bool isMeta)
     {
-        m_worldModel = worldModel;
-        m_element = element;
+        _worldModel = worldModel;
+        _element = element;
         LazyFields = new LazyFields(worldModel, this);
-        m_isMeta = isMeta;
+        _isMeta = isMeta;
     }
 
     internal bool MutableFieldsLocked { get; set; }
 
     internal LazyFields LazyFields { get; }
 
-    internal IEnumerable<string> FieldNames => m_attributes.Keys;
+    internal IEnumerable<string> FieldNames => _attributes.Keys;
 
     internal IEnumerable<string> FieldExtensionNames
     {
         get
         {
-            var result = new List<string>(m_extendableFields.Keys);
+            var result = new List<string>(_extendableFields.Keys);
 
-            foreach (var type in m_types)
+            foreach (var type in _types)
             {
                 result.AddRange(type.Fields.FieldExtensionNames);
             }
@@ -207,21 +207,21 @@ public class Fields
         }
     }
 
-    internal IEnumerable<Element> Types => m_types;
+    internal IEnumerable<Element> Types => _types;
     public event EventHandler<AttributeChangedEventArgs> AttributeChanged;
     public event EventHandler<AttributeChangedEventArgs> AttributeChangedSilent;
     internal event EventHandler<NameChangedEventArgs> NameChanged;
 
     internal Fields Clone(Element newElement)
     {
-        var clone = new Fields(m_worldModel, newElement, m_isMeta);
+        var clone = new Fields(_worldModel, newElement, _isMeta);
 
-        foreach (var type in m_types.Reverse())
+        foreach (var type in _types.Reverse())
         {
-            clone.m_types.Push(type);
+            clone._types.Push(type);
         }
 
-        foreach (var attribute in m_attributes)
+        foreach (var attribute in _attributes)
         {
             if (attribute.Key != "name")
             {
@@ -239,9 +239,9 @@ public class Fields
             return DefaultFormatter;
         }
 
-        if (s_formatters.ContainsKey(type))
+        if (Formatters.ContainsKey(type))
         {
-            return s_formatters[type];
+            return Formatters[type];
         }
 
         return DefaultFormatter;
@@ -276,18 +276,18 @@ public class Fields
 
     private void UndoLog(string property, object oldValue, object newValue, bool added)
     {
-        if (m_worldModel != null)
+        if (_worldModel != null)
         {
-            m_worldModel.UndoLogger.AddUndoAction(() =>
-                new UndoFieldSet(m_worldModel, m_element.Name, property, oldValue, newValue, added, m_isMeta));
+            _worldModel.UndoLogger.AddUndoAction(() =>
+                new UndoFieldSet(_worldModel, _element.Name, property, oldValue, newValue, added, _isMeta));
         }
     }
 
     internal void UndoLog(UndoLogger.IUndoAction action)
     {
-        if (m_worldModel != null)
+        if (_worldModel != null)
         {
-            m_worldModel.UndoLogger.AddUndoAction(() => action);
+            _worldModel.UndoLogger.AddUndoAction(() => action);
         }
     }
 
@@ -304,7 +304,7 @@ public class Fields
     internal void RemoveFieldInternal(string name)
     {
         var oldValue = Get(name);
-        m_attributes.Remove(name);
+        _attributes.Remove(name);
 
         if (AttributeChangedSilent != null && name != "name")
         {
@@ -314,7 +314,7 @@ public class Fields
 
     public void RemoveField(string name)
     {
-        UndoLog(new UndoFieldRemove(m_element.Name, name, m_attributes[name]));
+        UndoLog(new UndoFieldRemove(_element.Name, name, _attributes[name]));
         RemoveFieldInternal(name);
     }
 
@@ -324,7 +324,7 @@ public class Fields
         {
             // extendable fields should only ever exist in types, and be set at the start of the game,
             // so we should never need to worry about adding them to the undo log etc.
-            m_extendableFields[name] = value;
+            _extendableFields[name] = value;
         }
         else
         {
@@ -339,7 +339,7 @@ public class Fields
         var added = true;
         object oldValue = null;
 
-        if (m_attributes.ContainsKey(name))
+        if (_attributes.ContainsKey(name))
         {
             added = false;
             oldValue = Get(name);
@@ -367,7 +367,7 @@ public class Fields
             var mutableNewValue = value as IMutableField;
             if (mutableOldValue != null)
             {
-                if (m_worldModel.EditMode || mutableOldValue.RequiresCloning)
+                if (_worldModel.EditMode || mutableOldValue.RequiresCloning)
                 {
                     oldValue = mutableOldValue.Clone();
                 }
@@ -375,15 +375,15 @@ public class Fields
 
             if (mutableNewValue != null)
             {
-                if (m_worldModel.EditMode || mutableNewValue.RequiresCloning)
+                if (_worldModel.EditMode || mutableNewValue.RequiresCloning)
                 {
                     value = mutableNewValue.Clone();
                 }
 
                 var mutableValue = (IMutableField) value;
                 mutableValue.Locked = MutableFieldsLocked;
-                mutableValue.UndoLog = m_worldModel.UndoLogger;
-                mutableValue.Owner = m_element;
+                mutableValue.UndoLog = _worldModel.UndoLogger;
+                mutableValue.Owner = _element;
             }
         }
 
@@ -396,34 +396,34 @@ public class Fields
                     throw new ArgumentException("Invalid data type for 'name'");
                 }
 
-                m_element.SetNameFromFields(strValue);
+                _element.SetNameFromFields(strValue);
                 break;
             }
             case "parent":
-                m_element.SetParentFromFields(value as Element);
+                _element.SetParentFromFields(value as Element);
                 break;
             case "text":
-                m_element.SetTextFromFields(value as string);
+                _element.SetTextFromFields(value as string);
                 break;
         }
 
-        if (m_worldModel.Version >= WorldModelVersion.v530 && value == null)
+        if (_worldModel.Version >= WorldModelVersion.v530 && value == null)
         {
-            m_attributes.Remove(name);
+            _attributes.Remove(name);
         }
         else
         {
-            m_attributes[name] = value;
+            _attributes[name] = value;
         }
 
-        if (changed && allowUpdateSortOrder && name == "parent" && m_element.Initialised)
+        if (changed && allowUpdateSortOrder && name == "parent" && _element.Initialised)
         {
-            m_worldModel.UpdateElementSortOrder(m_element);
+            _worldModel.UpdateElementSortOrder(_element);
         }
 
         if (name == "name" && changed && value != null && !added && NameChanged != null)
         {
-            if (!m_worldModel.EditMode)
+            if (!_worldModel.EditMode)
             {
                 // Actually we could allow this I suppose but I don't think it's sensible.
                 throw new InvalidOperationException("Cannot change name of element when not in Edit mode");
@@ -432,7 +432,7 @@ public class Fields
             NameChanged(this, new NameChangedEventArgs
             {
                 OldName = (string) oldValue,
-                Element = m_element
+                Element = _element
             });
         }
 
@@ -478,18 +478,18 @@ public class Fields
     {
         var result = new AttributeData();
 
-        if (m_attributes.TryGetValue(attribute, out result.Value))
+        if (_attributes.TryGetValue(attribute, out result.Value))
         {
             if (withSource)
             {
-                result.Source = m_element.Name;
+                result.Source = _element.Name;
                 result.IsInherited = false;
             }
 
             return result;
         }
 
-        foreach (var type in m_types)
+        foreach (var type in _types)
         {
             if (type.Fields.Exists(attribute, false))
             {
@@ -545,12 +545,12 @@ public class Fields
 
     private bool HasExtendableField(string attribute)
     {
-        if (m_extendableFields.ContainsKey(attribute))
+        if (_extendableFields.ContainsKey(attribute))
         {
             return true;
         }
 
-        foreach (var type in m_types)
+        foreach (var type in _types)
         {
             if (type.Fields.HasExtendableField(attribute))
             {
@@ -565,13 +565,13 @@ public class Fields
     {
         IExtendableField result = null;
 
-        if (m_extendableFields.ContainsKey(attribute))
+        if (_extendableFields.ContainsKey(attribute))
         {
-            result = MergeExtendableFields(result, m_extendableFields[attribute]);
-            source.Add(m_element.Name);
+            result = MergeExtendableFields(result, _extendableFields[attribute]);
+            source.Add(_element.Name);
         }
 
-        foreach (var type in m_types)
+        foreach (var type in _types)
         {
             if (type.Fields.HasExtendableField(attribute))
             {
@@ -600,13 +600,13 @@ public class Fields
         string source = null;
         var isInherited = false;
 
-        if (m_attributes.ContainsKey(attribute))
+        if (_attributes.ContainsKey(attribute))
         {
-            source = m_element.Name;
+            source = _element.Name;
         }
         else
         {
-            foreach (var type in m_types)
+            foreach (var type in _types)
             {
                 if (type.Fields.Exists(attribute, true))
                 {
@@ -624,12 +624,12 @@ public class Fields
 
     internal bool Exists(string attribute, bool includeExtendableFields)
     {
-        if (m_attributes.ContainsKey(attribute))
+        if (_attributes.ContainsKey(attribute))
         {
             return true;
         }
 
-        foreach (var type in m_types)
+        foreach (var type in _types)
         {
             if (type.Fields.Exists(attribute, includeExtendableFields))
             {
@@ -647,21 +647,21 @@ public class Fields
 
     public void AddType(Element addType)
     {
-        if (m_element.ElemType == ElementType.ObjectType &&
-            (addType == m_element || addType.Fields.InheritsTypeRecursive(m_element)))
+        if (_element.ElemType == ElementType.ObjectType &&
+            (addType == _element || addType.Fields.InheritsTypeRecursive(_element)))
         {
             throw new Exception("Circular type reference");
         }
 
-        m_types.Push(addType);
+        _types.Push(addType);
     }
 
     public void AddTypeUndoable(Element addType)
     {
-        var oldValue = CloneStack(m_types);
+        var oldValue = CloneStack(_types);
         AddType(addType);
-        var newValue = CloneStack(m_types);
-        m_worldModel.UndoLogger.AddUndoAction(() => new UndoAddRemoveType(m_element.Name, oldValue, newValue));
+        var newValue = CloneStack(_types);
+        _worldModel.UndoLogger.AddUndoAction(() => new UndoAddRemoveType(_element.Name, oldValue, newValue));
         if (AttributeChangedSilent != null)
         {
             AttributeChangedSilent(this, new AttributeChangedEventArgs(true));
@@ -670,10 +670,10 @@ public class Fields
 
     public void RemoveTypeUndoable(Element removeType)
     {
-        var oldValue = CloneStack(m_types);
-        m_types = CloneStackAndDelete(m_types, removeType);
-        var newValue = CloneStack(m_types);
-        m_worldModel.UndoLogger.AddUndoAction(() => new UndoAddRemoveType(m_element.Name, oldValue, newValue));
+        var oldValue = CloneStack(_types);
+        _types = CloneStackAndDelete(_types, removeType);
+        var newValue = CloneStack(_types);
+        _worldModel.UndoLogger.AddUndoAction(() => new UndoAddRemoveType(_element.Name, oldValue, newValue));
         if (AttributeChangedSilent != null)
         {
             AttributeChangedSilent(this, new AttributeChangedEventArgs(true));
@@ -692,7 +692,7 @@ public class Fields
             return "null";
         }
 
-        return s_editFormatters.TryGetValue(value.GetType(), out var formatter)
+        return EditFormatters.TryGetValue(value.GetType(), out var formatter)
             ? formatter.Invoke(value)
             : FormatDebugData(value);
     }
@@ -721,12 +721,12 @@ public class Fields
         var result = new DebugData();
 
         // First we want all the types we include directly
-        foreach (var type in m_types)
+        foreach (var type in _types)
         {
             if (!result.Data.ContainsKey(type.Name))
             {
                 var newItem = new DebugDataItem(type.Name);
-                newItem.Source = m_element.Name;
+                newItem.Source = _element.Name;
                 newItem.IsDefaultType = WorldModel.DefaultTypeNames.ContainsValue(type.Name);
                 result.Data.Add(type.Name, newItem);
             }
@@ -735,7 +735,7 @@ public class Fields
                 // This element directly inherits a type which has also been included
                 // via inheriting another type
 
-                result.Data[type.Name].Source += "," + m_element.Name;
+                result.Data[type.Name].Source += "," + _element.Name;
             }
 
             // Next we want all the types that are inherited from those, as attributes
@@ -799,10 +799,10 @@ public class Fields
         // return a clone of the attributes dictionary as we don't
         // want external code changing any.
         var result = new Dictionary<string, object>();
-        foreach (var key in m_attributes.Keys)
+        foreach (var key in _attributes.Keys)
         {
             // ok so it's not strictly a clone for things like Lists
-            result.Add(key, m_attributes[key]);
+            result.Add(key, _attributes[key]);
         }
 
         return result;
@@ -810,7 +810,7 @@ public class Fields
 
     internal void DoUndoAddRemoveType(Stack<Element> newValue)
     {
-        m_types = newValue;
+        _types = newValue;
         if (AttributeChangedSilent != null)
         {
             AttributeChangedSilent(this, new AttributeChangedEventArgs(true));
@@ -843,17 +843,17 @@ public class Fields
 
     public bool InheritsType(Element type)
     {
-        return m_types.Contains(type);
+        return _types.Contains(type);
     }
 
     public bool InheritsTypeRecursive(Element type)
     {
-        if (m_types.Contains(type))
+        if (_types.Contains(type))
         {
             return true;
         }
 
-        foreach (var inheritedType in m_types)
+        foreach (var inheritedType in _types)
         {
             if (inheritedType.Fields.InheritsTypeRecursive(type))
             {
@@ -868,7 +868,7 @@ public class Fields
     {
         var nullifyAttributes = new List<string>();
 
-        foreach (var attribute in m_attributes)
+        foreach (var attribute in _attributes)
         {
             var elementValue = attribute.Value as Element;
             if (elementValue != null)
@@ -919,10 +919,10 @@ public class Fields
 
     public IEnumerable<string> GetAttributeNames(bool includeInheritedAttributes)
     {
-        var result = new List<string>(m_attributes.Select(a => a.Key));
+        var result = new List<string>(_attributes.Select(a => a.Key));
         if (includeInheritedAttributes)
         {
-            foreach (var type in m_types)
+            foreach (var type in _types)
             {
                 result.AddRange(type.Fields.GetAttributeNames(true).Where(a => !result.Contains(a)));
             }
@@ -995,137 +995,137 @@ public class Fields
 
 public class LazyFields
 {
-    private readonly Fields m_fields;
-    private readonly WorldModel m_worldModel;
-    private List<Action> m_actions = new();
-    private List<string> m_defaultTypes = new();
-    private Dictionary<string, IDictionary<string, string>> m_objectDictionaries = new();
-    private Dictionary<string, string> m_objectFields = new();
-    private Dictionary<string, IEnumerable<string>> m_objectLists = new();
-    private bool m_resolved;
-    private Dictionary<string, IDictionary<string, string>> m_scriptDictionaries = new();
-    private Dictionary<string, string> m_scripts = new();
-    private List<string> m_types = new();
+    private readonly Fields _fields;
+    private readonly WorldModel _worldModel;
+    private List<Action> _actions = new();
+    private List<string> _defaultTypes = new();
+    private Dictionary<string, IDictionary<string, string>> _objectDictionaries = new();
+    private Dictionary<string, string> _objectFields = new();
+    private Dictionary<string, IEnumerable<string>> _objectLists = new();
+    private bool _resolved;
+    private Dictionary<string, IDictionary<string, string>> _scriptDictionaries = new();
+    private Dictionary<string, string> _scripts = new();
+    private List<string> _types = new();
 
     internal LazyFields(WorldModel worldModel, Fields fields)
     {
-        m_worldModel = worldModel;
-        m_fields = fields;
+        _worldModel = worldModel;
+        _fields = fields;
     }
 
     public void Resolve(ScriptFactory scriptFactory)
     {
         CheckNotResolved();
-        foreach (var typename in m_defaultTypes)
+        foreach (var typename in _defaultTypes)
         {
             // It is legitimate for a default type not to exist
-            if (m_worldModel.Elements.ContainsKey(ElementType.ObjectType, typename))
+            if (_worldModel.Elements.ContainsKey(ElementType.ObjectType, typename))
             {
-                m_fields.AddType(m_worldModel.GetObjectType(typename));
+                _fields.AddType(_worldModel.GetObjectType(typename));
             }
         }
 
-        m_defaultTypes = null;
-        foreach (var typename in m_types)
+        _defaultTypes = null;
+        foreach (var typename in _types)
         {
             try
             {
-                m_fields.AddType(m_worldModel.GetObjectType(typename));
+                _fields.AddType(_worldModel.GetObjectType(typename));
             }
             catch (Exception ex)
             {
                 throw new Exception(
-                    string.Format("Error adding type '{0}' to element '{1}': {2}", typename, m_fields.Get("name"),
+                    string.Format("Error adding type '{0}' to element '{1}': {2}", typename, _fields.Get("name"),
                         ex.Message), ex);
             }
         }
 
-        m_types = null;
-        foreach (var property in m_objectFields.Keys)
+        _types = null;
+        foreach (var property in _objectFields.Keys)
         {
             try
             {
-                m_fields.Set(property, m_worldModel.Elements.Get(m_objectFields[property]));
+                _fields.Set(property, _worldModel.Elements.Get(_objectFields[property]));
             }
             catch (Exception ex)
             {
                 throw new Exception(
-                    string.Format("Error adding attribute '{0}' to element '{1}': {2}", property, m_fields.Get("name"),
+                    string.Format("Error adding attribute '{0}' to element '{1}': {2}", property, _fields.Get("name"),
                         ex.Message), ex);
             }
         }
 
-        m_objectFields = null;
-        foreach (var property in m_scripts.Keys)
+        _objectFields = null;
+        foreach (var property in _scripts.Keys)
         {
             try
             {
-                m_fields.Set(property, scriptFactory.CreateScript(m_scripts[property]));
+                _fields.Set(property, scriptFactory.CreateScript(_scripts[property]));
             }
             catch (Exception ex)
             {
                 throw new Exception(
                     string.Format("Error adding script attribute '{0}' to element '{1}': {2}", property,
-                        m_fields.Get("name"), ex.Message), ex);
+                        _fields.Get("name"), ex.Message), ex);
             }
         }
 
-        m_scripts = null;
-        foreach (var property in m_scriptDictionaries.Keys)
+        _scripts = null;
+        foreach (var property in _scriptDictionaries.Keys)
         {
             try
             {
-                m_fields.Set(property, ConvertToScriptDictionary(m_scriptDictionaries[property], scriptFactory));
+                _fields.Set(property, ConvertToScriptDictionary(_scriptDictionaries[property], scriptFactory));
             }
             catch (Exception ex)
             {
                 throw new Exception(
                     string.Format("Error adding script dictionary '{0}' to element '{1}': {2}", property,
-                        m_fields.Get("name"), ex.Message), ex);
+                        _fields.Get("name"), ex.Message), ex);
             }
         }
 
-        m_scriptDictionaries = null;
-        foreach (var property in m_objectLists.Keys)
+        _scriptDictionaries = null;
+        foreach (var property in _objectLists.Keys)
         {
             try
             {
-                m_fields.Set(property,
-                    new QuestList<Element>(m_objectLists[property].Select(n => m_worldModel.Elements.Get(n))));
+                _fields.Set(property,
+                    new QuestList<Element>(_objectLists[property].Select(n => _worldModel.Elements.Get(n))));
             }
             catch (Exception ex)
             {
                 throw new Exception(
                     string.Format("Error adding object list '{0}' to element '{1}': {2}", property,
-                        m_fields.Get("name"), ex.Message), ex);
+                        _fields.Get("name"), ex.Message), ex);
             }
         }
 
-        m_objectLists = null;
-        foreach (var property in m_objectDictionaries.Keys)
+        _objectLists = null;
+        foreach (var property in _objectDictionaries.Keys)
         {
             try
             {
-                m_fields.Set(property, ConvertToObjectDictionary(m_objectDictionaries[property]));
+                _fields.Set(property, ConvertToObjectDictionary(_objectDictionaries[property]));
             }
             catch (Exception ex)
             {
                 throw new Exception(
                     string.Format("Error adding object dictionary '{0}' to element '{1}': {2}", property,
-                        m_fields.Get("name"), ex.Message), ex);
+                        _fields.Get("name"), ex.Message), ex);
             }
         }
 
-        m_objectDictionaries = null;
-        foreach (var action in m_actions)
+        _objectDictionaries = null;
+        foreach (var action in _actions)
         {
             action();
         }
 
-        m_actions = null;
-        foreach (var field in m_fields.FieldNames)
+        _actions = null;
+        foreach (var field in _fields.FieldNames)
         {
-            var attribute = m_fields.Get(field);
+            var attribute = _fields.Get(field);
             var objectList = attribute as QuestList<object>;
             if (objectList != null)
             {
@@ -1139,7 +1139,7 @@ public class LazyFields
             }
         }
 
-        m_resolved = true;
+        _resolved = true;
     }
 
     private QuestDictionary<IScript> ConvertToScriptDictionary(IDictionary<string, string> dictionary,
@@ -1160,7 +1160,7 @@ public class LazyFields
         var newDictionary = new QuestDictionary<Element>();
         foreach (var item in dictionary)
         {
-            var element = m_worldModel.Elements.Get(item.Value);
+            var element = _worldModel.Elements.Get(item.Value);
             newDictionary.Add(item.Key, element);
         }
 
@@ -1170,49 +1170,49 @@ public class LazyFields
     public void AddType(string typename)
     {
         CheckNotResolved();
-        m_types.Add(typename);
+        _types.Add(typename);
     }
 
     public void AddDefaultType(string typename)
     {
         CheckNotResolved();
-        m_defaultTypes.Add(typename);
+        _defaultTypes.Add(typename);
     }
 
     public void AddObjectField(string property, string value)
     {
         CheckNotResolved();
-        m_objectFields.Add(property, value);
+        _objectFields.Add(property, value);
     }
 
     public void AddScript(string property, string value)
     {
         CheckNotResolved();
-        m_scripts.Add(property, value);
+        _scripts.Add(property, value);
     }
 
     public void AddScriptDictionary(string property, IDictionary<string, string> value)
     {
         CheckNotResolved();
-        m_scriptDictionaries.Add(property, value);
+        _scriptDictionaries.Add(property, value);
     }
 
     public void AddObjectList(string property, IEnumerable<string> value)
     {
         CheckNotResolved();
-        m_objectLists.Add(property, value);
+        _objectLists.Add(property, value);
     }
 
     public void AddObjectDictionary(string property, IDictionary<string, string> value)
     {
         CheckNotResolved();
-        m_objectDictionaries.Add(property, value);
+        _objectDictionaries.Add(property, value);
     }
 
     public void AddAction(Action action)
     {
         CheckNotResolved();
-        m_actions.Add(action);
+        _actions.Add(action);
     }
 
     private void ResolveObjectList(QuestList<object> list, ScriptFactory scriptFactory)
@@ -1269,14 +1269,14 @@ public class LazyFields
         var objRef = value as LazyObjectReference;
         if (objRef != null)
         {
-            replacement = m_worldModel.Elements.Get(objRef.ObjectName);
+            replacement = _worldModel.Elements.Get(objRef.ObjectName);
             return true;
         }
 
         var objList = value as LazyObjectList;
         if (objList != null)
         {
-            replacement = new QuestList<Element>(objList.Objects.Select(o => m_worldModel.Elements.Get(o)));
+            replacement = new QuestList<Element>(objList.Objects.Select(o => _worldModel.Elements.Get(o)));
             return true;
         }
 
@@ -1286,7 +1286,7 @@ public class LazyFields
             var newDictionary = new QuestDictionary<Element>();
             foreach (var kvp in objDictionary.Dictionary)
             {
-                newDictionary.Add(kvp.Key, m_worldModel.Elements.Get(kvp.Value));
+                newDictionary.Add(kvp.Key, _worldModel.Elements.Get(kvp.Value));
             }
 
             replacement = newDictionary;
@@ -1312,7 +1312,7 @@ public class LazyFields
 
     private void CheckNotResolved()
     {
-        if (m_resolved)
+        if (_resolved)
         {
             throw new Exception("LazyFields instance already resolved.");
         }
@@ -1321,42 +1321,42 @@ public class LazyFields
 
 public class UndoFieldSet : UndoLogger.IUndoAction
 {
-    private readonly bool m_added;
-    private readonly object m_newValue;
-    private readonly string m_newValueElementName;
-    private readonly object m_oldValue;
-    private readonly string m_oldValueElementName;
-    private readonly bool m_useMetaFields;
-    private readonly WorldModel m_worldModel;
+    private readonly bool _added;
+    private readonly object _newValue;
+    private readonly string _newValueElementName;
+    private readonly object _oldValue;
+    private readonly string _oldValueElementName;
+    private readonly bool _useMetaFields;
+    private readonly WorldModel _worldModel;
 
     public UndoFieldSet(WorldModel worldModel, string appliesTo, string property, object oldValue, object newValue,
         bool added, bool useMetaFields)
     {
         Debug.Assert(!string.IsNullOrEmpty(appliesTo));
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
         AppliesTo = appliesTo;
         Property = property;
-        m_useMetaFields = useMetaFields;
+        _useMetaFields = useMetaFields;
 
         if (oldValue is Element)
         {
-            m_oldValueElementName = ((Element) oldValue).Name;
+            _oldValueElementName = ((Element) oldValue).Name;
         }
         else
         {
-            m_oldValue = oldValue;
+            _oldValue = oldValue;
         }
 
         if (newValue is Element)
         {
-            m_newValueElementName = ((Element) newValue).Name;
+            _newValueElementName = ((Element) newValue).Name;
         }
         else
         {
-            m_newValue = newValue;
+            _newValue = newValue;
         }
 
-        m_added = added;
+        _added = added;
 
         //System.Diagnostics.Debug.Print("UndoFieldSet: {0}.{1} from '{2}' to '{3}'", appliesTo, property, oldValue, newValue);
     }
@@ -1369,18 +1369,18 @@ public class UndoFieldSet : UndoLogger.IUndoAction
     {
         get
         {
-            if (m_oldValueElementName != null)
+            if (_oldValueElementName != null)
             {
-                if (m_worldModel.Elements.ContainsKey(m_oldValueElementName))
+                if (_worldModel.Elements.ContainsKey(_oldValueElementName))
                 {
-                    return m_worldModel.Elements.Get(m_oldValueElementName);
+                    return _worldModel.Elements.Get(_oldValueElementName);
                 }
 
                 // element may have been deleted
                 return null;
             }
 
-            return m_oldValue;
+            return _oldValue;
         }
     }
 
@@ -1388,19 +1388,19 @@ public class UndoFieldSet : UndoLogger.IUndoAction
     {
         get
         {
-            if (m_newValueElementName != null)
+            if (_newValueElementName != null)
             {
-                return m_worldModel.Elements.Get(m_newValueElementName);
+                return _worldModel.Elements.Get(_newValueElementName);
             }
 
-            return m_newValue;
+            return _newValue;
         }
     }
 
     public void DoUndo(WorldModel worldModel)
     {
         var fields = GetFields(AppliesTo);
-        if (m_added)
+        if (_added)
         {
             fields.RemoveFieldInternal(Property);
         }
@@ -1418,7 +1418,7 @@ public class UndoFieldSet : UndoLogger.IUndoAction
         }
         else
         {
-            // When redoing a name change, m_appliesTo will be incorrect as it will be the new object name.
+            // When redoing a name change, _appliesTo will be incorrect as it will be the new object name.
             // So in this specific case we get the appliesTo name from the old property value.
             // (If OldValue is null then this is just setting the name property for a brand new object,
             // so the above comment doesn't apply, and this case is handled in the above "if")
@@ -1428,55 +1428,55 @@ public class UndoFieldSet : UndoLogger.IUndoAction
 
     private Fields GetFields(string elementName)
     {
-        var element = m_worldModel.Elements.Get(elementName);
-        return m_useMetaFields ? element.MetaFields : element.Fields;
+        var element = _worldModel.Elements.Get(elementName);
+        return _useMetaFields ? element.MetaFields : element.Fields;
     }
 }
 
 public class UndoFieldRemove : UndoLogger.IUndoAction
 {
-    private readonly string m_appliesTo;
-    private readonly object m_oldValue;
-    private readonly string m_property;
+    private readonly string _appliesTo;
+    private readonly object _oldValue;
+    private readonly string _property;
 
     public UndoFieldRemove(string appliesTo, string property, object oldValue)
     {
-        m_appliesTo = appliesTo;
-        m_property = property;
-        m_oldValue = oldValue;
+        _appliesTo = appliesTo;
+        _property = property;
+        _oldValue = oldValue;
     }
 
     public void DoUndo(WorldModel worldModel)
     {
-        worldModel.Object(m_appliesTo).Fields.SetFromUndo(m_property, m_oldValue);
+        worldModel.Object(_appliesTo).Fields.SetFromUndo(_property, _oldValue);
     }
 
     public void DoRedo(WorldModel worldModel)
     {
-        worldModel.Object(m_appliesTo).Fields.RemoveFieldInternal(m_property);
+        worldModel.Object(_appliesTo).Fields.RemoveFieldInternal(_property);
     }
 }
 
 public class UndoAddRemoveType : UndoLogger.IUndoAction
 {
-    private readonly string m_appliesTo;
-    private readonly Stack<Element> m_newValue;
-    private readonly Stack<Element> m_oldValue;
+    private readonly string _appliesTo;
+    private readonly Stack<Element> _newValue;
+    private readonly Stack<Element> _oldValue;
 
     public UndoAddRemoveType(string appliesTo, Stack<Element> oldValue, Stack<Element> newValue)
     {
-        m_appliesTo = appliesTo;
-        m_oldValue = oldValue;
-        m_newValue = newValue;
+        _appliesTo = appliesTo;
+        _oldValue = oldValue;
+        _newValue = newValue;
     }
 
     public void DoUndo(WorldModel worldModel)
     {
-        worldModel.Object(m_appliesTo).Fields.DoUndoAddRemoveType(m_oldValue);
+        worldModel.Object(_appliesTo).Fields.DoUndoAddRemoveType(_oldValue);
     }
 
     public void DoRedo(WorldModel worldModel)
     {
-        worldModel.Object(m_appliesTo).Fields.DoUndoAddRemoveType(m_newValue);
+        worldModel.Object(_appliesTo).Fields.DoUndoAddRemoveType(_newValue);
     }
 }

--- a/src/Engine/GameLoader/AttributeLoaders.cs
+++ b/src/Engine/GameLoader/AttributeLoaders.cs
@@ -290,7 +290,7 @@ internal partial class GameLoader
         // e.g. ask man about[ the] #subject#
 
         [GeneratedRegex("#([A-Za-z]\\w+)#")]
-        private partial Regex m_regex();
+        private partial Regex PatternVariableRegex();
 
         public override void Load(Element element, string attribute, string value)
         {
@@ -312,7 +312,7 @@ internal partial class GameLoader
         private void LoadCommand(Element element, string attribute, string value)
         {
             value = value.Replace("(", @"\(").Replace(")", @"\)").Replace(".", @"\.").Replace("?", @"\?");
-            value = m_regex().Replace(value, MatchReplace);
+            value = PatternVariableRegex().Replace(value, MatchReplace);
 
             if (value.Contains('#'))
             {

--- a/src/Engine/GameLoader/ElementLoaders.cs
+++ b/src/Engine/GameLoader/ElementLoaders.cs
@@ -264,11 +264,11 @@ internal partial class GameLoader
         }
 
         [GeneratedRegex("[A-Za-z0-9]+")]
-        private partial Regex m_regex();
+        private partial Regex CommandIdCharactersRegex();
 
         private string GetUniqueCommandId(string? pattern)
         {
-            var name = pattern == null ? null : m_regex().Match(pattern.Replace(" ", "")).Value;
+            var name = pattern == null ? null : CommandIdCharactersRegex().Match(pattern.Replace(" ", "")).Value;
 
             if (string.IsNullOrEmpty(name) || WorldModel.ObjectExists(name))
             {

--- a/src/Engine/ObjectFactory.cs
+++ b/src/Engine/ObjectFactory.cs
@@ -192,27 +192,27 @@ public abstract class ElementFactoryBase : IElementFactory
 
     protected class CreateDestroyLogEntry : UndoLogger.IUndoAction
     {
-        private readonly bool m_create;
-        private readonly Element m_element;
-        private readonly string m_name;
-        private readonly Action<string> m_notifyAdded;
-        private readonly Action<string> m_notifyRemoved;
-        private readonly ElementType m_type;
+        private readonly bool _create;
+        private readonly Element _element;
+        private readonly string _name;
+        private readonly Action<string> _notifyAdded;
+        private readonly Action<string> _notifyRemoved;
+        private readonly ElementType _type;
 
         public CreateDestroyLogEntry(string name, ElementType type, Element element, bool create,
             Action<string> notifyAdded, Action<string> notifyRemoved)
         {
-            m_name = name;
-            m_type = type;
-            m_create = create;
-            m_element = element;
-            m_notifyAdded = notifyAdded;
-            m_notifyRemoved = notifyRemoved;
+            _name = name;
+            _type = type;
+            _create = create;
+            _element = element;
+            _notifyAdded = notifyAdded;
+            _notifyRemoved = notifyRemoved;
         }
 
         public void DoUndo(WorldModel worldModel)
         {
-            if (m_create)
+            if (_create)
             {
                 DestroyElement(worldModel);
             }
@@ -224,7 +224,7 @@ public abstract class ElementFactoryBase : IElementFactory
 
         public void DoRedo(WorldModel worldModel)
         {
-            if (m_create)
+            if (_create)
             {
                 CreateElement(worldModel);
             }
@@ -236,14 +236,14 @@ public abstract class ElementFactoryBase : IElementFactory
 
         private void CreateElement(WorldModel worldModel)
         {
-            worldModel.Elements.Add(m_type, m_name, m_element);
-            m_notifyAdded(m_name);
+            worldModel.Elements.Add(_type, _name, _element);
+            _notifyAdded(_name);
         }
 
         private void DestroyElement(WorldModel worldModel)
         {
-            worldModel.Elements.Remove(m_type, m_name);
-            m_notifyRemoved(m_name);
+            worldModel.Elements.Remove(_type, _name);
+            _notifyRemoved(_name);
         }
     }
 }

--- a/src/Engine/OutputLogger.cs
+++ b/src/Engine/OutputLogger.cs
@@ -12,17 +12,17 @@ internal interface IOutputLogger
 
 internal class OutputLogger : IOutputLogger
 {
-    private readonly WorldModel m_worldModel;
+    private readonly WorldModel _worldModel;
 
     public OutputLogger(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     public void Save(string html)
     {
-        var element = m_worldModel.Elements.GetSingle(ElementType.Output) ??
-                      m_worldModel.GetElementFactory(ElementType.Output).Create();
+        var element = _worldModel.Elements.GetSingle(ElementType.Output) ??
+                      _worldModel.GetElementFactory(ElementType.Output).Create();
 
         element.Fields.Set("html", html);
     }
@@ -34,58 +34,58 @@ internal class OutputLogger : IOutputLogger
 
 internal class LegacyOutputLogger : IOutputLogger
 {
-    private readonly StringBuilder m_text = new();
-    private readonly WorldModel m_worldModel;
-    private bool m_anyText;
+    private readonly StringBuilder _text = new();
+    private readonly WorldModel _worldModel;
+    private bool _anyText;
 
     public LegacyOutputLogger(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     public void Clear()
     {
-        m_text.Clear();
-        m_anyText = false;
+        _text.Clear();
+        _anyText = false;
     }
 
     public void Save(string html)
     {
-        var element = m_worldModel.Elements.GetSingle(ElementType.Output);
+        var element = _worldModel.Elements.GetSingle(ElementType.Output);
         if (element == null)
         {
-            element = m_worldModel.GetElementFactory(ElementType.Output).Create();
+            element = _worldModel.GetElementFactory(ElementType.Output).Create();
         }
 
-        element.Fields.Set("text", m_text.ToString());
+        element.Fields.Set("text", _text.ToString());
     }
 
     public void AddText(string text, bool linebreak = true)
     {
-        if (m_anyText)
+        if (_anyText)
         {
-            m_text.Append((linebreak ? "<br/>" : string.Empty) + Environment.NewLine + text);
+            _text.Append((linebreak ? "<br/>" : string.Empty) + Environment.NewLine + text);
         }
         else
         {
-            m_text.Append(text);
-            m_anyText = true;
+            _text.Append(text);
+            _anyText = true;
         }
     }
 
     public void AddPicture(string filename)
     {
-        m_text.Append(string.Format("<output_picture filename=\"{0}\"/>", filename));
+        _text.Append(string.Format("<output_picture filename=\"{0}\"/>", filename));
     }
 
     public void SetFontName(string fontName)
     {
-        m_text.Append(string.Format("<output_setfontname name=\"{0}\"/>", fontName));
+        _text.Append(string.Format("<output_setfontname name=\"{0}\"/>", fontName));
     }
 
     public void SetFontSize(string fontSize)
     {
-        m_text.Append(string.Format("<output_setfontsize size=\"{0}\"/>", fontSize));
+        _text.Append(string.Format("<output_setfontsize size=\"{0}\"/>", fontSize));
     }
 
     public async Task DisplayOutputAsync(string text)
@@ -108,38 +108,38 @@ internal class LegacyOutputLogger : IOutputLogger
                         case "output_picture":
                             if (output.Length > 0)
                             {
-                                m_worldModel.Print(output.ToString());
+                                _worldModel.Print(output.ToString());
                                 output.Clear();
                             }
 
                             var filename = reader.GetAttribute("filename");
                             if (filename != null)
                             {
-                                await m_worldModel.PlayerUi.ShowPictureAsync(filename);
+                                await _worldModel.PlayerUi.ShowPictureAsync(filename);
                             }
 
                             break;
                         case "output_setfontsize":
                             if (output.Length > 0)
                             {
-                                m_worldModel.Print(output.ToString(), false);
+                                _worldModel.Print(output.ToString(), false);
                                 output.Clear();
                             }
 
                             var size = reader.GetAttribute("size");
-                            ((LegacyOutputLogger) m_worldModel.OutputLogger).SetFontSize(size);
-                            m_worldModel.PlayerUi.SetFontSize(size);
+                            ((LegacyOutputLogger) _worldModel.OutputLogger).SetFontSize(size);
+                            _worldModel.PlayerUi.SetFontSize(size);
                             break;
                         case "output_setfontname":
                             if (output.Length > 0)
                             {
-                                m_worldModel.Print(output.ToString(), false);
+                                _worldModel.Print(output.ToString(), false);
                                 output.Clear();
                             }
 
                             var name = reader.GetAttribute("name");
-                            ((LegacyOutputLogger) m_worldModel.OutputLogger).SetFontName(name);
-                            m_worldModel.PlayerUi.SetFont(name);
+                            ((LegacyOutputLogger) _worldModel.OutputLogger).SetFontName(name);
+                            _worldModel.PlayerUi.SetFont(name);
                             break;
                         default:
                             output.Append("<" + reader.Name);
@@ -187,6 +187,6 @@ internal class LegacyOutputLogger : IOutputLogger
             }
         }
 
-        m_worldModel.Print(output.ToString());
+        _worldModel.Print(output.ToString());
     }
 }

--- a/src/Engine/QuestDictionary.cs
+++ b/src/Engine/QuestDictionary.cs
@@ -21,8 +21,8 @@ public class QuestDictionaryUpdatedEventArgs<T> : EventArgs
 
 public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableField, IQuestDictionary
 {
-    private readonly OrderedDictionary<string, T> m_dictionary = new();
-    private UndoLogger m_undoLog;
+    private readonly OrderedDictionary<string, T> _dictionary = new();
+    private UndoLogger _undoLog;
 
     public QuestDictionary()
     {
@@ -34,7 +34,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
         {
             foreach (var kvp in dictionary)
             {
-                m_dictionary.Add(kvp.Key, kvp.Value);
+                _dictionary.Add(kvp.Key, kvp.Value);
             }
         }
     }
@@ -43,7 +43,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     public IEnumerator<KeyValuePair<string, T>> GetEnumerator()
     {
-        return m_dictionary.GetEnumerator();
+        return _dictionary.GetEnumerator();
     }
 
     #endregion
@@ -52,7 +52,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return m_dictionary.GetEnumerator();
+        return _dictionary.GetEnumerator();
     }
 
     #endregion
@@ -65,14 +65,14 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
         if (UndoLog != null)
         {
             // also set UndoLog property on added item, if it needs a reference to the undo logger
-            object value = m_dictionary[(string) key];
+            object value = _dictionary[(string) key];
             var mutableValue = value as IMutableField;
             if (mutableValue != null)
             {
                 mutableValue.UndoLog = UndoLog;
             }
 
-            UndoLog.AddUndoAction(() => new UndoDictionaryAdd(this, key, value, m_dictionary.IndexOfKey((string) key)));
+            UndoLog.AddUndoAction(() => new UndoDictionaryAdd(this, key, value, _dictionary.IndexOfKey((string) key)));
         }
     }
 
@@ -81,13 +81,13 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
         if (UndoLog != null)
         {
             UndoLog.AddUndoAction(() =>
-                new UndoDictionaryRemove(this, key, m_dictionary[(string) key], m_dictionary.IndexOfKey((string) key)));
+                new UndoDictionaryRemove(this, key, _dictionary[(string) key], _dictionary.IndexOfKey((string) key)));
         }
     }
 
     public int IndexOfKey(string key)
     {
-        return m_dictionary.IndexOfKey(key);
+        return _dictionary.IndexOfKey(key);
     }
 
     private void CheckNotLocked()
@@ -114,11 +114,11 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
         var result = string.Empty;
         var count = 0;
 
-        foreach (var kvp in m_dictionary)
+        foreach (var kvp in _dictionary)
         {
             count++;
             result += kvp.Key + " = " + converter(kvp.Value);
-            if (count < m_dictionary.Count)
+            if (count < _dictionary.Count)
             {
                 result += ";";
             }
@@ -151,29 +151,29 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     private class UndoDictionaryAdd : UndoLogger.IUndoAction
     {
-        private readonly object m_addedItem;
-        private readonly object m_addedKey;
-        private readonly IQuestDictionary m_appliesTo;
-        private readonly int m_index;
+        private readonly object _addedItem;
+        private readonly object _addedKey;
+        private readonly IQuestDictionary _appliesTo;
+        private readonly int _index;
 
         public UndoDictionaryAdd(IQuestDictionary appliesTo, object addedKey, object addedItem, int index)
         {
-            m_appliesTo = appliesTo;
-            m_addedKey = addedKey;
-            m_addedItem = addedItem;
-            m_index = index;
+            _appliesTo = appliesTo;
+            _addedKey = addedKey;
+            _addedItem = addedItem;
+            _index = index;
         }
 
         #region IUndoAction Members
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_appliesTo.Remove(m_addedKey);
+            _appliesTo.Remove(_addedKey);
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_appliesTo.Add(m_addedKey, m_addedItem, m_index);
+            _appliesTo.Add(_addedKey, _addedItem, _index);
         }
 
         #endregion
@@ -181,29 +181,29 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     private class UndoDictionaryRemove : UndoLogger.IUndoAction
     {
-        private readonly IQuestDictionary m_appliesTo;
-        private readonly int m_index;
-        private readonly object m_removedItem;
-        private readonly object m_removedKey;
+        private readonly IQuestDictionary _appliesTo;
+        private readonly int _index;
+        private readonly object _removedItem;
+        private readonly object _removedKey;
 
         public UndoDictionaryRemove(IQuestDictionary appliesTo, object removedKey, object removedItem, int index)
         {
-            m_appliesTo = appliesTo;
-            m_removedKey = removedKey;
-            m_removedItem = removedItem;
-            m_index = index;
+            _appliesTo = appliesTo;
+            _removedKey = removedKey;
+            _removedItem = removedItem;
+            _index = index;
         }
 
         #region IUndoAction Members
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_appliesTo.Add(m_removedKey, m_removedItem, m_index);
+            _appliesTo.Add(_removedKey, _removedItem, _index);
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_appliesTo.Remove(m_removedKey);
+            _appliesTo.Remove(_removedKey);
         }
 
         #endregion
@@ -215,15 +215,15 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     public UndoLogger UndoLog
     {
-        get => m_undoLog;
+        get => _undoLog;
         set
         {
-            if (m_undoLog == value)
+            if (_undoLog == value)
             {
                 return;
             }
 
-            m_undoLog = value;
+            _undoLog = value;
             foreach (var item in Values)
             {
                 var mutableValue = item as IMutableField;
@@ -238,7 +238,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
     public IMutableField Clone()
     {
         var result = new QuestDictionary<T>();
-        foreach (var kvp in m_dictionary)
+        foreach (var kvp in _dictionary)
         {
             var newValue = kvp.Value;
             var clonableValue = newValue as IMutableField;
@@ -270,23 +270,23 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
     public void Add(string key, T value, UpdateSource source)
     {
         CheckNotLocked();
-        m_dictionary.Add(key, value);
-        ItemAdded(key, value, source, m_dictionary.IndexOfKey(key));
+        _dictionary.Add(key, value);
+        ItemAdded(key, value, source, _dictionary.IndexOfKey(key));
     }
 
     public void Add(string key, T value, UpdateSource source, int index)
     {
         CheckNotLocked();
-        m_dictionary.Insert(index, key, value);
+        _dictionary.Insert(index, key, value);
         ItemAdded(key, value, source, index);
     }
 
     public bool ContainsKey(string key)
     {
-        return m_dictionary.ContainsKey(key);
+        return _dictionary.ContainsKey(key);
     }
 
-    public ICollection<string> Keys => m_dictionary.Keys;
+    public ICollection<string> Keys => _dictionary.Keys;
 
     public bool Remove(string key)
     {
@@ -296,32 +296,32 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
     public bool Remove(string key, UpdateSource source)
     {
         CheckNotLocked();
-        var removedValue = m_dictionary[key];
-        var removedIndex = m_dictionary.IndexOfKey(key);
+        var removedValue = _dictionary[key];
+        var removedIndex = _dictionary.IndexOfKey(key);
         ItemRemoved(key, removedValue, source, removedIndex);
-        return m_dictionary.Remove(key);
+        return _dictionary.Remove(key);
     }
 
     public bool TryGetValue(string key, out T value)
     {
-        return m_dictionary.TryGetValue(key, out value);
+        return _dictionary.TryGetValue(key, out value);
     }
 
-    public ICollection<T> Values => m_dictionary.Values;
+    public ICollection<T> Values => _dictionary.Values;
 
     public T this[string key]
     {
-        get => m_dictionary[key];
+        get => _dictionary[key];
         set
         {
             CheckNotLocked();
             if (ContainsKey(key))
             {
-                ItemRemoved(key, value, UpdateSource.System, m_dictionary.IndexOfKey(key));
+                ItemRemoved(key, value, UpdateSource.System, _dictionary.IndexOfKey(key));
             }
 
-            ItemAdded(key, value, UpdateSource.System, m_dictionary.IndexOfKey(key));
-            m_dictionary[key] = value;
+            ItemAdded(key, value, UpdateSource.System, _dictionary.IndexOfKey(key));
+            _dictionary[key] = value;
         }
     }
 
@@ -332,8 +332,8 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
     public void Add(KeyValuePair<string, T> item)
     {
         CheckNotLocked();
-        ((ICollection<KeyValuePair<string, T>>) m_dictionary).Add(item);
-        ItemAdded(item.Key, item.Value, UpdateSource.System, m_dictionary.IndexOfKey(item.Key));
+        ((ICollection<KeyValuePair<string, T>>) _dictionary).Add(item);
+        ItemAdded(item.Key, item.Value, UpdateSource.System, _dictionary.IndexOfKey(item.Key));
     }
 
     public void Clear()
@@ -343,23 +343,23 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     public bool Contains(KeyValuePair<string, T> item)
     {
-        return ((ICollection<KeyValuePair<string, T>>) m_dictionary).Contains(item);
+        return ((ICollection<KeyValuePair<string, T>>) _dictionary).Contains(item);
     }
 
     public void CopyTo(KeyValuePair<string, T>[] array, int arrayIndex)
     {
-        ((ICollection<KeyValuePair<string, T>>) m_dictionary).CopyTo(array, arrayIndex);
+        ((ICollection<KeyValuePair<string, T>>) _dictionary).CopyTo(array, arrayIndex);
     }
 
-    public int Count => m_dictionary.Count;
+    public int Count => _dictionary.Count;
 
-    public bool IsReadOnly => m_dictionary.IsReadOnly;
+    public bool IsReadOnly => _dictionary.IsReadOnly;
 
     public bool Remove(KeyValuePair<string, T> item)
     {
         CheckNotLocked();
-        ItemRemoved(item.Key, item.Value, UpdateSource.System, m_dictionary.IndexOfKey(item.Key));
-        return ((ICollection<KeyValuePair<string, T>>) m_dictionary).Remove(item);
+        ItemRemoved(item.Key, item.Value, UpdateSource.System, _dictionary.IndexOfKey(item.Key));
+        return ((ICollection<KeyValuePair<string, T>>) _dictionary).Remove(item);
     }
 
     #endregion
@@ -368,7 +368,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     public void Add(object key, object value)
     {
-        Add(key, value, m_dictionary.Count);
+        Add(key, value, _dictionary.Count);
     }
 
     public void Add(object key, object value, int index)
@@ -376,39 +376,39 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
         CheckNotLocked();
         try
         {
-            m_dictionary.Insert(index, (string) key, (T) value);
+            _dictionary.Insert(index, (string) key, (T) value);
         }
         catch (Exception ex)
         {
             throw new Exception(string.Format("Error adding key '{0}' to dictionary: {1}", key, ex.Message), ex);
         }
 
-        ItemAdded((string) key, (T) value, UpdateSource.System, m_dictionary.IndexOfKey((string) key));
+        ItemAdded((string) key, (T) value, UpdateSource.System, _dictionary.IndexOfKey((string) key));
     }
 
     public bool Contains(object key)
     {
-        return m_dictionary.ContainsKey((string) key);
+        return _dictionary.ContainsKey((string) key);
     }
 
     IDictionaryEnumerator IDictionary.GetEnumerator()
     {
-        return (IDictionaryEnumerator) m_dictionary.GetEnumerator();
+        return (IDictionaryEnumerator) _dictionary.GetEnumerator();
     }
 
-    public bool IsFixedSize => ((IDictionary) m_dictionary).IsFixedSize;
+    public bool IsFixedSize => ((IDictionary) _dictionary).IsFixedSize;
 
-    ICollection IDictionary.Keys => (ICollection) m_dictionary.Keys;
+    ICollection IDictionary.Keys => (ICollection) _dictionary.Keys;
 
     public void Remove(object key)
     {
         CheckNotLocked();
-        ItemRemoved((string) key, m_dictionary[(string) key], UpdateSource.System,
-            m_dictionary.IndexOfKey((string) key));
-        m_dictionary.Remove((string) key);
+        ItemRemoved((string) key, _dictionary[(string) key], UpdateSource.System,
+            _dictionary.IndexOfKey((string) key));
+        _dictionary.Remove((string) key);
     }
 
-    ICollection IDictionary.Values => (ICollection) m_dictionary.Values;
+    ICollection IDictionary.Values => (ICollection) _dictionary.Values;
 
     public object this[object key]
     {
@@ -422,12 +422,12 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     public void CopyTo(Array array, int index)
     {
-        ((ICollection) m_dictionary).CopyTo(array, index);
+        ((ICollection) _dictionary).CopyTo(array, index);
     }
 
-    public bool IsSynchronized => ((ICollection) m_dictionary).IsSynchronized;
+    public bool IsSynchronized => ((ICollection) _dictionary).IsSynchronized;
 
-    public object SyncRoot => ((ICollection) m_dictionary).SyncRoot;
+    public object SyncRoot => ((ICollection) _dictionary).SyncRoot;
 
     #endregion
 }
@@ -485,9 +485,9 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
 {
     private const int DefaultInitialCapacity = 0;
 
-    private static readonly string _keyTypeName = typeof(TKey).FullName;
-    private static readonly string _valueTypeName = typeof(TValue).FullName;
-    private static readonly bool _valueTypeIsReferenceType = !typeof(ValueType).IsAssignableFrom(typeof(TValue));
+    private static readonly string KeyTypeName = typeof(TKey).FullName;
+    private static readonly string ValueTypeName = typeof(TValue).FullName;
+    private static readonly bool ValueTypeIsReferenceType = !typeof(ValueType).IsAssignableFrom(typeof(TValue));
     private readonly IEqualityComparer<TKey> _comparer;
     private readonly int _initialCapacity;
 
@@ -1264,7 +1264,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
             return (TKey) keyObject;
         }
 
-        throw new ArgumentException("'key' must be of type " + _keyTypeName, "key");
+        throw new ArgumentException("'key' must be of type " + KeyTypeName, "key");
     }
 
     /// <summary>
@@ -1285,7 +1285,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     {
         if (null == value)
         {
-            if (_valueTypeIsReferenceType)
+            if (ValueTypeIsReferenceType)
             {
                 return default;
             }
@@ -1298,7 +1298,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
             return (TValue) value;
         }
 
-        throw new ArgumentException("'value' must be of type " + _valueTypeName, "value");
+        throw new ArgumentException("'value' must be of type " + ValueTypeName, "value");
     }
 
     /// <summary>

--- a/src/Engine/QuestList.cs
+++ b/src/Engine/QuestList.cs
@@ -24,23 +24,23 @@ public class QuestListUpdatedEventArgs<T> : EventArgs
 
 public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollection, IExtendableField
 {
-    private readonly List<T> m_list;
-    private UndoLogger m_undoLog;
+    private readonly List<T> _list;
+    private UndoLogger _undoLog;
 
     public QuestList()
     {
-        m_list = new List<T>();
+        _list = new List<T>();
     }
 
     public QuestList(IEnumerable<T> collection)
     {
         if (collection == null)
         {
-            m_list = new List<T>();
+            _list = new List<T>();
         }
         else
         {
-            m_list = new List<T>(collection);
+            _list = new List<T>(collection);
         }
     }
 
@@ -73,7 +73,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public IEnumerator<T> GetEnumerator()
     {
-        return m_list.GetEnumerator();
+        return _list.GetEnumerator();
     }
 
     #endregion
@@ -82,22 +82,22 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return m_list.GetEnumerator();
+        return _list.GetEnumerator();
     }
 
     #endregion
 
     public UndoLogger UndoLog
     {
-        get => m_undoLog;
+        get => _undoLog;
         set
         {
-            if (m_undoLog == value)
+            if (_undoLog == value)
             {
                 return;
             }
 
-            m_undoLog = value;
+            _undoLog = value;
             foreach (var item in this)
             {
                 var mutableValue = item as IMutableField;
@@ -113,7 +113,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public IMutableField Clone()
     {
-        return new QuestList<T>(m_list);
+        return new QuestList<T>(_list);
     }
 
     public bool Locked { get; set; }
@@ -147,10 +147,10 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public bool Contains(object item)
     {
-        return m_list.Contains((T) item);
+        return _list.Contains((T) item);
     }
 
-    public object this[int index] => m_list[index];
+    public object this[int index] => _list[index];
     public event EventHandler<QuestListUpdatedEventArgs<T>> Added;
     public event EventHandler<QuestListUpdatedEventArgs<T>> Removed;
 
@@ -168,12 +168,12 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
         CheckNotLocked();
         if (index == null)
         {
-            m_list.Add(item);
-            index = m_list.Count - 1;
+            _list.Add(item);
+            index = _list.Count - 1;
         }
         else
         {
-            m_list.Insert(index.Value, item);
+            _list.Insert(index.Value, item);
         }
 
         ItemAdded(item, source, index.Value);
@@ -184,9 +184,9 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
         CheckNotLocked();
 
         // initial index of the added items, to be passed to the UndoLogger
-        var index = m_list.Count;
+        var index = _list.Count;
 
-        m_list.AddRange(collection);
+        _list.AddRange(collection);
         foreach (var item in collection)
         {
             ItemAdded(item, UpdateSource.System, index);
@@ -196,7 +196,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     private bool RemoveInternal(T item)
     {
-        var index = m_list.IndexOf(item);
+        var index = _list.IndexOf(item);
         if (index == -1)
         {
             return false;
@@ -210,13 +210,13 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     {
         CheckNotLocked();
         UndoLogRemove(item, index);
-        m_list.RemoveAt(index);
+        _list.RemoveAt(index);
         ItemRemoved(item, source, index);
     }
 
     public void RemoveByIndex(int index, UpdateSource source)
     {
-        RemoveInternal(m_list[index], source, index);
+        RemoveInternal(_list[index], source, index);
     }
 
     private void UndoLogAdd(object item, int index)
@@ -366,32 +366,32 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     internal T[] ToArray()
     {
-        return m_list.ToArray();
+        return _list.ToArray();
     }
 
     private class UndoListAdd : UndoLogger.IUndoAction
     {
-        private readonly object m_addedItem;
-        private readonly IQuestList m_appliesTo;
-        private readonly int m_index;
+        private readonly object _addedItem;
+        private readonly IQuestList _appliesTo;
+        private readonly int _index;
 
         public UndoListAdd(IQuestList appliesTo, object addedItem, int index)
         {
-            m_appliesTo = appliesTo;
-            m_addedItem = addedItem;
-            m_index = index;
+            _appliesTo = appliesTo;
+            _addedItem = addedItem;
+            _index = index;
         }
 
         #region IUndoAction Members
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_appliesTo.Remove(m_addedItem, UpdateSource.System, m_index);
+            _appliesTo.Remove(_addedItem, UpdateSource.System, _index);
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_appliesTo.Add(m_addedItem, UpdateSource.System, m_index);
+            _appliesTo.Add(_addedItem, UpdateSource.System, _index);
         }
 
         #endregion
@@ -399,27 +399,27 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     private class UndoListRemove : UndoLogger.IUndoAction
     {
-        private readonly IQuestList m_appliesTo;
-        private readonly int m_index;
-        private readonly object m_removedItem;
+        private readonly IQuestList _appliesTo;
+        private readonly int _index;
+        private readonly object _removedItem;
 
         public UndoListRemove(IQuestList appliesTo, object removedItem, int index)
         {
-            m_appliesTo = appliesTo;
-            m_removedItem = removedItem;
-            m_index = index;
+            _appliesTo = appliesTo;
+            _removedItem = removedItem;
+            _index = index;
         }
 
         #region IUndoAction Members
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_appliesTo.Add(m_removedItem, UpdateSource.System, m_index);
+            _appliesTo.Add(_removedItem, UpdateSource.System, _index);
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_appliesTo.Remove(m_removedItem, UpdateSource.System, m_index);
+            _appliesTo.Remove(_removedItem, UpdateSource.System, _index);
         }
 
         #endregion
@@ -429,14 +429,14 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public void CopyTo(Array array, int index)
     {
-        ((ICollection) m_list).CopyTo(array, index);
+        ((ICollection) _list).CopyTo(array, index);
     }
 
-    public int Count => m_list.Count;
+    public int Count => _list.Count;
 
-    public bool IsSynchronized => ((ICollection) m_list).IsSynchronized;
+    public bool IsSynchronized => ((ICollection) _list).IsSynchronized;
 
-    public object SyncRoot => ((ICollection) m_list).SyncRoot;
+    public object SyncRoot => ((ICollection) _list).SyncRoot;
 
     #endregion
 
@@ -444,7 +444,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public int IndexOf(T item)
     {
-        return m_list.IndexOf(item);
+        return _list.IndexOf(item);
     }
 
     public void Insert(int index, T item)
@@ -459,7 +459,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     T IList<T>.this[int index]
     {
-        get => m_list[index];
+        get => _list[index];
         set => throw new NotImplementedException();
     }
 
@@ -474,15 +474,15 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public bool Contains(T item)
     {
-        return m_list.Contains(item);
+        return _list.Contains(item);
     }
 
     public void CopyTo(T[] array, int arrayIndex)
     {
-        m_list.CopyTo(array, arrayIndex);
+        _list.CopyTo(array, arrayIndex);
     }
 
-    public bool IsReadOnly => ((ICollection<T>) m_list).IsReadOnly;
+    public bool IsReadOnly => ((ICollection<T>) _list).IsReadOnly;
 
     #endregion
 }

--- a/src/Engine/RegexCache.cs
+++ b/src/Engine/RegexCache.cs
@@ -5,18 +5,18 @@ namespace QuestViva.Engine;
 
 internal class RegexCache
 {
-    private readonly Dictionary<string, Regex> m_cache = new();
+    private readonly Dictionary<string, Regex> _cache = new();
 
     public Regex GetRegex(string regex, string cacheID)
     {
         Regex result;
-        if (m_cache.TryGetValue(cacheID, out result))
+        if (_cache.TryGetValue(cacheID, out result))
         {
             return result;
         }
 
         result = new Regex(regex, RegexOptions.IgnoreCase);
-        m_cache.Add(cacheID, result);
+        _cache.Add(cacheID, result);
         return result;
     }
 }

--- a/src/Engine/ScriptFactory.cs
+++ b/src/Engine/ScriptFactory.cs
@@ -13,11 +13,11 @@ public interface IScriptFactory
 
 public partial class ScriptFactory : IScriptFactory
 {
-    private readonly bool m_lazyLoadingEnabled = true;
-    private readonly FunctionCallScriptConstructor m_procConstructor;
+    private readonly bool _lazyLoadingEnabled = true;
+    private readonly FunctionCallScriptConstructor _procConstructor;
 
-    private readonly Dictionary<string, IScriptConstructor> m_scriptConstructors = new();
-    private readonly SetScriptConstructor m_setConstructor;
+    private readonly Dictionary<string, IScriptConstructor> _scriptConstructors = new();
+    private readonly SetScriptConstructor _setConstructor;
 
     public ScriptFactory(WorldModel worldModel)
     {
@@ -68,8 +68,8 @@ public partial class ScriptFactory : IScriptFactory
         ];
         foreach (var c in constructors) AddConstructor(c);
 
-        m_setConstructor = (SetScriptConstructor) InitScriptConstructor(new SetScriptConstructor());
-        m_procConstructor = (FunctionCallScriptConstructor) InitScriptConstructor(new FunctionCallScriptConstructor());
+        _setConstructor = (SetScriptConstructor) InitScriptConstructor(new SetScriptConstructor());
+        _procConstructor = (FunctionCallScriptConstructor) InitScriptConstructor(new FunctionCallScriptConstructor());
     }
 
     internal WorldModel WorldModel { get; }
@@ -81,7 +81,7 @@ public partial class ScriptFactory : IScriptFactory
 
     public IScript CreateScript(string line, ScriptContext scriptContext)
     {
-        return CreateScript(line, scriptContext, m_lazyLoadingEnabled);
+        return CreateScript(line, scriptContext, _lazyLoadingEnabled);
     }
 
     public IScript CreateScript(string line, ScriptContext scriptContext, bool lazy, bool addExceptionsToLog = true)
@@ -190,7 +190,7 @@ public partial class ScriptFactory : IScriptFactory
                         {
                             try
                             {
-                                if (m_lazyLoadingEnabled)
+                                if (_lazyLoadingEnabled)
                                 {
                                     newScript = new LazyLoadScript(this, constructor, line, scriptContext);
                                 }
@@ -222,13 +222,13 @@ public partial class ScriptFactory : IScriptFactory
                             if (newScript == null)
                             {
                                 // See if the script is like "myvar = 2". newScript will be null otherwise.
-                                newScript = m_setConstructor.Create(line, scriptContext);
+                                newScript = _setConstructor.Create(line, scriptContext);
                             }
 
                             if (newScript == null)
                             {
                                 // See if the script calls a procedure defined by the game
-                                newScript = m_procConstructor.Create(line, scriptContext);
+                                newScript = _procConstructor.Create(line, scriptContext);
                             }
                         }
                     }
@@ -242,7 +242,7 @@ public partial class ScriptFactory : IScriptFactory
                     }
                     else
                     {
-                        if (!m_lazyLoadingEnabled)
+                        if (!_lazyLoadingEnabled)
                         {
                             newScript.Line = line;
                         }
@@ -268,7 +268,7 @@ public partial class ScriptFactory : IScriptFactory
     {
         if (constructor.Keyword != null)
         {
-            m_scriptConstructors.Add(constructor.Keyword, InitScriptConstructor(constructor));
+            _scriptConstructors.Add(constructor.Keyword, InitScriptConstructor(constructor));
         }
     }
 
@@ -300,13 +300,13 @@ public partial class ScriptFactory : IScriptFactory
     }
 
     [GeneratedRegex(@"^\W")]
-    private static partial Regex s_nonWordCharacterRegex();
+    private static partial Regex NonWordCharacterRegex();
 
     private IScriptConstructor GetScriptConstructor(string line)
     {
         IScriptConstructor constructor = null;
         var strength = 0;
-        foreach (var c in m_scriptConstructors.Values)
+        foreach (var c in _scriptConstructors.Values)
         {
             if (line.StartsWith(c.Keyword))
             {
@@ -315,7 +315,7 @@ public partial class ScriptFactory : IScriptFactory
                 // a match for "msg".
 
                 if (line.Length == c.Keyword.Length ||
-                    s_nonWordCharacterRegex().IsMatch(line.Substring(c.Keyword.Length)) ||
+                    NonWordCharacterRegex().IsMatch(line.Substring(c.Keyword.Length)) ||
                     c is CommentScriptConstructor || c is JSScriptConstructor)
                 {
                     if (c.Keyword.Length > strength)

--- a/src/Engine/Scripts/CommentScript.cs
+++ b/src/Engine/Scripts/CommentScript.cs
@@ -20,18 +20,18 @@ public class CommentScriptConstructor : IScriptConstructor
 
 public class CommentScript : ScriptBase
 {
-    private string m_comment;
+    private string _comment;
 
     public CommentScript(string comment)
     {
-        m_comment = comment;
+        _comment = comment;
     }
 
     public override string Keyword => "//";
 
     protected override ScriptBase CloneScript()
     {
-        return new CommentScript(m_comment);
+        return new CommentScript(_comment);
     }
 
     public override Task ExecuteAsync(Context c)
@@ -42,17 +42,17 @@ public class CommentScript : ScriptBase
     public override string Save()
     {
         return "// " + string.Join(Environment.NewLine + "// ",
-            m_comment.Split(new[] {"\n"}, StringSplitOptions.RemoveEmptyEntries));
+            _comment.Split(new[] {"\n"}, StringSplitOptions.RemoveEmptyEntries));
     }
 
     public override object GetParameter(int index)
     {
-        return m_comment;
+        return _comment;
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_comment = (string) value;
+        _comment = (string) value;
     }
 
     public void AddLine(string line)
@@ -62,6 +62,6 @@ public class CommentScript : ScriptBase
             throw new ArgumentException("Expected comment line: " + line);
         }
 
-        m_comment += Environment.NewLine + line.Substring(2).Trim();
+        _comment += Environment.NewLine + line.Substring(2).Trim();
     }
 }

--- a/src/Engine/Scripts/CreateScript.cs
+++ b/src/Engine/Scripts/CreateScript.cs
@@ -29,57 +29,57 @@ public class CreateScriptConstructor : ScriptConstructorBase
 
 public class CreateScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_expr;
-    private IFunction<string> m_type;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _expr;
+    private IFunction<string> _type;
 
     public CreateScript(ScriptContext scriptContext, IFunction<string> expr)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_expr = expr;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _expr = expr;
     }
 
     public CreateScript(ScriptContext scriptContext, IFunction<string> expr, IFunction<string> type)
         : this(scriptContext, expr)
     {
-        m_type = type;
+        _type = type;
     }
 
     public override string Keyword => "create";
 
     protected override ScriptBase CloneScript()
     {
-        if (m_type == null)
+        if (_type == null)
         {
-            return new CreateScript(m_scriptContext, m_expr.Clone());
+            return new CreateScript(_scriptContext, _expr.Clone());
         }
 
-        return new CreateScript(m_scriptContext, m_expr.Clone(), m_type.Clone());
+        return new CreateScript(_scriptContext, _expr.Clone(), _type.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        if (m_type == null)
+        if (_type == null)
         {
-            m_worldModel.ObjectFactory.CreateObject(await m_expr.ExecuteAsync(c));
+            _worldModel.ObjectFactory.CreateObject(await _expr.ExecuteAsync(c));
         }
         else
         {
-            m_worldModel.ObjectFactory.CreateObject(await m_expr.ExecuteAsync(c), ObjectType.Object, true,
-                new List<string> {await m_type.ExecuteAsync(c)});
+            _worldModel.ObjectFactory.CreateObject(await _expr.ExecuteAsync(c), ObjectType.Object, true,
+                new List<string> {await _type.ExecuteAsync(c)});
         }
     }
 
     public override string Save()
     {
-        if (m_type == null)
+        if (_type == null)
         {
-            return SaveScript("create", m_expr.Save());
+            return SaveScript("create", _expr.Save());
         }
 
-        return SaveScript("create", m_expr.Save(), m_type.Save());
+        return SaveScript("create", _expr.Save(), _type.Save());
     }
 
     public override object GetParameter(int index)
@@ -87,9 +87,9 @@ public class CreateScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_expr.Save();
+                return _expr.Save();
             case 1:
-                return m_type == null ? null : m_type.Save();
+                return _type == null ? null : _type.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -100,10 +100,10 @@ public class CreateScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_expr = new Expression<string>((string) value, m_scriptContext);
+                _expr = new Expression<string>((string) value, _scriptContext);
                 break;
             case 1:
-                m_type = value == null ? null : new Expression<string>((string) value, m_scriptContext);
+                _type = value == null ? null : new Expression<string>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -147,76 +147,76 @@ public class CreateExitScriptConstructor : ScriptConstructorBase
 
 public class CreateExitScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<Element> m_from;
-    private IFunction<string> m_id;
-    private IFunction<string> m_initialType;
-    private IFunction<string> m_name;
-    private IFunction<Element> m_to;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<Element> _from;
+    private IFunction<string> _id;
+    private IFunction<string> _initialType;
+    private IFunction<string> _name;
+    private IFunction<Element> _to;
 
     public CreateExitScript(ScriptContext scriptContext, IFunction<string> name, IFunction<Element> from,
         IFunction<Element> to)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_name = name;
-        m_from = from;
-        m_to = to;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _name = name;
+        _from = from;
+        _to = to;
     }
 
     public CreateExitScript(ScriptContext scriptContext, IFunction<string> name, IFunction<Element> from,
         IFunction<Element> to, IFunction<string> initialType)
         : this(scriptContext, name, from, to)
     {
-        m_initialType = initialType;
+        _initialType = initialType;
     }
 
     public CreateExitScript(ScriptContext scriptContext, IFunction<string> name, IFunction<Element> from,
         IFunction<Element> to, IFunction<string> initialType, IFunction<string> id)
         : this(scriptContext, name, from, to, initialType)
     {
-        m_id = id;
+        _id = id;
     }
 
     public override string Keyword => "create exit";
 
     protected override ScriptBase CloneScript()
     {
-        if (m_initialType == null)
+        if (_initialType == null)
         {
-            return new CreateExitScript(m_scriptContext, m_name.Clone(), m_from.Clone(), m_to.Clone());
+            return new CreateExitScript(_scriptContext, _name.Clone(), _from.Clone(), _to.Clone());
         }
 
-        if (m_id == null)
+        if (_id == null)
         {
-            return new CreateExitScript(m_scriptContext, m_name.Clone(), m_from.Clone(), m_to.Clone(),
-                m_initialType.Clone());
+            return new CreateExitScript(_scriptContext, _name.Clone(), _from.Clone(), _to.Clone(),
+                _initialType.Clone());
         }
 
-        return new CreateExitScript(m_scriptContext, m_name.Clone(), m_from.Clone(), m_to.Clone(),
-            m_initialType.Clone(), m_id.Clone());
+        return new CreateExitScript(_scriptContext, _name.Clone(), _from.Clone(), _to.Clone(),
+            _initialType.Clone(), _id.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        m_worldModel.ObjectFactory.CreateExit(m_id == null ? null : await m_id.ExecuteAsync(c), await m_name.ExecuteAsync(c),
-            await m_from.ExecuteAsync(c), await m_to.ExecuteAsync(c), m_initialType == null ? null : await m_initialType.ExecuteAsync(c));
+        _worldModel.ObjectFactory.CreateExit(_id == null ? null : await _id.ExecuteAsync(c), await _name.ExecuteAsync(c),
+            await _from.ExecuteAsync(c), await _to.ExecuteAsync(c), _initialType == null ? null : await _initialType.ExecuteAsync(c));
     }
 
     public override string Save()
     {
-        if (m_initialType == null)
+        if (_initialType == null)
         {
-            return SaveScript("create exit", m_name.Save(), m_from.Save(), m_to.Save());
+            return SaveScript("create exit", _name.Save(), _from.Save(), _to.Save());
         }
 
-        if (m_id == null)
+        if (_id == null)
         {
-            return SaveScript("create exit", m_name.Save(), m_from.Save(), m_to.Save(), m_initialType.Save());
+            return SaveScript("create exit", _name.Save(), _from.Save(), _to.Save(), _initialType.Save());
         }
 
-        return SaveScript("create exit", m_id.Save(), m_name.Save(), m_from.Save(), m_to.Save(), m_initialType.Save());
+        return SaveScript("create exit", _id.Save(), _name.Save(), _from.Save(), _to.Save(), _initialType.Save());
     }
 
     public override object GetParameter(int index)
@@ -224,15 +224,15 @@ public class CreateExitScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_id == null ? null : m_id.Save();
+                return _id == null ? null : _id.Save();
             case 1:
-                return m_name.Save();
+                return _name.Save();
             case 2:
-                return m_from.Save();
+                return _from.Save();
             case 3:
-                return m_to.Save();
+                return _to.Save();
             case 4:
-                return m_initialType == null ? null : m_initialType.Save();
+                return _initialType == null ? null : _initialType.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -243,19 +243,19 @@ public class CreateExitScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_id = value == null ? null : new Expression<string>((string) value, m_scriptContext);
+                _id = value == null ? null : new Expression<string>((string) value, _scriptContext);
                 break;
             case 1:
-                m_name = new Expression<string>((string) value, m_scriptContext);
+                _name = new Expression<string>((string) value, _scriptContext);
                 break;
             case 2:
-                m_from = new Expression<Element>((string) value, m_scriptContext);
+                _from = new Expression<Element>((string) value, _scriptContext);
                 break;
             case 3:
-                m_to = new Expression<Element>((string) value, m_scriptContext);
+                _to = new Expression<Element>((string) value, _scriptContext);
                 break;
             case 4:
-                m_initialType = value == null ? null : new Expression<string>((string) value, m_scriptContext);
+                _initialType = value == null ? null : new Expression<string>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -280,43 +280,43 @@ public class CreateTimerScriptConstructor : ScriptConstructorBase
 
 public class CreateTimerScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_expr;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _expr;
 
     public CreateTimerScript(ScriptContext scriptContext, IFunction<string> expr)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_expr = expr;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _expr = expr;
     }
 
     public override string Keyword => "create timer";
 
     protected override ScriptBase CloneScript()
     {
-        return new CreateTimerScript(m_scriptContext, m_expr.Clone());
+        return new CreateTimerScript(_scriptContext, _expr.Clone());
     }
 
 
     public override async Task ExecuteAsync(Context c)
     {
-        m_worldModel.GetElementFactory(ElementType.Timer).Create(await m_expr.ExecuteAsync(c));
+        _worldModel.GetElementFactory(ElementType.Timer).Create(await _expr.ExecuteAsync(c));
     }
 
     public override string Save()
     {
-        return SaveScript("create timer", m_expr.Save());
+        return SaveScript("create timer", _expr.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_expr.Save();
+        return _expr.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_expr = new Expression<string>((string) value, m_scriptContext);
+        _expr = new Expression<string>((string) value, _scriptContext);
     }
 }
 
@@ -337,41 +337,41 @@ public class CreateTurnScriptConstructor : ScriptConstructorBase
 
 public class CreateTurnScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_expr;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _expr;
 
     public CreateTurnScript(ScriptContext scriptContext, IFunction<string> expr)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_expr = expr;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _expr = expr;
     }
 
     public override string Keyword => "create turnscript";
 
     protected override ScriptBase CloneScript()
     {
-        return new CreateTurnScript(m_scriptContext, m_expr.Clone());
+        return new CreateTurnScript(_scriptContext, _expr.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        m_worldModel.ObjectFactory.CreateTurnScript(await m_expr.ExecuteAsync(c), null);
+        _worldModel.ObjectFactory.CreateTurnScript(await _expr.ExecuteAsync(c), null);
     }
 
     public override string Save()
     {
-        return SaveScript("create turnscript", m_expr.Save());
+        return SaveScript("create turnscript", _expr.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_expr.Save();
+        return _expr.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_expr = new Expression<string>((string) value, m_scriptContext);
+        _expr = new Expression<string>((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/DestroyScript.cs
+++ b/src/Engine/Scripts/DestroyScript.cs
@@ -20,31 +20,31 @@ public class DestroyScriptConstructor : ScriptConstructorBase
 
 public class DestroyScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_expr;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _expr;
 
     public DestroyScript(ScriptContext scriptContext, IFunction<string> expr)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_expr = expr;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _expr = expr;
     }
 
     public override string Keyword => "destroy";
 
     protected override ScriptBase CloneScript()
     {
-        return new DestroyScript(m_scriptContext, m_expr.Clone());
+        return new DestroyScript(_scriptContext, _expr.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var elementName = await m_expr.ExecuteAsync(c);
-        var element = m_worldModel.Elements.Get(elementName);
+        var elementName = await _expr.ExecuteAsync(c);
+        var element = _worldModel.Elements.Get(elementName);
         if (element.ElemType == ElementType.Object || element.ElemType == ElementType.Timer)
         {
-            m_worldModel.GetElementFactory(element.ElemType).DestroyElement(elementName);
+            _worldModel.GetElementFactory(element.ElemType).DestroyElement(elementName);
         }
         else
         {
@@ -55,16 +55,16 @@ public class DestroyScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("destroy", m_expr.Save());
+        return SaveScript("destroy", _expr.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_expr.Save();
+        return _expr.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_expr = new Expression<string>((string) value, m_scriptContext);
+        _expr = new Expression<string>((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/DictionaryAddScript.cs
+++ b/src/Engine/Scripts/DictionaryAddScript.cs
@@ -24,36 +24,36 @@ public class DictionaryAddScriptConstructor : ScriptConstructorBase
 
 public class DictionaryAddScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private IFunctionDynamic m_dictionary;
-    private IFunction<string> m_key;
-    private IFunction<object> m_value;
-    private WorldModel m_worldModel;
+    private readonly ScriptContext _scriptContext;
+    private IFunctionDynamic _dictionary;
+    private IFunction<string> _key;
+    private IFunction<object> _value;
+    private WorldModel _worldModel;
 
     public DictionaryAddScript(ScriptContext scriptContext, IFunctionDynamic dictionary, IFunction<string> key,
         IFunction<object> value)
     {
-        m_scriptContext = scriptContext;
-        m_dictionary = dictionary;
-        m_key = key;
-        m_value = value;
-        m_worldModel = scriptContext.WorldModel;
+        _scriptContext = scriptContext;
+        _dictionary = dictionary;
+        _key = key;
+        _value = value;
+        _worldModel = scriptContext.WorldModel;
     }
 
     public override string Keyword => "dictionary add";
 
     protected override ScriptBase CloneScript()
     {
-        return new DictionaryAddScript(m_scriptContext, m_dictionary.Clone(), m_key.Clone(), m_value.Clone());
+        return new DictionaryAddScript(_scriptContext, _dictionary.Clone(), _key.Clone(), _value.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_dictionary.ExecuteAsync(c) as IDictionary;
+        var result = await _dictionary.ExecuteAsync(c) as IDictionary;
 
         if (result != null)
         {
-            result.Add(await m_key.ExecuteAsync(c), await m_value.ExecuteAsync(c));
+            result.Add(await _key.ExecuteAsync(c), await _value.ExecuteAsync(c));
         }
         else
         {
@@ -63,7 +63,7 @@ public class DictionaryAddScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("dictionary add", m_dictionary.Save(), m_key.Save(), m_value.Save());
+        return SaveScript("dictionary add", _dictionary.Save(), _key.Save(), _value.Save());
     }
 
     public override object GetParameter(int index)
@@ -71,11 +71,11 @@ public class DictionaryAddScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_dictionary.Save();
+                return _dictionary.Save();
             case 1:
-                return m_key.Save();
+                return _key.Save();
             case 2:
-                return m_value.Save();
+                return _value.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -86,13 +86,13 @@ public class DictionaryAddScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_dictionary = new ExpressionDynamic((string) value, m_scriptContext);
+                _dictionary = new ExpressionDynamic((string) value, _scriptContext);
                 break;
             case 1:
-                m_key = new Expression<string>((string) value, m_scriptContext);
+                _key = new Expression<string>((string) value, _scriptContext);
                 break;
             case 2:
-                m_value = new Expression<object>((string) value, m_scriptContext);
+                _value = new Expression<object>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -119,33 +119,33 @@ public class DictionaryRemoveScriptConstructor : ScriptConstructorBase
 
 public class DictionaryRemoveScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private IFunctionDynamic m_dictionary;
-    private IFunction<string> m_key;
-    private WorldModel m_worldModel;
+    private readonly ScriptContext _scriptContext;
+    private IFunctionDynamic _dictionary;
+    private IFunction<string> _key;
+    private WorldModel _worldModel;
 
     public DictionaryRemoveScript(ScriptContext scriptContext, IFunctionDynamic dictionary, IFunction<string> key)
     {
-        m_scriptContext = scriptContext;
-        m_dictionary = dictionary;
-        m_key = key;
-        m_worldModel = scriptContext.WorldModel;
+        _scriptContext = scriptContext;
+        _dictionary = dictionary;
+        _key = key;
+        _worldModel = scriptContext.WorldModel;
     }
 
     public override string Keyword => "dictionary remove";
 
     protected override ScriptBase CloneScript()
     {
-        return new DictionaryRemoveScript(m_scriptContext, m_dictionary.Clone(), m_key.Clone());
+        return new DictionaryRemoveScript(_scriptContext, _dictionary.Clone(), _key.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_dictionary.ExecuteAsync(c) as IDictionary;
+        var result = await _dictionary.ExecuteAsync(c) as IDictionary;
 
         if (result != null)
         {
-            result.Remove(await m_key.ExecuteAsync(c));
+            result.Remove(await _key.ExecuteAsync(c));
         }
         else
         {
@@ -155,7 +155,7 @@ public class DictionaryRemoveScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("dictionary remove", m_dictionary.Save(), m_key.Save());
+        return SaveScript("dictionary remove", _dictionary.Save(), _key.Save());
     }
 
     public override object GetParameter(int index)
@@ -163,9 +163,9 @@ public class DictionaryRemoveScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_dictionary.Save();
+                return _dictionary.Save();
             case 1:
-                return m_key.Save();
+                return _key.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -176,10 +176,10 @@ public class DictionaryRemoveScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_dictionary = new ExpressionDynamic((string) value, m_scriptContext);
+                _dictionary = new ExpressionDynamic((string) value, _scriptContext);
                 break;
             case 1:
-                m_key = new Expression<string>((string) value, m_scriptContext);
+                _key = new Expression<string>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/DoScript.cs
+++ b/src/Engine/Scripts/DoScript.cs
@@ -36,58 +36,58 @@ public class DoScriptConstructor : ScriptConstructorBase
 
 public class DoActionScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_action;
-    private IFunction<Element> m_obj;
-    private IFunction<IDictionary> m_parameters;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _action;
+    private IFunction<Element> _obj;
+    private IFunction<IDictionary> _parameters;
 
     public DoActionScript(ScriptContext scriptContext, IFunction<Element> obj, IFunction<string> action)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_obj = obj;
-        m_action = action;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _obj = obj;
+        _action = action;
     }
 
     public DoActionScript(ScriptContext scriptContext, IFunction<Element> obj, IFunction<string> action,
         IFunction<IDictionary> parameters)
         : this(scriptContext, obj, action)
     {
-        m_parameters = parameters;
+        _parameters = parameters;
     }
 
     public override string Keyword => "do";
 
     protected override ScriptBase CloneScript()
     {
-        return new DoActionScript(m_scriptContext, m_obj.Clone(), m_action.Clone(),
-            m_parameters == null ? null : m_parameters.Clone());
+        return new DoActionScript(_scriptContext, _obj.Clone(), _action.Clone(),
+            _parameters == null ? null : _parameters.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var obj = await m_obj.ExecuteAsync(c);
-        var action = obj.GetAction(await m_action.ExecuteAsync(c));
-        if (m_parameters == null)
+        var obj = await _obj.ExecuteAsync(c);
+        var action = obj.GetAction(await _action.ExecuteAsync(c));
+        if (_parameters == null)
         {
-            await m_worldModel.RunScriptAsync(action, obj);
+            await _worldModel.RunScriptAsync(action, obj);
         }
         else
         {
-            await m_worldModel.RunScriptAsync(action, new Parameters(await m_parameters.ExecuteAsync(c)), obj);
+            await _worldModel.RunScriptAsync(action, new Parameters(await _parameters.ExecuteAsync(c)), obj);
         }
     }
 
     public override string Save()
     {
-        var parameters = m_parameters == null ? null : m_parameters.Save();
+        var parameters = _parameters == null ? null : _parameters.Save();
         if (!string.IsNullOrEmpty(parameters))
         {
-            return SaveScript("do", m_obj.Save(), m_action.Save(), m_parameters.Save());
+            return SaveScript("do", _obj.Save(), _action.Save(), _parameters.Save());
         }
 
-        return SaveScript("do", m_obj.Save(), m_action.Save());
+        return SaveScript("do", _obj.Save(), _action.Save());
     }
 
     public override object GetParameter(int index)
@@ -95,11 +95,11 @@ public class DoActionScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_obj.Save();
+                return _obj.Save();
             case 1:
-                return m_action.Save();
+                return _action.Save();
             case 2:
-                return m_parameters == null ? null : m_parameters.Save();
+                return _parameters == null ? null : _parameters.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -110,13 +110,13 @@ public class DoActionScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_obj = new Expression<Element>((string) value, m_scriptContext);
+                _obj = new Expression<Element>((string) value, _scriptContext);
                 break;
             case 1:
-                m_action = new Expression<string>((string) value, m_scriptContext);
+                _action = new Expression<string>((string) value, _scriptContext);
                 break;
             case 2:
-                m_parameters = new Expression<IDictionary>((string) value, m_scriptContext);
+                _parameters = new Expression<IDictionary>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/ErrorScript.cs
+++ b/src/Engine/Scripts/ErrorScript.cs
@@ -24,42 +24,42 @@ public class ErrorScriptConstructor : ScriptConstructorBase
 
 public class ErrorScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private IFunctionDynamic m_function;
-    private WorldModel m_worldModel;
+    private readonly ScriptContext _scriptContext;
+    private IFunctionDynamic _function;
+    private WorldModel _worldModel;
 
     public ErrorScript(ScriptContext scriptContext, IFunctionDynamic function)
     {
-        m_scriptContext = scriptContext;
-        m_function = function;
-        m_worldModel = scriptContext.WorldModel;
+        _scriptContext = scriptContext;
+        _function = function;
+        _worldModel = scriptContext.WorldModel;
     }
 
     public override string Keyword => "error";
 
     protected override ScriptBase CloneScript()
     {
-        return new ErrorScript(m_scriptContext, m_function.Clone());
+        return new ErrorScript(_scriptContext, _function.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_function.ExecuteAsync(c);
+        var result = await _function.ExecuteAsync(c);
         throw new Exception(Utility.ExpressionResultToString(result));
     }
 
     public override string Save()
     {
-        return SaveScript("error", m_function.Save());
+        return SaveScript("error", _function.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_function.Save();
+        return _function.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_function = new ExpressionDynamic((string) value, m_scriptContext);
+        _function = new ExpressionDynamic((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/FailedScript.cs
+++ b/src/Engine/Scripts/FailedScript.cs
@@ -3,18 +3,18 @@ namespace QuestViva.Engine.Scripts;
 
 internal class FailedScript : ScriptBase
 {
-    private string m_script;
+    private string _script;
 
     public FailedScript(string script)
     {
-        m_script = script;
+        _script = script;
     }
 
     public override string Keyword => "@failed";
 
     protected override ScriptBase CloneScript()
     {
-        return new FailedScript(m_script);
+        return new FailedScript(_script);
     }
 
     public override Task ExecuteAsync(Context c)
@@ -24,7 +24,7 @@ internal class FailedScript : ScriptBase
 
     public override string Save()
     {
-        return m_script;
+        return _script;
     }
 
     protected override void SetParameterInternal(int index, object value)
@@ -34,7 +34,7 @@ internal class FailedScript : ScriptBase
             throw new ArgumentOutOfRangeException();
         }
 
-        m_script = (string) value;
+        _script = (string) value;
     }
 
     public override object GetParameter(int index)
@@ -44,6 +44,6 @@ internal class FailedScript : ScriptBase
             throw new ArgumentOutOfRangeException();
         }
 
-        return m_script;
+        return _script;
     }
 }

--- a/src/Engine/Scripts/FinishScript.cs
+++ b/src/Engine/Scripts/FinishScript.cs
@@ -18,23 +18,23 @@ public class FinishScriptConstructor : ScriptConstructorBase
 
 public class FinishScript : ScriptBase
 {
-    private readonly WorldModel m_worldModel;
+    private readonly WorldModel _worldModel;
 
     public FinishScript(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     public override string Keyword => "finish";
 
     protected override ScriptBase CloneScript()
     {
-        return new FinishScript(m_worldModel);
+        return new FinishScript(_worldModel);
     }
 
     public override Task ExecuteAsync(Context c)
     {
-        m_worldModel.FinishGame();
+        _worldModel.FinishGame();
         return Task.CompletedTask;
     }
 

--- a/src/Engine/Scripts/FirstTimeScript.cs
+++ b/src/Engine/Scripts/FirstTimeScript.cs
@@ -36,32 +36,32 @@ public class FirstTimeScriptConstructor : IScriptConstructor
 
 public class FirstTimeScript : ScriptBase, IFirstTimeScript
 {
-    private readonly IScript m_firstTimeScript;
-    private readonly IScriptFactory m_scriptFactory;
-    private readonly WorldModel m_worldModel;
-    private bool m_hasRun;
-    private IScript m_otherwiseScript;
+    private readonly IScript _firstTimeScript;
+    private readonly IScriptFactory _scriptFactory;
+    private readonly WorldModel _worldModel;
+    private bool _hasRun;
+    private IScript _otherwiseScript;
 
     public FirstTimeScript(WorldModel worldModel, IScriptFactory scriptFactory, IScript firstTimeScript)
     {
-        m_worldModel = worldModel;
-        m_scriptFactory = scriptFactory;
-        m_firstTimeScript = firstTimeScript;
+        _worldModel = worldModel;
+        _scriptFactory = scriptFactory;
+        _firstTimeScript = firstTimeScript;
     }
 
     public override string Keyword => "firsttime";
 
     public void SetOtherwiseScript(IScript script)
     {
-        m_otherwiseScript = script;
+        _otherwiseScript = script;
     }
 
     protected override ScriptBase CloneScript()
     {
-        var result = new FirstTimeScript(m_worldModel, m_scriptFactory, (IScript) m_firstTimeScript.Clone());
-        if (m_otherwiseScript != null)
+        var result = new FirstTimeScript(_worldModel, _scriptFactory, (IScript) _firstTimeScript.Clone());
+        if (_otherwiseScript != null)
         {
-            result.m_otherwiseScript = (IScript) m_otherwiseScript.Clone();
+            result._otherwiseScript = (IScript) _otherwiseScript.Clone();
         }
 
         return result;
@@ -69,45 +69,45 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
 
     protected override void ParentUpdated()
     {
-        m_firstTimeScript.Parent = Parent;
+        _firstTimeScript.Parent = Parent;
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        if (!m_hasRun)
+        if (!_hasRun)
         {
-            m_hasRun = true;
-            m_worldModel.UndoLogger.AddUndoAction(() => new UndoFirstTime(this));
-            await m_firstTimeScript.ExecuteAsync(c);
+            _hasRun = true;
+            _worldModel.UndoLogger.AddUndoAction(() => new UndoFirstTime(this));
+            await _firstTimeScript.ExecuteAsync(c);
         }
         else
         {
-            if (m_otherwiseScript != null)
+            if (_otherwiseScript != null)
             {
-                await m_otherwiseScript.ExecuteAsync(c);
+                await _otherwiseScript.ExecuteAsync(c);
             }
         }
     }
 
     public override string Save()
     {
-        if (m_worldModel.EditMode || !m_hasRun)
+        if (_worldModel.EditMode || !_hasRun)
         {
-            if (m_otherwiseScript == null)
+            if (_otherwiseScript == null)
             {
-                return SaveScript("firsttime", m_firstTimeScript);
+                return SaveScript("firsttime", _firstTimeScript);
             }
 
-            return SaveScript("firsttime", m_firstTimeScript) + Environment.NewLine +
-                   SaveScript("otherwise", m_otherwiseScript);
+            return SaveScript("firsttime", _firstTimeScript) + Environment.NewLine +
+                   SaveScript("otherwise", _otherwiseScript);
         }
 
-        if (m_otherwiseScript == null)
+        if (_otherwiseScript == null)
         {
             return string.Empty;
         }
 
-        return m_otherwiseScript.Save();
+        return _otherwiseScript.Save();
     }
 
     public override object GetParameter(int index)
@@ -115,9 +115,9 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
         switch (index)
         {
             case 0:
-                return m_firstTimeScript;
+                return _firstTimeScript;
             case 1:
-                return m_otherwiseScript;
+                return _otherwiseScript;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -132,7 +132,7 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
                 throw new InvalidOperationException(
                     "Attempt to use SetParameter to change the script of a 'firsttime' script");
             case 1:
-                m_otherwiseScript = (IScript) value;
+                _otherwiseScript = (IScript) value;
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -141,21 +141,21 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
 
     private class UndoFirstTime : UndoLogger.IUndoAction
     {
-        private readonly FirstTimeScript m_parent;
+        private readonly FirstTimeScript _parent;
 
         public UndoFirstTime(FirstTimeScript parent)
         {
-            m_parent = parent;
+            _parent = parent;
         }
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_parent.m_hasRun = false;
+            _parent._hasRun = false;
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_parent.m_hasRun = true;
+            _parent._hasRun = true;
         }
     }
 }

--- a/src/Engine/Scripts/ForEachScript.cs
+++ b/src/Engine/Scripts/ForEachScript.cs
@@ -33,35 +33,35 @@ public class ForEachScriptConstructor : IScriptConstructor
 
 public class ForEachScript : ScriptBase
 {
-    private readonly IScript m_loopScript;
-    private readonly ScriptContext m_scriptContext;
-    private IFunctionDynamic m_list;
-    private string m_variable;
+    private readonly IScript _loopScript;
+    private readonly ScriptContext _scriptContext;
+    private IFunctionDynamic _list;
+    private string _variable;
 
     public ForEachScript(ScriptContext scriptContext, string variable, IFunctionDynamic list, IScript loopScript)
     {
-        m_scriptContext = scriptContext;
-        m_variable = variable;
-        m_list = list;
-        m_loopScript = loopScript;
+        _scriptContext = scriptContext;
+        _variable = variable;
+        _list = list;
+        _loopScript = loopScript;
     }
 
     public override string Keyword => "foreach";
 
     protected override ScriptBase CloneScript()
     {
-        return new ForEachScript(m_scriptContext, m_variable, m_list.Clone(), (IScript) m_loopScript.Clone());
+        return new ForEachScript(_scriptContext, _variable, _list.Clone(), (IScript) _loopScript.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_list.ExecuteAsync(c);
+        var result = await _list.ExecuteAsync(c);
         IEnumerable resultList = null;
 
         // Cannot foreach over strings as of Quest 5.3, as the Char data type is not supported (retained functionality
         // for pre-5.3 to prevent breaking existing scripts)
 
-        if (m_scriptContext.WorldModel.Version < WorldModelVersion.v530 || !(result is string))
+        if (_scriptContext.WorldModel.Version < WorldModelVersion.v530 || !(result is string))
         {
             var resultDictionary = result as IDictionary;
             if (resultDictionary != null)
@@ -81,8 +81,8 @@ public class ForEachScript : ScriptBase
 
         foreach (var variable in resultList)
         {
-            c.Parameters[m_variable] = variable;
-            await m_loopScript.ExecuteAsync(c);
+            c.Parameters[_variable] = variable;
+            await _loopScript.ExecuteAsync(c);
             if (c.IsReturned)
             {
                 break;
@@ -92,7 +92,7 @@ public class ForEachScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("foreach", m_loopScript, m_variable, m_list.Save());
+        return SaveScript("foreach", _loopScript, _variable, _list.Save());
     }
 
     public override object GetParameter(int index)
@@ -100,11 +100,11 @@ public class ForEachScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_variable;
+                return _variable;
             case 1:
-                return m_list.Save();
+                return _list.Save();
             case 2:
-                return m_loopScript;
+                return _loopScript;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -115,10 +115,10 @@ public class ForEachScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_variable = (string) value;
+                _variable = (string) value;
                 break;
             case 1:
-                m_list = new ExpressionDynamic((string) value, m_scriptContext);
+                _list = new ExpressionDynamic((string) value, _scriptContext);
                 break;
             case 2:
                 throw new InvalidOperationException(

--- a/src/Engine/Scripts/ForScript.cs
+++ b/src/Engine/Scripts/ForScript.cs
@@ -44,65 +44,65 @@ public class ForScriptConstructor : IScriptConstructor
 
 public class ForScript : ScriptBase
 {
-    private readonly IScript m_loopScript;
-    private readonly ScriptContext m_scriptContext;
-    private readonly IScriptFactory m_scriptFactory;
-    private IFunction<int> m_from;
-    private IFunction<int> m_step;
-    private IFunction<int> m_to;
-    private string m_variable;
-    private WorldModel m_worldModel;
+    private readonly IScript _loopScript;
+    private readonly ScriptContext _scriptContext;
+    private readonly IScriptFactory _scriptFactory;
+    private IFunction<int> _from;
+    private IFunction<int> _step;
+    private IFunction<int> _to;
+    private string _variable;
+    private WorldModel _worldModel;
 
     public ForScript(ScriptContext scriptContext, IScriptFactory scriptFactory, string variable, IFunction<int> from,
         IFunction<int> to, IScript loopScript)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_scriptFactory = scriptFactory;
-        m_variable = variable;
-        m_from = from;
-        m_to = to;
-        m_loopScript = loopScript;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _scriptFactory = scriptFactory;
+        _variable = variable;
+        _from = from;
+        _to = to;
+        _loopScript = loopScript;
     }
 
     public ForScript(ScriptContext scriptContext, IScriptFactory scriptFactory, string variable, IFunction<int> from,
         IFunction<int> to, IFunction<int> step, IScript loopScript)
         : this(scriptContext, scriptFactory, variable, from, to, loopScript)
     {
-        m_step = step;
+        _step = step;
     }
 
     public override string Keyword => "for";
 
     protected override ScriptBase CloneScript()
     {
-        return new ForScript(m_scriptContext, m_scriptFactory, m_variable, m_from.Clone(), m_to.Clone(),
-            m_step == null ? null : m_step.Clone(), (IScript) m_loopScript.Clone());
+        return new ForScript(_scriptContext, _scriptFactory, _variable, _from.Clone(), _to.Clone(),
+            _step == null ? null : _step.Clone(), (IScript) _loopScript.Clone());
     }
 
     protected override void ParentUpdated()
     {
-        m_loopScript.Parent = Parent;
+        _loopScript.Parent = Parent;
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var from = await m_from.ExecuteAsync(c);
-        var to = await m_to.ExecuteAsync(c);
-        var step = m_step == null ? 1 : await m_step.ExecuteAsync(c);
+        var from = await _from.ExecuteAsync(c);
+        var to = await _to.ExecuteAsync(c);
+        var step = _step == null ? 1 : await _step.ExecuteAsync(c);
         int count;
-        c.Parameters[m_variable] = 0;
+        c.Parameters[_variable] = 0;
 
         for (count = from; (step > 0 && count <= to) || (step < 0 && count >= to); count += step)
         {
-            c.Parameters[m_variable] = count;
-            await m_loopScript.ExecuteAsync(c);
+            c.Parameters[_variable] = count;
+            await _loopScript.ExecuteAsync(c);
             if (c.IsReturned)
             {
                 break;
             }
 
-            var newCount = c.Parameters[m_variable];
+            var newCount = c.Parameters[_variable];
             if (newCount is int)
             {
                 count = (int) newCount;
@@ -117,12 +117,12 @@ public class ForScript : ScriptBase
 
     public override string Save()
     {
-        if (m_step == null)
+        if (_step == null)
         {
-            return SaveScript("for", m_loopScript, m_variable, m_from.Save(), m_to.Save());
+            return SaveScript("for", _loopScript, _variable, _from.Save(), _to.Save());
         }
 
-        return SaveScript("for", m_loopScript, m_variable, m_from.Save(), m_to.Save(), m_step.Save());
+        return SaveScript("for", _loopScript, _variable, _from.Save(), _to.Save(), _step.Save());
     }
 
     public override object GetParameter(int index)
@@ -130,15 +130,15 @@ public class ForScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_variable;
+                return _variable;
             case 1:
-                return m_from.Save();
+                return _from.Save();
             case 2:
-                return m_to.Save();
+                return _to.Save();
             case 3:
-                return m_step == null ? null : m_step.Save();
+                return _step == null ? null : _step.Save();
             case 4:
-                return m_loopScript;
+                return _loopScript;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -149,16 +149,16 @@ public class ForScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_variable = (string) value;
+                _variable = (string) value;
                 break;
             case 1:
-                m_from = new Expression<int>((string) value, m_scriptContext);
+                _from = new Expression<int>((string) value, _scriptContext);
                 break;
             case 2:
-                m_to = new Expression<int>((string) value, m_scriptContext);
+                _to = new Expression<int>((string) value, _scriptContext);
                 break;
             case 3:
-                m_step = new Expression<int>((string) value, m_scriptContext);
+                _step = new Expression<int>((string) value, _scriptContext);
                 break;
             case 4:
                 // any updates to the script should change the script itself - nothing should cause SetParameter to be triggered.
@@ -170,6 +170,6 @@ public class ForScript : ScriptBase
 
     public override IEnumerable<string> GetDefinedVariables()
     {
-        return new List<string> {m_variable};
+        return new List<string> {_variable};
     }
 }

--- a/src/Engine/Scripts/FunctionCallScript.cs
+++ b/src/Engine/Scripts/FunctionCallScript.cs
@@ -67,10 +67,10 @@ public class FunctionCallScriptConstructor : IScriptConstructor
 
 public class FunctionCallScript : ScriptBase, IFunctionCallScript
 {
-    private readonly FunctionCallParameters m_parameters;
-    private readonly WorldModel m_worldModel;
-    private IScript m_paramFunction;
-    private string m_procedure;
+    private readonly FunctionCallParameters _parameters;
+    private readonly WorldModel _worldModel;
+    private IScript _paramFunction;
+    private string _procedure;
 
     public FunctionCallScript(WorldModel worldModel, string procedure)
         : this(worldModel, procedure, null, null)
@@ -80,32 +80,32 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
     public FunctionCallScript(WorldModel worldModel, string procedure, IList<IFunction<object>> parameters,
         IScript paramFunction)
     {
-        m_worldModel = worldModel;
-        m_procedure = procedure;
-        m_parameters = new FunctionCallParameters(worldModel, parameters);
-        m_paramFunction = paramFunction;
+        _worldModel = worldModel;
+        _procedure = procedure;
+        _parameters = new FunctionCallParameters(worldModel, parameters);
+        _paramFunction = paramFunction;
 
-        m_parameters.ParametersAsQuestList.Added += Parameters_Added;
-        m_parameters.ParametersAsQuestList.Removed += Parameters_Removed;
+        _parameters.ParametersAsQuestList.Added += Parameters_Added;
+        _parameters.ParametersAsQuestList.Removed += Parameters_Removed;
     }
 
     public event EventHandler<ScriptUpdatedEventArgs> FunctionCallParametersUpdated;
 
     public override async Task ExecuteAsync(Context c)
     {
-        if ((m_parameters.Parameters == null || m_parameters.Parameters.Count == 0) && m_paramFunction == null)
+        if ((_parameters.Parameters == null || _parameters.Parameters.Count == 0) && _paramFunction == null)
         {
-            await m_worldModel.RunProcedureAsync(m_procedure);
+            await _worldModel.RunProcedureAsync(_procedure);
         }
         else
         {
             var paramValues = new Parameters();
-            var proc = m_worldModel.Procedure(m_procedure);
+            var proc = _worldModel.Procedure(_procedure);
 
             var paramNames = proc.Fields[FieldDefinitions.ParamNames];
 
-            var paramCount = m_parameters.Parameters.Count;
-            if (m_paramFunction != null)
+            var paramCount = _parameters.Parameters.Count;
+            if (_paramFunction != null)
             {
                 paramCount++;
             }
@@ -114,73 +114,73 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
             {
                 throw new Exception(string.Format(
                     "Too many parameters passed to {0} function - {1} passed, but only {2} expected",
-                    m_procedure,
+                    _procedure,
                     paramCount,
                     paramNames.Count));
             }
 
-            if (m_worldModel.Version >= WorldModelVersion.v520)
+            if (_worldModel.Version >= WorldModelVersion.v520)
             {
                 if (paramCount < paramNames.Count)
                 {
                     throw new Exception(string.Format(
                         "Too few parameters passed to {0} function - only {1} passed, but {2} expected",
-                        m_procedure,
+                        _procedure,
                         paramCount,
                         paramNames.Count));
                 }
             }
 
             var cnt = 0;
-            foreach (var f in m_parameters.Parameters)
+            foreach (var f in _parameters.Parameters)
             {
                 paramValues.Add((string) paramNames[cnt], await f.ExecuteAsync(c));
                 cnt++;
             }
 
-            if (m_paramFunction != null)
+            if (_paramFunction != null)
             {
-                paramValues.Add((string) paramNames[cnt], m_paramFunction);
+                paramValues.Add((string) paramNames[cnt], _paramFunction);
             }
 
-            await m_worldModel.RunProcedureAsync(m_procedure, paramValues, false);
+            await _worldModel.RunProcedureAsync(_procedure, paramValues, false);
         }
     }
 
-    public override string Keyword => "(function)" + m_procedure;
+    public override string Keyword => "(function)" + _procedure;
 
     public override string Save()
     {
-        if (m_worldModel.Procedure(m_procedure) == null)
+        if (_worldModel.Procedure(_procedure) == null)
         {
             // TO DO: this is the wrong place to be throwing an exception, because Save may be called while editing a script,
             // and maybe the user simply hasn't created their function yet. Maybe instead we should append to a list of warnings
             // when doing an actual File Save, then we can display any warnings after saving.
-            //throw new Exception(string.Format("Unable to save call to function '{0}' - function does not exist", m_procedure));
+            //throw new Exception(string.Format("Unable to save call to function '{0}' - function does not exist", _procedure));
         }
 
-        if ((m_parameters == null || m_parameters.ParametersAsQuestList.Count == 0) && m_paramFunction == null)
+        if ((_parameters == null || _parameters.ParametersAsQuestList.Count == 0) && _paramFunction == null)
         {
-            return m_procedure;
+            return _procedure;
         }
 
         var saveParameters = new List<string>();
-        foreach (var p in m_parameters.ParametersAsQuestList)
+        foreach (var p in _parameters.ParametersAsQuestList)
         {
             saveParameters.Add(p);
         }
 
-        if (m_paramFunction == null)
+        if (_paramFunction == null)
         {
-            return SaveScript(m_procedure, saveParameters.ToArray());
+            return SaveScript(_procedure, saveParameters.ToArray());
         }
 
         if (saveParameters.Count > 0)
         {
-            return SaveScript(m_procedure, m_paramFunction, saveParameters.ToArray());
+            return SaveScript(_procedure, _paramFunction, saveParameters.ToArray());
         }
 
-        return SaveScript(m_procedure + "()", m_paramFunction);
+        return SaveScript(_procedure + "()", _paramFunction);
     }
 
     public override object GetParameter(int index)
@@ -188,9 +188,9 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         switch (index)
         {
             case 0:
-                return m_procedure;
+                return _procedure;
             case 1:
-                return m_parameters.ParametersAsQuestList;
+                return _parameters.ParametersAsQuestList;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -198,7 +198,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
 
     public object GetFunctionCallParameter(int index)
     {
-        if (index >= m_parameters.ParametersAsQuestList.Count)
+        if (index >= _parameters.ParametersAsQuestList.Count)
         {
             // In the editor, when a blank function call is created, it will have no parameters, but
             // if the editor requests a first parameter then we want to return a blank default instead
@@ -206,29 +206,29 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
             return "";
         }
 
-        return m_parameters.ParametersAsQuestList[index];
+        return _parameters.ParametersAsQuestList[index];
     }
 
     public void SetFunctionCallParameter(int index, object value)
     {
-        if (index < m_parameters.ParametersAsQuestList.Count)
+        if (index < _parameters.ParametersAsQuestList.Count)
         {
             // In the editor, when a blank function call is created, it will have no parameters
-            m_parameters.ParametersAsQuestList.Remove(m_parameters.ParametersAsQuestList[index], UpdateSource.User,
+            _parameters.ParametersAsQuestList.Remove(_parameters.ParametersAsQuestList[index], UpdateSource.User,
                 index);
         }
 
-        m_parameters.ParametersAsQuestList.Add(value, UpdateSource.User, index);
+        _parameters.ParametersAsQuestList.Add(value, UpdateSource.User, index);
     }
 
     public IScript GetFunctionCallParameterScript()
     {
-        return m_paramFunction;
+        return _paramFunction;
     }
 
     public void SetFunctionCallParameterScript(IScript script)
     {
-        m_paramFunction = script;
+        _paramFunction = script;
     }
 
     // Only an EditableScript wrapper - i.e. a script currently open in the editor - subscribes
@@ -256,8 +256,8 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
 
     protected override ScriptBase CloneScript()
     {
-        return new FunctionCallScript(m_worldModel, m_procedure, m_parameters == null ? null : m_parameters.Parameters,
-            m_paramFunction);
+        return new FunctionCallScript(_worldModel, _procedure, _parameters == null ? null : _parameters.Parameters,
+            _paramFunction);
     }
 
     protected override void SetParameterInternal(int index, object value)
@@ -265,7 +265,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         switch (index)
         {
             case 0:
-                m_procedure = (string) value;
+                _procedure = (string) value;
                 break;
             case 1:
                 // any updates to the parameters should change the list itself - nothing should cause SetParameter to be triggered.

--- a/src/Engine/Scripts/GetInputScript.cs
+++ b/src/Engine/Scripts/GetInputScript.cs
@@ -19,32 +19,32 @@ public class GetInputScriptConstructor : IScriptConstructor
 
 public class GetInputScript : ScriptBase
 {
-    private readonly IScript m_callbackScript;
-    private readonly ScriptContext m_scriptContext;
-    private readonly IScriptFactory m_scriptFactory;
-    private readonly WorldModel m_worldModel;
+    private readonly IScript _callbackScript;
+    private readonly ScriptContext _scriptContext;
+    private readonly IScriptFactory _scriptFactory;
+    private readonly WorldModel _worldModel;
 
     public GetInputScript(ScriptContext scriptContext, IScriptFactory scriptFactory, IScript callbackScript)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_scriptFactory = scriptFactory;
-        m_callbackScript = callbackScript;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _scriptFactory = scriptFactory;
+        _callbackScript = callbackScript;
     }
 
     public override string Keyword => "get input";
 
     protected override ScriptBase CloneScript()
     {
-        return new GetInputScript(m_scriptContext, m_scriptFactory, (IScript) m_callbackScript.Clone());
+        return new GetInputScript(_scriptContext, _scriptFactory, (IScript) _callbackScript.Clone());
     }
 
     public override Task ExecuteAsync(Context c)
     {
-        m_worldModel._commandOverride = true;
-        WorldModel.BeginPrompt(ref m_worldModel._commandInputTcs);
-        m_worldModel.BeginDormantSuspension();
-        m_worldModel.SignalTurnSuspended();
+        _worldModel._commandOverride = true;
+        WorldModel.BeginPrompt(ref _worldModel._commandInputTcs);
+        _worldModel.BeginDormantSuspension();
+        _worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c);
         return Task.CompletedTask;
     }
@@ -54,26 +54,26 @@ public class GetInputScript : ScriptBase
         var resolved = false;
         try
         {
-            var result = await m_worldModel._commandInputTcs.Task;
+            var result = await _worldModel._commandInputTcs.Task;
             resolved = true;
-            m_worldModel.SignalCallbackResolving();
-            m_worldModel._commandOverride = false;
+            _worldModel.SignalCallbackResolving();
+            _worldModel._commandOverride = false;
             c.Parameters["result"] = result;
-            await m_worldModel.RunScriptAsync(m_callbackScript, c);
+            await _worldModel.RunScriptAsync(_callbackScript, c);
         }
         catch (OperationCanceledException) { }
-        catch (Exception ex) { m_worldModel.LogException(ex); }
+        catch (Exception ex) { _worldModel.LogException(ex); }
         finally
         {
-            if (!resolved) m_worldModel.SignalCallbackResolving();
-            await m_worldModel.EndPendingCallbackAsync();
-            m_worldModel.SignalTurnSuspended();
+            if (!resolved) _worldModel.SignalCallbackResolving();
+            await _worldModel.EndPendingCallbackAsync();
+            _worldModel.SignalTurnSuspended();
         }
     }
 
     public override string Save()
     {
-        return SaveScript("get input", m_callbackScript);
+        return SaveScript("get input", _callbackScript);
     }
 
     public override object GetParameter(int index)
@@ -81,7 +81,7 @@ public class GetInputScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_callbackScript;
+                return _callbackScript;
             default:
                 throw new ArgumentOutOfRangeException();
         }

--- a/src/Engine/Scripts/IfScript.cs
+++ b/src/Engine/Scripts/IfScript.cs
@@ -86,13 +86,13 @@ public class IfScriptConstructor : IScriptConstructor
 
 public class IfScript : ScriptBase, IIfScript
 {
-    private readonly List<IElseIfScript> m_elseIfScript = new();
-    private readonly ScriptContext m_scriptContext;
+    private readonly List<IElseIfScript> _elseIfScript = new();
+    private readonly ScriptContext _scriptContext;
 
-    private bool m_hasElse;
+    private bool _hasElse;
 
-    private int m_lastElseIfId;
-    private WorldModel m_worldModel;
+    private int _lastElseIfId;
+    private WorldModel _worldModel;
 
     public IfScript(IFunction<bool> expression, IScript thenScript, ScriptContext scriptContext)
         : this(expression, thenScript, null, scriptContext)
@@ -104,8 +104,8 @@ public class IfScript : ScriptBase, IIfScript
         Expression = expression;
         ThenScript = thenScript;
         ElseScript = elseScript;
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
     }
 
     public event EventHandler<IfScriptUpdatedEventArgs> IfScriptUpdated;
@@ -114,14 +114,14 @@ public class IfScript : ScriptBase, IIfScript
     {
         if (UndoLog != null)
         {
-            Debug.Assert(elseScript == null || !m_hasElse,
+            Debug.Assert(elseScript == null || !_hasElse,
                 "UndoSetElse assumes that we only ever set the Else script once");
 
             UndoLog.StartTransaction("Add Else script");
-            UndoLog.AddUndoAction(() => new UndoSetElse(this, ElseScript, elseScript, m_hasElse, true));
+            UndoLog.AddUndoAction(() => new UndoSetElse(this, ElseScript, elseScript, _hasElse, true));
         }
 
-        m_hasElse = true;
+        _hasElse = true;
         SetElseSilent(elseScript);
 
         if (UndoLog != null)
@@ -132,7 +132,7 @@ public class IfScript : ScriptBase, IIfScript
 
     public IElseIfScript AddElseIf(string expression, IScript script)
     {
-        IFunction<bool> expr = new Expression<bool>(expression, m_scriptContext);
+        IFunction<bool> expr = new Expression<bool>(expression, _scriptContext);
         return AddElseIf(expr, script);
     }
 
@@ -172,7 +172,7 @@ public class IfScript : ScriptBase, IIfScript
         }
     }
 
-    public IList<IElseIfScript> ElseIfScripts => m_elseIfScript.AsReadOnly();
+    public IList<IElseIfScript> ElseIfScripts => _elseIfScript.AsReadOnly();
 
     public string ExpressionString
     {
@@ -193,14 +193,14 @@ public class IfScript : ScriptBase, IIfScript
     protected override ScriptBase CloneScript()
     {
         var clone = new IfScript(Expression.Clone(), (IScript) ThenScript.Clone(),
-            ElseScript == null ? null : (IScript) ElseScript.Clone(), m_scriptContext);
-        clone.m_hasElse = m_hasElse;
-        foreach (ElseIfScript elseif in m_elseIfScript)
+            ElseScript == null ? null : (IScript) ElseScript.Clone(), _scriptContext);
+        clone._hasElse = _hasElse;
+        foreach (ElseIfScript elseif in _elseIfScript)
         {
-            clone.m_elseIfScript.Add(elseif.Clone(clone));
+            clone._elseIfScript.Add(elseif.Clone(clone));
         }
 
-        clone.m_lastElseIfId = m_lastElseIfId;
+        clone._lastElseIfId = _lastElseIfId;
         return clone;
     }
 
@@ -220,13 +220,13 @@ public class IfScript : ScriptBase, IIfScript
 
     private string GetNewElseIfID()
     {
-        m_lastElseIfId++;
-        return "elseif" + m_lastElseIfId;
+        _lastElseIfId++;
+        return "elseif" + _lastElseIfId;
     }
 
     private void AddElseIfSilent(IElseIfScript elseIfScript)
     {
-        m_elseIfScript.Add(elseIfScript);
+        _elseIfScript.Add(elseIfScript);
 
         if (IfScriptUpdated != null)
         {
@@ -238,7 +238,7 @@ public class IfScript : ScriptBase, IIfScript
 
     private void RemoveElseIfSilent(IElseIfScript elseIfScript)
     {
-        m_elseIfScript.Remove(elseIfScript);
+        _elseIfScript.Remove(elseIfScript);
 
         if (IfScriptUpdated != null)
         {
@@ -250,19 +250,19 @@ public class IfScript : ScriptBase, IIfScript
 
     private void SetExpressionSilent(string newValue)
     {
-        Expression = new Expression<bool>(newValue, m_scriptContext);
+        Expression = new Expression<bool>(newValue, _scriptContext);
         NotifyUpdate(0, newValue);
     }
 
     public class ElseIfScript : IElseIfScript
     {
-        private readonly IfScript m_parent;
+        private readonly IfScript _parent;
 
         public ElseIfScript(IFunction<bool> expression, IScript script, IfScript parent, string id)
         {
             Expression = expression;
             Script = script;
-            m_parent = parent;
+            _parent = parent;
             Id = id;
         }
 
@@ -275,7 +275,7 @@ public class IfScript : ScriptBase, IIfScript
             get => Expression.Save();
             set
             {
-                m_parent.UndoLog.AddUndoAction(() => new UndoChangeExpression(this, Expression.Save(), value));
+                _parent.UndoLog.AddUndoAction(() => new UndoChangeExpression(this, Expression.Save(), value));
                 SetExpressionSilent(value);
             }
         }
@@ -287,138 +287,138 @@ public class IfScript : ScriptBase, IIfScript
 
         internal void SetExpressionSilent(string newValue)
         {
-            Expression = new Expression<bool>(newValue, m_parent.m_scriptContext);
-            m_parent.NotifyUpdate(Id, newValue);
+            Expression = new Expression<bool>(newValue, _parent._scriptContext);
+            _parent.NotifyUpdate(Id, newValue);
         }
     }
 
     private class UndoChangeExpression : UndoLogger.IUndoAction
     {
-        private readonly ElseIfScript m_elseIfScript;
-        private readonly string m_newValue;
-        private readonly string m_oldValue;
-        private readonly IfScript m_script;
+        private readonly ElseIfScript _elseIfScript;
+        private readonly string _newValue;
+        private readonly string _oldValue;
+        private readonly IfScript _script;
 
         private UndoChangeExpression(string oldValue, string newValue)
         {
-            m_oldValue = oldValue;
-            m_newValue = newValue;
+            _oldValue = oldValue;
+            _newValue = newValue;
         }
 
         public UndoChangeExpression(IfScript script, string oldValue, string newValue)
             : this(oldValue, newValue)
         {
-            m_script = script;
+            _script = script;
         }
 
         public UndoChangeExpression(ElseIfScript elseIfscript, string oldValue, string newValue)
             : this(oldValue, newValue)
         {
-            m_elseIfScript = elseIfscript;
+            _elseIfScript = elseIfscript;
         }
 
         public void DoUndo(WorldModel worldModel)
         {
-            if (m_script != null)
+            if (_script != null)
             {
-                m_script.SetExpressionSilent(m_oldValue);
+                _script.SetExpressionSilent(_oldValue);
             }
 
-            if (m_elseIfScript != null)
+            if (_elseIfScript != null)
             {
-                m_elseIfScript.SetExpressionSilent(m_oldValue);
+                _elseIfScript.SetExpressionSilent(_oldValue);
             }
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            if (m_script != null)
+            if (_script != null)
             {
-                m_script.SetExpressionSilent(m_newValue);
+                _script.SetExpressionSilent(_newValue);
             }
 
-            if (m_elseIfScript != null)
+            if (_elseIfScript != null)
             {
-                m_elseIfScript.SetExpressionSilent(m_newValue);
+                _elseIfScript.SetExpressionSilent(_newValue);
             }
         }
     }
 
     // We only need an UndoSetElse and not an UndoSetThen, because an "if" *always*
     // has a "then". So here we implictly assume that the old value was null, and that
-    // m_hasElse was false.
+    // _hasElse was false.
 
     private class UndoSetElse : UndoLogger.IUndoAction
     {
-        private readonly bool m_newHasElse;
-        private readonly IScript m_newValue;
-        private readonly bool m_oldHasElse;
-        private readonly IScript m_oldValue;
-        private readonly IfScript m_script;
+        private readonly bool _newHasElse;
+        private readonly IScript _newValue;
+        private readonly bool _oldHasElse;
+        private readonly IScript _oldValue;
+        private readonly IfScript _script;
 
         public UndoSetElse(IfScript script, IScript oldValue, IScript newValue, bool oldHasElse, bool newHasElse)
         {
-            m_script = script;
-            m_oldValue = oldValue;
-            m_newValue = newValue;
-            m_oldHasElse = oldHasElse;
-            m_newHasElse = newHasElse;
+            _script = script;
+            _oldValue = oldValue;
+            _newValue = newValue;
+            _oldHasElse = oldHasElse;
+            _newHasElse = newHasElse;
         }
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_script.m_hasElse = m_oldHasElse;
-            m_script.SetElseSilent(m_oldValue);
+            _script._hasElse = _oldHasElse;
+            _script.SetElseSilent(_oldValue);
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_script.m_hasElse = m_newHasElse;
-            m_script.SetElseSilent(m_newValue);
+            _script._hasElse = _newHasElse;
+            _script.SetElseSilent(_newValue);
         }
     }
 
     private class UndoAddElseIf : UndoLogger.IUndoAction
     {
-        private readonly IElseIfScript m_elseIf;
-        private readonly IfScript m_script;
+        private readonly IElseIfScript _elseIf;
+        private readonly IfScript _script;
 
         public UndoAddElseIf(IfScript script, IElseIfScript elseIf)
         {
-            m_script = script;
-            m_elseIf = elseIf;
+            _script = script;
+            _elseIf = elseIf;
         }
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_script.RemoveElseIfSilent(m_elseIf);
+            _script.RemoveElseIfSilent(_elseIf);
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_script.AddElseIfSilent(m_elseIf);
+            _script.AddElseIfSilent(_elseIf);
         }
     }
 
     private class UndoRemoveElseIf : UndoLogger.IUndoAction
     {
-        private readonly IElseIfScript m_elseIf;
-        private readonly IfScript m_script;
+        private readonly IElseIfScript _elseIf;
+        private readonly IfScript _script;
 
         public UndoRemoveElseIf(IfScript script, IElseIfScript elseIf)
         {
-            m_script = script;
-            m_elseIf = elseIf;
+            _script = script;
+            _elseIf = elseIf;
         }
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_script.AddElseIfSilent(m_elseIf);
+            _script.AddElseIfSilent(_elseIf);
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_script.RemoveElseIfSilent(m_elseIf);
+            _script.RemoveElseIfSilent(_elseIf);
         }
     }
 
@@ -432,9 +432,9 @@ public class IfScript : ScriptBase, IIfScript
             return;
         }
 
-        if (m_elseIfScript != null)
+        if (_elseIfScript != null)
         {
-            foreach (ElseIfScript elseIfScript in m_elseIfScript)
+            foreach (ElseIfScript elseIfScript in _elseIfScript)
             {
                 if (await elseIfScript.Expression.ExecuteAsync(c))
                 {
@@ -453,9 +453,9 @@ public class IfScript : ScriptBase, IIfScript
     public override string Save()
     {
         var result = SaveScript("if", ThenScript, Expression.Save());
-        if (m_elseIfScript != null)
+        if (_elseIfScript != null)
         {
-            foreach (ElseIfScript elseIf in m_elseIfScript)
+            foreach (ElseIfScript elseIf in _elseIfScript)
             {
                 result += Environment.NewLine + SaveScript("else if", elseIf.Script, elseIf.Expression.Save());
             }

--- a/src/Engine/Scripts/InsertScript.cs
+++ b/src/Engine/Scripts/InsertScript.cs
@@ -20,34 +20,34 @@ public class InsertScriptConstructor : ScriptConstructorBase
 
 public class InsertScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_filename;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _filename;
 
     public InsertScript(ScriptContext scriptContext, IFunction<string> filename)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_filename = filename;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _filename = filename;
     }
 
     public override string Keyword => "insert";
 
     protected override ScriptBase CloneScript()
     {
-        return new InsertScript(m_scriptContext, m_filename.Clone());
+        return new InsertScript(_scriptContext, _filename.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        if (m_worldModel.Version >= WorldModelVersion.v540)
+        if (_worldModel.Version >= WorldModelVersion.v540)
         {
             throw new Exception(
                 "The 'insert' script command is not supported for games with WorldModel version 540 or later. You can output HTML directly using the 'msg' command instead.");
         }
 
-        var filename = await m_filename.ExecuteAsync(c);
-        if (m_worldModel.Version == WorldModelVersion.v500)
+        var filename = await _filename.ExecuteAsync(c);
+        if (_worldModel.Version == WorldModelVersion.v500)
         {
             // v500 games used Frame.htm for static panel feature. This is now implemented natively
             // in Player and WebPlayer.
@@ -57,7 +57,7 @@ public class InsertScript : ScriptBase
             }
         }
 
-        var stream = m_worldModel.GetResourceStream(filename);
+        var stream = _worldModel.GetResourceStream(filename);
         if (stream == null)
         {
             return;
@@ -65,21 +65,21 @@ public class InsertScript : ScriptBase
 
         using var reader = new StreamReader(stream);
         var html = reader.ReadToEnd();
-        m_worldModel.PlayerUi.WriteHTML(html);
+        _worldModel.PlayerUi.WriteHTML(html);
     }
 
     public override string Save()
     {
-        return SaveScript("insert", m_filename.Save());
+        return SaveScript("insert", _filename.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_filename.Save();
+        return _filename.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_filename = new Expression<string>((string) value, m_scriptContext);
+        _filename = new Expression<string>((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/InvokeScript.cs
+++ b/src/Engine/Scripts/InvokeScript.cs
@@ -30,53 +30,53 @@ public class InvokeScriptConstructor : ScriptConstructorBase
 
 public class InvokeScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<IDictionary> m_parameters;
-    private IFunction<IScript> m_script;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<IDictionary> _parameters;
+    private IFunction<IScript> _script;
 
     public InvokeScript(ScriptContext scriptContext, IFunction<IScript> script)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_script = script;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _script = script;
     }
 
     public InvokeScript(ScriptContext scriptContext, IFunction<IScript> script, IFunction<IDictionary> parameters)
         : this(scriptContext, script)
     {
-        m_parameters = parameters;
+        _parameters = parameters;
     }
 
     public override string Keyword => "invoke";
 
     protected override ScriptBase CloneScript()
     {
-        return new InvokeScript(m_scriptContext, m_script.Clone(), m_parameters == null ? null : m_parameters.Clone());
+        return new InvokeScript(_scriptContext, _script.Clone(), _parameters == null ? null : _parameters.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var script = await m_script.ExecuteAsync(c);
-        if (m_parameters == null)
+        var script = await _script.ExecuteAsync(c);
+        if (_parameters == null)
         {
-            await m_worldModel.RunScriptAsync(script);
+            await _worldModel.RunScriptAsync(script);
         }
         else
         {
-            await m_worldModel.RunScriptAsync(script, new Parameters(await m_parameters.ExecuteAsync(c)));
+            await _worldModel.RunScriptAsync(script, new Parameters(await _parameters.ExecuteAsync(c)));
         }
     }
 
     public override string Save()
     {
-        var parameters = m_parameters == null ? null : m_parameters.Save();
+        var parameters = _parameters == null ? null : _parameters.Save();
         if (string.IsNullOrEmpty(parameters))
         {
-            return SaveScript("invoke", m_script.Save());
+            return SaveScript("invoke", _script.Save());
         }
 
-        return SaveScript("invoke", m_script.Save(), parameters);
+        return SaveScript("invoke", _script.Save(), parameters);
     }
 
     public override object GetParameter(int index)
@@ -84,9 +84,9 @@ public class InvokeScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_script.Save();
+                return _script.Save();
             case 1:
-                return m_parameters == null ? null : m_parameters.Save();
+                return _parameters == null ? null : _parameters.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -97,10 +97,10 @@ public class InvokeScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_script = new Expression<IScript>((string) value, m_scriptContext);
+                _script = new Expression<IScript>((string) value, _scriptContext);
                 break;
             case 1:
-                m_parameters = new Expression<IDictionary>((string) value, m_scriptContext);
+                _parameters = new Expression<IDictionary>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/JSScript.cs
+++ b/src/Engine/Scripts/JSScript.cs
@@ -6,7 +6,7 @@ namespace QuestViva.Engine.Scripts;
 
 public class JSScriptConstructor : IScriptConstructor
 {
-    private static readonly Regex s_jsFunctionName = new(@"^JS\.([\w\.\@]*)");
+    private static readonly Regex JsFunctionName = new(@"^JS\.([\w\.\@]*)");
     public string Keyword => "JS.";
 
     public IScript Create(string script, ScriptContext scriptContext)
@@ -25,12 +25,12 @@ public class JSScriptConstructor : IScriptConstructor
             }
         }
 
-        if (!s_jsFunctionName.IsMatch(script))
+        if (!JsFunctionName.IsMatch(script))
         {
             throw new Exception(string.Format("Invalid JS function name in '{0}'", script));
         }
 
-        var functionName = s_jsFunctionName.Match(script).Groups[1].Value;
+        var functionName = JsFunctionName.Match(script).Groups[1].Value;
 
         return new JSScript(scriptContext, functionName, expressions);
     }
@@ -42,54 +42,54 @@ public class JSScriptConstructor : IScriptConstructor
 
 public class JSScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private string m_function;
-    private List<IFunctionDynamic> m_parameters;
+    private readonly ScriptContext _scriptContext;
+    private string _function;
+    private List<IFunctionDynamic> _parameters;
 
     public JSScript(ScriptContext scriptContext, string function, List<IFunctionDynamic> parameters)
     {
-        m_scriptContext = scriptContext;
-        m_function = function;
-        m_parameters = parameters;
+        _scriptContext = scriptContext;
+        _function = function;
+        _parameters = parameters;
     }
 
     public override string Keyword => "JS.";
 
     protected override ScriptBase CloneScript()
     {
-        return new JSScript(m_scriptContext, m_function,
-            m_parameters == null ? null : new List<IFunctionDynamic>(m_parameters));
+        return new JSScript(_scriptContext, _function,
+            _parameters == null ? null : new List<IFunctionDynamic>(_parameters));
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        if (string.IsNullOrEmpty(m_function))
+        if (string.IsNullOrEmpty(_function))
         {
             return;
         }
 
-        if (m_parameters != null)
+        if (_parameters != null)
         {
-            var paramValues = new object[m_parameters.Count];
-            for (var i = 0; i < m_parameters.Count; i++)
-                paramValues[i] = await m_parameters[i].ExecuteAsync(c);
-            await m_scriptContext.WorldModel.PlayerUi.RunScriptAsync(m_function, paramValues);
+            var paramValues = new object[_parameters.Count];
+            for (var i = 0; i < _parameters.Count; i++)
+                paramValues[i] = await _parameters[i].ExecuteAsync(c);
+            await _scriptContext.WorldModel.PlayerUi.RunScriptAsync(_function, paramValues);
         }
         else
         {
-            await m_scriptContext.WorldModel.PlayerUi.RunScriptAsync(m_function, null);
+            await _scriptContext.WorldModel.PlayerUi.RunScriptAsync(_function, null);
         }
     }
 
     public override string Save()
     {
-        if (string.IsNullOrEmpty(m_function))
+        if (string.IsNullOrEmpty(_function))
         {
             return "JS.";
         }
 
-        return SaveScript("JS." + m_function,
-            m_parameters == null ? new[] {string.Empty} : m_parameters.Select(p => p.Save()).ToArray());
+        return SaveScript("JS." + _function,
+            _parameters == null ? new[] {string.Empty} : _parameters.Select(p => p.Save()).ToArray());
     }
 
     protected override void SetParameterInternal(int index, object value)
@@ -97,9 +97,9 @@ public class JSScript : ScriptBase
         var constuctor = new JSScriptConstructor();
         try
         {
-            var newScript = (JSScript) constuctor.Create("JS." + (string) value, m_scriptContext);
-            m_function = newScript.m_function;
-            m_parameters = newScript.m_parameters;
+            var newScript = (JSScript) constuctor.Create("JS." + (string) value, _scriptContext);
+            _function = newScript._function;
+            _parameters = newScript._parameters;
         }
         catch
         {

--- a/src/Engine/Scripts/LazyLoadScript.cs
+++ b/src/Engine/Scripts/LazyLoadScript.cs
@@ -5,36 +5,36 @@ namespace QuestViva.Engine.Scripts;
 
 public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
 {
-    private readonly IScriptConstructor m_scriptConstructor;
-    private readonly ScriptContext m_scriptContext;
-    private readonly ScriptFactory m_scriptFactory;
-    private readonly WorldModel m_worldModel;
-    private IScriptParent m_parent;
-    private IScript m_script;
-    private string m_scriptString;
+    private readonly IScriptConstructor _scriptConstructor;
+    private readonly ScriptContext _scriptContext;
+    private readonly ScriptFactory _scriptFactory;
+    private readonly WorldModel _worldModel;
+    private IScriptParent _parent;
+    private IScript _script;
+    private string _scriptString;
 
     public LazyLoadScript(ScriptFactory scriptFactory, string scriptString, ScriptContext scriptContext)
     {
-        m_scriptFactory = scriptFactory;
-        m_scriptString = scriptString;
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptFactory.WorldModel;
+        _scriptFactory = scriptFactory;
+        _scriptString = scriptString;
+        _scriptContext = scriptContext;
+        _worldModel = scriptFactory.WorldModel;
     }
 
     public LazyLoadScript(ScriptFactory scriptFactory, IScriptConstructor scriptConstructor, string scriptString,
         ScriptContext scriptContext)
     {
-        m_scriptFactory = scriptFactory;
-        m_scriptConstructor = scriptConstructor;
-        m_scriptString = scriptString;
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptConstructor.WorldModel;
+        _scriptFactory = scriptFactory;
+        _scriptConstructor = scriptConstructor;
+        _scriptString = scriptString;
+        _scriptContext = scriptContext;
+        _worldModel = scriptConstructor.WorldModel;
     }
 
     public void SetOtherwiseScript(IScript script)
     {
         Initialise();
-        ((FirstTimeScript) m_script).SetOtherwiseScript(script);
+        ((FirstTimeScript) _script).SetOtherwiseScript(script);
     }
 
     public event EventHandler<IfScriptUpdatedEventArgs> IfScriptUpdated
@@ -42,31 +42,31 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         add
         {
             Initialise();
-            ((IfScript) m_script).IfScriptUpdated += value;
+            ((IfScript) _script).IfScriptUpdated += value;
         }
         remove
         {
             Initialise();
-            ((IfScript) m_script).IfScriptUpdated -= value;
+            ((IfScript) _script).IfScriptUpdated -= value;
         }
     }
 
     public void SetElse(IScript elseScript)
     {
         Initialise();
-        ((IfScript) m_script).SetElse(elseScript);
+        ((IfScript) _script).SetElse(elseScript);
     }
 
     public IElseIfScript AddElseIf(string expression, IScript script)
     {
         Initialise();
-        return ((IfScript) m_script).AddElseIf(expression, script);
+        return ((IfScript) _script).AddElseIf(expression, script);
     }
 
     public IElseIfScript AddElseIf(IFunction<bool> expression, IScript script)
     {
         Initialise();
-        return ((IfScript) m_script).AddElseIf(expression, script);
+        return ((IfScript) _script).AddElseIf(expression, script);
     }
 
     public IFunction<bool> Expression
@@ -74,7 +74,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return ((IfScript) m_script).Expression;
+            return ((IfScript) _script).Expression;
         }
     }
 
@@ -83,12 +83,12 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return ((IfScript) m_script).ThenScript;
+            return ((IfScript) _script).ThenScript;
         }
         set
         {
             Initialise();
-            ((IfScript) m_script).ThenScript = value;
+            ((IfScript) _script).ThenScript = value;
         }
     }
 
@@ -97,7 +97,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return ((IfScript) m_script).ElseScript;
+            return ((IfScript) _script).ElseScript;
         }
     }
 
@@ -106,7 +106,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return ((IfScript) m_script).ElseIfScripts;
+            return ((IfScript) _script).ElseIfScripts;
         }
     }
 
@@ -115,19 +115,19 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return ((IfScript) m_script).ExpressionString;
+            return ((IfScript) _script).ExpressionString;
         }
         set
         {
             Initialise();
-            ((IfScript) m_script).ExpressionString = value;
+            ((IfScript) _script).ExpressionString = value;
         }
     }
 
     public void RemoveElseIf(IElseIfScript elseIfScript)
     {
         Initialise();
-        ((IfScript) m_script).RemoveElseIf(elseIfScript);
+        ((IfScript) _script).RemoveElseIf(elseIfScript);
     }
 
     public IEnumerable<IScript> Scripts
@@ -135,50 +135,50 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return ((MultiScript) m_script).Scripts;
+            return ((MultiScript) _script).Scripts;
         }
     }
 
     public void Add(params IScript[] scripts)
     {
         Initialise();
-        ((MultiScript) m_script).Add(scripts);
+        ((MultiScript) _script).Add(scripts);
     }
 
     public void Remove(int index)
     {
         Initialise();
-        ((MultiScript) m_script).Remove(index);
+        ((MultiScript) _script).Remove(index);
     }
 
     public void Swap(int index1, int index2)
     {
         Initialise();
-        ((MultiScript) m_script).Swap(index1, index2);
+        ((MultiScript) _script).Swap(index1, index2);
     }
 
     public void Insert(int index, IScript script)
     {
         Initialise();
-        ((MultiScript) m_script).Insert(index, script);
+        ((MultiScript) _script).Insert(index, script);
     }
 
     public void LoadCode(string code)
     {
         Initialise();
-        ((MultiScript) m_script).LoadCode(code);
+        ((MultiScript) _script).LoadCode(code);
     }
 
     public IMutableField Clone()
     {
-        if (m_script != null)
+        if (_script != null)
         {
-            return m_script.Clone();
+            return _script.Clone();
         }
 
-        var result = new LazyLoadScript(m_scriptFactory, m_scriptString, m_scriptContext);
-        result.Line = m_scriptString;
-        result.Parent = m_parent;
+        var result = new LazyLoadScript(_scriptFactory, _scriptString, _scriptContext);
+        result.Line = _scriptString;
+        result.Parent = _parent;
         return result;
     }
 
@@ -187,66 +187,66 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         add
         {
             Initialise();
-            m_script.ScriptUpdated += value;
+            _script.ScriptUpdated += value;
         }
         remove
         {
             Initialise();
-            m_script.ScriptUpdated -= value;
+            _script.ScriptUpdated -= value;
         }
     }
 
     public Task ExecuteAsync(Context c)
     {
         Initialise();
-        return m_script.ExecuteAsync(c);
+        return _script.ExecuteAsync(c);
     }
 
     public string Line
     {
         get
         {
-            if (m_script == null)
+            if (_script == null)
             {
-                return m_scriptString;
+                return _scriptString;
             }
 
-            return m_script.Line;
+            return _script.Line;
         }
         set
         {
-            if (m_script == null)
+            if (_script == null)
             {
-                m_scriptString = value;
+                _scriptString = value;
                 return;
             }
 
-            m_script.Line = value;
+            _script.Line = value;
         }
     }
 
     public string Save()
     {
         Initialise();
-        return m_script.Save();
+        return _script.Save();
     }
 
     public void SetParameter(int index, object value)
     {
         Initialise();
-        m_script.SetParameter(index, value);
+        _script.SetParameter(index, value);
     }
 
     public void SetParameterSilent(int index, object value)
     {
         Initialise();
-        m_script.SetParameterSilent(index, value);
+        _script.SetParameterSilent(index, value);
     }
 
     public object GetParameter(int index)
     {
         Initialise();
-        return m_script.GetParameter(index);
+        return _script.GetParameter(index);
     }
 
     public string Keyword
@@ -254,7 +254,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return m_script.Keyword;
+            return _script.Keyword;
         }
     }
 
@@ -262,29 +262,29 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
     {
         get
         {
-            if (m_script == null)
+            if (_script == null)
             {
-                return m_parent;
+                return _parent;
             }
 
-            return m_script.Parent;
+            return _script.Parent;
         }
         set
         {
-            if (m_script == null)
+            if (_script == null)
             {
-                m_parent = value;
+                _parent = value;
                 return;
             }
 
-            m_script.Parent = value;
+            _script.Parent = value;
         }
     }
 
     public IEnumerable<string> GetDefinedVariables()
     {
         Initialise();
-        return m_script.GetDefinedVariables();
+        return _script.GetDefinedVariables();
     }
 
     public UndoLogger UndoLog
@@ -292,12 +292,12 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return m_script.UndoLog;
+            return _script.UndoLog;
         }
         set
         {
             Initialise();
-            m_script.UndoLog = value;
+            _script.UndoLog = value;
         }
     }
 
@@ -306,12 +306,12 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return m_script.Owner;
+            return _script.Owner;
         }
         set
         {
             Initialise();
-            m_script.Owner = value;
+            _script.Owner = value;
         }
     }
 
@@ -320,12 +320,12 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return m_script.Locked;
+            return _script.Locked;
         }
         set
         {
             Initialise();
-            m_script.Locked = value;
+            _script.Locked = value;
         }
     }
 
@@ -334,54 +334,54 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         get
         {
             Initialise();
-            return m_script.RequiresCloning;
+            return _script.RequiresCloning;
         }
     }
 
     private void Initialise()
     {
-        if (m_script != null)
+        if (_script != null)
         {
             return;
         }
 
         try
         {
-            if (m_scriptConstructor == null)
+            if (_scriptConstructor == null)
             {
-                m_script = m_scriptFactory.CreateScript(m_scriptString, m_scriptContext, false, false);
+                _script = _scriptFactory.CreateScript(_scriptString, _scriptContext, false, false);
             }
             else
             {
-                m_script = m_scriptConstructor.Create(m_scriptString, m_scriptContext);
-                m_script.Line = m_scriptString;
+                _script = _scriptConstructor.Create(_scriptString, _scriptContext);
+                _script.Line = _scriptString;
             }
         }
         catch
         {
-            if (!m_worldModel.EditMode)
+            if (!_worldModel.EditMode)
             {
                 throw;
             }
 
-            m_script = new FailedScript(m_scriptString);
-            if (m_scriptConstructor == null)
+            _script = new FailedScript(_scriptString);
+            if (_scriptConstructor == null)
             {
-                m_script = new MultiScript(m_scriptFactory.WorldModel, m_script);
+                _script = new MultiScript(_scriptFactory.WorldModel, _script);
             }
         }
 
-        m_script.Parent = m_parent;
-        m_scriptString = null;
+        _script.Parent = _parent;
+        _scriptString = null;
     }
 
     public override string ToString()
     {
-        if (m_script != null)
+        if (_script != null)
         {
-            return m_script.ToString();
+            return _script.ToString();
         }
 
-        return m_scriptString;
+        return _scriptString;
     }
 }

--- a/src/Engine/Scripts/ListAddScript.cs
+++ b/src/Engine/Scripts/ListAddScript.cs
@@ -22,33 +22,33 @@ public class ListAddScriptConstructor : ScriptConstructorBase
 
 public class ListAddScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private IFunctionDynamic m_list;
-    private IFunction<object> m_value;
-    private WorldModel m_worldModel;
+    private readonly ScriptContext _scriptContext;
+    private IFunctionDynamic _list;
+    private IFunction<object> _value;
+    private WorldModel _worldModel;
 
     public ListAddScript(ScriptContext scriptContext, IFunctionDynamic list, IFunction<object> value)
     {
-        m_scriptContext = scriptContext;
-        m_list = list;
-        m_value = value;
-        m_worldModel = scriptContext.WorldModel;
+        _scriptContext = scriptContext;
+        _list = list;
+        _value = value;
+        _worldModel = scriptContext.WorldModel;
     }
 
     public override string Keyword => "list add";
 
     protected override ScriptBase CloneScript()
     {
-        return new ListAddScript(m_scriptContext, m_list.Clone(), m_value.Clone());
+        return new ListAddScript(_scriptContext, _list.Clone(), _value.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_list.ExecuteAsync(c) as IQuestList;
+        var result = await _list.ExecuteAsync(c) as IQuestList;
 
         if (result != null)
         {
-            result.Add(await m_value.ExecuteAsync(c));
+            result.Add(await _value.ExecuteAsync(c));
         }
         else
         {
@@ -58,7 +58,7 @@ public class ListAddScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("list add", m_list.Save(), m_value.Save());
+        return SaveScript("list add", _list.Save(), _value.Save());
     }
 
     public override object GetParameter(int index)
@@ -66,9 +66,9 @@ public class ListAddScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_list.Save();
+                return _list.Save();
             case 1:
-                return m_value.Save();
+                return _value.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -79,10 +79,10 @@ public class ListAddScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_list = new ExpressionDynamic((string) value, m_scriptContext);
+                _list = new ExpressionDynamic((string) value, _scriptContext);
                 break;
             case 1:
-                m_value = new Expression<object>((string) value, m_scriptContext);
+                _value = new Expression<object>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -109,33 +109,33 @@ public class ListRemoveScriptConstructor : ScriptConstructorBase
 
 public class ListRemoveScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private IFunctionDynamic m_list;
-    private IFunction<object> m_value;
-    private WorldModel m_worldModel;
+    private readonly ScriptContext _scriptContext;
+    private IFunctionDynamic _list;
+    private IFunction<object> _value;
+    private WorldModel _worldModel;
 
     public ListRemoveScript(ScriptContext scriptContext, IFunctionDynamic list, IFunction<object> value)
     {
-        m_scriptContext = scriptContext;
-        m_list = list;
-        m_value = value;
-        m_worldModel = scriptContext.WorldModel;
+        _scriptContext = scriptContext;
+        _list = list;
+        _value = value;
+        _worldModel = scriptContext.WorldModel;
     }
 
     public override string Keyword => "list remove";
 
     protected override ScriptBase CloneScript()
     {
-        return new ListRemoveScript(m_scriptContext, m_list.Clone(), m_value.Clone());
+        return new ListRemoveScript(_scriptContext, _list.Clone(), _value.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_list.ExecuteAsync(c) as IQuestList;
+        var result = await _list.ExecuteAsync(c) as IQuestList;
 
         if (result != null)
         {
-            result.Remove(await m_value.ExecuteAsync(c));
+            result.Remove(await _value.ExecuteAsync(c));
         }
         else
         {
@@ -145,7 +145,7 @@ public class ListRemoveScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("list remove", m_list.Save(), m_value.Save());
+        return SaveScript("list remove", _list.Save(), _value.Save());
     }
 
     public override object GetParameter(int index)
@@ -153,9 +153,9 @@ public class ListRemoveScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_list.Save();
+                return _list.Save();
             case 1:
-                return m_value.Save();
+                return _value.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -166,10 +166,10 @@ public class ListRemoveScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_list = new ExpressionDynamic((string) value, m_scriptContext);
+                _list = new ExpressionDynamic((string) value, _scriptContext);
                 break;
             case 1:
-                m_value = new Expression<object>((string) value, m_scriptContext);
+                _value = new Expression<object>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/MsgScript.cs
+++ b/src/Engine/Scripts/MsgScript.cs
@@ -24,42 +24,42 @@ public class MsgScriptConstructor : ScriptConstructorBase
 
 public class MsgScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunctionDynamic m_function;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunctionDynamic _function;
 
     public MsgScript(ScriptContext scriptContext, IFunctionDynamic function)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_function = function;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _function = function;
     }
 
     public override string Keyword => "msg";
 
     protected override ScriptBase CloneScript()
     {
-        return new MsgScript(m_scriptContext, m_function.Clone());
+        return new MsgScript(_scriptContext, _function.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_function.ExecuteAsync(c);
-        await m_worldModel.PrintAsync(Utility.ExpressionResultToString(result));
+        var result = await _function.ExecuteAsync(c);
+        await _worldModel.PrintAsync(Utility.ExpressionResultToString(result));
     }
 
     public override string Save()
     {
-        return SaveScript("msg", m_function.Save());
+        return SaveScript("msg", _function.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_function.Save();
+        return _function.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_function = new ExpressionDynamic((string) value, m_scriptContext);
+        _function = new ExpressionDynamic((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/MultiScript.cs
+++ b/src/Engine/Scripts/MultiScript.cs
@@ -13,32 +13,32 @@ public interface IMultiScript : IScript
 
 public class MultiScript : ScriptBase, IScriptParent, IMultiScript
 {
-    private readonly WorldModel m_worldModel;
+    private readonly WorldModel _worldModel;
 
-    private ScriptFactory m_scriptFactory;
-    private List<IScript> m_scripts;
+    private ScriptFactory _scriptFactory;
+    private List<IScript> _scripts;
 
     public MultiScript(WorldModel worldModel, params IScript[] scripts)
         : this(worldModel)
     {
-        m_scripts = new List<IScript>(scripts);
+        _scripts = new List<IScript>(scripts);
     }
 
     private MultiScript(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     private ScriptFactory ScriptFactory
     {
         get
         {
-            if (m_scriptFactory == null)
+            if (_scriptFactory == null)
             {
-                m_scriptFactory = new ScriptFactory(m_worldModel);
+                _scriptFactory = new ScriptFactory(_worldModel);
             }
 
-            return m_scriptFactory;
+            return _scriptFactory;
         }
     }
 
@@ -46,7 +46,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
 
     public void Add(params IScript[] scripts)
     {
-        m_scripts.AddRange(scripts);
+        _scripts.AddRange(scripts);
         if (UndoLog != null)
         {
             foreach (var script in scripts)
@@ -66,10 +66,10 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
     {
         if (UndoLog != null)
         {
-            UndoLog.AddUndoAction(() => new UndoMultiScriptAddRemove(this, m_scripts[index], false, index));
+            UndoLog.AddUndoAction(() => new UndoMultiScriptAddRemove(this, _scripts[index], false, index));
         }
 
-        RemoveSilent(m_scripts[index]);
+        RemoveSilent(_scripts[index]);
     }
 
     public void Insert(int index, IScript script)
@@ -99,7 +99,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         IScript script;
 
         // This swap assumes index1 < index2
-        script = m_scripts[index1];
+        script = _scripts[index1];
         Remove(index1);
         Insert(index2, script);
 
@@ -107,17 +107,17 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         // move the second script, as it's already in the correct place
         if (index1 != index2 - 1)
         {
-            script = m_scripts[index2 - 1];
+            script = _scripts[index2 - 1];
             Remove(index2 - 1);
             Insert(index1, script);
         }
     }
 
-    public IEnumerable<IScript> Scripts => m_scripts.AsReadOnly();
+    public IEnumerable<IScript> Scripts => _scripts.AsReadOnly();
 
     public override async Task ExecuteAsync(Context c)
     {
-        foreach (var script in m_scripts)
+        foreach (var script in _scripts)
         {
             await script.ExecuteAsync(c);
             if (c.IsReturned)
@@ -132,7 +132,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         get
         {
             var result = string.Empty;
-            foreach (var script in m_scripts)
+            foreach (var script in _scripts)
             {
                 result += script.Line + Environment.NewLine;
             }
@@ -146,7 +146,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
     {
         var result = string.Empty;
 
-        foreach (var script in m_scripts)
+        foreach (var script in _scripts)
         {
             if (result.Length > 0)
             {
@@ -170,7 +170,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         var newScriptList = new List<IScript>(newScript.Scripts);
         if (UndoLog != null)
         {
-            UndoLog.AddUndoAction(() => new UndoMultiScriptLoadCode(this, m_scripts, newScriptList));
+            UndoLog.AddUndoAction(() => new UndoMultiScriptLoadCode(this, _scripts, newScriptList));
         }
 
         ReplaceScripts(newScriptList);
@@ -181,7 +181,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         if (Parent == null)
         {
             var result = new List<string>();
-            foreach (var script in m_scripts)
+            foreach (var script in _scripts)
             {
                 // add any variables defined by the child script to the list
                 var definedVariables = script.GetDefinedVariables();
@@ -199,13 +199,13 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
 
     protected override ScriptBase CloneScript()
     {
-        var clone = new MultiScript(m_worldModel);
-        clone.m_scripts = new List<IScript>();
-        foreach (var script in m_scripts)
+        var clone = new MultiScript(_worldModel);
+        clone._scripts = new List<IScript>();
+        foreach (var script in _scripts)
         {
             var clonedScript = (IScript) script.Clone();
             clonedScript.Parent = clone;
-            clone.m_scripts.Add(clonedScript);
+            clone._scripts.Add(clonedScript);
         }
 
         return clone;
@@ -214,21 +214,21 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
     private void RemoveSilent(IScript script)
     {
         script.Parent = null;
-        m_scripts.Remove(script);
+        _scripts.Remove(script);
         NotifyUpdate(null, script);
     }
 
     private void AddSilent(IScript script)
     {
         script.Parent = this;
-        m_scripts.Add(script);
+        _scripts.Add(script);
         NotifyUpdate(script, null);
     }
 
     private void InsertSilent(int index, IScript script)
     {
         script.Parent = this;
-        m_scripts.Insert(index, script);
+        _scripts.Insert(index, script);
         NotifyUpdate(script, index);
     }
 
@@ -239,13 +239,13 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
 
     private void ReplaceScripts(List<IScript> newScripts)
     {
-        foreach (var script in m_scripts)
+        foreach (var script in _scripts)
         {
             script.Parent = null;
         }
 
-        m_scripts = newScripts;
-        foreach (var script in m_scripts)
+        _scripts = newScripts;
+        foreach (var script in _scripts)
         {
             script.Parent = this;
         }
@@ -255,65 +255,65 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
 
     private class UndoMultiScriptLoadCode : UndoLogger.IUndoAction
     {
-        private readonly MultiScript m_appliesTo;
-        private readonly List<IScript> m_newScripts;
-        private readonly List<IScript> m_oldScripts;
+        private readonly MultiScript _appliesTo;
+        private readonly List<IScript> _newScripts;
+        private readonly List<IScript> _oldScripts;
 
         public UndoMultiScriptLoadCode(MultiScript appliesTo, List<IScript> oldScripts, List<IScript> newScripts)
         {
-            m_appliesTo = appliesTo;
-            m_oldScripts = oldScripts;
-            m_newScripts = newScripts;
+            _appliesTo = appliesTo;
+            _oldScripts = oldScripts;
+            _newScripts = newScripts;
         }
 
         public void DoUndo(WorldModel worldModel)
         {
-            m_appliesTo.ReplaceScripts(m_oldScripts);
+            _appliesTo.ReplaceScripts(_oldScripts);
         }
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_appliesTo.ReplaceScripts(m_newScripts);
+            _appliesTo.ReplaceScripts(_newScripts);
         }
     }
 
     private class UndoMultiScriptAddRemove : UndoLogger.IUndoAction
     {
-        private readonly MultiScript m_appliesTo;
-        private readonly int? m_index;
-        private readonly bool m_isAdd;
-        private readonly IScript m_script;
+        private readonly MultiScript _appliesTo;
+        private readonly int? _index;
+        private readonly bool _isAdd;
+        private readonly IScript _script;
 
         public UndoMultiScriptAddRemove(MultiScript appliesTo, IScript script, bool isAdd, int? index)
         {
-            m_appliesTo = appliesTo;
-            m_script = script;
-            m_isAdd = isAdd;
-            m_index = index;
+            _appliesTo = appliesTo;
+            _script = script;
+            _isAdd = isAdd;
+            _index = index;
         }
 
         private void DoAdd()
         {
-            if (m_index.HasValue)
+            if (_index.HasValue)
             {
-                m_appliesTo.InsertSilent(m_index.Value, m_script);
+                _appliesTo.InsertSilent(_index.Value, _script);
             }
             else
             {
-                m_appliesTo.AddSilent(m_script);
+                _appliesTo.AddSilent(_script);
             }
         }
 
         private void DoRemove()
         {
-            m_appliesTo.RemoveSilent(m_script);
+            _appliesTo.RemoveSilent(_script);
         }
 
         #region IUndoAction Members
 
         public void DoUndo(WorldModel worldModel)
         {
-            if (m_isAdd)
+            if (_isAdd)
             {
                 DoRemove();
             }
@@ -325,7 +325,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
 
         public void DoRedo(WorldModel worldModel)
         {
-            if (m_isAdd)
+            if (_isAdd)
             {
                 DoAdd();
             }

--- a/src/Engine/Scripts/OnReadyScript.cs
+++ b/src/Engine/Scripts/OnReadyScript.cs
@@ -19,34 +19,34 @@ public class OnReadyScriptConstructor : IScriptConstructor
 
 public class OnReadyScript : ScriptBase
 {
-    private readonly IScript m_callbackScript;
-    private readonly ScriptContext m_scriptContext;
-    private readonly IScriptFactory m_scriptFactory;
-    private readonly WorldModel m_worldModel;
+    private readonly IScript _callbackScript;
+    private readonly ScriptContext _scriptContext;
+    private readonly IScriptFactory _scriptFactory;
+    private readonly WorldModel _worldModel;
 
     public OnReadyScript(ScriptContext scriptContext, IScriptFactory scriptFactory, IScript callbackScript)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_scriptFactory = scriptFactory;
-        m_callbackScript = callbackScript;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _scriptFactory = scriptFactory;
+        _callbackScript = callbackScript;
     }
 
     public override string Keyword => "on ready";
 
     protected override ScriptBase CloneScript()
     {
-        return new OnReadyScript(m_scriptContext, m_scriptFactory, (IScript) m_callbackScript.Clone());
+        return new OnReadyScript(_scriptContext, _scriptFactory, (IScript) _callbackScript.Clone());
     }
 
     public override Task ExecuteAsync(Context c)
     {
-        return m_worldModel.AddOnReady(m_callbackScript, c);
+        return _worldModel.AddOnReady(_callbackScript, c);
     }
 
     public override string Save()
     {
-        return SaveScript("on ready", m_callbackScript);
+        return SaveScript("on ready", _callbackScript);
     }
 
     public override object GetParameter(int index)
@@ -54,7 +54,7 @@ public class OnReadyScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_callbackScript;
+                return _callbackScript;
             default:
                 throw new ArgumentOutOfRangeException();
         }

--- a/src/Engine/Scripts/PictureScript.cs
+++ b/src/Engine/Scripts/PictureScript.cs
@@ -20,51 +20,51 @@ public class PictureScriptConstructor : ScriptConstructorBase
 
 public class PictureScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_filename;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _filename;
 
     public PictureScript(ScriptContext scriptContext, IFunction<string> function)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_filename = function;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _filename = function;
     }
 
     public override string Keyword => "picture";
 
     protected override ScriptBase CloneScript()
     {
-        return new PictureScript(m_scriptContext, m_filename.Clone());
+        return new PictureScript(_scriptContext, _filename.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var filename = await m_filename.ExecuteAsync(c);
+        var filename = await _filename.ExecuteAsync(c);
 
-        if (m_worldModel.Version >= WorldModelVersion.v540)
+        if (_worldModel.Version >= WorldModelVersion.v540)
         {
-            await m_worldModel.PrintAsync("<img src=\"" + await m_worldModel.GetExternalUrlAsync(filename) + "\" />");
+            await _worldModel.PrintAsync("<img src=\"" + await _worldModel.GetExternalUrlAsync(filename) + "\" />");
         }
         else
         {
-            await m_worldModel.PlayerUi.ShowPictureAsync(filename);
-            ((LegacyOutputLogger) m_worldModel.OutputLogger).AddPicture(filename);
+            await _worldModel.PlayerUi.ShowPictureAsync(filename);
+            ((LegacyOutputLogger) _worldModel.OutputLogger).AddPicture(filename);
         }
     }
 
     public override string Save()
     {
-        return SaveScript("picture", m_filename.Save());
+        return SaveScript("picture", _filename.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_filename.Save();
+        return _filename.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_filename = new Expression<string>((string) value, m_scriptContext);
+        _filename = new Expression<string>((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/PlaySoundScript.cs
+++ b/src/Engine/Scripts/PlaySoundScript.cs
@@ -23,34 +23,34 @@ public class PlaySoundScriptConstructor : ScriptConstructorBase
 
 public class PlaySoundScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_filename;
-    private IFunction<bool> m_loop;
-    private IFunction<bool> m_synchronous;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _filename;
+    private IFunction<bool> _loop;
+    private IFunction<bool> _synchronous;
 
     public PlaySoundScript(ScriptContext scriptContext, IFunction<string> function, IFunction<bool> synchronous,
         IFunction<bool> loop)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_filename = function;
-        m_synchronous = synchronous;
-        m_loop = loop;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _filename = function;
+        _synchronous = synchronous;
+        _loop = loop;
     }
 
     public override string Keyword => "play sound";
 
     protected override ScriptBase CloneScript()
     {
-        return new PlaySoundScript(m_scriptContext, m_filename.Clone(), m_synchronous.Clone(), m_loop.Clone());
+        return new PlaySoundScript(_scriptContext, _filename.Clone(), _synchronous.Clone(), _loop.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var filename = await m_filename.ExecuteAsync(c);
-        var synchronous = await m_synchronous.ExecuteAsync(c);
-        var loop = await m_loop.ExecuteAsync(c);
+        var filename = await _filename.ExecuteAsync(c);
+        var synchronous = await _synchronous.ExecuteAsync(c);
+        var loop = await _loop.ExecuteAsync(c);
 
         if (synchronous && loop)
         {
@@ -59,10 +59,10 @@ public class PlaySoundScript : ScriptBase
 
         if (synchronous)
         {
-            var tcs = WorldModel.BeginPrompt(ref m_worldModel._waitTcs);
-            await m_worldModel.PlayerUi.PlaySoundAsync(filename, true, loop);
-            m_worldModel.BeginPendingCallback();
-            m_worldModel.SignalTurnSuspended();
+            var tcs = WorldModel.BeginPrompt(ref _worldModel._waitTcs);
+            await _worldModel.PlayerUi.PlaySoundAsync(filename, true, loop);
+            _worldModel.BeginPendingCallback();
+            _worldModel.SignalTurnSuspended();
             try
             {
                 await tcs.Task;
@@ -70,19 +70,19 @@ public class PlaySoundScript : ScriptBase
             catch (OperationCanceledException) { }
             finally
             {
-                await m_worldModel.EndPendingCallbackAsync();
-                m_worldModel.SignalTurnSuspended();
+                await _worldModel.EndPendingCallbackAsync();
+                _worldModel.SignalTurnSuspended();
             }
         }
         else
         {
-            await m_worldModel.PlayerUi.PlaySoundAsync(filename, false, loop);
+            await _worldModel.PlayerUi.PlaySoundAsync(filename, false, loop);
         }
     }
 
     public override string Save()
     {
-        return SaveScript("play sound", m_filename.Save(), m_synchronous.Save(), m_loop.Save());
+        return SaveScript("play sound", _filename.Save(), _synchronous.Save(), _loop.Save());
     }
 
     public override object GetParameter(int index)
@@ -90,11 +90,11 @@ public class PlaySoundScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_filename.Save();
+                return _filename.Save();
             case 1:
-                return m_synchronous.Save();
+                return _synchronous.Save();
             case 2:
-                return m_loop.Save();
+                return _loop.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -105,13 +105,13 @@ public class PlaySoundScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_filename = new Expression<string>((string) value, m_scriptContext);
+                _filename = new Expression<string>((string) value, _scriptContext);
                 break;
             case 1:
-                m_synchronous = new Expression<bool>((string) value, m_scriptContext);
+                _synchronous = new Expression<bool>((string) value, _scriptContext);
                 break;
             case 2:
-                m_loop = new Expression<bool>((string) value, m_scriptContext);
+                _loop = new Expression<bool>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -136,23 +136,23 @@ public class StopSoundScriptConstructor : ScriptConstructorBase
 
 public class StopSoundScript : ScriptBase
 {
-    private readonly WorldModel m_worldModel;
+    private readonly WorldModel _worldModel;
 
     public StopSoundScript(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     public override string Keyword => "stop sound";
 
     protected override ScriptBase CloneScript()
     {
-        return new StopSoundScript(m_worldModel);
+        return new StopSoundScript(_worldModel);
     }
 
     public override Task ExecuteAsync(Context c)
     {
-        m_worldModel.PlayerUi.StopSound();
+        _worldModel.PlayerUi.StopSound();
         return Task.CompletedTask;
     }
 

--- a/src/Engine/Scripts/RequestSaveScript.cs
+++ b/src/Engine/Scripts/RequestSaveScript.cs
@@ -26,23 +26,23 @@ public class RequestSaveScriptConstructor : ScriptConstructorBase
 
 public class RequestSaveScript : ScriptBase
 {
-    private readonly WorldModel m_worldModel;
+    private readonly WorldModel _worldModel;
 
     public RequestSaveScript(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     public override string Keyword => "requestsave";
 
     protected override ScriptBase CloneScript()
     {
-        return new RequestSaveScript(m_worldModel);
+        return new RequestSaveScript(_worldModel);
     }
 
     public override Task ExecuteAsync(Context c)
     {
-        m_worldModel.PlayerUi.RequestSave(null);
+        _worldModel.PlayerUi.RequestSave(null);
         return Task.CompletedTask;
     }
 

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -49,60 +49,60 @@ public class RequestScriptConstructor : ScriptConstructorBase
 
 public class RequestScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_data;
-    private Request m_request;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _data;
+    private Request _request;
 
     public RequestScript(ScriptContext scriptContext, string request, IFunction<string> data)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_data = data;
-        m_request = (Request) Enum.Parse(typeof(Request), request);
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _data = data;
+        _request = (Request) Enum.Parse(typeof(Request), request);
     }
 
     public override string Keyword => "request";
 
     protected override ScriptBase CloneScript()
     {
-        return new RequestScript(m_scriptContext, m_request.ToString(), m_data.Clone());
+        return new RequestScript(_scriptContext, _request.ToString(), _data.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var data = await m_data.ExecuteAsync(c);
+        var data = await _data.ExecuteAsync(c);
 
         // TO DO: Replace with dictionary mapping the enum to lambda functions
-        switch (m_request)
+        switch (_request)
         {
             case Request.UpdateLocation:
-                m_worldModel.PlayerUi.LocationUpdated(data);
+                _worldModel.PlayerUi.LocationUpdated(data);
                 break;
             case Request.GameName:
-                m_worldModel.PlayerUi.UpdateGameName(data);
+                _worldModel.PlayerUi.UpdateGameName(data);
                 break;
             case Request.ClearScreen:
-                m_worldModel.PlayerUi.ClearScreen();
-                m_worldModel.OutputLogger.Clear();
+                _worldModel.PlayerUi.ClearScreen();
+                _worldModel.OutputLogger.Clear();
                 break;
             case Request.ShowPicture:
-                await m_worldModel.PlayerUi.ShowPictureAsync(data);
+                await _worldModel.PlayerUi.ShowPictureAsync(data);
                 // TO DO: Picture should be added to the OutputLogger, but the data we
                 // get here includes the full path/URL - we want the original filename
                 // only, so this would be a breaking change.
                 break;
             case Request.PanesVisible:
-                m_worldModel.PlayerUi.SetPanesVisible(data);
+                _worldModel.PlayerUi.SetPanesVisible(data);
                 break;
             case Request.Background:
-                m_worldModel.PlayerUi.SetBackground(data);
+                _worldModel.PlayerUi.SetBackground(data);
                 break;
             case Request.Foreground:
-                m_worldModel.PlayerUi.SetForeground(data);
+                _worldModel.PlayerUi.SetForeground(data);
                 break;
             case Request.RunScript:
-                if (m_worldModel.Version == WorldModelVersion.v500)
+                if (_worldModel.Version == WorldModelVersion.v500)
                 {
                     // v500 games used Frame.js functions for static panel feature. This is now implemented natively
                     // in Player and WebPlayer.
@@ -114,14 +114,14 @@ public class RequestScript : ScriptBase
                     if (data.StartsWith("setFramePicture;"))
                     {
                         var frameArgs = data.Split(';');
-                        m_worldModel.PlayerUi.SetPanelContents("<img src=\"" + frameArgs[1].Trim() +
+                        _worldModel.PlayerUi.SetPanelContents("<img src=\"" + frameArgs[1].Trim() +
                                                                "\" onload=\"setPanelHeight()\"/>");
                         return;
                     }
 
                     if (data == "clearFramePicture")
                     {
-                        m_worldModel.PlayerUi.SetPanelContents("");
+                        _worldModel.PlayerUi.SetPanelContents("");
                     }
                 }
 
@@ -129,54 +129,54 @@ public class RequestScript : ScriptBase
                 var functionName = jsArgs[0];
                 if (jsArgs.Length == 0)
                 {
-                    await m_worldModel.PlayerUi.RunScriptAsync(functionName, null);
+                    await _worldModel.PlayerUi.RunScriptAsync(functionName, null);
                 }
                 else
                 {
-                    await m_worldModel.PlayerUi.RunScriptAsync(functionName, jsArgs.Skip(1).ToArray());
+                    await _worldModel.PlayerUi.RunScriptAsync(functionName, jsArgs.Skip(1).ToArray());
                 }
 
                 break;
             case Request.Quit:
-                m_worldModel.Finish();
+                _worldModel.Finish();
                 break;
             case Request.FontName:
-                if (m_worldModel.Version >= WorldModelVersion.v540)
+                if (_worldModel.Version >= WorldModelVersion.v540)
                 {
                     throw new InvalidOperationException(
                         "FontName request is not supported for games with WorldModel version 540 or later.");
                 }
 
-                m_worldModel.PlayerUi.SetFont(data);
-                ((LegacyOutputLogger) m_worldModel.OutputLogger).SetFontName(data);
+                _worldModel.PlayerUi.SetFont(data);
+                ((LegacyOutputLogger) _worldModel.OutputLogger).SetFontName(data);
                 break;
             case Request.FontSize:
-                if (m_worldModel.Version >= WorldModelVersion.v540)
+                if (_worldModel.Version >= WorldModelVersion.v540)
                 {
                     throw new InvalidOperationException(
                         "FontSize request is not supported for games with WorldModel version 540 or later.");
                 }
 
-                m_worldModel.PlayerUi.SetFontSize(data);
-                ((LegacyOutputLogger) m_worldModel.OutputLogger).SetFontSize(data);
+                _worldModel.PlayerUi.SetFontSize(data);
+                ((LegacyOutputLogger) _worldModel.OutputLogger).SetFontSize(data);
                 break;
             case Request.LinkForeground:
-                m_worldModel.PlayerUi.SetLinkForeground(data);
+                _worldModel.PlayerUi.SetLinkForeground(data);
                 break;
             case Request.Show:
-                m_worldModel.PlayerUi.Show(data);
+                _worldModel.PlayerUi.Show(data);
                 break;
             case Request.Hide:
-                m_worldModel.PlayerUi.Hide(data);
+                _worldModel.PlayerUi.Hide(data);
                 break;
             case Request.SetCompassDirections:
-                m_worldModel.PlayerUi.SetCompassDirections(data.Split(';'));
+                _worldModel.PlayerUi.SetCompassDirections(data.Split(';'));
                 break;
             case Request.SetStatus:
-                m_worldModel.PlayerUi.SetStatusText(data.Replace("\n", Environment.NewLine));
+                _worldModel.PlayerUi.SetStatusText(data.Replace("\n", Environment.NewLine));
                 break;
             case Request.Pause:
-                if (m_worldModel.Version >= WorldModelVersion.v550 && m_worldModel.Version < WorldModelVersion.v600)
+                if (_worldModel.Version >= WorldModelVersion.v550 && _worldModel.Version < WorldModelVersion.v600)
                 {
                     throw new Exception(
                         "The 'Pause' request is not supported for games with WorldModel version 550–580. Use the 'SetTimeout' function instead, or set the game's WorldModel version to 600 or later.");
@@ -185,34 +185,34 @@ public class RequestScript : ScriptBase
                 int ms;
                 if (int.TryParse(data, out ms))
                 {
-                    await m_worldModel.DoPauseAsync(ms);
+                    await _worldModel.DoPauseAsync(ms);
                 }
 
                 break;
             case Request.Wait:
-                if (m_worldModel.Version >= WorldModelVersion.v540 && m_worldModel.Version < WorldModelVersion.v600)
+                if (_worldModel.Version >= WorldModelVersion.v540 && _worldModel.Version < WorldModelVersion.v600)
                 {
                     throw new Exception(
                         "The 'Wait' request is not supported for games with WorldModel version 540–580. Use the 'wait' script command instead, or set the game's WorldModel version to 600 or later.");
                 }
 
-                await m_worldModel.DoWaitAsync();
+                await _worldModel.DoWaitAsync();
                 break;
             case Request.SetInterfaceString:
                 var args = data.Split('=');
-                m_worldModel.PlayerUi.SetInterfaceString(args[0], args[1]);
+                _worldModel.PlayerUi.SetInterfaceString(args[0], args[1]);
                 break;
             case Request.RequestSave:
-                m_worldModel.PlayerUi.RequestSave(null);
+                _worldModel.PlayerUi.RequestSave(null);
                 break;
             case Request.SetPanelContents:
-                m_worldModel.PlayerUi.SetPanelContents(data);
+                _worldModel.PlayerUi.SetPanelContents(data);
                 break;
             case Request.Log:
-                m_worldModel.PlayerUi.Log(data);
+                _worldModel.PlayerUi.Log(data);
                 break;
             case Request.Speak:
-                m_worldModel.PlayerUi.Speak(data);
+                _worldModel.PlayerUi.Speak(data);
                 break;
             default:
                 throw new ArgumentOutOfRangeException("request", "Unhandled request type");
@@ -221,7 +221,7 @@ public class RequestScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("request", m_request.ToString(), m_data.Save());
+        return SaveScript("request", _request.ToString(), _data.Save());
     }
 
     public override object GetParameter(int index)
@@ -229,9 +229,9 @@ public class RequestScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_request.ToString();
+                return _request.ToString();
             case 1:
-                return m_data.Save();
+                return _data.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -242,10 +242,10 @@ public class RequestScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_request = (Request) Enum.Parse(typeof(Request), (string) value);
+                _request = (Request) Enum.Parse(typeof(Request), (string) value);
                 break;
             case 1:
-                m_data = new Expression<string>((string) value, m_scriptContext);
+                _data = new Expression<string>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/RequestSpeakScript.cs
+++ b/src/Engine/Scripts/RequestSpeakScript.cs
@@ -30,42 +30,42 @@ public class RequestSpeakScriptConstructor : ScriptConstructorBase
 
 public class RequestSpeakScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunctionDynamic m_function;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunctionDynamic _function;
 
     public RequestSpeakScript(ScriptContext scriptContext, IFunctionDynamic function)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_function = function;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _function = function;
     }
 
     public override string Keyword => "requestspeak";
 
     protected override ScriptBase CloneScript()
     {
-        return new RequestSpeakScript(m_scriptContext, m_function.Clone());
+        return new RequestSpeakScript(_scriptContext, _function.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_function.ExecuteAsync(c);
-        m_worldModel.PlayerUi.Speak(Utility.ExpressionResultToString(result));
+        var result = await _function.ExecuteAsync(c);
+        _worldModel.PlayerUi.Speak(Utility.ExpressionResultToString(result));
     }
 
     public override string Save()
     {
-        return SaveScript("requestspeak", m_function.Save());
+        return SaveScript("requestspeak", _function.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_function.Save();
+        return _function.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_function = new ExpressionDynamic((string) value, m_scriptContext);
+        _function = new ExpressionDynamic((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/ReturnScript.cs
+++ b/src/Engine/Scripts/ReturnScript.cs
@@ -20,30 +20,30 @@ public class ReturnScriptConstructor : ScriptConstructorBase
 
 public class ReturnScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunctionDynamic m_returnValue;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunctionDynamic _returnValue;
 
     public ReturnScript(ScriptContext scriptContext, IFunctionDynamic returnValue)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_returnValue = returnValue;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _returnValue = returnValue;
     }
 
     public override string Keyword => "return";
 
     protected override ScriptBase CloneScript()
     {
-        return new ReturnScript(m_scriptContext, m_returnValue.Clone());
+        return new ReturnScript(_scriptContext, _returnValue.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        c.ReturnValue = await m_returnValue.ExecuteAsync(c);
+        c.ReturnValue = await _returnValue.ExecuteAsync(c);
         // Leaving this set to v550 for backwards compatibility
         // Some things do not work in 550 games when this is changed to 580
-        if (m_worldModel.Version >= WorldModelVersion.v550)
+        if (_worldModel.Version >= WorldModelVersion.v550)
         {
             c.IsReturned = true;
         }
@@ -51,16 +51,16 @@ public class ReturnScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("return", m_returnValue.Save());
+        return SaveScript("return", _returnValue.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_returnValue.Save();
+        return _returnValue.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_returnValue = new ExpressionDynamic((string) value, m_scriptContext);
+        _returnValue = new ExpressionDynamic((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/RunDelegateScript.cs
+++ b/src/Engine/Scripts/RunDelegateScript.cs
@@ -47,64 +47,64 @@ public class RunDelegateScriptConstructor : ScriptConstructorBase
 
 public class RunDelegateScript : ScriptBase
 {
-    private readonly FunctionCallParameters m_parameters;
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<Element> m_appliesTo;
-    private IFunction<string> m_delegate;
+    private readonly FunctionCallParameters _parameters;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<Element> _appliesTo;
+    private IFunction<string> _delegate;
 
     public RunDelegateScript(ScriptContext scriptContext, IFunction<Element> obj, IFunction<string> del,
         IList<IFunction<object>> parameters)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_delegate = del;
-        m_parameters = new FunctionCallParameters(m_worldModel, parameters);
-        m_appliesTo = obj;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _delegate = del;
+        _parameters = new FunctionCallParameters(_worldModel, parameters);
+        _appliesTo = obj;
     }
 
     public override string Keyword => "rundelegate";
 
     protected override ScriptBase CloneScript()
     {
-        return new RunDelegateScript(m_scriptContext, m_appliesTo.Clone(), m_delegate.Clone(), m_parameters.Parameters);
+        return new RunDelegateScript(_scriptContext, _appliesTo.Clone(), _delegate.Clone(), _parameters.Parameters);
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        if (m_parameters == null)
+        if (_parameters == null)
         {
             throw new NotImplementedException();
         }
 
-        var obj = await m_appliesTo.ExecuteAsync(c);
-        var delName = await m_delegate.ExecuteAsync(c);
+        var obj = await _appliesTo.ExecuteAsync(c);
+        var delName = await _delegate.ExecuteAsync(c);
         var impl = obj.Fields.Get(delName) as DelegateImplementation;
 
         if (impl == null)
         {
             throw new Exception(
-                string.Format("Object '{0}' has no delegate implementation '{1}'", obj.Name, m_delegate));
+                string.Format("Object '{0}' has no delegate implementation '{1}'", obj.Name, _delegate));
         }
 
         var paramValues = new Parameters();
 
         var cnt = 0;
-        foreach (var f in m_parameters.Parameters)
+        foreach (var f in _parameters.Parameters)
         {
             paramValues.Add((string) impl.Definition.Fields[FieldDefinitions.ParamNames][cnt], await f.ExecuteAsync(c));
             cnt++;
         }
 
-        await m_worldModel.RunScriptAsync(impl.Implementation.Fields[FieldDefinitions.Script], paramValues, obj);
+        await _worldModel.RunScriptAsync(impl.Implementation.Fields[FieldDefinitions.Script], paramValues, obj);
     }
 
     public override string Save()
     {
         var saveParameters = new List<string>();
-        saveParameters.Add(m_appliesTo.Save());
-        saveParameters.Add(m_delegate.Save());
-        foreach (var p in m_parameters.ParametersAsQuestList)
+        saveParameters.Add(_appliesTo.Save());
+        saveParameters.Add(_delegate.Save());
+        foreach (var p in _parameters.ParametersAsQuestList)
         {
             saveParameters.Add(p);
         }
@@ -117,11 +117,11 @@ public class RunDelegateScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_appliesTo.Save();
+                return _appliesTo.Save();
             case 1:
-                return m_delegate.Save();
+                return _delegate.Save();
             case 2:
-                return m_parameters.ParametersAsQuestList;
+                return _parameters.ParametersAsQuestList;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -132,10 +132,10 @@ public class RunDelegateScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_appliesTo = new Expression<Element>((string) value, m_scriptContext);
+                _appliesTo = new Expression<Element>((string) value, _scriptContext);
                 break;
             case 1:
-                m_delegate = new Expression<string>((string) value, m_scriptContext);
+                _delegate = new Expression<string>((string) value, _scriptContext);
                 break;
             case 2:
                 // any updates to the parameters should change the list itself - nothing should cause SetParameter to be triggered.

--- a/src/Engine/Scripts/SetFieldScript.cs
+++ b/src/Engine/Scripts/SetFieldScript.cs
@@ -21,38 +21,38 @@ public class SetFieldScriptConstructor : ScriptConstructorBase
 
 public class SetFieldScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private IFunction<string> m_field;
-    private IFunction<Element> m_obj;
-    private IFunction<object> m_value;
-    private WorldModel m_worldModel;
+    private readonly ScriptContext _scriptContext;
+    private IFunction<string> _field;
+    private IFunction<Element> _obj;
+    private IFunction<object> _value;
+    private WorldModel _worldModel;
 
     public SetFieldScript(ScriptContext scriptContext, IFunction<Element> obj, IFunction<string> field,
         IFunction<object> value)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_obj = obj;
-        m_field = field;
-        m_value = value;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _obj = obj;
+        _field = field;
+        _value = value;
     }
 
     public override string Keyword => "set";
 
     protected override ScriptBase CloneScript()
     {
-        return new SetFieldScript(m_scriptContext, m_obj.Clone(), m_field.Clone(), m_value.Clone());
+        return new SetFieldScript(_scriptContext, _obj.Clone(), _field.Clone(), _value.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var obj = await m_obj.ExecuteAsync(c);
-        await obj.SetFieldAsync(await m_field.ExecuteAsync(c), await m_value.ExecuteAsync(c));
+        var obj = await _obj.ExecuteAsync(c);
+        await obj.SetFieldAsync(await _field.ExecuteAsync(c), await _value.ExecuteAsync(c));
     }
 
     public override string Save()
     {
-        return SaveScript("set", m_obj.Save(), m_field.Save(), m_value.Save());
+        return SaveScript("set", _obj.Save(), _field.Save(), _value.Save());
     }
 
     public override object GetParameter(int index)
@@ -60,11 +60,11 @@ public class SetFieldScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_obj.Save();
+                return _obj.Save();
             case 1:
-                return m_field.Save();
+                return _field.Save();
             case 2:
-                return m_value.Save();
+                return _value.Save();
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -75,13 +75,13 @@ public class SetFieldScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_obj = new Expression<Element>((string) value, m_scriptContext);
+                _obj = new Expression<Element>((string) value, _scriptContext);
                 break;
             case 1:
-                m_field = new Expression<string>((string) value, m_scriptContext);
+                _field = new Expression<string>((string) value, _scriptContext);
                 break;
             case 2:
-                m_value = new Expression<object>((string) value, m_scriptContext);
+                _value = new Expression<object>((string) value, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/SetScript.cs
+++ b/src/Engine/Scripts/SetScript.cs
@@ -96,36 +96,36 @@ public class SetScriptConstructor : IScriptConstructor
 
 public abstract class SetScriptBase : ScriptBase
 {
-    private IFunction<Element> m_appliesTo;
-    private string m_property;
-    protected ScriptContext m_scriptContext;
+    private IFunction<Element> _appliesTo;
+    private string _property;
+    protected ScriptContext _scriptContext;
 
     internal SetScriptBase(SetScriptConstructor constructor, ScriptContext scriptContext, IFunction<Element> appliesTo,
         string property)
     {
         Constructor = constructor;
         WorldModel = constructor.WorldModel;
-        m_scriptContext = scriptContext;
+        _scriptContext = scriptContext;
         AppliesTo = appliesTo;
         Property = property;
     }
 
     protected IFunction<Element> AppliesTo
     {
-        get => m_appliesTo;
+        get => _appliesTo;
         private set
         {
-            m_appliesTo = value;
+            _appliesTo = value;
             AddAttributeNameToWorldModel();
         }
     }
 
     protected string Property
     {
-        get => m_property;
+        get => _property;
         private set
         {
-            m_property = value;
+            _property = value;
             AddAttributeNameToWorldModel();
         }
     }
@@ -180,7 +180,7 @@ public abstract class SetScriptBase : ScriptBase
         {
             case 0:
                 string variable;
-                AppliesTo = Constructor.GetAppliesTo(m_scriptContext, (string) value, out variable);
+                AppliesTo = Constructor.GetAppliesTo(_scriptContext, (string) value, out variable);
                 Property = variable;
                 break;
             case 1:
@@ -209,13 +209,13 @@ public abstract class SetScriptBase : ScriptBase
 
 public class SetExpressionScript : SetScriptBase
 {
-    private Expression<object> m_expr;
+    private Expression<object> _expr;
 
     public SetExpressionScript(SetScriptConstructor constructor, ScriptContext scriptContext,
         IFunction<Element> appliesTo, string property, Expression<object> expr)
         : base(constructor, scriptContext, appliesTo, property)
     {
-        m_expr = expr;
+        _expr = expr;
     }
 
     protected override string GetEqualsString => " = ";
@@ -224,13 +224,13 @@ public class SetExpressionScript : SetScriptBase
 
     protected override ScriptBase CloneScript()
     {
-        return new SetExpressionScript(Constructor, m_scriptContext, AppliesTo == null ? null : AppliesTo.Clone(),
-            Property, (Expression<object>) m_expr.Clone());
+        return new SetExpressionScript(Constructor, _scriptContext, AppliesTo == null ? null : AppliesTo.Clone(),
+            Property, (Expression<object>) _expr.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_expr.ExecuteAsync(c);
+        var result = await _expr.ExecuteAsync(c);
         if (AppliesTo != null)
         {
             // we're setting an object property
@@ -246,31 +246,31 @@ public class SetExpressionScript : SetScriptBase
 
     protected override string GetSaveString()
     {
-        return m_expr.Save();
+        return _expr.Save();
     }
 
     protected override void SetValue(string newValue)
     {
-        m_expr = new Expression<object>(newValue, m_scriptContext);
+        _expr = new Expression<object>(newValue, _scriptContext);
     }
 
     protected override object GetValue()
     {
-        return m_expr.Save();
+        return _expr.Save();
     }
 }
 
 public class SetScriptScript : SetScriptBase
 {
-    private readonly IScriptFactory m_scriptFactory;
-    private IScript m_script;
+    private readonly IScriptFactory _scriptFactory;
+    private IScript _script;
 
     public SetScriptScript(SetScriptConstructor constructor, ScriptContext scriptContext, IFunction<Element> appliesTo,
         string property, IScript script)
         : base(constructor, scriptContext, appliesTo, property)
     {
-        m_script = script;
-        m_scriptFactory = constructor.ScriptFactory;
+        _script = script;
+        _scriptFactory = constructor.ScriptFactory;
     }
 
     protected override string GetEqualsString => " => ";
@@ -279,8 +279,8 @@ public class SetScriptScript : SetScriptBase
 
     protected override ScriptBase CloneScript()
     {
-        return new SetScriptScript(Constructor, m_scriptContext, AppliesTo == null ? null : AppliesTo.Clone(), Property,
-            (IScript) m_script.Clone());
+        return new SetScriptScript(Constructor, _scriptContext, AppliesTo == null ? null : AppliesTo.Clone(), Property,
+            (IScript) _script.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
@@ -289,27 +289,27 @@ public class SetScriptScript : SetScriptBase
         {
             // we're setting an object property
             var obj = await AppliesTo.ExecuteAsync(c);
-            await obj.SetFieldAsync(Property, m_script);
+            await obj.SetFieldAsync(Property, _script);
         }
         else
         {
             // we're setting a local variable
-            c.Parameters[Property] = m_script;
+            c.Parameters[Property] = _script;
         }
     }
 
     protected override string GetSaveString()
     {
-        return SaveScript("", m_script).Trim();
+        return SaveScript("", _script).Trim();
     }
 
     protected override void SetValue(string newValue)
     {
-        m_script = m_scriptFactory.CreateScript(newValue);
+        _script = _scriptFactory.CreateScript(newValue);
     }
 
     protected override object GetValue()
     {
-        return m_script;
+        return _script;
     }
 }

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -33,39 +33,39 @@ public class ShowMenuScriptConstructor : IScriptConstructor
 
 public class ShowMenuScript : ScriptBase
 {
-    private readonly IScript m_callbackScript;
-    private readonly ScriptContext m_scriptContext;
-    private readonly IScriptFactory m_scriptFactory;
-    private readonly WorldModel m_worldModel;
-    private IFunction<bool> m_allowCancel;
-    private IFunction<string> m_caption;
-    private IFunctionDynamic m_options;
+    private readonly IScript _callbackScript;
+    private readonly ScriptContext _scriptContext;
+    private readonly IScriptFactory _scriptFactory;
+    private readonly WorldModel _worldModel;
+    private IFunction<bool> _allowCancel;
+    private IFunction<string> _caption;
+    private IFunctionDynamic _options;
 
     public ShowMenuScript(ScriptContext scriptContext, IScriptFactory scriptFactory, IFunction<string> caption,
         IFunctionDynamic options, IFunction<bool> allowCancel, IScript callbackScript)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_scriptFactory = scriptFactory;
-        m_caption = caption;
-        m_options = options;
-        m_allowCancel = allowCancel;
-        m_callbackScript = callbackScript;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _scriptFactory = scriptFactory;
+        _caption = caption;
+        _options = options;
+        _allowCancel = allowCancel;
+        _callbackScript = callbackScript;
     }
 
     public override string Keyword => "show menu";
 
     protected override ScriptBase CloneScript()
     {
-        return new ShowMenuScript(m_scriptContext, m_scriptFactory, m_caption.Clone(), m_options.Clone(),
-            m_allowCancel.Clone(), (IScript) m_callbackScript.Clone());
+        return new ShowMenuScript(_scriptContext, _scriptFactory, _caption.Clone(), _options.Clone(),
+            _allowCancel.Clone(), (IScript) _callbackScript.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var caption = await m_caption.ExecuteAsync(c);
-        var options = await m_options.ExecuteAsync(c);
-        var allowCancel = await m_allowCancel.ExecuteAsync(c);
+        var caption = await _caption.ExecuteAsync(c);
+        var options = await _options.ExecuteAsync(c);
+        var allowCancel = await _allowCancel.ExecuteAsync(c);
 
         IDictionary<string, string> optionsDictionary;
         if (options is IList<string> stringListOptions)
@@ -83,13 +83,13 @@ public class ShowMenuScript : ScriptBase
             throw new Exception("Unknown menu options type");
         }
 
-        await m_worldModel.PrintAsync(caption);
+        await _worldModel.PrintAsync(caption);
         var menuData = new MenuData(caption, optionsDictionary, allowCancel);
-        m_worldModel.PlayerUi.ShowMenu(menuData);
+        _worldModel.PlayerUi.ShowMenu(menuData);
 
-        WorldModel.BeginPrompt(ref m_worldModel._menuTcs);
-        m_worldModel.BeginDormantSuspension();
-        m_worldModel.SignalTurnSuspended();
+        WorldModel.BeginPrompt(ref _worldModel._menuTcs);
+        _worldModel.BeginDormantSuspension();
+        _worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c, optionsDictionary);
     }
 
@@ -98,27 +98,27 @@ public class ShowMenuScript : ScriptBase
         var resolved = false;
         try
         {
-            var response = await m_worldModel._menuTcs!.Task;
+            var response = await _worldModel._menuTcs!.Task;
             resolved = true;
-            m_worldModel.SignalCallbackResolving();
+            _worldModel.SignalCallbackResolving();
             if (response != null)
-                await m_worldModel.PrintAsync(" - " + optionsDictionary[response]);
+                await _worldModel.PrintAsync(" - " + optionsDictionary[response]);
             c.Parameters["result"] = response;
-            await m_worldModel.RunScriptAsync(m_callbackScript, c);
+            await _worldModel.RunScriptAsync(_callbackScript, c);
         }
         catch (OperationCanceledException) { }
-        catch (Exception ex) { m_worldModel.LogException(ex); }
+        catch (Exception ex) { _worldModel.LogException(ex); }
         finally
         {
-            if (!resolved) m_worldModel.SignalCallbackResolving();
-            await m_worldModel.EndPendingCallbackAsync();
-            m_worldModel.SignalTurnSuspended();
+            if (!resolved) _worldModel.SignalCallbackResolving();
+            await _worldModel.EndPendingCallbackAsync();
+            _worldModel.SignalTurnSuspended();
         }
     }
 
     public override string Save()
     {
-        return SaveScript("show menu", m_callbackScript, m_caption.Save(), m_options.Save(), m_allowCancel.Save());
+        return SaveScript("show menu", _callbackScript, _caption.Save(), _options.Save(), _allowCancel.Save());
     }
 
     public override object GetParameter(int index)
@@ -126,13 +126,13 @@ public class ShowMenuScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_caption.Save();
+                return _caption.Save();
             case 1:
-                return m_options.Save();
+                return _options.Save();
             case 2:
-                return m_allowCancel.Save();
+                return _allowCancel.Save();
             case 3:
-                return m_callbackScript;
+                return _callbackScript;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -143,13 +143,13 @@ public class ShowMenuScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_caption = new Expression<string>((string) value, m_scriptContext);
+                _caption = new Expression<string>((string) value, _scriptContext);
                 break;
             case 1:
-                m_options = new ExpressionDynamic((string) value, m_scriptContext);
+                _options = new ExpressionDynamic((string) value, _scriptContext);
                 break;
             case 2:
-                m_allowCancel = new Expression<bool>((string) value, m_scriptContext);
+                _allowCancel = new Expression<bool>((string) value, _scriptContext);
                 break;
             case 3:
                 throw new InvalidOperationException(

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -87,55 +87,55 @@ public class SwitchScriptConstructor : IScriptConstructor
 
 public class SwitchScript : ScriptBase
 {
-    private readonly IScript m_default;
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private SwitchCases m_cases;
-    private IFunctionDynamic m_expr;
+    private readonly IScript _default;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private SwitchCases _cases;
+    private IFunctionDynamic _expr;
 
     public SwitchScript(ScriptContext scriptContext, IFunctionDynamic expression,
         Dictionary<IFunctionDynamic, IScript> cases, IScript defaultScript)
         : this(scriptContext, expression, defaultScript)
     {
-        m_cases = new SwitchCases(this, cases);
+        _cases = new SwitchCases(this, cases);
     }
 
     private SwitchScript(ScriptContext scriptContext, IFunctionDynamic expression, IScript defaultScript)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_expr = expression;
-        m_default = defaultScript ?? new MultiScript(m_worldModel);
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _expr = expression;
+        _default = defaultScript ?? new MultiScript(_worldModel);
     }
 
     public override string Keyword => "switch";
 
     protected override ScriptBase CloneScript()
     {
-        var clone = new SwitchScript(m_scriptContext, m_expr.Clone(), (IScript) m_default.Clone());
-        clone.m_cases = m_cases.Clone(clone);
+        var clone = new SwitchScript(_scriptContext, _expr.Clone(), (IScript) _default.Clone());
+        clone._cases = _cases.Clone(clone);
         return clone;
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await m_expr.ExecuteAsync(c);
+        var result = await _expr.ExecuteAsync(c);
         // using .ToString() here as an object comparison of ints won't work
-        var success = await m_cases.ExecuteAsync(c, Utility.ExpressionResultToString(result));
+        var success = await _cases.ExecuteAsync(c, Utility.ExpressionResultToString(result));
 
-        if (!success && m_default != null)
+        if (!success && _default != null)
         {
-            await m_default.ExecuteAsync(c);
+            await _default.ExecuteAsync(c);
         }
     }
 
     public override string Save()
     {
-        var result = SaveScript("switch", m_expr.Save()) + " {" + Environment.NewLine;
-        result += m_cases.Save();
-        if (m_default != null && ((IMultiScript) m_default).Scripts.Count() > 0)
+        var result = SaveScript("switch", _expr.Save()) + " {" + Environment.NewLine;
+        result += _cases.Save();
+        if (_default != null && ((IMultiScript) _default).Scripts.Count() > 0)
         {
-            result += SaveScript("default", m_default);
+            result += SaveScript("default", _default);
         }
 
         result += Environment.NewLine + "}";
@@ -147,11 +147,11 @@ public class SwitchScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_expr.Save();
+                return _expr.Save();
             case 1:
-                return m_cases.CasesAsQuestDictionary;
+                return _cases.CasesAsQuestDictionary;
             case 2:
-                return m_default;
+                return _default;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -162,7 +162,7 @@ public class SwitchScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_expr = new ExpressionDynamic((string) value, m_scriptContext);
+                _expr = new ExpressionDynamic((string) value, _scriptContext);
                 break;
             case 1:
                 // any updates to the cases should change the scriptdictionary itself - nothing should cause SetParameter to be triggered.
@@ -179,8 +179,8 @@ public class SwitchScript : ScriptBase
     // using the standard scriptdictionary editor control.
     private class SwitchCases
     {
-        private readonly SwitchScript m_parent;
-        private Dictionary<string, IFunctionDynamic> m_compiledExpressions = new();
+        private readonly SwitchScript _parent;
+        private Dictionary<string, IFunctionDynamic> _compiledExpressions = new();
 
         public SwitchCases(SwitchScript parent, Dictionary<IFunctionDynamic, IScript> cases)
             : this(parent)
@@ -197,16 +197,16 @@ public class SwitchScript : ScriptBase
                 }
 
                 CasesAsQuestDictionary.Add(caseString, script);
-                m_compiledExpressions.Add(caseString, compiledExpression);
+                _compiledExpressions.Add(caseString, compiledExpression);
             }
         }
 
         private SwitchCases(SwitchScript parent)
         {
-            m_parent = parent;
-            if (parent.m_worldModel.EditMode)
+            _parent = parent;
+            if (parent._worldModel.EditMode)
             {
-                CasesAsQuestDictionary.UndoLog = parent.m_worldModel.UndoLogger;
+                CasesAsQuestDictionary.UndoLog = parent._worldModel.UndoLogger;
             }
         }
 
@@ -216,10 +216,10 @@ public class SwitchScript : ScriptBase
         {
             var clone = new SwitchCases(newParent);
             clone.CasesAsQuestDictionary = (QuestDictionary<IScript>) CasesAsQuestDictionary.Clone();
-            clone.m_compiledExpressions = new Dictionary<string, IFunctionDynamic>();
-            foreach (var compiledExpression in m_compiledExpressions)
+            clone._compiledExpressions = new Dictionary<string, IFunctionDynamic>();
+            foreach (var compiledExpression in _compiledExpressions)
             {
-                clone.m_compiledExpressions.Add(compiledExpression.Key, compiledExpression.Value);
+                clone._compiledExpressions.Add(compiledExpression.Key, compiledExpression.Value);
             }
 
             return clone;
@@ -230,7 +230,7 @@ public class SwitchScript : ScriptBase
             var result = string.Empty;
             foreach (var caseItem in CasesAsQuestDictionary)
             {
-                result += m_parent.SaveScript("case", caseItem.Value, caseItem.Key);
+                result += _parent.SaveScript("case", caseItem.Value, caseItem.Key);
             }
 
             return result;
@@ -240,7 +240,7 @@ public class SwitchScript : ScriptBase
         {
             foreach (var switchCase in CasesAsQuestDictionary)
             {
-                var expr = m_compiledExpressions[switchCase.Key];
+                var expr = _compiledExpressions[switchCase.Key];
 
                 if (result == Utility.ExpressionResultToString(await expr.ExecuteAsync(c)))
                 {

--- a/src/Engine/Scripts/UndoScript.cs
+++ b/src/Engine/Scripts/UndoScript.cs
@@ -20,23 +20,23 @@ public class UndoScriptConstructor : ScriptConstructorBase
 
 public class UndoScript : ScriptBase
 {
-    private readonly WorldModel m_worldModel;
+    private readonly WorldModel _worldModel;
 
     public UndoScript(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     public override string Keyword => "undo";
 
     protected override ScriptBase CloneScript()
     {
-        return new UndoScript(m_worldModel);
+        return new UndoScript(_worldModel);
     }
 
     public override Task ExecuteAsync(Context c)
     {
-        return m_worldModel.UndoLogger.RollbackTransaction();
+        return _worldModel.UndoLogger.RollbackTransaction();
     }
 
     public override string Save()
@@ -72,41 +72,41 @@ public class StartTransactionConstructor : ScriptConstructorBase
 
 public class StartTransactionScript : ScriptBase
 {
-    private readonly ScriptContext m_scriptContext;
-    private readonly WorldModel m_worldModel;
-    private IFunction<string> m_command;
+    private readonly ScriptContext _scriptContext;
+    private readonly WorldModel _worldModel;
+    private IFunction<string> _command;
 
     public StartTransactionScript(ScriptContext scriptContext, IFunction<string> command)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_command = command;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _command = command;
     }
 
     public override string Keyword => "start transaction";
 
     protected override ScriptBase CloneScript()
     {
-        return new StartTransactionScript(m_scriptContext, m_command.Clone());
+        return new StartTransactionScript(_scriptContext, _command.Clone());
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        m_worldModel.UndoLogger.RollTransaction(await m_command.ExecuteAsync(c));
+        _worldModel.UndoLogger.RollTransaction(await _command.ExecuteAsync(c));
     }
 
     public override string Save()
     {
-        return SaveScript("start transaction", m_command.Save());
+        return SaveScript("start transaction", _command.Save());
     }
 
     public override object GetParameter(int index)
     {
-        return m_command.Save();
+        return _command.Save();
     }
 
     protected override void SetParameterInternal(int index, object value)
     {
-        m_command = new Expression<string>((string) value, m_scriptContext);
+        _command = new Expression<string>((string) value, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/WaitScript.cs
+++ b/src/Engine/Scripts/WaitScript.cs
@@ -20,30 +20,30 @@ public class WaitScriptConstructor : IScriptConstructor
 
 public class WaitScript : ScriptBase
 {
-    private readonly IScript m_callbackScript;
-    private readonly IScriptFactory m_scriptFactory;
-    private readonly WorldModel m_worldModel;
+    private readonly IScript _callbackScript;
+    private readonly IScriptFactory _scriptFactory;
+    private readonly WorldModel _worldModel;
 
     public WaitScript(WorldModel worldModel, IScriptFactory scriptFactory, IScript callbackScript)
     {
-        m_worldModel = worldModel;
-        m_scriptFactory = scriptFactory;
-        m_callbackScript = callbackScript;
+        _worldModel = worldModel;
+        _scriptFactory = scriptFactory;
+        _callbackScript = callbackScript;
     }
 
     public override string Keyword => "wait";
 
     protected override ScriptBase CloneScript()
     {
-        return new WaitScript(m_worldModel, m_scriptFactory, (IScript) m_callbackScript.Clone());
+        return new WaitScript(_worldModel, _scriptFactory, (IScript) _callbackScript.Clone());
     }
 
     public override Task ExecuteAsync(Context c)
     {
-        m_worldModel.PlayerUi.DoWait();
-        WorldModel.BeginPrompt(ref m_worldModel._waitTcs);
-        m_worldModel.BeginDormantSuspension();
-        m_worldModel.SignalTurnSuspended();
+        _worldModel.PlayerUi.DoWait();
+        WorldModel.BeginPrompt(ref _worldModel._waitTcs);
+        _worldModel.BeginDormantSuspension();
+        _worldModel.SignalTurnSuspended();
         _ = AwaitWaitAndRunCallbackAsync(c);
         return Task.CompletedTask;
     }
@@ -53,25 +53,25 @@ public class WaitScript : ScriptBase
         var resolved = false;
         try
         {
-            await m_worldModel._waitTcs.Task;
+            await _worldModel._waitTcs.Task;
             resolved = true;
-            m_worldModel.SignalCallbackResolving();
-            if (m_callbackScript != null)
-                await m_worldModel.RunScriptAsync(m_callbackScript, c);
+            _worldModel.SignalCallbackResolving();
+            if (_callbackScript != null)
+                await _worldModel.RunScriptAsync(_callbackScript, c);
         }
         catch (OperationCanceledException) { }
-        catch (Exception ex) { m_worldModel.LogException(ex); }
+        catch (Exception ex) { _worldModel.LogException(ex); }
         finally
         {
-            if (!resolved) m_worldModel.SignalCallbackResolving();
-            await m_worldModel.EndPendingCallbackAsync();
-            m_worldModel.SignalTurnSuspended();
+            if (!resolved) _worldModel.SignalCallbackResolving();
+            await _worldModel.EndPendingCallbackAsync();
+            _worldModel.SignalTurnSuspended();
         }
     }
 
     public override string Save()
     {
-        return SaveScript("wait", m_callbackScript);
+        return SaveScript("wait", _callbackScript);
     }
 
     public override object GetParameter(int index)
@@ -79,7 +79,7 @@ public class WaitScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_callbackScript;
+                return _callbackScript;
             default:
                 throw new ArgumentOutOfRangeException();
         }

--- a/src/Engine/Scripts/WhileScript.cs
+++ b/src/Engine/Scripts/WhileScript.cs
@@ -24,39 +24,39 @@ public class WhileScriptConstructor : IScriptConstructor
 
 public class WhileScript : ScriptBase
 {
-    private readonly IScript m_loopScript;
-    private readonly ScriptContext m_scriptContext;
-    private readonly IScriptFactory m_scriptFactory;
-    private IFunction<bool> m_expression;
-    private WorldModel m_worldModel;
+    private readonly IScript _loopScript;
+    private readonly ScriptContext _scriptContext;
+    private readonly IScriptFactory _scriptFactory;
+    private IFunction<bool> _expression;
+    private WorldModel _worldModel;
 
     public WhileScript(ScriptContext scriptContext, IScriptFactory scriptFactory, IFunction<bool> expression,
         IScript loopScript)
     {
-        m_scriptContext = scriptContext;
-        m_worldModel = scriptContext.WorldModel;
-        m_scriptFactory = scriptFactory;
-        m_expression = expression;
-        m_loopScript = loopScript;
+        _scriptContext = scriptContext;
+        _worldModel = scriptContext.WorldModel;
+        _scriptFactory = scriptFactory;
+        _expression = expression;
+        _loopScript = loopScript;
     }
 
     public override string Keyword => "while";
 
     protected override ScriptBase CloneScript()
     {
-        return new WhileScript(m_scriptContext, m_scriptFactory, m_expression.Clone(), (IScript) m_loopScript.Clone());
+        return new WhileScript(_scriptContext, _scriptFactory, _expression.Clone(), (IScript) _loopScript.Clone());
     }
 
     protected override void ParentUpdated()
     {
-        m_loopScript.Parent = Parent;
+        _loopScript.Parent = Parent;
     }
 
     public override async Task ExecuteAsync(Context c)
     {
-        while (await m_expression.ExecuteAsync(c))
+        while (await _expression.ExecuteAsync(c))
         {
-            await m_loopScript.ExecuteAsync(c);
+            await _loopScript.ExecuteAsync(c);
             if (c.IsReturned)
             {
                 break;
@@ -66,7 +66,7 @@ public class WhileScript : ScriptBase
 
     public override string Save()
     {
-        return SaveScript("while", m_loopScript, m_expression.Save());
+        return SaveScript("while", _loopScript, _expression.Save());
     }
 
     public override object GetParameter(int index)
@@ -74,9 +74,9 @@ public class WhileScript : ScriptBase
         switch (index)
         {
             case 0:
-                return m_expression.Save();
+                return _expression.Save();
             case 1:
-                return m_loopScript;
+                return _loopScript;
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -87,7 +87,7 @@ public class WhileScript : ScriptBase
         switch (index)
         {
             case 0:
-                m_expression = new Expression<bool>((string) value, m_scriptContext);
+                _expression = new Expression<bool>((string) value, _scriptContext);
                 break;
             case 1:
                 // any updates to the script should change the script itself - nothing should cause SetParameter to be triggered.

--- a/src/Engine/Templates.cs
+++ b/src/Engine/Templates.cs
@@ -7,12 +7,12 @@ namespace QuestViva.Engine;
 
 public partial class Template
 {
-    private readonly Dictionary<string, Element> m_templateLookup = new();
-    private readonly WorldModel m_worldModel;
+    private readonly Dictionary<string, Element> _templateLookup = new();
+    private readonly WorldModel _worldModel;
 
     public Template(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     internal Element AddTemplate(string templateName, string text, bool isCommandTemplate, bool isBaseTemplate = false)
@@ -23,7 +23,7 @@ public partial class Template
         // exports that inline a full library per language one after another) must still win over an
         // earlier one from the same scan - only non-base (library) definitions are blocked here.
         Element existingTemplate;
-        if (m_templateLookup.TryGetValue(templateName, out existingTemplate))
+        if (_templateLookup.TryGetValue(templateName, out existingTemplate))
         {
             if (existingTemplate.Fields[FieldDefinitions.IsBaseTemplate] && !isBaseTemplate)
             {
@@ -31,9 +31,9 @@ public partial class Template
             }
         }
 
-        var elementName = m_worldModel.GetUniqueId("template");
+        var elementName = _worldModel.GetUniqueId("template");
 
-        var template = m_worldModel.GetElementFactory(ElementType.Template).Create(elementName);
+        var template = _worldModel.GetElementFactory(ElementType.Template).Create(elementName);
         template.Fields[FieldDefinitions.TemplateName] = templateName;
         template.Fields[FieldDefinitions.Text] = text;
         template.Fields[FieldDefinitions.Anonymous] = true;
@@ -44,19 +44,19 @@ public partial class Template
             template.Fields[FieldDefinitions.IsVerb] = true;
         }
 
-        m_templateLookup[templateName] = template;
+        _templateLookup[templateName] = template;
 
         return template;
     }
 
     public string GetText(string t, bool throwException = true)
     {
-        if (m_templateLookup.TryGetValue(t, out var value))
+        if (_templateLookup.TryGetValue(t, out var value))
         {
             return value.Text;
         }
 
-        if (m_worldModel.EditMode && throwException)
+        if (_worldModel.EditMode && throwException)
         {
             return $"{{UNKNOWN TEMPLATE: {t}}}";
         }
@@ -94,14 +94,14 @@ public partial class Template
 
     private async Task<string> GetDynamicTextInternalAsync(string t, Parameters parameters)
     {
-        if (!m_worldModel.Elements.ContainsKey(ElementType.DynamicTemplate, t))
+        if (!_worldModel.Elements.ContainsKey(ElementType.DynamicTemplate, t))
         {
             return GetText(t);
         }
 
         var c = new Context();
         c.Parameters = parameters;
-        var template = m_worldModel.Elements.Get(ElementType.DynamicTemplate, t);
+        var template = _worldModel.Elements.Get(ElementType.DynamicTemplate, t);
         return await template.Fields[FieldDefinitions.Function].ExecuteAsync(c);
     }
 
@@ -109,15 +109,15 @@ public partial class Template
     {
         Element template;
 
-        if (!m_templateLookup.ContainsKey(c))
+        if (!_templateLookup.ContainsKey(c))
         {
             template = AddTemplate(c, "", true);
         }
         else
         {
-            template = m_templateLookup[c];
+            template = _templateLookup[c];
 
-            if (m_worldModel.Version >= WorldModelVersion.v530 &&
+            if (_worldModel.Version >= WorldModelVersion.v530 &&
                 template.MetaFields[MetaFieldDefinitions.Filename] != filename)
             {
                 // As of Quest 5.3, if the existing verbtemplate was defined in a different file, clear it out.
@@ -138,19 +138,19 @@ public partial class Template
     internal Element AddDynamicTemplate(string t, string expression)
     {
         Element template;
-        if (m_worldModel.Elements.ContainsKey(ElementType.DynamicTemplate, t))
+        if (_worldModel.Elements.ContainsKey(ElementType.DynamicTemplate, t))
         {
-            template = m_worldModel.Elements.Get(ElementType.DynamicTemplate, t);
+            template = _worldModel.Elements.Get(ElementType.DynamicTemplate, t);
         }
         else
         {
-            template = m_worldModel.GetElementFactory(ElementType.DynamicTemplate).Create(t);
+            template = _worldModel.GetElementFactory(ElementType.DynamicTemplate).Create(t);
         }
 
-        if (!m_worldModel.EditMode)
+        if (!_worldModel.EditMode)
         {
             template.Fields[FieldDefinitions.Function] =
-                new Expression<string>(expression, new ScriptContext(m_worldModel));
+                new Expression<string>(expression, new ScriptContext(_worldModel));
         }
         else
         {
@@ -162,21 +162,21 @@ public partial class Template
 
     public bool TemplateExists(string name)
     {
-        return m_templateLookup.ContainsKey(name);
+        return _templateLookup.ContainsKey(name);
     }
 
     public bool DynamicTemplateExists(string name)
     {
-        return m_worldModel.Elements.ContainsKey(ElementType.DynamicTemplate, name);
+        return _worldModel.Elements.ContainsKey(ElementType.DynamicTemplate, name);
     }
 
     internal Element GetTemplateElement(string name)
     {
-        return m_templateLookup[name];
+        return _templateLookup[name];
     }
 
     [GeneratedRegex(@"\[(?<name>.*?)\]")]
-    private partial Regex m_templateRegex();
+    private partial Regex TemplateRegex();
 
     public string ReplaceTemplateText(string text)
     {
@@ -185,7 +185,7 @@ public partial class Template
             return null;
         }
 
-        var regex = m_templateRegex();
+        var regex = TemplateRegex();
         var start = 0;
 
         while (true)

--- a/src/Engine/TimerRunner.cs
+++ b/src/Engine/TimerRunner.cs
@@ -6,12 +6,12 @@ namespace QuestViva.Engine;
 
 internal class TimerRunner
 {
-    private readonly WorldModel m_worldModel;
-    private Element m_gameElement;
+    private readonly WorldModel _worldModel;
+    private Element _gameElement;
 
     public TimerRunner(WorldModel worldModel, bool initialise)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
         if (initialise)
         {
             // When a game begins, set initial triggers. We don't need to do this when loading
@@ -27,7 +27,7 @@ internal class TimerRunner
     {
         get
         {
-            return m_worldModel.Elements.GetElements(ElementType.Timer).Where(t => t.Fields[FieldDefinitions.Enabled]);
+            return _worldModel.Elements.GetElements(ElementType.Timer).Where(t => t.Fields[FieldDefinitions.Enabled]);
         }
     }
 
@@ -35,7 +35,7 @@ internal class TimerRunner
     {
         get
         {
-            return m_worldModel.Elements.GetElements(ElementType.Timer).Where(t => !t.Fields[FieldDefinitions.Enabled]);
+            return _worldModel.Elements.GetElements(ElementType.Timer).Where(t => !t.Fields[FieldDefinitions.Enabled]);
         }
     }
 
@@ -43,12 +43,12 @@ internal class TimerRunner
     {
         get
         {
-            if (m_gameElement == null)
+            if (_gameElement == null)
             {
-                m_gameElement = m_worldModel.Elements.Get("game");
+                _gameElement = _worldModel.Elements.Get("game");
             }
 
-            return m_gameElement;
+            return _gameElement;
         }
     }
 

--- a/src/Engine/UndoLogger.cs
+++ b/src/Engine/UndoLogger.cs
@@ -3,16 +3,16 @@ namespace QuestViva.Engine;
 
 public class UndoLogger
 {
-    private readonly Stack<Transaction> m_redoTransactions = new();
-    private readonly Stack<Transaction> m_undoTransactions = new();
-    private readonly WorldModel m_worldModel;
-    private Transaction m_currentTransaction;
+    private readonly Stack<Transaction> _redoTransactions = new();
+    private readonly Stack<Transaction> _undoTransactions = new();
+    private readonly WorldModel _worldModel;
+    private Transaction _currentTransaction;
 
-    private bool m_logging;
+    private bool _logging;
 
     internal UndoLogger(WorldModel worldModel)
     {
-        m_worldModel = worldModel;
+        _worldModel = worldModel;
     }
 
     public event EventHandler TransactionsUpdated;
@@ -20,31 +20,31 @@ public class UndoLogger
 
     public void StartTransaction(string command)
     {
-        if (m_logging)
+        if (_logging)
         {
             throw new Exception("Starting transaction when previous transaction not finished");
         }
 
-        m_logging = true;
+        _logging = true;
         Transaction previousTransaction = null;
-        if (m_currentTransaction != null)
+        if (_currentTransaction != null)
         {
-            previousTransaction = m_currentTransaction.Count > 0
-                ? m_currentTransaction
-                : m_currentTransaction.PreviousTransaction;
+            previousTransaction = _currentTransaction.Count > 0
+                ? _currentTransaction
+                : _currentTransaction.PreviousTransaction;
         }
 
-        m_currentTransaction = new Transaction(command);
-        m_currentTransaction.PreviousTransaction = previousTransaction;
+        _currentTransaction = new Transaction(command);
+        _currentTransaction.PreviousTransaction = previousTransaction;
     }
 
     public void EndTransaction()
     {
-        m_logging = false;
-        if (m_currentTransaction.Count > 0)
+        _logging = false;
+        if (_currentTransaction.Count > 0)
         {
-            m_undoTransactions.Push(m_currentTransaction);
-            m_redoTransactions.Clear();
+            _undoTransactions.Push(_currentTransaction);
+            _redoTransactions.Clear();
             TransactionCommitted?.Invoke(this, EventArgs.Empty);
         }
 
@@ -53,7 +53,7 @@ public class UndoLogger
 
     public void RollTransaction(string command)
     {
-        if (m_currentTransaction != null)
+        if (_currentTransaction != null)
         {
             EndTransaction();
         }
@@ -71,37 +71,37 @@ public class UndoLogger
 
     internal void AddUndoAction(Func<IUndoAction> getAction)
     {
-        if (!m_logging)
+        if (!_logging)
         {
             return;
         }
 
-        m_currentTransaction.AddUndoAction(getAction());
+        _currentTransaction.AddUndoAction(getAction());
     }
 
     public async Task RollbackTransaction()
     {
-        if (m_logging)
+        if (_logging)
         {
             EndTransaction();
         }
 
         await Undo();
-        if (m_currentTransaction != null)
+        if (_currentTransaction != null)
         {
-            m_currentTransaction = m_currentTransaction.PreviousTransaction;
+            _currentTransaction = _currentTransaction.PreviousTransaction;
         }
     }
 
     public async Task Undo()
     {
-        const string NothingToUndoTemplate = "NothingToUndo";
+        const string nothingToUndoTemplate = "NothingToUndo";
 
-        if (m_undoTransactions.Count == 0)
+        if (_undoTransactions.Count == 0)
         {
-            if (m_worldModel.Template.TemplateExists(NothingToUndoTemplate))
+            if (_worldModel.Template.TemplateExists(nothingToUndoTemplate))
             {
-                await m_worldModel.PrintTemplateAsync("NothingToUndo");
+                await _worldModel.PrintTemplateAsync("NothingToUndo");
             }
             else
             {
@@ -111,33 +111,33 @@ public class UndoLogger
             return;
         }
 
-        var undoTransaction = m_undoTransactions.Pop();
-        await undoTransaction.DoUndo(m_worldModel);
-        m_redoTransactions.Push(undoTransaction);
+        var undoTransaction = _undoTransactions.Pop();
+        await undoTransaction.DoUndo(_worldModel);
+        _redoTransactions.Push(undoTransaction);
         OnTransactionsUpdated();
     }
 
     public void Redo()
     {
-        if (m_redoTransactions.Count == 0)
+        if (_redoTransactions.Count == 0)
         {
             throw new InvalidOperationException("No transactions to redo");
         }
 
-        var redoTransaction = m_redoTransactions.Pop();
-        redoTransaction.DoRedo(m_worldModel);
-        m_undoTransactions.Push(redoTransaction);
+        var redoTransaction = _redoTransactions.Pop();
+        redoTransaction.DoRedo(_worldModel);
+        _undoTransactions.Push(redoTransaction);
         OnTransactionsUpdated();
     }
 
     public IEnumerable<string> UndoList()
     {
-        return GetTransactionList(m_undoTransactions);
+        return GetTransactionList(_undoTransactions);
     }
 
     public IEnumerable<string> RedoList()
     {
-        return GetTransactionList(m_redoTransactions);
+        return GetTransactionList(_redoTransactions);
     }
 
     private IEnumerable<string> GetTransactionList(Stack<Transaction> transactions)
@@ -159,14 +159,14 @@ public class UndoLogger
 
     private class Transaction
     {
-        private readonly List<IUndoAction> m_attributes = new();
+        private readonly List<IUndoAction> _attributes = new();
 
         public Transaction(string command)
         {
             Description = command;
         }
 
-        public int Count => m_attributes.Count;
+        public int Count => _attributes.Count;
 
         internal string Description { get; }
 
@@ -174,13 +174,13 @@ public class UndoLogger
 
         public void AddUndoAction(IUndoAction action)
         {
-            m_attributes.Add(action);
+            _attributes.Add(action);
         }
 
         public async Task DoUndo(WorldModel worldModel)
         {
             const string undoTurnTemplate = "UndoTurn";
-            m_attributes.Reverse();
+            _attributes.Reverse();
             if (!worldModel.EditMode)
             {
                 if (worldModel.Template.DynamicTemplateExists(undoTurnTemplate))
@@ -189,7 +189,7 @@ public class UndoLogger
                 }
             }
 
-            foreach (var l in m_attributes)
+            foreach (var l in _attributes)
             {
                 l.DoUndo(worldModel);
             }
@@ -197,8 +197,8 @@ public class UndoLogger
 
         public void DoRedo(WorldModel worldModel)
         {
-            m_attributes.Reverse(); // Undo reverses attributes, so put them back in the correct order
-            foreach (var l in m_attributes)
+            _attributes.Reverse(); // Undo reverses attributes, so put them back in the correct order
+            foreach (var l in _attributes)
             {
                 l.DoRedo(worldModel);
             }

--- a/src/Engine/Utility.cs
+++ b/src/Engine/Utility.cs
@@ -20,17 +20,17 @@ public class MismatchingQuotesException : Exception
 
 public static partial class Utility
 {
-    private const string k_spaceReplacementString = "___SPACE___";
+    private const string SpaceReplacementString = "___SPACE___";
 
     public static readonly string[] DisallowedAttributes =
         {"object", "command", "turnscript", "game", "exit", "type", "finish"};
 
-    private static readonly List<string> s_keywords = new() {"and", "or", "xor", "not", "if", "in"};
-    private static readonly HashSet<string> s_keywordsSet = new(s_keywords);
+    private static readonly List<string> Keywords = new() {"and", "or", "xor", "not", "if", "in"};
+    private static readonly HashSet<string> KeywordsSet = new(Keywords);
 
-    private static readonly string[] s_listSplitDelimiters = new[] {"; ", ";"};
+    private static readonly string[] ListSplitDelimiters = new[] {"; ", ";"};
 
-    public static IList<string> ExpressionKeywords => s_keywords.AsReadOnly();
+    public static IList<string> ExpressionKeywords => Keywords.AsReadOnly();
 
     public static string GetParameter(string script)
     {
@@ -203,11 +203,11 @@ public static partial class Utility
 
     public static string ResolveElementName(string name)
     {
-        return name.Replace(k_spaceReplacementString, " ");
+        return name.Replace(SpaceReplacementString, " ");
     }
 
     [GeneratedRegex(@"//")]
-    private static partial Regex s_detectComments();
+    private static partial Regex DetectCommentsRegex();
 
     private static string ReplaceRegexMatchesRespectingQuotes(string input, Regex regex, string replaceWith,
         bool replaceInsideQuote)
@@ -239,7 +239,7 @@ public static partial class Utility
             {
                 if (IsSplitVariableName(words[i - 1], words[i]))
                 {
-                    result.Append(k_spaceReplacementString);
+                    result.Append(SpaceReplacementString);
                 }
                 else
                 {
@@ -256,19 +256,19 @@ public static partial class Utility
     // Given two words e.g. "my" and "variable", see if they together comprise a variable name
 
     [GeneratedRegex(@"(\w+)$")]
-    private static partial Regex s_wordRegex1();
+    private static partial Regex WordRegex1();
 
     [GeneratedRegex(@"^(\w+)")]
-    private static partial Regex s_wordRegex2();
+    private static partial Regex WordRegex2();
 
     private static bool IsSplitVariableName(string word1, string word2)
     {
-        var match1 = s_wordRegex1().Match(word1);
-        var match2 = s_wordRegex2().Match(word2);
+        var match1 = WordRegex1().Match(word1);
+        var match2 = WordRegex2().Match(word2);
 
         if (!match1.Success || !match2.Success) return false;
-        if (s_keywordsSet.Contains(match1.Groups[1].Value)) return false;
-        if (s_keywordsSet.Contains(match2.Groups[1].Value)) return false;
+        if (KeywordsSet.Contains(match1.Groups[1].Value)) return false;
+        if (KeywordsSet.Contains(match2.Groups[1].Value)) return false;
 
         return true;
     }
@@ -372,7 +372,7 @@ public static partial class Utility
         // Replace any occurrences of "//" which are inside string expressions. Then any occurrences of "//"
         // which remain mark the beginning of a comment.
         var obfuscateDoubleSlashesInsideStrings =
-            ReplaceRegexMatchesRespectingQuotes(input, s_detectComments(), "--", true);
+            ReplaceRegexMatchesRespectingQuotes(input, DetectCommentsRegex(), "--", true);
         if (obfuscateDoubleSlashesInsideStrings.Contains("//"))
         {
             return input[..obfuscateDoubleSlashesInsideStrings.IndexOf("//", StringComparison.Ordinal)];
@@ -430,7 +430,7 @@ public static partial class Utility
 
     public static string[] ListSplit(string value)
     {
-        return value.Split(s_listSplitDelimiters, StringSplitOptions.None);
+        return value.Split(ListSplitDelimiters, StringSplitOptions.None);
     }
 
     public static string ObscureStrings(string input)
@@ -627,11 +627,11 @@ public static partial class Utility
     //  - can contain spaces, but not at the beginning or end
     //  - cannot be "object", "finish" etc. (attributes only)
     [GeneratedRegex(@"^[A-Za-z_][\w ]*$")]
-    private static partial Regex s_validAttributeName();
+    private static partial Regex ValidAttributeNameRegex();
 
     public static bool IsValidFieldName(string name)
     {
-        if (!s_validAttributeName().IsMatch(name))
+        if (!ValidAttributeNameRegex().IsMatch(name))
         {
             return false;
         }
@@ -641,7 +641,7 @@ public static partial class Utility
             return false;
         }
 
-        if (name.Split(' ').Any(w => s_keywords.Contains(w)))
+        if (name.Split(' ').Any(w => Keywords.Contains(w)))
         {
             return false;
         }

--- a/src/Engine/Walkthrough.cs
+++ b/src/Engine/Walkthrough.cs
@@ -5,41 +5,41 @@ namespace QuestViva.Engine;
 
 public sealed class Walkthroughs : IWalkthroughs
 {
-    private readonly Dictionary<string, IWalkthrough> m_walkthroughs = new();
+    private readonly Dictionary<string, IWalkthrough> _walkthroughs = new();
 
     public Walkthroughs(WorldModel worldModel)
     {
         foreach (var walkthroughElement in worldModel.Elements.GetElements(ElementType.Walkthrough))
         {
-            m_walkthroughs.Add(walkthroughElement.Name, new Walkthrough(walkthroughElement, this));
+            _walkthroughs.Add(walkthroughElement.Name, new Walkthrough(walkthroughElement, this));
         }
     }
 
-    IDictionary<string, IWalkthrough> IWalkthroughs.Walkthroughs => m_walkthroughs;
+    IDictionary<string, IWalkthrough> IWalkthroughs.Walkthroughs => _walkthroughs;
 }
 
 public class Walkthrough : IWalkthrough
 {
-    private readonly Element m_element;
-    private readonly IWalkthroughs m_walkthroughs;
+    private readonly Element _element;
+    private readonly IWalkthroughs _walkthroughs;
 
     public Walkthrough(Element element, Walkthroughs walkthroughs)
     {
-        m_element = element;
-        m_walkthroughs = walkthroughs;
+        _element = element;
+        _walkthroughs = walkthroughs;
     }
 
     public string[] Steps
     {
         get
         {
-            if (m_element.Parent == null)
+            if (_element.Parent == null)
             {
                 return ThisSteps();
             }
 
             var result = new List<string>();
-            result.AddRange(m_walkthroughs.Walkthroughs[m_element.Parent.Name].Steps);
+            result.AddRange(_walkthroughs.Walkthroughs[_element.Parent.Name].Steps);
             result.AddRange(ThisSteps());
             return result.ToArray();
         }
@@ -48,7 +48,7 @@ public class Walkthrough : IWalkthrough
     private string[] ThisSteps()
     {
         var result = new List<string>();
-        IEnumerable<string> steps = m_element.Fields[FieldDefinitions.Steps];
+        IEnumerable<string> steps = _element.Fields[FieldDefinitions.Steps];
         if (steps != null)
         {
             result.AddRange(steps);

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -32,7 +32,7 @@ public partial class WorldModel : IGame, IGameDebug
 
     private static readonly Dictionary<Type, string> TypesToTypeNames = new();
 
-    private static List<string>? FunctionNames;
+    private static List<string>? _functionNames;
     private readonly List<string> _attributeNames = [];
     private readonly Dictionary<string, ElementType> _debuggerElementTypes = new();
     private readonly Dictionary<string, ObjectType> _debuggerObjectTypes = new();
@@ -1690,7 +1690,7 @@ public partial class WorldModel : IGame, IGameDebug
     }
 
     [GeneratedRegex(@"\d*$")]
-    private static partial Regex s_removeTrailingDigits();
+    private static partial Regex RemoveTrailingDigitsRegex();
 
     public string GetUniqueElementName(string elementName)
     {
@@ -1702,7 +1702,7 @@ public partial class WorldModel : IGame, IGameDebug
         }
 
         // Otherwise get a uniquely numbered element
-        var root = s_removeTrailingDigits().Replace(elementName, "");
+        var root = RemoveTrailingDigitsRegex().Replace(elementName, "");
         var elementAlreadyExists = true;
         var number = 0;
         string result = null!;
@@ -1769,9 +1769,9 @@ public partial class WorldModel : IGame, IGameDebug
 
     public IEnumerable<string> GetBuiltInFunctionNames()
     {
-        if (FunctionNames != null)
+        if (_functionNames != null)
         {
-            return FunctionNames.AsReadOnly();
+            return _functionNames.AsReadOnly();
         }
 
         var methods = typeof(ExpressionOwner).GetMethods();
@@ -1780,9 +1780,9 @@ public partial class WorldModel : IGame, IGameDebug
 
         var allMethods = methods.Union(stringMethods).Union(dateTimeMethods);
 
-        FunctionNames = new List<string>(allMethods.Select(m => m.Name));
+        _functionNames = new List<string>(allMethods.Select(m => m.Name));
 
-        return FunctionNames.AsReadOnly();
+        return _functionNames.AsReadOnly();
     }
 
     // Signatures (name + parameter names) for the built-in expression functions, reflected from

--- a/src/Legacy/TextFormatter.cs
+++ b/src/Legacy/TextFormatter.cs
@@ -4,16 +4,16 @@ namespace QuestViva.Legacy;
 
 public class TextFormatter
 {
-    private string align = "";
+    private string _align = "";
     // the Player generates style tags for us
     // so all we need to do is have some kind of <color> <fontsize> <justify> tags etc.
     // it would actually be a really good idea for the player to handle the <wait> and <clear> tags too...?
 
-    private bool bold;
-    private string colour = "";
-    private int fontSize;
-    private bool italic;
-    private bool underline;
+    private bool _bold;
+    private string _colour = "";
+    private int _fontSize;
+    private bool _italic;
+    private bool _underline;
 
     public string OutputHTML(string input)
     {
@@ -63,57 +63,57 @@ public class TextFormatter
                 {
                     case "xb":
                     {
-                        bold = false;
+                        _bold = false;
                         break;
                     }
                     case "xi":
                     {
-                        italic = false;
+                        _italic = false;
                         break;
                     }
                     case "xu":
                     {
-                        underline = false;
+                        _underline = false;
                         break;
                     }
                     case "cb":
                     {
-                        colour = "";
+                        _colour = "";
                         break;
                     }
                     case "cr":
                     {
-                        colour = "red";
+                        _colour = "red";
                         break;
                     }
                     case "cl":
                     {
-                        colour = "blue";
+                        _colour = "blue";
                         break;
                     }
                     case "cy":
                     {
-                        colour = "yellow";
+                        _colour = "yellow";
                         break;
                     }
                     case "cg":
                     {
-                        colour = "green";
+                        _colour = "green";
                         break;
                     }
                     case "jl":
                     {
-                        align = "";
+                        _align = "";
                         break;
                     }
                     case "jc":
                     {
-                        align = "center";
+                        _align = "center";
                         break;
                     }
                     case "jr":
                     {
-                        align = "right";
+                        _align = "right";
                         break;
                     }
 
@@ -135,17 +135,17 @@ public class TextFormatter
                     {
                         case "b":
                         {
-                            bold = true;
+                            _bold = true;
                             break;
                         }
                         case "i":
                         {
-                            italic = true;
+                            _italic = true;
                             break;
                         }
                         case "u":
                         {
-                            underline = true;
+                            _underline = true;
                             break;
                         }
                         case "n":
@@ -175,7 +175,7 @@ public class TextFormatter
                         if (position < input.Length - 2)
                         {
                             var sizeCode = input.Substring(position + 1, 2);
-                            if (int.TryParse(sizeCode, out fontSize))
+                            if (int.TryParse(sizeCode, out _fontSize))
                             {
                                 foundCode = true;
                                 position += 3;
@@ -205,63 +205,63 @@ public class TextFormatter
 
         var output = "";
 
-        if (align.Length > 0)
+        if (_align.Length > 0)
         {
-            output += "<align align=\"" + align + "\">";
+            output += "<align align=\"" + _align + "\">";
         }
 
-        if (fontSize > 0)
+        if (_fontSize > 0)
         {
-            output += "<font size=\"" + fontSize + "\">";
+            output += "<font size=\"" + _fontSize + "\">";
         }
 
-        if (colour.Length > 0)
+        if (_colour.Length > 0)
         {
-            output += "<color color=\"" + colour + "\">";
+            output += "<color color=\"" + _colour + "\">";
         }
 
-        if (bold)
+        if (_bold)
         {
             output += "<b>";
         }
 
-        if (italic)
+        if (_italic)
         {
             output += "<i>";
         }
 
-        if (underline)
+        if (_underline)
         {
             output += "<u>";
         }
 
         output += input;
-        if (underline)
+        if (_underline)
         {
             output += "</u>";
         }
 
-        if (italic)
+        if (_italic)
         {
             output += "</i>";
         }
 
-        if (bold)
+        if (_bold)
         {
             output += "</b>";
         }
 
-        if (colour.Length > 0)
+        if (_colour.Length > 0)
         {
             output += "</color>";
         }
 
-        if (fontSize > 0)
+        if (_fontSize > 0)
         {
             output += "</font>";
         }
 
-        if (align.Length > 0)
+        if (_align.Length > 0)
         {
             output += "</align>";
         }

--- a/src/Legacy/V4Game.Part2.cs
+++ b/src/Legacy/V4Game.Part2.cs
@@ -10,7 +10,7 @@ namespace QuestViva.Legacy;
 
 public partial class V4Game
 {
-    private string m_menuResponse;
+    private string _menuResponse;
 
     public int ASLVersion { get; private set; }
 
@@ -145,7 +145,7 @@ public partial class V4Game
 
     public async Task SetMenuResponse(string response)
     {
-        m_menuResponse = response;
+        _menuResponse = response;
         _turnSuspendedTcs = new TaskCompletionSource();
         _waitTcs?.TrySetResult();
         await _turnSuspendedTcs.Task;
@@ -8169,7 +8169,7 @@ public partial class V4Game
         _waitTcs = new TaskCompletionSource();
         SignalTurnSuspended();
         await _waitTcs.Task;
-        return m_menuResponse;
+        return _menuResponse;
     }
 
 

--- a/src/PlayerCore/PlayerHelper.cs
+++ b/src/PlayerCore/PlayerHelper.cs
@@ -20,42 +20,42 @@ public interface IPlayerHelperUI : IPlayer
 /// </summary>
 public class PlayerHelper
 {
-    private static readonly Dictionary<string, string> s_mimeTypes = new();
-    private readonly IPlayerHelperUI m_playerUI;
+    private static readonly Dictionary<string, string> MimeTypes = new();
+    private readonly IPlayerHelperUI _playerUI;
 
-    private string m_font = "";
-    private string m_fontSize = "";
-    private string m_fontSizeOverride = "";
-    private string m_foreground = "";
-    private string m_foregroundOverride = "";
+    private string _font = "";
+    private string _fontSize = "";
+    private string _fontSizeOverride = "";
+    private string _foreground = "";
+    private string _foregroundOverride = "";
 
-    private int m_linkCount;
-    private string m_linkForeground = "";
-    private string m_textBuffer = "";
+    private int _linkCount;
+    private string _linkForeground = "";
+    private string _textBuffer = "";
 
     static PlayerHelper()
     {
-        s_mimeTypes.Add(".jpg", "image/jpeg");
-        s_mimeTypes.Add(".jpeg", "image/jpeg");
-        s_mimeTypes.Add(".gif", "image/gif");
-        s_mimeTypes.Add(".bmp", "image/bmp");
-        s_mimeTypes.Add(".png", "image/png");
-        s_mimeTypes.Add(".wav", "audio/wav");
-        s_mimeTypes.Add(".mp3", "audio/mpeg");
-        s_mimeTypes.Add(".ogg", "audio/ogg");
-        s_mimeTypes.Add(".js", "application/javascript");
-        s_mimeTypes.Add(".ttf", "application/font-woff");
-        s_mimeTypes.Add(".svg", "image/svg+xml");
+        MimeTypes.Add(".jpg", "image/jpeg");
+        MimeTypes.Add(".jpeg", "image/jpeg");
+        MimeTypes.Add(".gif", "image/gif");
+        MimeTypes.Add(".bmp", "image/bmp");
+        MimeTypes.Add(".png", "image/png");
+        MimeTypes.Add(".wav", "audio/wav");
+        MimeTypes.Add(".mp3", "audio/mpeg");
+        MimeTypes.Add(".ogg", "audio/ogg");
+        MimeTypes.Add(".js", "application/javascript");
+        MimeTypes.Add(".ttf", "application/font-woff");
+        MimeTypes.Add(".svg", "image/svg+xml");
     }
 
     public PlayerHelper(IGame game, IPlayerHelperUI playerUI)
     {
         UseGameColours = true;
         UseGameFont = true;
-        m_playerUI = playerUI;
+        _playerUI = playerUI;
         Game = game;
 
-        Game.PrintText += m_game_PrintText;
+        Game.PrintText += OnGamePrintText;
     }
 
     public IGame Game { get; }
@@ -79,7 +79,7 @@ public class PlayerHelper
         return (result, errors);
     }
 
-    private void m_game_PrintText(string text)
+    private void OnGamePrintText(string text)
     {
         PrintText(text);
     }
@@ -144,13 +144,13 @@ public class PlayerHelper
                             WriteText("<u>");
                             break;
                         case "color":
-                            m_foregroundOverride = reader.GetAttribute("color");
+                            _foregroundOverride = reader.GetAttribute("color");
                             break;
                         case "font":
-                            m_fontSizeOverride = reader.GetAttribute("size");
+                            _fontSizeOverride = reader.GetAttribute("size");
                             break;
                         case "align":
-                            m_playerUI.SetAlignment(reader.GetAttribute("align"));
+                            _playerUI.SetAlignment(reader.GetAttribute("align"));
                             break;
                         case "a":
                             generatingLink = true;
@@ -211,13 +211,13 @@ public class PlayerHelper
                             WriteText("</u>");
                             break;
                         case "color":
-                            m_foregroundOverride = "";
+                            _foregroundOverride = "";
                             break;
                         case "font":
-                            m_fontSizeOverride = "";
+                            _fontSizeOverride = "";
                             break;
                         case "align":
-                            m_playerUI.SetAlignment("");
+                            _playerUI.SetAlignment("");
                             alignmentSet = true;
                             break;
                         case "a":
@@ -241,7 +241,7 @@ public class PlayerHelper
             }
         }
 
-        if (m_textBuffer.EndsWith("</ul>") || m_textBuffer.EndsWith("</ol>"))
+        if (_textBuffer.EndsWith("</ul>") || _textBuffer.EndsWith("</ol>"))
         {
             nobr = true;
         }
@@ -252,7 +252,7 @@ public class PlayerHelper
             // there's no need to submit an extra <br> tag as subsequent text will be in a
             // brand new <div> element.
 
-            if (!(alignmentSet && m_textBuffer.Length == 0))
+            if (!(alignmentSet && _textBuffer.Length == 0))
             {
                 WriteText("<br />");
             }
@@ -293,9 +293,9 @@ public class PlayerHelper
         var style = "";
         if (UseGameFont)
         {
-            if (!string.IsNullOrEmpty(m_font))
+            if (!string.IsNullOrEmpty(_font))
             {
-                style += string.Format("font-family:{0};", m_font);
+                style += string.Format("font-family:{0};", _font);
             }
         }
         else
@@ -312,10 +312,10 @@ public class PlayerHelper
             }
             else
             {
-                colour = m_foregroundOverride;
+                colour = _foregroundOverride;
                 if (colour.Length == 0)
                 {
-                    colour = m_foreground;
+                    colour = _foreground;
                 }
             }
         }
@@ -332,10 +332,10 @@ public class PlayerHelper
         string fontSize;
         if (UseGameFont)
         {
-            fontSize = m_fontSizeOverride;
+            fontSize = _fontSizeOverride;
             if (fontSize.Length == 0)
             {
-                fontSize = m_fontSize;
+                fontSize = _fontSize;
             }
         }
         else
@@ -354,8 +354,8 @@ public class PlayerHelper
     private void AddLink(string text, string command, string verbs, string colour, string elementId)
     {
         var onclick = string.Empty;
-        m_linkCount++;
-        var linkid = "verbLink" + m_linkCount;
+        _linkCount++;
+        var linkid = "verbLink" + _linkCount;
 
         if (string.IsNullOrEmpty(verbs))
         {
@@ -364,7 +364,7 @@ public class PlayerHelper
 
         WriteText(string.Format("<a id=\"{0}\" style=\"{1}\" class=\"cmdlink\"{2}>{3}</a>",
             linkid,
-            GetCurrentFormat(colour ?? m_linkForeground),
+            GetCurrentFormat(colour ?? _linkForeground),
             onclick,
             text
         ));
@@ -373,31 +373,31 @@ public class PlayerHelper
         // written. So, clear the text buffer, then add the binding.
         if (!string.IsNullOrEmpty(verbs))
         {
-            m_playerUI.OutputText(ClearBuffer());
-            m_playerUI.BindMenu(linkid, verbs, text, elementId);
+            _playerUI.OutputText(ClearBuffer());
+            _playerUI.BindMenu(linkid, verbs, text, elementId);
         }
     }
 
     private void AddExternalLink(string text, string href, string colour, string onclick)
     {
         WriteText(string.Format("<a style=\"{0}\" class=\"cmdlink\" onclick=\"{1}\">{2}</a>",
-            GetCurrentFormat(colour ?? m_linkForeground),
+            GetCurrentFormat(colour ?? _linkForeground),
             onclick ?? string.Format("goUrl('{0}')", href),
             text));
     }
 
     private void WriteText(string text)
     {
-        m_textBuffer += text;
+        _textBuffer += text;
     }
 
     public string ClearBuffer()
     {
         string output;
-        lock (m_textBuffer)
+        lock (_textBuffer)
         {
-            output = m_textBuffer;
-            m_textBuffer = "";
+            output = _textBuffer;
+            _textBuffer = "";
         }
 
         return output;
@@ -410,22 +410,22 @@ public class PlayerHelper
 
     public void SetForeground(string colour)
     {
-        m_foreground = colour;
+        _foreground = colour;
     }
 
     public void SetLinkForeground(string colour)
     {
-        m_linkForeground = colour;
+        _linkForeground = colour;
     }
 
     public void SetFont(string fontName)
     {
-        m_font = fontName;
+        _font = fontName;
     }
 
     public void SetFontSize(string fontSize)
     {
-        m_fontSize = fontSize;
+        _fontSize = fontSize;
     }
 
     public void AppendText(string text)
@@ -512,7 +512,7 @@ public class PlayerHelper
     public static string GetContentType(string filename)
     {
         string result;
-        return s_mimeTypes.TryGetValue(Path.GetExtension(filename).ToLower(), out result) ? result : "";
+        return MimeTypes.TryGetValue(Path.GetExtension(filename).ToLower(), out result) ? result : "";
     }
 
     public class CommandData

--- a/tests/EditorCoreTests/EditableListTests.cs
+++ b/tests/EditorCoreTests/EditableListTests.cs
@@ -5,13 +5,13 @@ namespace QuestViva.EditorCoreTests;
 [TestClass]
 public class EditableListTests : EditorControllerTestBase
 {
-    private IEditableList<string> m_list;
-    private object m_listattr;
+    private IEditableList<string> _list;
+    private object _listattr;
 
     public override void DoExtraInitialisation()
     {
-        m_listattr = Controller.GetEditorData("testobj").GetAttribute("listattr");
-        m_list = m_listattr as IEditableList<string>;
+        _listattr = Controller.GetEditorData("testobj").GetAttribute("listattr");
+        _list = _listattr as IEditableList<string>;
     }
 
     private string GetItemListString(IEditableList<string> list)
@@ -27,35 +27,35 @@ public class EditableListTests : EditorControllerTestBase
     [TestMethod]
     public void TestListSetup()
     {
-        Assert.IsInstanceOfType(m_listattr, typeof(IEditableList<string>));
-        Assert.AreEqual("one;two;three;four;five", GetItemListString(m_list));
+        Assert.IsInstanceOfType(_listattr, typeof(IEditableList<string>));
+        Assert.AreEqual("one;two;three;four;five", GetItemListString(_list));
     }
 
     [TestMethod]
     public void TestListAdd()
     {
-        m_list.Add("new");
-        Assert.AreEqual("one;two;three;four;five;new", GetItemListString(m_list));
+        _list.Add("new");
+        Assert.AreEqual("one;two;three;four;five;new", GetItemListString(_list));
 
         Controller.Undo();
-        Assert.AreEqual("one;two;three;four;five", GetItemListString(m_list));
+        Assert.AreEqual("one;two;three;four;five", GetItemListString(_list));
     }
 
     [TestMethod]
     public void TestListRemove()
     {
         // Remove individual item
-        m_list.Remove(GetItemListKeys(m_list)[2]);
-        Assert.AreEqual("one;two;four;five", GetItemListString(m_list));
+        _list.Remove(GetItemListKeys(_list)[2]);
+        Assert.AreEqual("one;two;four;five", GetItemListString(_list));
 
         Controller.Undo();
-        Assert.AreEqual("one;two;three;four;five", GetItemListString(m_list));
+        Assert.AreEqual("one;two;three;four;five", GetItemListString(_list));
 
         // Remove multiple items
-        m_list.Remove(GetItemListKeys(m_list)[0], GetItemListKeys(m_list)[3]);
-        Assert.AreEqual("two;three;five", GetItemListString(m_list));
+        _list.Remove(GetItemListKeys(_list)[0], GetItemListKeys(_list)[3]);
+        Assert.AreEqual("two;three;five", GetItemListString(_list));
 
         Controller.Undo();
-        Assert.AreEqual("one;two;three;four;five", GetItemListString(m_list));
+        Assert.AreEqual("one;two;three;four;five", GetItemListString(_list));
     }
 }

--- a/tests/EditorCoreTests/EditorControllerTestBase.cs
+++ b/tests/EditorCoreTests/EditorControllerTestBase.cs
@@ -7,7 +7,7 @@ namespace QuestViva.EditorCoreTests;
 [TestClass]
 public abstract class EditorControllerTestBase
 {
-    private readonly EditorTreeData m_tree = new();
+    private readonly EditorTreeData _tree = new();
 
     protected EditorController Controller { get; private set; }
 
@@ -19,12 +19,12 @@ public abstract class EditorControllerTestBase
     public async Task Init()
     {
         Controller = new EditorController();
-        Controller.ClearTree += m_controller_ClearTree;
-        Controller.BeginTreeUpdate += m_controller_BeginTreeUpdate;
-        Controller.EndTreeUpdate += m_controller_EndTreeUpdate;
-        Controller.AddedNode += m_controller_AddedNode;
-        Controller.UndoListUpdated += m_controller_UndoListUpdated;
-        Controller.RedoListUpdated += m_controller_RedoListUpdated;
+        Controller.ClearTree += OnControllerClearTree;
+        Controller.BeginTreeUpdate += OnControllerBeginTreeUpdate;
+        Controller.EndTreeUpdate += OnControllerEndTreeUpdate;
+        Controller.AddedNode += OnControllerAddedNode;
+        Controller.UndoListUpdated += OnControllerUndoListUpdated;
+        Controller.RedoListUpdated += OnControllerRedoListUpdated;
         var bytes = GetResourceBytes("QuestViva.EditorCoreTests.test.aslx");
         await Controller.Initialise(new ByteArrayGameDataProvider(bytes, "test.aslx"));
         DoExtraInitialisation();
@@ -48,32 +48,32 @@ public abstract class EditorControllerTestBase
         Controller.Dispose();
     }
 
-    private void m_controller_ClearTree(object sender, EventArgs e)
+    private void OnControllerClearTree(object sender, EventArgs e)
     {
-        m_tree.Clear();
+        _tree.Clear();
     }
 
-    private void m_controller_BeginTreeUpdate(object sender, EventArgs e)
+    private void OnControllerBeginTreeUpdate(object sender, EventArgs e)
     {
-        m_tree.BeginUpdate();
+        _tree.BeginUpdate();
     }
 
-    private void m_controller_EndTreeUpdate(object sender, EventArgs e)
+    private void OnControllerEndTreeUpdate(object sender, EventArgs e)
     {
-        m_tree.EndUpdate();
+        _tree.EndUpdate();
     }
 
-    private void m_controller_AddedNode(object sender, EditorController.AddedNodeEventArgs e)
+    private void OnControllerAddedNode(object sender, EditorController.AddedNodeEventArgs e)
     {
-        m_tree.Add(e.Key, e.Text, e.Parent);
+        _tree.Add(e.Key, e.Text, e.Parent);
     }
 
-    private void m_controller_UndoListUpdated(object sender, EditorController.UpdateUndoListEventArgs e)
+    private void OnControllerUndoListUpdated(object sender, EditorController.UpdateUndoListEventArgs e)
     {
         UndoList = new List<string>(e.UndoList);
     }
 
-    private void m_controller_RedoListUpdated(object sender, EditorController.UpdateUndoListEventArgs e)
+    private void OnControllerRedoListUpdated(object sender, EditorController.UpdateUndoListEventArgs e)
     {
         RedoList = new List<string>(e.UndoList);
     }

--- a/tests/EditorCoreTests/EditorTreeData.cs
+++ b/tests/EditorCoreTests/EditorTreeData.cs
@@ -9,38 +9,38 @@ public class EditorTreeItem
 
 public class EditorTreeData
 {
-    private readonly Dictionary<string, EditorTreeItem> m_items = new();
-    private bool m_frozen = true;
+    private readonly Dictionary<string, EditorTreeItem> _items = new();
+    private bool _frozen = true;
 
     public void Clear()
     {
-        m_items.Clear();
+        _items.Clear();
     }
 
     public void Add(string key, string text, string parent)
     {
-        var parentItem = parent == null ? null : m_items[parent];
+        var parentItem = parent == null ? null : _items[parent];
         var newItem = new EditorTreeItem {Key = key, Parent = parentItem, Text = text};
         Add(newItem);
     }
 
     public void Add(EditorTreeItem item)
     {
-        if (m_frozen)
+        if (_frozen)
         {
             throw new InvalidOperationException("Can't add to tree when frozen - expected BeginUpdate event first.");
         }
 
-        m_items.Add(item.Key, item);
+        _items.Add(item.Key, item);
     }
 
     public void BeginUpdate()
     {
-        m_frozen = false;
+        _frozen = false;
     }
 
     public void EndUpdate()
     {
-        m_frozen = true;
+        _frozen = true;
     }
 }

--- a/tests/EditorCoreTests/IncludedLibraryTests.cs
+++ b/tests/EditorCoreTests/IncludedLibraryTests.cs
@@ -134,7 +134,7 @@ public class IncludedLibraryTests
         Assert.IsTrue(ok, $"Initialisation failed for template '{templateName}'");
 
         // Building the tree at least once (as every real caller does right after a successful
-        // Initialise — see WasmEditorBridge.Initialise) is what populates m_elementTreeStructure;
+        // Initialise — see WasmEditorBridge.Initialise) is what populates _elementTreeStructure;
         // without it, later element-creation calls NRE deep in EditorController's tree-update path.
         controller.UpdateTree();
 

--- a/tests/EngineTests/CloneTests.cs
+++ b/tests/EngineTests/CloneTests.cs
@@ -5,69 +5,69 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class CloneTests
 {
-    private const string attributeName = "attribute";
-    private const string attributeValue = "attributevalue";
-    private const string listAttributeName = "listattribute";
-    private readonly List<string> listAttributeValue = new() {"one", "two", "three"};
-    private Element m_original;
+    private const string AttributeName = "attribute";
+    private const string AttributeValue = "attributevalue";
+    private const string ListAttributeName = "listattribute";
+    private readonly List<string> _listAttributeValue = new() {"one", "two", "three"};
+    private Element _original;
 
-    private WorldModel m_worldModel;
+    private WorldModel _worldModel;
 
     [TestInitialize]
     public void Setup()
     {
-        m_worldModel = Helpers.CreateWorldModel();
+        _worldModel = Helpers.CreateWorldModel();
 
-        m_original = m_worldModel.GetElementFactory(ElementType.Object).Create("original");
-        m_original.Fields.Set(attributeName, attributeValue);
-        m_original.Fields.Set(listAttributeName, new QuestList<string>(listAttributeValue));
-        m_original.Fields.Resolve(null);
-        Assert.AreEqual(attributeValue, m_original.Fields.GetString(attributeName));
-        Assert.AreEqual(3, m_original.Fields.GetAsType<QuestList<string>>(listAttributeName).Count);
+        _original = _worldModel.GetElementFactory(ElementType.Object).Create("original");
+        _original.Fields.Set(AttributeName, AttributeValue);
+        _original.Fields.Set(ListAttributeName, new QuestList<string>(_listAttributeValue));
+        _original.Fields.Resolve(null);
+        Assert.AreEqual(AttributeValue, _original.Fields.GetString(AttributeName));
+        Assert.AreEqual(3, _original.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
     }
 
     [TestMethod]
     public void TestClone()
     {
-        var clone = m_original.Clone();
+        var clone = _original.Clone();
 
         // Original and clone must be different objects
-        Assert.AreNotSame(m_original, clone);
+        Assert.AreNotSame(_original, clone);
 
         // Attribute values must be the same
-        Assert.AreEqual(attributeValue, clone.Fields.GetString(attributeName));
-        Assert.AreEqual(3, clone.Fields.GetAsType<QuestList<string>>(listAttributeName).Count);
+        Assert.AreEqual(AttributeValue, clone.Fields.GetString(AttributeName));
+        Assert.AreEqual(3, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
 
         // Names must not match
-        Assert.AreNotEqual(m_original.Name, clone.Name);
+        Assert.AreNotEqual(_original.Name, clone.Name);
 
         // Both original and clone must be accessible by their names
-        Assert.AreSame(m_original, m_worldModel.Elements.Get(m_original.Name));
-        Assert.AreSame(clone, m_worldModel.Elements.Get(clone.Name));
+        Assert.AreSame(_original, _worldModel.Elements.Get(_original.Name));
+        Assert.AreSame(clone, _worldModel.Elements.Get(clone.Name));
     }
 
     [TestMethod]
     public async Task TestUndoCloning()
     {
-        var originalObjectCount = m_worldModel.Elements.Count(ElementType.Object);
+        var originalObjectCount = _worldModel.Elements.Count(ElementType.Object);
 
-        m_worldModel.UndoLogger.StartTransaction("Create clone");
-        var clone = m_original.Clone();
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.StartTransaction("Create clone");
+        var clone = _original.Clone();
+        _worldModel.UndoLogger.EndTransaction();
 
-        Assert.AreEqual(originalObjectCount + 1, m_worldModel.Elements.Count(ElementType.Object));
+        Assert.AreEqual(originalObjectCount + 1, _worldModel.Elements.Count(ElementType.Object));
 
-        await m_worldModel.UndoLogger.Undo();
-        Assert.AreEqual(originalObjectCount, m_worldModel.Elements.Count(ElementType.Object));
+        await _worldModel.UndoLogger.Undo();
+        Assert.AreEqual(originalObjectCount, _worldModel.Elements.Count(ElementType.Object));
 
-        m_worldModel.UndoLogger.Redo();
-        Assert.AreEqual(originalObjectCount + 1, m_worldModel.Elements.Count(ElementType.Object));
+        _worldModel.UndoLogger.Redo();
+        Assert.AreEqual(originalObjectCount + 1, _worldModel.Elements.Count(ElementType.Object));
 
-        await m_worldModel.UndoLogger.Undo();
-        Assert.AreEqual(originalObjectCount, m_worldModel.Elements.Count(ElementType.Object));
+        await _worldModel.UndoLogger.Undo();
+        Assert.AreEqual(originalObjectCount, _worldModel.Elements.Count(ElementType.Object));
 
-        m_worldModel.UndoLogger.Redo();
-        Assert.AreEqual(originalObjectCount + 1, m_worldModel.Elements.Count(ElementType.Object));
+        _worldModel.UndoLogger.Redo();
+        Assert.AreEqual(originalObjectCount + 1, _worldModel.Elements.Count(ElementType.Object));
     }
 
     [TestMethod]
@@ -75,61 +75,61 @@ public class CloneTests
     {
         const string newAttributeValue = "newattributevalue";
 
-        var clone = m_original.Clone();
+        var clone = _original.Clone();
 
-        m_worldModel.UndoLogger.StartTransaction("Change attribute");
-        clone.Fields.Set(attributeName, newAttributeValue);
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.StartTransaction("Change attribute");
+        clone.Fields.Set(AttributeName, newAttributeValue);
+        _worldModel.UndoLogger.EndTransaction();
 
         // Cloned's field value is changed
-        Assert.AreEqual(newAttributeValue, clone.Fields.GetString(attributeName));
+        Assert.AreEqual(newAttributeValue, clone.Fields.GetString(AttributeName));
 
         // Original's field value is not changed
-        Assert.AreEqual(attributeValue, m_original.Fields.GetString(attributeName));
+        Assert.AreEqual(AttributeValue, _original.Fields.GetString(AttributeName));
 
-        await m_worldModel.UndoLogger.Undo();
+        await _worldModel.UndoLogger.Undo();
 
         // Cloned's field value is back to original value
-        Assert.AreEqual(attributeValue, clone.Fields.GetString(attributeName));
+        Assert.AreEqual(AttributeValue, clone.Fields.GetString(AttributeName));
     }
 
     [TestMethod]
     public async Task TestChangingClonedListAttribute()
     {
-        var clone = m_original.Clone();
+        var clone = _original.Clone();
 
-        m_worldModel.UndoLogger.StartTransaction("Change attribute");
-        clone.Fields.GetAsType<QuestList<string>>(listAttributeName).Add("newvalue");
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.StartTransaction("Change attribute");
+        clone.Fields.GetAsType<QuestList<string>>(ListAttributeName).Add("newvalue");
+        _worldModel.UndoLogger.EndTransaction();
 
         // Cloned's field value is changed
-        Assert.AreEqual(4, clone.Fields.GetAsType<QuestList<string>>(listAttributeName).Count);
+        Assert.AreEqual(4, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
 
         // Original's field value is not changed
-        Assert.AreEqual(3, m_original.Fields.GetAsType<QuestList<string>>(listAttributeName).Count);
+        Assert.AreEqual(3, _original.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
 
-        await m_worldModel.UndoLogger.Undo();
+        await _worldModel.UndoLogger.Undo();
 
         // Cloned's field value is back to original value
-        Assert.AreEqual(3, clone.Fields.GetAsType<QuestList<string>>(listAttributeName).Count);
+        Assert.AreEqual(3, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
     }
 
     [TestMethod]
     public void TestMultipleClones()
     {
-        var clone = m_original.Clone();
-        var clone2 = m_original.Clone();
-        var clone3 = m_original.Clone();
+        var clone = _original.Clone();
+        var clone2 = _original.Clone();
+        var clone3 = _original.Clone();
         var clone4 = clone.Clone();
         var clone5 = clone.Clone();
         var clone6 = clone4.Clone();
 
-        Assert.AreEqual(m_original.Name + "1", clone.Name);
-        Assert.AreEqual(m_original.Name + "2", clone2.Name);
-        Assert.AreEqual(m_original.Name + "3", clone3.Name);
-        Assert.AreEqual(m_original.Name + "4", clone4.Name);
-        Assert.AreEqual(m_original.Name + "5", clone5.Name);
-        Assert.AreEqual(m_original.Name + "6", clone6.Name);
+        Assert.AreEqual(_original.Name + "1", clone.Name);
+        Assert.AreEqual(_original.Name + "2", clone2.Name);
+        Assert.AreEqual(_original.Name + "3", clone3.Name);
+        Assert.AreEqual(_original.Name + "4", clone4.Name);
+        Assert.AreEqual(_original.Name + "5", clone5.Name);
+        Assert.AreEqual(_original.Name + "6", clone6.Name);
     }
 
     [TestMethod]
@@ -138,22 +138,22 @@ public class CloneTests
         // Create a child object of the original
         const string childAttrName = "childattribute";
         const string childAttrValue = "childvalue";
-        var child = m_worldModel.GetElementFactory(ElementType.Object).Create("child");
+        var child = _worldModel.GetElementFactory(ElementType.Object).Create("child");
         child.Fields.Set(childAttrName, childAttrValue);
-        child.Parent = m_original;
+        child.Parent = _original;
 
-        var originalElementCount = m_worldModel.Elements.Count(ElementType.Object);
+        var originalElementCount = _worldModel.Elements.Count(ElementType.Object);
 
         // Clone the original object. The cloned object should have a cloned child too.
-        m_worldModel.UndoLogger.StartTransaction("Create clone");
-        var clone = m_original.Clone();
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.StartTransaction("Create clone");
+        var clone = _original.Clone();
+        _worldModel.UndoLogger.EndTransaction();
 
         // We should now have 2 more objects
-        Assert.AreEqual(originalElementCount + 2, m_worldModel.Elements.Count(ElementType.Object));
+        Assert.AreEqual(originalElementCount + 2, _worldModel.Elements.Count(ElementType.Object));
 
-        var cloneChildren = new List<Element>(m_worldModel.Elements.GetChildElements(clone));
-        var originalChildren = new List<Element>(m_worldModel.Elements.GetChildElements(m_original));
+        var cloneChildren = new List<Element>(_worldModel.Elements.GetChildElements(clone));
+        var originalChildren = new List<Element>(_worldModel.Elements.GetChildElements(_original));
 
         // Check the original and the clone now each have one child
         Assert.AreEqual(1, cloneChildren.Count);
@@ -168,7 +168,7 @@ public class CloneTests
         Assert.AreEqual(childAttrValue, cloneChildren[0].Fields.GetString(childAttrName));
 
         // Now undo, and verify we have the original number of objects again
-        await m_worldModel.UndoLogger.Undo();
-        Assert.AreEqual(originalElementCount, m_worldModel.Elements.Count(ElementType.Object));
+        await _worldModel.UndoLogger.Undo();
+        Assert.AreEqual(originalElementCount, _worldModel.Elements.Count(ElementType.Object));
     }
 }

--- a/tests/EngineTests/ComplexTypesTests.cs
+++ b/tests/EngineTests/ComplexTypesTests.cs
@@ -5,26 +5,26 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class ComplexTypesTests
 {
-    private Element m_object;
-    private WorldModel m_worldModel;
+    private Element _object;
+    private WorldModel _worldModel;
 
     [TestInitialize]
     public void Setup()
     {
-        m_worldModel = Helpers.CreateWorldModel();
+        _worldModel = Helpers.CreateWorldModel();
 
-        m_object = m_worldModel.GetElementFactory(ElementType.Object).Create("object");
+        _object = _worldModel.GetElementFactory(ElementType.Object).Create("object");
         var list = new QuestList<object> {"string1"};
         var dictionary = new QuestDictionary<object> {{"key1", "nested string"}};
         list.Add(dictionary);
-        m_object.Fields.Set("list", list);
-        m_object.Fields.Resolve(null);
+        _object.Fields.Set("list", list);
+        _object.Fields.Resolve(null);
     }
 
     [TestMethod]
     public void TestSetup()
     {
-        var obj = m_worldModel.Elements.Get("object");
+        var obj = _worldModel.Elements.Get("object");
         Assert.IsNotNull(obj);
         var list = obj.Fields.GetAsType<QuestList<object>>("list");
         Assert.IsNotNull(list);
@@ -38,35 +38,35 @@ public class ComplexTypesTests
     [TestMethod]
     public void TestAddListItemUndoRedo()
     {
-        var obj = m_worldModel.Elements.Get("object");
+        var obj = _worldModel.Elements.Get("object");
         var list = obj.Fields.GetAsType<QuestList<object>>("list");
         Assert.AreEqual(2, list.Count);
 
-        m_worldModel.UndoLogger.StartTransaction("Add list item");
+        _worldModel.UndoLogger.StartTransaction("Add list item");
         list.Add("new item");
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.EndTransaction();
 
         Assert.AreEqual(3, list.Count);
 
-        m_worldModel.UndoLogger.Undo();
+        _worldModel.UndoLogger.Undo();
         Assert.AreEqual(2, list.Count);
     }
 
     [TestMethod]
     public void TestNestedDictionaryAddUndoRedo()
     {
-        var obj = m_worldModel.Elements.Get("object");
+        var obj = _worldModel.Elements.Get("object");
         var list = obj.Fields.GetAsType<QuestList<object>>("list");
         var dictionary = list[1] as QuestDictionary<object>;
         Assert.AreEqual(1, dictionary.Count);
 
-        m_worldModel.UndoLogger.StartTransaction("Add dictionary item");
+        _worldModel.UndoLogger.StartTransaction("Add dictionary item");
         dictionary.Add("key2", "new string");
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.EndTransaction();
 
         Assert.AreEqual(2, dictionary.Count);
 
-        m_worldModel.UndoLogger.Undo();
+        _worldModel.UndoLogger.Undo();
         Assert.AreEqual(1, dictionary.Count);
     }
 }

--- a/tests/EngineTests/ElementsTests.cs
+++ b/tests/EngineTests/ElementsTests.cs
@@ -5,12 +5,12 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class ElementsTests
 {
-    private WorldModel m_worldModel;
+    private WorldModel _worldModel;
 
     [TestInitialize]
     public void Setup()
     {
-        m_worldModel = Helpers.CreateWorldModel();
+        _worldModel = Helpers.CreateWorldModel();
 
         // a
         // - b
@@ -19,23 +19,23 @@ public class ElementsTests
         // - e
         // f
 
-        var a = m_worldModel.GetElementFactory(ElementType.Object).Create("a");
-        var b = m_worldModel.GetElementFactory(ElementType.Object).Create("b");
+        var a = _worldModel.GetElementFactory(ElementType.Object).Create("a");
+        var b = _worldModel.GetElementFactory(ElementType.Object).Create("b");
         b.Parent = a;
-        var c = m_worldModel.GetElementFactory(ElementType.Object).Create("c");
+        var c = _worldModel.GetElementFactory(ElementType.Object).Create("c");
         c.Parent = b;
-        var d = m_worldModel.GetElementFactory(ElementType.Object).Create("d");
+        var d = _worldModel.GetElementFactory(ElementType.Object).Create("d");
         d.Parent = b;
-        var e = m_worldModel.GetElementFactory(ElementType.Object).Create("e");
+        var e = _worldModel.GetElementFactory(ElementType.Object).Create("e");
         e.Parent = a;
-        var f = m_worldModel.GetElementFactory(ElementType.Object).Create("f");
+        var f = _worldModel.GetElementFactory(ElementType.Object).Create("f");
     }
 
     [TestMethod]
     public void TestGetChildrenOfA()
     {
         var childList = new List<string>(
-            m_worldModel.Elements.GetChildElements(m_worldModel.Elements.Get("a")).Select(e => e.Name));
+            _worldModel.Elements.GetChildElements(_worldModel.Elements.Get("a")).Select(e => e.Name));
 
         // all children of a should be b,c,d,e
 
@@ -50,7 +50,7 @@ public class ElementsTests
     public void TestGetChildrenOfF()
     {
         var childList = new List<string>(
-            m_worldModel.Elements.GetChildElements(m_worldModel.Elements.Get("f")).Select(e => e.Name));
+            _worldModel.Elements.GetChildElements(_worldModel.Elements.Get("f")).Select(e => e.Name));
 
         // no children of f
 
@@ -61,18 +61,18 @@ public class ElementsTests
     public void TestSortIndexes()
     {
         // d is after c
-        Assert.IsTrue(m_worldModel.Elements.Get("d").MetaFields[MetaFieldDefinitions.SortIndex]
-                      > m_worldModel.Elements.Get("c").MetaFields[MetaFieldDefinitions.SortIndex],
+        Assert.IsTrue(_worldModel.Elements.Get("d").MetaFields[MetaFieldDefinitions.SortIndex]
+                      > _worldModel.Elements.Get("c").MetaFields[MetaFieldDefinitions.SortIndex],
             "d should be after c in the sort order");
 
         // e is after b
-        Assert.IsTrue(m_worldModel.Elements.Get("e").MetaFields[MetaFieldDefinitions.SortIndex]
-                      > m_worldModel.Elements.Get("b").MetaFields[MetaFieldDefinitions.SortIndex],
+        Assert.IsTrue(_worldModel.Elements.Get("e").MetaFields[MetaFieldDefinitions.SortIndex]
+                      > _worldModel.Elements.Get("b").MetaFields[MetaFieldDefinitions.SortIndex],
             "e should be after b in the sort order");
 
         // f is after a
-        Assert.IsTrue(m_worldModel.Elements.Get("f").MetaFields[MetaFieldDefinitions.SortIndex]
-                      > m_worldModel.Elements.Get("a").MetaFields[MetaFieldDefinitions.SortIndex],
+        Assert.IsTrue(_worldModel.Elements.Get("f").MetaFields[MetaFieldDefinitions.SortIndex]
+                      > _worldModel.Elements.Get("a").MetaFields[MetaFieldDefinitions.SortIndex],
             "f should be after a in the sort order");
     }
 
@@ -87,26 +87,26 @@ public class ElementsTests
         // - d
         // f
 
-        var d = m_worldModel.Elements.Get("d");
-        d.Parent = m_worldModel.Elements.Get("a");
+        var d = _worldModel.Elements.Get("d");
+        d.Parent = _worldModel.Elements.Get("a");
 
         // e is after b
-        Assert.IsTrue(m_worldModel.Elements.Get("e").MetaFields[MetaFieldDefinitions.SortIndex]
-                      > m_worldModel.Elements.Get("b").MetaFields[MetaFieldDefinitions.SortIndex],
+        Assert.IsTrue(_worldModel.Elements.Get("e").MetaFields[MetaFieldDefinitions.SortIndex]
+                      > _worldModel.Elements.Get("b").MetaFields[MetaFieldDefinitions.SortIndex],
             "e should be after b in the sort order");
 
         // d is after e
-        Assert.IsTrue(m_worldModel.Elements.Get("d").MetaFields[MetaFieldDefinitions.SortIndex]
-                      > m_worldModel.Elements.Get("e").MetaFields[MetaFieldDefinitions.SortIndex],
+        Assert.IsTrue(_worldModel.Elements.Get("d").MetaFields[MetaFieldDefinitions.SortIndex]
+                      > _worldModel.Elements.Get("e").MetaFields[MetaFieldDefinitions.SortIndex],
             "d should be after e in the sort order");
     }
 
     [TestMethod]
     public void UpdateParentByFieldName()
     {
-        var element = m_worldModel.GetElementFactory(ElementType.Object).Create("element");
-        var parent1 = m_worldModel.GetElementFactory(ElementType.Object).Create("parent");
-        var parent2 = m_worldModel.GetElementFactory(ElementType.Object).Create("parent2");
+        var element = _worldModel.GetElementFactory(ElementType.Object).Create("element");
+        var parent1 = _worldModel.GetElementFactory(ElementType.Object).Create("parent");
+        var parent2 = _worldModel.GetElementFactory(ElementType.Object).Create("parent2");
 
         element.Parent = parent1;
         Assert.AreEqual(parent1, element.Parent);

--- a/tests/EngineTests/FieldsTests.cs
+++ b/tests/EngineTests/FieldsTests.cs
@@ -5,24 +5,24 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class FieldsTests
 {
-    private const string inheritedAttributeName = "inheritedattribute";
-    private const string inheritedAttributeValue = "inheritedattributevalue";
+    private const string InheritedAttributeName = "inheritedattribute";
+    private const string InheritedAttributeValue = "inheritedattributevalue";
 
-    private const string inheritedAttribute2Name = "otherattribute";
-    private const string inheritedAttribute2Value = "othervalue";
+    private const string InheritedAttribute2Name = "otherattribute";
+    private const string InheritedAttribute2Value = "othervalue";
 
-    private const string attributeDefinedByDefaultName = "somedefaultattribute";
-    private const string attributeDefinedByDefaultValue = "somedefaultvalue";
+    private const string AttributeDefinedByDefaultName = "somedefaultattribute";
+    private const string AttributeDefinedByDefaultValue = "somedefaultvalue";
 
-    private const string attributeDefinedByDefault2Name = "otherdefaultattribute";
-    private const string attributeDefinedByDefault2Value = "otherdefaultvalue";
-    private const string attributeDefinedByDefault2OverriddenValue = "overriddendefaultvalue";
-    private Element m_defaultType;
-    private Element m_object;
-    private Element m_objectType;
-    private Element m_subType;
+    private const string AttributeDefinedByDefault2Name = "otherdefaultattribute";
+    private const string AttributeDefinedByDefault2Value = "otherdefaultvalue";
+    private const string AttributeDefinedByDefault2OverriddenValue = "overriddendefaultvalue";
+    private Element _defaultType;
+    private Element _object;
+    private Element _objectType;
+    private Element _subType;
 
-    private WorldModel m_worldModel;
+    private WorldModel _worldModel;
 
     [TestInitialize]
     public void Setup()
@@ -31,23 +31,23 @@ public class FieldsTests
         const string subInheritedTypeName = "subtype";
         const string defaultObject = "defaultobject";
 
-        m_worldModel = Helpers.CreateWorldModel();
+        _worldModel = Helpers.CreateWorldModel();
 
-        m_defaultType = m_worldModel.GetElementFactory(ElementType.ObjectType).Create(defaultObject);
-        m_defaultType.Fields.Set(attributeDefinedByDefaultName, attributeDefinedByDefaultValue);
-        m_defaultType.Fields.Set(attributeDefinedByDefault2Name, attributeDefinedByDefault2Value);
+        _defaultType = _worldModel.GetElementFactory(ElementType.ObjectType).Create(defaultObject);
+        _defaultType.Fields.Set(AttributeDefinedByDefaultName, AttributeDefinedByDefaultValue);
+        _defaultType.Fields.Set(AttributeDefinedByDefault2Name, AttributeDefinedByDefault2Value);
 
-        m_subType = m_worldModel.GetElementFactory(ElementType.ObjectType).Create(subInheritedTypeName);
-        m_subType.Fields.Set(inheritedAttribute2Name, inheritedAttribute2Value);
-        m_subType.Fields.Set(attributeDefinedByDefault2Name, attributeDefinedByDefault2OverriddenValue);
+        _subType = _worldModel.GetElementFactory(ElementType.ObjectType).Create(subInheritedTypeName);
+        _subType.Fields.Set(InheritedAttribute2Name, InheritedAttribute2Value);
+        _subType.Fields.Set(AttributeDefinedByDefault2Name, AttributeDefinedByDefault2OverriddenValue);
 
-        m_objectType = m_worldModel.GetElementFactory(ElementType.ObjectType).Create(inheritedTypeName);
-        m_objectType.Fields.Set(inheritedAttributeName, inheritedAttributeValue);
-        m_objectType.Fields.AddType(m_subType);
+        _objectType = _worldModel.GetElementFactory(ElementType.ObjectType).Create(inheritedTypeName);
+        _objectType.Fields.Set(InheritedAttributeName, InheritedAttributeValue);
+        _objectType.Fields.AddType(_subType);
 
-        m_object = m_worldModel.GetElementFactory(ElementType.Object).Create("object");
-        m_object.Fields.Resolve(null);
-        m_object.Fields.AddType(m_objectType);
+        _object = _worldModel.GetElementFactory(ElementType.Object).Create("object");
+        _object.Fields.Resolve(null);
+        _object.Fields.AddType(_objectType);
     }
 
     [TestMethod]
@@ -56,71 +56,71 @@ public class FieldsTests
         const string property = "property";
         const string value1 = "first value";
         const string value2 = "second value";
-        m_object.Fields.Set(property, value1);
-        Assert.AreEqual(value1, m_object.Fields.Get(property));
+        _object.Fields.Set(property, value1);
+        Assert.AreEqual(value1, _object.Fields.Get(property));
 
-        m_worldModel.UndoLogger.StartTransaction("Set value2");
-        m_object.Fields.Set(property, value2);
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.StartTransaction("Set value2");
+        _object.Fields.Set(property, value2);
+        _worldModel.UndoLogger.EndTransaction();
 
-        Assert.AreEqual(value2, m_object.Fields.Get(property));
-        m_worldModel.UndoLogger.Undo();
-        Assert.AreEqual(value1, m_object.Fields.Get(property));
+        Assert.AreEqual(value2, _object.Fields.Get(property));
+        _worldModel.UndoLogger.Undo();
+        Assert.AreEqual(value1, _object.Fields.Get(property));
     }
 
     [TestMethod]
     public void TestInheritedFields()
     {
         const string newValue = "newvalue";
-        Assert.AreEqual(inheritedAttributeValue, m_object.Fields.Get(inheritedAttributeName));
+        Assert.AreEqual(InheritedAttributeValue, _object.Fields.Get(InheritedAttributeName));
 
-        m_worldModel.UndoLogger.StartTransaction("Override inherited field value");
-        m_object.Fields.Set(inheritedAttributeName, newValue);
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.StartTransaction("Override inherited field value");
+        _object.Fields.Set(InheritedAttributeName, newValue);
+        _worldModel.UndoLogger.EndTransaction();
 
-        Assert.AreEqual(newValue, m_object.Fields.Get(inheritedAttributeName));
-        m_worldModel.UndoLogger.Undo();
-        Assert.AreEqual(inheritedAttributeValue, m_object.Fields.Get(inheritedAttributeName));
+        Assert.AreEqual(newValue, _object.Fields.Get(InheritedAttributeName));
+        _worldModel.UndoLogger.Undo();
+        Assert.AreEqual(InheritedAttributeValue, _object.Fields.Get(InheritedAttributeName));
     }
 
     [TestMethod]
     public void TestSubinheritedFields()
     {
         // Test fields from:
-        //    m_subType -> m_objectType -> m_object
-        Assert.AreEqual(inheritedAttribute2Value, m_object.Fields.Get(inheritedAttribute2Name));
+        //    _subType -> _objectType -> _object
+        Assert.AreEqual(InheritedAttribute2Value, _object.Fields.Get(InheritedAttribute2Name));
 
         // Test that defaultobject values are picked up
-        Assert.AreEqual(attributeDefinedByDefaultValue, m_object.Fields.Get(attributeDefinedByDefaultName));
+        Assert.AreEqual(AttributeDefinedByDefaultValue, _object.Fields.Get(AttributeDefinedByDefaultName));
 
         // Test a defaultobject value overridden by a subtype
-        Assert.AreEqual(attributeDefinedByDefault2OverriddenValue, m_object.Fields.Get(attributeDefinedByDefault2Name));
+        Assert.AreEqual(AttributeDefinedByDefault2OverriddenValue, _object.Fields.Get(AttributeDefinedByDefault2Name));
     }
 
     [TestMethod]
     public void TestObjectCreationUndo()
     {
-        m_worldModel.UndoLogger.StartTransaction("Create new object");
-        m_worldModel.GetElementFactory(ElementType.Object).Create("newobj");
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.StartTransaction("Create new object");
+        _worldModel.GetElementFactory(ElementType.Object).Create("newobj");
+        _worldModel.UndoLogger.EndTransaction();
 
         // There should be 3 elements now - game, object, newobj
-        Assert.AreEqual(3, m_worldModel.Elements.GetElements(ElementType.Object).Count());
+        Assert.AreEqual(3, _worldModel.Elements.GetElements(ElementType.Object).Count());
 
-        m_worldModel.UndoLogger.Undo();
+        _worldModel.UndoLogger.Undo();
 
         // Now we should have 2 elements again
-        Assert.AreEqual(2, m_worldModel.Elements.GetElements(ElementType.Object).Count());
+        Assert.AreEqual(2, _worldModel.Elements.GetElements(ElementType.Object).Count());
     }
 
     [TestMethod]
     public void TestObjectDeletionUndo()
     {
-        var obj = m_worldModel.GetElementFactory(ElementType.Object).Create("newobj");
-        var type = m_worldModel.GetElementFactory(ElementType.ObjectType).Create("objtype");
+        var obj = _worldModel.GetElementFactory(ElementType.Object).Create("newobj");
+        var type = _worldModel.GetElementFactory(ElementType.ObjectType).Create("objtype");
         type.Fields.Set("attrfromtype", "attrvalue");
         type.Fields.Set("overridenattr", "valuefromtype1");
-        var type2 = m_worldModel.GetElementFactory(ElementType.ObjectType).Create("objtype2");
+        var type2 = _worldModel.GetElementFactory(ElementType.ObjectType).Create("objtype2");
         type2.Fields.Set("overridenattr", "valuefromtype2");
         obj.Fields.AddType(type);
         obj.Fields.AddType(type2);
@@ -131,53 +131,53 @@ public class FieldsTests
         Assert.AreEqual("fromobjvalue", obj.Fields.GetString("attrfromobj"));
         Assert.AreEqual("attrvalue", obj.Fields.GetString("attrfromtype"));
         Assert.AreEqual("valuefromtype2", obj.Fields.GetString("overridenattr"));
-        Assert.AreEqual(attributeDefinedByDefaultValue, obj.Fields.GetString(attributeDefinedByDefaultName));
-        Assert.AreEqual(attributeDefinedByDefault2Value, obj.Fields.GetString(attributeDefinedByDefault2Name));
+        Assert.AreEqual(AttributeDefinedByDefaultValue, obj.Fields.GetString(AttributeDefinedByDefaultName));
+        Assert.AreEqual(AttributeDefinedByDefault2Value, obj.Fields.GetString(AttributeDefinedByDefault2Name));
 
         // There should be 3 elements now - game, object, newobj
-        Assert.AreEqual(3, m_worldModel.Elements.GetElements(ElementType.Object).Count());
+        Assert.AreEqual(3, _worldModel.Elements.GetElements(ElementType.Object).Count());
 
         // Delete the object
-        m_worldModel.UndoLogger.StartTransaction("Destroy object");
-        m_worldModel.GetElementFactory(ElementType.Object).DestroyElement("newobj");
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.StartTransaction("Destroy object");
+        _worldModel.GetElementFactory(ElementType.Object).DestroyElement("newobj");
+        _worldModel.UndoLogger.EndTransaction();
 
         // Now we should have 2 elements again
-        Assert.AreEqual(2, m_worldModel.Elements.GetElements(ElementType.Object).Count());
+        Assert.AreEqual(2, _worldModel.Elements.GetElements(ElementType.Object).Count());
 
         // Undo the deletion
-        m_worldModel.UndoLogger.Undo();
+        _worldModel.UndoLogger.Undo();
 
         // There should be 3 elements now - game, object, newobj
-        Assert.AreEqual(3, m_worldModel.Elements.GetElements(ElementType.Object).Count());
+        Assert.AreEqual(3, _worldModel.Elements.GetElements(ElementType.Object).Count());
 
         // Ensure our object reference is pointing to the one in the worldmodel
-        obj = m_worldModel.Elements.Get(ElementType.Object, "newobj");
+        obj = _worldModel.Elements.Get(ElementType.Object, "newobj");
 
         // Test the initial values again
         Assert.AreEqual("fromobjvalue", obj.Fields.GetString("attrfromobj"));
         Assert.AreEqual("attrvalue", obj.Fields.GetString("attrfromtype"));
         Assert.AreEqual("valuefromtype2", obj.Fields.GetString("overridenattr"));
-        Assert.AreEqual(attributeDefinedByDefaultValue, obj.Fields.GetString(attributeDefinedByDefaultName));
+        Assert.AreEqual(AttributeDefinedByDefaultValue, obj.Fields.GetString(AttributeDefinedByDefaultName));
     }
 
     [TestMethod]
     public void TestMetaFieldUndoRedo()
     {
-        var obj = m_worldModel.GetElementFactory(ElementType.Object).Create("newobj");
+        var obj = _worldModel.GetElementFactory(ElementType.Object).Create("newobj");
         const string initialValue = "initialValue";
         const string alteredValue = "alteredValue";
 
         obj.MetaFields[MetaFieldDefinitions.Filename] = initialValue;
         Assert.AreEqual(initialValue, obj.MetaFields[MetaFieldDefinitions.Filename]);
 
-        m_worldModel.UndoLogger.StartTransaction("Set metafield");
+        _worldModel.UndoLogger.StartTransaction("Set metafield");
         obj.MetaFields[MetaFieldDefinitions.Filename] = alteredValue;
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.EndTransaction();
 
         Assert.AreEqual(alteredValue, obj.MetaFields[MetaFieldDefinitions.Filename]);
 
-        m_worldModel.UndoLogger.Undo();
+        _worldModel.UndoLogger.Undo();
 
         Assert.AreEqual(initialValue, obj.MetaFields[MetaFieldDefinitions.Filename]);
     }

--- a/tests/EngineTests/MultiScriptTests.cs
+++ b/tests/EngineTests/MultiScriptTests.cs
@@ -7,12 +7,12 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class MultiScriptTests
 {
-    private WorldModel m_worldModel;
+    private WorldModel _worldModel;
 
     [TestInitialize]
     public void Setup()
     {
-        m_worldModel = Helpers.CreateWorldModel();
+        _worldModel = Helpers.CreateWorldModel();
     }
 
     private MultiScript CreateMultiScript(params string[] lines)
@@ -28,8 +28,8 @@ public class MultiScriptTests
             source.Add(script.Object);
         }
 
-        var result = new MultiScript(m_worldModel, source.ToArray());
-        result.UndoLog = m_worldModel.UndoLogger;
+        var result = new MultiScript(_worldModel, source.ToArray());
+        result.UndoLog = _worldModel.UndoLogger;
 
         return result;
     }
@@ -55,9 +55,9 @@ public class MultiScriptTests
 
         // Swap lines 2 and 3
 
-        m_worldModel.UndoLogger.StartTransaction("Swap lines 2 and 3");
+        _worldModel.UndoLogger.StartTransaction("Swap lines 2 and 3");
         multiScript.Swap(1, 2);
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.EndTransaction();
 
         // Check they are swapped correctly
 
@@ -65,24 +65,24 @@ public class MultiScriptTests
 
         // Undo - should be back to original
 
-        await m_worldModel.UndoLogger.Undo();
+        await _worldModel.UndoLogger.Undo();
         Assert.AreEqual("line 1;line 2;line 3;line 4", GetLinesString(multiScript));
 
         // Redo - lines 2 and 3 swapped again
 
-        m_worldModel.UndoLogger.Redo();
+        _worldModel.UndoLogger.Redo();
         Assert.AreEqual("line 1;line 3;line 2;line 4", GetLinesString(multiScript));
 
         // Undo - should be back to original
 
-        await m_worldModel.UndoLogger.Undo();
+        await _worldModel.UndoLogger.Undo();
         Assert.AreEqual("line 1;line 2;line 3;line 4", GetLinesString(multiScript));
 
         // Now swap two non-consecutive elements, lines 1 and 4
 
-        m_worldModel.UndoLogger.StartTransaction("Swap lines 1 and 4");
+        _worldModel.UndoLogger.StartTransaction("Swap lines 1 and 4");
         multiScript.Swap(0, 3);
-        m_worldModel.UndoLogger.EndTransaction();
+        _worldModel.UndoLogger.EndTransaction();
 
         // Check they are swapped correctly
 
@@ -90,7 +90,7 @@ public class MultiScriptTests
 
         // Undo - should be back to original
 
-        await m_worldModel.UndoLogger.Undo();
+        await _worldModel.UndoLogger.Undo();
         Assert.AreEqual("line 1;line 2;line 3;line 4", GetLinesString(multiScript));
     }
 }

--- a/tests/EngineTests/QuestListTest.cs
+++ b/tests/EngineTests/QuestListTest.cs
@@ -5,17 +5,17 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class QuestListTest
 {
-    private Element a, b, c;
-    private WorldModel m_worldModel;
+    private Element _a, _b, _c;
+    private WorldModel _worldModel;
 
     [TestInitialize]
     public void Setup()
     {
-        m_worldModel = Helpers.CreateWorldModel();
+        _worldModel = Helpers.CreateWorldModel();
 
-        a = m_worldModel.GetElementFactory(ElementType.Object).Create("a");
-        b = m_worldModel.GetElementFactory(ElementType.Object).Create("b");
-        c = m_worldModel.GetElementFactory(ElementType.Object).Create("c");
+        _a = _worldModel.GetElementFactory(ElementType.Object).Create("a");
+        _b = _worldModel.GetElementFactory(ElementType.Object).Create("b");
+        _c = _worldModel.GetElementFactory(ElementType.Object).Create("c");
     }
 
     [TestMethod]
@@ -29,10 +29,10 @@ public class QuestListTest
         Assert.IsTrue(actual.SequenceEqual(expected));
 
         //element lists
-        var elList = new QuestList<Element> {a, a, b, c};
+        var elList = new QuestList<Element> {_a, _a, _b, _c};
 
-        var expectedEList = new QuestList<Element> {b, c};
-        var actualEList = elList.Exclude(a);
+        var expectedEList = new QuestList<Element> {_b, _c};
+        var actualEList = elList.Exclude(_a);
         Assert.IsTrue(actualEList.SequenceEqual(expectedEList));
     }
 
@@ -48,10 +48,10 @@ public class QuestListTest
         Assert.IsTrue(actual.SequenceEqual(expected));
 
         //element lists
-        var elList = new QuestList<Element> {a, a, b, c};
-        var excludeEList = new QuestList<Element> {a, b};
+        var elList = new QuestList<Element> {_a, _a, _b, _c};
+        var excludeEList = new QuestList<Element> {_a, _b};
 
-        var expectedEList = new QuestList<Element> {c};
+        var expectedEList = new QuestList<Element> {_c};
         var actualEList = elList.Exclude(excludeEList);
         Assert.IsTrue(actualEList.SequenceEqual(expectedEList));
     }

--- a/tests/EngineTests/RegistrationTests.cs
+++ b/tests/EngineTests/RegistrationTests.cs
@@ -76,7 +76,7 @@ public class RegistrationTests
     {
         var factory = new ScriptFactory(new WorldModel());
         var registered = (Dictionary<string, IScriptConstructor>)
-            typeof(ScriptFactory).GetField("m_scriptConstructors", NonPublicInstance)!.GetValue(factory)!;
+            typeof(ScriptFactory).GetField("_scriptConstructors", NonPublicInstance)!.GetValue(factory)!;
 
         var missing = FindImplementations(typeof(IScriptConstructor))
             .Select(t => (IScriptConstructor)Activator.CreateInstance(t)!)

--- a/tests/EngineTests/SwitchScriptConstructorTest.cs
+++ b/tests/EngineTests/SwitchScriptConstructorTest.cs
@@ -6,23 +6,23 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class SwitchScriptConstructorTest
 {
-    private SwitchScriptConstructor m_constructor;
-    private ScriptFactory m_scriptFactory;
-    private WorldModel m_worldModel;
+    private SwitchScriptConstructor _constructor;
+    private ScriptFactory _scriptFactory;
+    private WorldModel _worldModel;
 
-    private ScriptContext scriptContext;
+    private ScriptContext _scriptContext;
 
     [TestInitialize]
     public void Setup()
     {
-        m_worldModel = Helpers.CreateWorldModel();
-        m_scriptFactory = new ScriptFactory(m_worldModel);
+        _worldModel = Helpers.CreateWorldModel();
+        _scriptFactory = new ScriptFactory(_worldModel);
 
-        m_constructor = new SwitchScriptConstructor();
-        m_constructor.WorldModel = m_worldModel;
-        m_constructor.ScriptFactory = m_scriptFactory;
+        _constructor = new SwitchScriptConstructor();
+        _constructor.WorldModel = _worldModel;
+        _constructor.ScriptFactory = _scriptFactory;
 
-        scriptContext = new ScriptContext(m_worldModel);
+        _scriptContext = new ScriptContext(_worldModel);
     }
 
     [TestMethod]
@@ -33,7 +33,7 @@ public class SwitchScriptConstructorTest
                 msg (""!"")
             }
             }";
-        var script = m_constructor.Create(text, scriptContext);
+        var script = _constructor.Create(text, _scriptContext);
         var actualCases = (QuestDictionary<IScript>) script.GetParameter(1);
 
         Assert.AreEqual(1, actualCases.Count);
@@ -44,7 +44,7 @@ public class SwitchScriptConstructorTest
                 msg (""!"")
             }
             }";
-        script = m_constructor.Create(text, scriptContext);
+        script = _constructor.Create(text, _scriptContext);
         actualCases = (QuestDictionary<IScript>) script.GetParameter(1);
 
         Assert.AreEqual(2, actualCases.Count);

--- a/tests/EngineTests/TemplateTests.cs
+++ b/tests/EngineTests/TemplateTests.cs
@@ -7,39 +7,39 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class TemplateTests
 {
-    private WorldModel m_worldModel;
+    private WorldModel _worldModel;
 
     [TestInitialize]
     public void Init()
     {
-        m_worldModel = Helpers.CreateWorldModel();
-        m_worldModel.Template.AddTemplate("Test1", "my text", false);
-        m_worldModel.Template.AddTemplate("Test2", "other text", false);
+        _worldModel = Helpers.CreateWorldModel();
+        _worldModel.Template.AddTemplate("Test1", "my text", false);
+        _worldModel.Template.AddTemplate("Test2", "other text", false);
     }
 
     [TestMethod]
     public void TestGetText()
     {
-        Assert.AreEqual("my text", m_worldModel.Template.GetText("Test1"));
-        Assert.AreEqual("other text", m_worldModel.Template.GetText("Test2"));
+        Assert.AreEqual("my text", _worldModel.Template.GetText("Test1"));
+        Assert.AreEqual("other text", _worldModel.Template.GetText("Test2"));
     }
 
     [TestMethod]
     public void TestReplaceTemplateText()
     {
-        Assert.AreEqual("this is my text", m_worldModel.Template.ReplaceTemplateText("this is [Test1]"));
-        Assert.AreEqual("this is other text", m_worldModel.Template.ReplaceTemplateText("this is [Test2]"));
-        Assert.AreEqual("my text is my other text", m_worldModel.Template.ReplaceTemplateText("[Test1] is my [Test2]"));
+        Assert.AreEqual("this is my text", _worldModel.Template.ReplaceTemplateText("this is [Test1]"));
+        Assert.AreEqual("this is other text", _worldModel.Template.ReplaceTemplateText("this is [Test2]"));
+        Assert.AreEqual("my text is my other text", _worldModel.Template.ReplaceTemplateText("[Test1] is my [Test2]"));
     }
 
     [TestMethod]
     public void TestReplaceTemplateText_InvalidTemplateNames()
     {
-        Assert.AreEqual("[unknown]", m_worldModel.Template.ReplaceTemplateText("[unknown]"));
-        Assert.AreEqual("[unknown] and my text", m_worldModel.Template.ReplaceTemplateText("[unknown] and [Test1]"));
-        Assert.AreEqual("other text and [unknown]", m_worldModel.Template.ReplaceTemplateText("[Test2] and [unknown]"));
+        Assert.AreEqual("[unknown]", _worldModel.Template.ReplaceTemplateText("[unknown]"));
+        Assert.AreEqual("[unknown] and my text", _worldModel.Template.ReplaceTemplateText("[unknown] and [Test1]"));
+        Assert.AreEqual("other text and [unknown]", _worldModel.Template.ReplaceTemplateText("[Test2] and [unknown]"));
         Assert.AreEqual("[unknown1], my text, [unknown2], other text",
-            m_worldModel.Template.ReplaceTemplateText("[unknown1], [Test1], [unknown2], [Test2]"));
+            _worldModel.Template.ReplaceTemplateText("[unknown1], [Test1], [unknown2], [Test2]"));
     }
 
     // Regression test for a bug affecting games loaded as a bare .aslx (not a compiled .quest

--- a/tests/LegacyTests/TestPlayer.cs
+++ b/tests/LegacyTests/TestPlayer.cs
@@ -4,9 +4,9 @@ namespace QuestViva.LegacyTests;
 
 internal class TestPlayer : IPlayer
 {
-    private readonly List<string> m_output = new();
+    private readonly List<string> _output = new();
 
-    public int BufferLength => m_output.Count;
+    public int BufferLength => _output.Count;
 
     public MenuData LatestMenu { get; set; }
 
@@ -170,12 +170,12 @@ internal class TestPlayer : IPlayer
 
     public void ClearBuffer()
     {
-        m_output.Clear();
+        _output.Clear();
     }
 
     public string Buffer(int index)
     {
-        return m_output[index];
+        return _output[index];
     }
 
     public void PrintText(string text)
@@ -187,6 +187,6 @@ internal class TestPlayer : IPlayer
 
         // remove <output> and </output>
         text = text.Substring(8, text.Length - 17);
-        m_output.Add(text);
+        _output.Add(text);
     }
 }

--- a/tests/LegacyTests/V4GameTests.cs
+++ b/tests/LegacyTests/V4GameTests.cs
@@ -6,8 +6,8 @@ namespace QuestViva.LegacyTests;
 [TestClass]
 public class V4GameTests
 {
-    private readonly TestPlayer m_player = new();
-    private IGame m_game;
+    private readonly TestPlayer _player = new();
+    private IGame _game;
 
     [TestInitialize]
     public async Task Init()
@@ -15,97 +15,97 @@ public class V4GameTests
         var filename = Path.Combine(["..", "..", "..", "test1.asl"]);
         var gameDataProvider = new FileGameDataProvider(filename);
         var gameData = await gameDataProvider.GetData();
-        m_game = new V4Game(gameData, null);
-        m_game.PrintText += m_player.PrintText;
-        await m_game.Initialise(m_player);
-        await m_game.Begin();
+        _game = new V4Game(gameData, null);
+        _game.PrintText += _player.PrintText;
+        await _game.Initialise(_player);
+        await _game.Begin();
     }
 
     [TestMethod]
     public async Task TestLookAt()
     {
-        m_player.ClearBuffer();
-        await m_game.SendCommand("look at object");
-        Assert.AreEqual("&gt; look at object", m_player.Buffer(0));
-        Assert.AreEqual("object look desc", m_player.Buffer(1));
+        _player.ClearBuffer();
+        await _game.SendCommand("look at object");
+        Assert.AreEqual("&gt; look at object", _player.Buffer(0));
+        Assert.AreEqual("object look desc", _player.Buffer(1));
     }
 
     [TestMethod]
     public async Task TestWait()
     {
-        m_player.ClearBuffer();
-        await m_game.SendCommand("wait");
-        Assert.AreEqual("Start wait", m_player.Buffer(1));
-        Assert.AreEqual(true, m_player.IsWaiting);
-        Assert.AreEqual(2, m_player.BufferLength, "Expected nothing else in the output buffer after the wait command");
-        m_player.IsWaiting = false;
-        await m_game.FinishWait();
-        Assert.AreEqual("Done wait", m_player.Buffer(2));
+        _player.ClearBuffer();
+        await _game.SendCommand("wait");
+        Assert.AreEqual("Start wait", _player.Buffer(1));
+        Assert.AreEqual(true, _player.IsWaiting);
+        Assert.AreEqual(2, _player.BufferLength, "Expected nothing else in the output buffer after the wait command");
+        _player.IsWaiting = false;
+        await _game.FinishWait();
+        Assert.AreEqual("Done wait", _player.Buffer(2));
     }
 
     [TestMethod]
     public async Task TestEnter()
     {
-        m_player.ClearBuffer();
-        await m_game.SendCommand("enter");
-        Assert.AreEqual("Enter text", m_player.Buffer(1));
-        Assert.AreEqual(2, m_player.BufferLength, "Expected nothing else in the output buffer after the enter command");
-        await m_game.SendCommand("response");
-        Assert.AreEqual("You entered: response", m_player.Buffer(2));
+        _player.ClearBuffer();
+        await _game.SendCommand("enter");
+        Assert.AreEqual("Enter text", _player.Buffer(1));
+        Assert.AreEqual(2, _player.BufferLength, "Expected nothing else in the output buffer after the enter command");
+        await _game.SendCommand("response");
+        Assert.AreEqual("You entered: response", _player.Buffer(2));
     }
 
     [TestMethod]
     public async Task TestMenu()
     {
-        m_player.ClearBuffer();
-        m_player.LatestMenu = null;
-        await m_game.SendCommand("x twin");
-        Assert.AreEqual("- <i>Please select which twin you mean:</i>", m_player.Buffer(1));
-        Assert.AreEqual(2, m_player.BufferLength, "Expected nothing else in the output buffer after menu displayed");
-        Assert.AreNotEqual(null, m_player.LatestMenu);
-        Assert.AreEqual(2, m_player.LatestMenu.Options.Count);
-        Assert.AreEqual("Twin 1", m_player.LatestMenu.Options.ElementAt(0).Value);
-        Assert.AreEqual("Twin 2", m_player.LatestMenu.Options.ElementAt(1).Value);
-        await m_game.SetMenuResponse(m_player.LatestMenu.Options.ElementAt(0).Key);
-        Assert.AreEqual("It's twin 1", m_player.Buffer(3));
+        _player.ClearBuffer();
+        _player.LatestMenu = null;
+        await _game.SendCommand("x twin");
+        Assert.AreEqual("- <i>Please select which twin you mean:</i>", _player.Buffer(1));
+        Assert.AreEqual(2, _player.BufferLength, "Expected nothing else in the output buffer after menu displayed");
+        Assert.AreNotEqual(null, _player.LatestMenu);
+        Assert.AreEqual(2, _player.LatestMenu.Options.Count);
+        Assert.AreEqual("Twin 1", _player.LatestMenu.Options.ElementAt(0).Value);
+        Assert.AreEqual("Twin 2", _player.LatestMenu.Options.ElementAt(1).Value);
+        await _game.SetMenuResponse(_player.LatestMenu.Options.ElementAt(0).Key);
+        Assert.AreEqual("It's twin 1", _player.Buffer(3));
     }
 
     [TestMethod]
     public async Task TestAsk()
     {
-        m_player.ClearBuffer();
-        m_player.QuestionData = null;
-        await m_game.SendCommand("ask");
-        Assert.AreEqual("Some text", m_player.Buffer(1));
-        Assert.AreEqual(2, m_player.BufferLength, "Expected nothing else in the output buffer after question is asked");
-        Assert.AreEqual("question text", m_player.QuestionData);
-        await m_game.SetQuestionResponse(true);
-        Assert.AreEqual("response yes", m_player.Buffer(2));
+        _player.ClearBuffer();
+        _player.QuestionData = null;
+        await _game.SendCommand("ask");
+        Assert.AreEqual("Some text", _player.Buffer(1));
+        Assert.AreEqual(2, _player.BufferLength, "Expected nothing else in the output buffer after question is asked");
+        Assert.AreEqual("question text", _player.QuestionData);
+        await _game.SetQuestionResponse(true);
+        Assert.AreEqual("response yes", _player.Buffer(2));
     }
 
     [TestMethod]
     public async Task TestStatusVariables()
     {
-        Assert.AreEqual("Test variable: 0", m_player.StatusText);
-        await m_game.SendCommand("setstatus");
-        Assert.AreEqual("Test variable: 1", m_player.StatusText);
+        Assert.AreEqual("Test variable: 0", _player.StatusText);
+        await _game.SendCommand("setstatus");
+        Assert.AreEqual("Test variable: 1", _player.StatusText);
     }
 
     [TestMethod]
     public async Task TestLocation()
     {
-        Assert.AreEqual("Room", m_player.Location);
-        await m_game.SendCommand("south");
-        Assert.AreEqual("Room2", m_player.Location);
+        Assert.AreEqual("Room", _player.Location);
+        await _game.SendCommand("south");
+        Assert.AreEqual("Room2", _player.Location);
     }
 
     [TestMethod]
     public void TestInitialGameProperties()
     {
-        Assert.AreEqual("Unit Test 1", m_player.GameName);
-        Assert.AreEqual("#000000", m_player.Background);
-        Assert.AreEqual("#FFFFFF", m_player.Foreground);
-        Assert.AreEqual("TestFont", m_player.FontName);
-        Assert.AreEqual("30", m_player.FontSize);
+        Assert.AreEqual("Unit Test 1", _player.GameName);
+        Assert.AreEqual("#000000", _player.Background);
+        Assert.AreEqual("#FFFFFF", _player.Foreground);
+        Assert.AreEqual("TestFont", _player.FontName);
+        Assert.AreEqual("30", _player.FontSize);
     }
 }

--- a/tests/e2e/verify-appshell-verbs-editor.mjs
+++ b/tests/e2e/verify-appshell-verbs-editor.mjs
@@ -206,7 +206,7 @@ async function run() {
 
 
     // The new verb command element lands under the game's synthetic "Verbs" tree node (key
-    // "_gameVerbs" — see EditorController's k_verbs), alongside any library-defined verbs.
+    // "_gameVerbs" — see EditorController's Verbs), alongside any library-defined verbs.
     // The game node starts collapsed by default (#827), so expand it first to make its
     // Verbs/Commands/Advanced headers visible.
     await page.locator('[data-scope="tree-view"][data-value="game"][data-part="branch-control"] button[aria-label="Expand"]').click();

--- a/tests/e2e/verify-wasmplayer-debugger.mjs
+++ b/tests/e2e/verify-wasmplayer-debugger.mjs
@@ -196,7 +196,7 @@ check(
 // The table's Value column still shows the human-readable display string
 // (Element.ToString()'s "Type: name", e.g. "Object: kitchen"), but the
 // override input is pre-filled from DebugDataItem.EditValue — the same
-// value pre-formatted as valid script syntax (Fields.cs's s_editFormatters) —
+// value pre-formatted as valid script syntax (Fields.cs's EditFormatters) —
 // so it should show just the bare name, already appliable as-is.
 const parentValueCell = await previewPage.$eval('[data-attr-row="parent"] td:nth-child(2)', el => el.textContent);
 check('Value column shows the display form ("Object: kitchen")', /Object:\s*kitchen/i.test(parentValueCell));


### PR DESCRIPTION
Continues the C# cleanup started with the file-scoped namespace conversion, replacing the old VB-era `m_`/`s_`/`k_` prefixes with Rider's default naming conventions, and enforcing them at build time so they can't creep back in.

## Conventions
| Symbol | Style | Example |
|---|---|---|
| private instance field, private static (mutable) field | `_camelCase` | `m_worldModel` → `_worldModel` |
| private static readonly field, private const | `PascalCase` | `s_formatters` → `Formatters`, `k_verbs` → `Verbs` |
| local const | `camelCase` | `k_noType` → `noType` |

## What changed
- **456 field renames across the solution**, done with Roslyn's `Renamer` (semantic, cross-project) rather than regex, skipping anything that would clash with an existing symbol. Pure identifier changes — no BOM, line-ending, or whitespace churn.
- Handled by hand:
  - VB-style event handlers `m_x_Event` → `OnXEvent` (e.g. `m_source_Added` → `OnSourceAdded`)
  - `[GeneratedRegex]` methods that were still named like fields → PascalCase `*Regex` (e.g. `s_wordRegex1` → `WordRegex1`, `m_regex` → `PatternVariableRegex` / `CommandIdCharactersRegex`)
  - `EditableScript.s_regex` → `AttributeRegex` (plain `Regex` would shadow the type)
  - `RegistrationTests`' reflection lookup of `"m_scriptConstructors"`
- Comments / commented-out code / docs / AppShell + e2e comments referencing renamed fields updated to the new names (comment-only in `src/AppShell`). WorldModel's references to Quest 5.10.2's `m_callbacks` etc. deliberately left as-is, since they describe the old code.
- **Enforcement:** naming rules added to `.editorconfig` (`IDE1006` at warning), plus `EnforceCodeStyleInBuild` in `Directory.Build.props` — with the existing `TreatWarningsAsErrors`, a violation now fails the build.

## Follow-ups
- `.git-blame-ignore-revs` listing this PR's squash commit (plus `80f1c554`, the file-scoped namespace reformat) — has to be a separate PR since the squash hash only exists after merge.
- Nullability: next phase of the cleanup, per folder, starting with Engine's core types.

## Test plan
- [x] `dotnet build --configuration Release` and Debug: clean, no warnings
- [x] `dotnet test --configuration Release`: all 403 tests pass
- [x] Deliberate `private int m_probe;` fails the build with IDE1006 (probe removed)
- [x] Scripted diff check: every changed line is explained by the renames
- [x] `npm run lint` in `src/AppShell`
- [x] `node tests/e2e/find-affected-tests.mjs` → all 47 flagged scripts pass against a local AppShell dev server (fresh WasmEditor build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
