### PR TITLE
chore: add .git-blame-ignore-revs for bulk reformat and rename commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,20 @@
+# Bulk mechanical changes (reformatting, renames) to skip in `git blame`.
+# GitHub applies this automatically. Locally, opt in once with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# PRs are squash-merged, so list the squash commit on main, not branch commits.
+
+# File-scoped namespace (WorldModel.cs)
+33e62a49cc7439def416ee43bca99b8c7933ef63
+
+# Reformat and Cleanup (Rider bulk cleanup: file-scoped namespaces across all projects)
+80f1c554719d58996d86ce01ce3cce2234007e10
+
+# chore(Engine): normalize whitespace/encoding in Core .aslx libraries (#2064)
+41bb38e54c8c97d8ed4a158a25182f52a0966db8
+
+# chore(Engine): fix script indentation depth across Core .aslx libraries (#2065)
+b6bae26e592fc44a0fc39230147720ea819d8e4e
+
+# chore: adopt Rider naming conventions for fields and enforce at build time (#2238)
+7f08ebdbb05d0b1c337e52ca71c8328b3b81ca71


### PR DESCRIPTION
Adds a `.git-blame-ignore-revs` so `git blame` skips over bulk mechanical changes and attributes lines to the commit that actually last changed them. GitHub's blame view picks this file up automatically; locally, opt in once with:

```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

## Ignored commits
| Commit | What |
|---|---|
| `33e62a49` | File-scoped namespace conversion of `WorldModel.cs` (whitespace-only) |
| `80f1c554` | Rider "Reformat and Cleanup" across all C# projects (file-scoped namespaces) |
| `41bb38e5` | #2064 — normalize whitespace/encoding in Core `.aslx` libraries |
| `b6bae26e` | #2065 — fix script indentation depth in Core `.aslx` libraries (whitespace-only) |
| `7f08ebdb` | #2238 — field naming convention renames |

These were chosen by scanning history since 2024 for large commits that are mostly whitespace (`git show -w`), plus the #2238 rename. #2238 is listed by its squash commit on `main`, since branch commit hashes don't survive a squash merge.

## Test plan
- [x] `git blame --ignore-revs-file .git-blame-ignore-revs` sharply cuts the lines attributed to these commits:
  - `src/Engine/Fields.cs`: 1052 → 287 of 1482 lines
  - `src/EditorCore/EditorController.cs`: 2121 → 637 of 3269 lines
  - `src/Engine/Core/CoreCommands.aslx`: 1024 → 131 of 1035 lines

  The remainder are lines git's ignore heuristic can't match to an earlier version (e.g. lines Rider's cleanup rewrote rather than just re-indented). Those stay attributed to the ignored commit, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

