### PR TITLE
refactor(Engine): enable nullable reference types in core types

### DIFF
--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -11,7 +11,7 @@ public delegate void ErrorHandler(Exception ex);
 public interface IGame
 {
     List<string> Errors { get; }
-    string GameID { get; }
+    string? GameID { get; }
     Task<bool> Initialise(IPlayer player);
     Task Begin();
     Task SendCommand(string command);

--- a/src/Engine/Element.cs
+++ b/src/Engine/Element.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Common;
+﻿using QuestViva.Common;
 using QuestViva.Engine.Scripts;
 
 namespace QuestViva.Engine;
@@ -53,11 +52,12 @@ public class Element : IComparable
     private static readonly Dictionary<ElementType, string> ElemTypeStrings;
     private static readonly Dictionary<string, ElementType> MapElemTypeStringsToElementType;
 
-    private string _name;
+    // Set from the "name" field as part of creating the element, so is never null once in use
+    private string _name = null!;
 
-    private Element _parent;
+    private Element? _parent;
 
-    private string _text;
+    private string? _text;
     private ElementType _elemType;
 
     private ObjectType _type;
@@ -82,7 +82,7 @@ public class Element : IComparable
         foreach (ElementType t in Enum.GetValues<ElementType>())
         {
             ElemTypeStrings.Add(t,
-                ((ElementTypeInfo) typeof(ElementType).GetField(t.ToString())
+                ((ElementTypeInfo) typeof(ElementType).GetField(t.ToString())!
                     .GetCustomAttributes(typeof(ElementTypeInfo), false)[0]).Name);
         }
 
@@ -98,7 +98,7 @@ public class Element : IComparable
     {
     }
 
-    internal Element(WorldModel worldModel, Element element)
+    internal Element(WorldModel worldModel, Element? element)
     {
         _worldModel = worldModel;
 
@@ -131,13 +131,13 @@ public class Element : IComparable
         set => Fields.Set("name", value);
     }
 
-    public Element Parent
+    public Element? Parent
     {
         get => _parent;
         set => Fields.Set("parent", value);
     }
 
-    public string Text
+    public string? Text
     {
         get => _text;
         set => Fields.Set("text", value);
@@ -171,7 +171,7 @@ public class Element : IComparable
 
     internal WorldModel WorldModel => _worldModel;
 
-    public int CompareTo(object obj)
+    public int CompareTo(object? obj)
     {
         return this == obj ? 0 : -1;
     }
@@ -196,7 +196,7 @@ public class Element : IComparable
         return TypeStrings[type];
     }
 
-    private void Fields_AttributeChangedSilent(object sender, AttributeChangedEventArgs e)
+    private void Fields_AttributeChangedSilent(object? sender, AttributeChangedEventArgs e)
     {
         // used by the Editor to receive notifications of updates when undoing
         if (e.InheritedTypesSet)
@@ -205,16 +205,16 @@ public class Element : IComparable
         }
         else
         {
-            _worldModel.NotifyElementFieldUpdate(this, e.Property, e.Value, true);
+            _worldModel.NotifyElementFieldUpdate(this, e.Property!, e.Value, true);
         }
     }
 
-    private void Fields_AttributeChanged(object sender, AttributeChangedEventArgs e)
+    private void Fields_AttributeChanged(object? sender, AttributeChangedEventArgs e)
     {
-        _worldModel.NotifyElementFieldUpdate(this, e.Property, e.Value, false);
+        _worldModel.NotifyElementFieldUpdate(this, e.Property!, e.Value, false);
     }
 
-    internal async Task SetFieldAsync(string fieldName, object value)
+    internal async Task SetFieldAsync(string fieldName, object? value)
     {
         var oldValue = Fields.Get(fieldName);
         var changed = value == null ? oldValue != null : !value.Equals(oldValue);
@@ -222,25 +222,26 @@ public class Element : IComparable
         if (changed && !_worldModel.EditMode)
         {
             var changedScriptName = "changed" + fieldName;
-            if (Fields.HasType<IScript>(changedScriptName))
+            if (Fields.GetAsType<IScript>(changedScriptName) is { } changedScript)
             {
                 var parameters = new Parameters("oldvalue", oldValue);
-                await _worldModel.RunScriptAsync(Fields.GetAsType<IScript>(changedScriptName), parameters, this);
+                await _worldModel.RunScriptAsync(changedScript, parameters, this);
             }
         }
     }
 
-    private void MetaFields_AttributeChanged(object sender, AttributeChangedEventArgs e)
+    private void MetaFields_AttributeChanged(object? sender, AttributeChangedEventArgs e)
     {
-        _worldModel.NotifyElementMetaFieldUpdate(this, e.Property, e.Value, false);
+        _worldModel.NotifyElementMetaFieldUpdate(this, e.Property!, e.Value, false);
     }
 
-    private void MetaFields_AttributeChangedSilent(object sender, AttributeChangedEventArgs e)
+    private void MetaFields_AttributeChangedSilent(object? sender, AttributeChangedEventArgs e)
     {
-        _worldModel.NotifyElementMetaFieldUpdate(this, e.Property, e.Value, true);
+        // Inherited types are only ever added to Fields, never MetaFields, so this is always a property change
+        _worldModel.NotifyElementMetaFieldUpdate(this, e.Property!, e.Value, true);
     }
 
-    public IScript GetAction(string action)
+    public IScript? GetAction(string action)
     {
         return Fields.GetAsType<IScript>(action);
     }
@@ -250,7 +251,7 @@ public class Element : IComparable
         _name = name;
     }
 
-    internal void SetParentFromFields(Element parent)
+    internal void SetParentFromFields(Element? parent)
     {
         if (parent == this)
         {
@@ -261,7 +262,7 @@ public class Element : IComparable
         _parent = parent;
     }
 
-    internal void SetTextFromFields(string text)
+    internal void SetTextFromFields(string? text)
     {
         _text = text;
     }

--- a/src/Engine/Elements.cs
+++ b/src/Engine/Elements.cs
@@ -1,4 +1,5 @@
-﻿#nullable disable
+﻿using System.Diagnostics.CodeAnalysis;
+
 namespace QuestViva.Engine;
 
 public class Elements
@@ -37,7 +38,7 @@ public class Elements
 
     public IEnumerable<Element> Objects => GetElements(ElementType.Object);
 
-    public event EventHandler<NameChangedEventArgs> ElementRenamed;
+    public event EventHandler<NameChangedEventArgs>? ElementRenamed;
 
     public void Add(ElementType t, string key, Element e)
     {
@@ -85,7 +86,7 @@ public class Elements
         e.Fields.NameChanged += ElementNameChanged;
     }
 
-    private void ElementNameChanged(object sender, NameChangedEventArgs e)
+    private void ElementNameChanged(object? sender, NameChangedEventArgs e)
     {
         if (string.IsNullOrEmpty(e.Element.Name))
         {
@@ -119,7 +120,7 @@ public class Elements
 
     // Called by Element.SetParentFromFields whenever an element's parent changes, so the
     // parent -> children index stays in sync without needing a full rescan of all elements.
-    internal void UpdateParentIndex(Element child, Element oldParent, Element newParent)
+    internal void UpdateParentIndex(Element child, Element? oldParent, Element? newParent)
     {
         if (!_indexedElements.Contains(child))
         {
@@ -132,7 +133,7 @@ public class Elements
         AddToParentIndex(child, newParent);
     }
 
-    private void AddToParentIndex(Element child, Element parent)
+    private void AddToParentIndex(Element child, Element? parent)
     {
         if (parent == null)
         {
@@ -149,7 +150,7 @@ public class Elements
         children.Add(child);
     }
 
-    private void RemoveFromParentIndex(Element child, Element parent)
+    private void RemoveFromParentIndex(Element child, Element? parent)
     {
         if (parent == null)
         {
@@ -218,7 +219,7 @@ public class Elements
         }
     }
 
-    public bool TryGetValue(ElementType t, string key, out Element element)
+    public bool TryGetValue(ElementType t, string key, [MaybeNullWhen(false)] out Element element)
     {
         return _elements[t].TryGetValue(key, out element);
     }
@@ -233,7 +234,7 @@ public class Elements
         return _allElements.Count;
     }
 
-    public Element GetSingle(ElementType t)
+    public Element? GetSingle(ElementType t)
     {
         foreach (var e in _elements[t].Values)
         {
@@ -262,7 +263,7 @@ public class Elements
         }
     }
 
-    public IEnumerable<Element> GetDirectChildren(Element parent)
+    public IEnumerable<Element> GetDirectChildren(Element? parent)
     {
         if (parent == null)
         {
@@ -272,7 +273,7 @@ public class Elements
         return _childrenByParent.TryGetValue(parent, out var children) ? children : [];
     }
 
-    internal int GetNextSortIndex(Element parent)
+    internal int GetNextSortIndex(Element? parent)
     {
         if (parent == null)
         {

--- a/src/Engine/Fields.cs
+++ b/src/Engine/Fields.cs
@@ -1,5 +1,5 @@
-﻿#nullable disable
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using QuestViva.Common;
 using QuestViva.Engine.Functions;
 using QuestViva.Engine.Scripts;
@@ -9,7 +9,7 @@ namespace QuestViva.Engine;
 
 public class AttributeChangedEventArgs : EventArgs
 {
-    internal AttributeChangedEventArgs(string property, object value, object oldValue)
+    internal AttributeChangedEventArgs(string property, object? value, object? oldValue)
     {
         Property = property;
         Value = value;
@@ -21,23 +21,24 @@ public class AttributeChangedEventArgs : EventArgs
         InheritedTypesSet = inheritedTypesSet;
     }
 
-    public string Property { get; private set; }
-    public object Value { get; private set; }
-    public object OldValue { get; private set; }
+    // Property is only null when InheritedTypesSet is true (the element's inherited types changed)
+    public string? Property { get; private set; }
+    public object? Value { get; private set; }
+    public object? OldValue { get; private set; }
     public bool InheritedTypesSet { get; private set; }
 }
 
 public class NameChangedEventArgs : EventArgs
 {
-    public string OldName { get; set; }
-    public Element Element { get; set; }
+    public required string OldName { get; set; }
+    public required Element Element { get; set; }
 }
 
 public interface IMutableField
 {
-    UndoLogger UndoLog { get; set; }
+    UndoLogger? UndoLog { get; set; }
 
-    Element Owner { get; set; }
+    Element? Owner { get; set; }
 
     /// <summary>
     ///     True if we're in an inherited type, so we must be unmodifable. Implementors must check this and throw an exception
@@ -148,9 +149,9 @@ public class Fields
     // so the debugger's override hint still covers that residual case.
     private static readonly Dictionary<Type, DebugFormatDelegate> EditFormatters = new()
     {
-        {typeof(bool), v => (bool) v ? "true" : "false"},
-        {typeof(string), v => "\"" + ((string) v).Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""},
-        {typeof(Element), v => ((Element) v).Name}
+        {typeof(bool), v => (bool) v! ? "true" : "false"},
+        {typeof(string), v => "\"" + ((string) v!).Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""},
+        {typeof(Element), v => ((Element) v!).Name}
     };
 
     // Which value kinds the debugger's override control should even offer —
@@ -166,12 +167,12 @@ public class Fields
         typeof(int), typeof(double), typeof(long), typeof(float), typeof(decimal), typeof(short)
     };
 
-    private static bool CanOverrideValue(object value)
+    private static bool CanOverrideValue(object? value)
     {
         return value == null || OverridableValueTypes.Contains(value.GetType());
     }
 
-    private readonly Dictionary<string, object> _attributes = new();
+    private readonly Dictionary<string, object?> _attributes = new();
     private readonly Element _element;
     private readonly Dictionary<string, IExtendableField> _extendableFields = new();
     private readonly bool _isMeta;
@@ -208,9 +209,9 @@ public class Fields
     }
 
     internal IEnumerable<Element> Types => _types;
-    public event EventHandler<AttributeChangedEventArgs> AttributeChanged;
-    public event EventHandler<AttributeChangedEventArgs> AttributeChangedSilent;
-    internal event EventHandler<NameChangedEventArgs> NameChanged;
+    public event EventHandler<AttributeChangedEventArgs>? AttributeChanged;
+    public event EventHandler<AttributeChangedEventArgs>? AttributeChangedSilent;
+    internal event EventHandler<NameChangedEventArgs>? NameChanged;
 
     internal Fields Clone(Element newElement)
     {
@@ -232,7 +233,7 @@ public class Fields
         return clone;
     }
 
-    private DebugFormatDelegate GetFormatter(Type type)
+    private DebugFormatDelegate GetFormatter(Type? type)
     {
         if (type == null)
         {
@@ -247,19 +248,19 @@ public class Fields
         return DefaultFormatter;
     }
 
-    private string DefaultFormatter(object input)
+    private string DefaultFormatter(object? input)
     {
         if (input == null)
         {
             return "(null)";
         }
 
-        return input.ToString();
+        return input.ToString() ?? string.Empty;
     }
 
-    private static string ListFormatter(object input)
+    private static string ListFormatter(object? input)
     {
-        var list = (List<string>) input;
+        var list = (List<string>) input!;
         var output = string.Empty;
         if (list.Count == 0)
         {
@@ -274,7 +275,7 @@ public class Fields
         return output.Substring(0, output.Length - 2);
     }
 
-    private void UndoLog(string property, object oldValue, object newValue, bool added)
+    private void UndoLog(string property, object? oldValue, object? newValue, bool added)
     {
         if (_worldModel != null)
         {
@@ -291,12 +292,12 @@ public class Fields
         }
     }
 
-    public void Set(string name, object value)
+    public void Set(string name, object? value)
     {
         Set(name, value, true, true);
     }
 
-    internal void SetFromUndo(string name, object value)
+    internal void SetFromUndo(string name, object? value)
     {
         Set(name, value, false, false, false);
     }
@@ -332,12 +333,12 @@ public class Fields
         }
     }
 
-    private void Set(string name, object value, bool raiseEvent, bool cloneClonableValues,
+    private void Set(string name, object? value, bool raiseEvent, bool cloneClonableValues,
         bool allowUpdateSortOrder = true)
     {
         bool changed;
         var added = true;
-        object oldValue = null;
+        object? oldValue = null;
 
         if (_attributes.ContainsKey(name))
         {
@@ -377,13 +378,13 @@ public class Fields
             {
                 if (_worldModel.EditMode || mutableNewValue.RequiresCloning)
                 {
-                    value = mutableNewValue.Clone();
+                    mutableNewValue = mutableNewValue.Clone();
+                    value = mutableNewValue;
                 }
 
-                var mutableValue = (IMutableField) value;
-                mutableValue.Locked = MutableFieldsLocked;
-                mutableValue.UndoLog = _worldModel.UndoLogger;
-                mutableValue.Owner = _element;
+                mutableNewValue.Locked = MutableFieldsLocked;
+                mutableNewValue.UndoLog = _worldModel.UndoLogger;
+                mutableNewValue.Owner = _element;
             }
         }
 
@@ -431,7 +432,7 @@ public class Fields
 
             NameChanged(this, new NameChangedEventArgs
             {
-                OldName = (string) oldValue,
+                OldName = (string) oldValue!,
                 Element = _element
             });
         }
@@ -458,7 +459,7 @@ public class Fields
         }
     }
 
-    public Type GetCurrentType(string attribute)
+    public Type? GetCurrentType(string attribute)
     {
         var value = Get(attribute);
         if (value == null)
@@ -469,7 +470,7 @@ public class Fields
         return value.GetType();
     }
 
-    public object Get(string attribute)
+    public object? Get(string attribute)
     {
         return Get(attribute, false).Value;
     }
@@ -561,9 +562,9 @@ public class Fields
         return false;
     }
 
-    private IExtendableField GetExtendableField(string attribute, List<string> source)
+    private IExtendableField? GetExtendableField(string attribute, List<string> source)
     {
-        IExtendableField result = null;
+        IExtendableField? result = null;
 
         if (_extendableFields.ContainsKey(attribute))
         {
@@ -575,7 +576,7 @@ public class Fields
         {
             if (type.Fields.HasExtendableField(attribute))
             {
-                result = MergeExtendableFields(result, type.Fields.GetExtendableField(attribute, source));
+                result = MergeExtendableFields(result, type.Fields.GetExtendableField(attribute, source)!);
                 // Don't need to add to source here as the call to GetExtendableField will do that automatically
             }
         }
@@ -583,7 +584,7 @@ public class Fields
         return result;
     }
 
-    private IExtendableField MergeExtendableFields(IExtendableField field, IExtendableField parent)
+    private IExtendableField MergeExtendableFields(IExtendableField? field, IExtendableField parent)
     {
         if (field == null)
         {
@@ -597,7 +598,7 @@ public class Fields
     {
         var result = new DebugDataItem(FormatDebugData(Get(attribute)));
 
-        string source = null;
+        string? source = null;
         var isInherited = false;
 
         if (_attributes.ContainsKey(attribute))
@@ -680,12 +681,12 @@ public class Fields
         }
     }
 
-    private string FormatDebugData(object value)
+    private string FormatDebugData(object? value)
     {
         return GetFormatter(value == null ? null : value.GetType()).Invoke(value);
     }
 
-    private string FormatEditValue(object value)
+    private string FormatEditValue(object? value)
     {
         if (value == null)
         {
@@ -757,7 +758,7 @@ public class Fields
         return result;
     }
 
-    public T GetAsType<T>(string attribute)
+    public T? GetAsType<T>(string attribute)
     {
         var value = Get(attribute);
         if (value is T)
@@ -774,7 +775,7 @@ public class Fields
         return value is T;
     }
 
-    public string GetString(string attribute)
+    public string? GetString(string attribute)
     {
         return GetAsType<string>(attribute);
     }
@@ -784,7 +785,7 @@ public class Fields
         return HasType<string>(attribute);
     }
 
-    public Element GetObject(string attribute)
+    public Element? GetObject(string attribute)
     {
         return GetAsType<Element>(attribute);
     }
@@ -794,11 +795,11 @@ public class Fields
         return HasType<Element>(attribute);
     }
 
-    public Dictionary<string, object> GetAllAttributes()
+    public Dictionary<string, object?> GetAllAttributes()
     {
         // return a clone of the attributes dictionary as we don't
         // want external code changing any.
-        var result = new Dictionary<string, object>();
+        var result = new Dictionary<string, object?>();
         foreach (var key in _attributes.Keys)
         {
             // ok so it's not strictly a clone for things like Lists
@@ -822,7 +823,7 @@ public class Fields
         return CloneStackAndDelete(input, null);
     }
 
-    private Stack<Element> CloneStackAndDelete(Stack<Element> input, Element elementToDelete)
+    private Stack<Element> CloneStackAndDelete(Stack<Element> input, Element? elementToDelete)
     {
         var result = new Stack<Element>();
         foreach (var item in input.Reverse())
@@ -931,36 +932,36 @@ public class Fields
         return result;
     }
 
-    private delegate string DebugFormatDelegate(object input);
+    private delegate string DebugFormatDelegate(object? input);
 
     private struct AttributeData
     {
-        public object Value;
-        public string Source;
+        public object? Value;
+        public string? Source;
         public bool IsInherited;
     }
 
     #region Indexed Properties
 
-    public string this[IField<string> field]
+    public string? this[IField<string> field]
     {
         get => GetAsType<string>(field.Property);
         set => Set(field.Property, value);
     }
 
-    public QuestList<string> this[IField<QuestList<string>> field]
+    public QuestList<string>? this[IField<QuestList<string>> field]
     {
         get => GetAsType<QuestList<string>>(field.Property);
         set => Set(field.Property, value);
     }
 
-    public IScript this[IField<IScript> field]
+    public IScript? this[IField<IScript> field]
     {
         get => GetAsType<IScript>(field.Property);
         set => Set(field.Property, value);
     }
 
-    public Element this[IField<Element> field]
+    public Element? this[IField<Element> field]
     {
         get => GetAsType<Element>(field.Property);
         set => Set(field.Property, value);
@@ -978,13 +979,13 @@ public class Fields
         set => Set(field.Property, value);
     }
 
-    public IFunction<string> this[IField<IFunction<string>> field]
+    public IFunction<string>? this[IField<IFunction<string>> field]
     {
         get => GetAsType<IFunction<string>>(field.Property);
         set => Set(field.Property, value);
     }
 
-    public QuestList<object> this[IField<QuestList<object>> field]
+    public QuestList<object>? this[IField<QuestList<object>> field]
     {
         get => GetAsType<QuestList<object>>(field.Property);
         set => Set(field.Property, value);
@@ -999,7 +1000,7 @@ public class LazyFields
     private readonly WorldModel _worldModel;
     private List<Action> _actions = new();
     private List<string> _defaultTypes = new();
-    private Dictionary<string, IDictionary<string, string>> _objectDictionaries = new();
+    private Dictionary<string, IDictionary<string, string?>> _objectDictionaries = new();
     private Dictionary<string, string> _objectFields = new();
     private Dictionary<string, IEnumerable<string>> _objectLists = new();
     private bool _resolved;
@@ -1025,7 +1026,8 @@ public class LazyFields
             }
         }
 
-        _defaultTypes = null;
+        // Each pending collection is released once resolved - CheckNotResolved stops any later use
+        _defaultTypes = null!;
         foreach (var typename in _types)
         {
             try
@@ -1040,7 +1042,7 @@ public class LazyFields
             }
         }
 
-        _types = null;
+        _types = null!;
         foreach (var property in _objectFields.Keys)
         {
             try
@@ -1055,7 +1057,7 @@ public class LazyFields
             }
         }
 
-        _objectFields = null;
+        _objectFields = null!;
         foreach (var property in _scripts.Keys)
         {
             try
@@ -1070,7 +1072,7 @@ public class LazyFields
             }
         }
 
-        _scripts = null;
+        _scripts = null!;
         foreach (var property in _scriptDictionaries.Keys)
         {
             try
@@ -1085,7 +1087,7 @@ public class LazyFields
             }
         }
 
-        _scriptDictionaries = null;
+        _scriptDictionaries = null!;
         foreach (var property in _objectLists.Keys)
         {
             try
@@ -1101,7 +1103,7 @@ public class LazyFields
             }
         }
 
-        _objectLists = null;
+        _objectLists = null!;
         foreach (var property in _objectDictionaries.Keys)
         {
             try
@@ -1116,13 +1118,13 @@ public class LazyFields
             }
         }
 
-        _objectDictionaries = null;
+        _objectDictionaries = null!;
         foreach (var action in _actions)
         {
             action();
         }
 
-        _actions = null;
+        _actions = null!;
         foreach (var field in _fields.FieldNames)
         {
             var attribute = _fields.Get(field);
@@ -1155,12 +1157,12 @@ public class LazyFields
         return newDictionary;
     }
 
-    private QuestDictionary<Element> ConvertToObjectDictionary(IDictionary<string, string> dictionary)
+    private QuestDictionary<Element> ConvertToObjectDictionary(IDictionary<string, string?> dictionary)
     {
         var newDictionary = new QuestDictionary<Element>();
         foreach (var item in dictionary)
         {
-            var element = _worldModel.Elements.Get(item.Value);
+            var element = _worldModel.Elements.Get(item.Value!);
             newDictionary.Add(item.Key, element);
         }
 
@@ -1203,7 +1205,7 @@ public class LazyFields
         _objectLists.Add(property, value);
     }
 
-    public void AddObjectDictionary(string property, IDictionary<string, string> value)
+    public void AddObjectDictionary(string property, IDictionary<string, string?> value)
     {
         CheckNotResolved();
         _objectDictionaries.Add(property, value);
@@ -1221,10 +1223,7 @@ public class LazyFields
         {
             var value = list[i];
 
-            object replacement;
-            var replace = ReplaceValue(value, scriptFactory, out replacement);
-
-            if (replace)
+            if (ReplaceValue(value, scriptFactory, out var replacement))
             {
                 list.RemoveAt(i);
                 list.Insert(i, replacement);
@@ -1238,17 +1237,14 @@ public class LazyFields
 
         foreach (var item in copy)
         {
-            object replacement;
-            var replace = ReplaceValue(item.Value, scriptFactory, out replacement);
-
-            if (replace)
+            if (ReplaceValue(item.Value, scriptFactory, out var replacement))
             {
                 dictionary[item.Key] = replacement;
             }
         }
     }
 
-    private bool ReplaceValue(object value, ScriptFactory scriptFactory, out object replacement)
+    private bool ReplaceValue(object? value, ScriptFactory scriptFactory, [NotNullWhen(true)] out object? replacement)
     {
         replacement = null;
 
@@ -1322,14 +1318,14 @@ public class LazyFields
 public class UndoFieldSet : UndoLogger.IUndoAction
 {
     private readonly bool _added;
-    private readonly object _newValue;
-    private readonly string _newValueElementName;
-    private readonly object _oldValue;
-    private readonly string _oldValueElementName;
+    private readonly object? _newValue;
+    private readonly string? _newValueElementName;
+    private readonly object? _oldValue;
+    private readonly string? _oldValueElementName;
     private readonly bool _useMetaFields;
     private readonly WorldModel _worldModel;
 
-    public UndoFieldSet(WorldModel worldModel, string appliesTo, string property, object oldValue, object newValue,
+    public UndoFieldSet(WorldModel worldModel, string appliesTo, string property, object? oldValue, object? newValue,
         bool added, bool useMetaFields)
     {
         Debug.Assert(!string.IsNullOrEmpty(appliesTo));
@@ -1365,7 +1361,7 @@ public class UndoFieldSet : UndoLogger.IUndoAction
 
     public string Property { get; }
 
-    public object OldValue
+    public object? OldValue
     {
         get
         {
@@ -1384,7 +1380,7 @@ public class UndoFieldSet : UndoLogger.IUndoAction
         }
     }
 
-    public object NewValue
+    public object? NewValue
     {
         get
         {
@@ -1412,7 +1408,8 @@ public class UndoFieldSet : UndoLogger.IUndoAction
 
     public void DoRedo(WorldModel worldModel)
     {
-        if (Property != "name" || OldValue == null)
+        var oldValue = OldValue;
+        if (Property != "name" || oldValue == null)
         {
             GetFields(AppliesTo).SetFromUndo(Property, NewValue);
         }
@@ -1422,7 +1419,7 @@ public class UndoFieldSet : UndoLogger.IUndoAction
             // So in this specific case we get the appliesTo name from the old property value.
             // (If OldValue is null then this is just setting the name property for a brand new object,
             // so the above comment doesn't apply, and this case is handled in the above "if")
-            GetFields((string) OldValue).SetFromUndo(Property, NewValue);
+            GetFields((string) oldValue).SetFromUndo(Property, NewValue);
         }
     }
 
@@ -1436,10 +1433,10 @@ public class UndoFieldSet : UndoLogger.IUndoAction
 public class UndoFieldRemove : UndoLogger.IUndoAction
 {
     private readonly string _appliesTo;
-    private readonly object _oldValue;
+    private readonly object? _oldValue;
     private readonly string _property;
 
-    public UndoFieldRemove(string appliesTo, string property, object oldValue)
+    public UndoFieldRemove(string appliesTo, string property, object? oldValue)
     {
         _appliesTo = appliesTo;
         _property = property;

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -51,7 +51,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         return element.Fields.HasString(property);
     }
 
-    public string GetString( /* Element */ object? obj, string? property)
+    public string? GetString( /* Element */ object? obj, string? property)
     {
         ArgumentNullException.ThrowIfNull(obj);
         ArgumentNullException.ThrowIfNull(property);
@@ -131,7 +131,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         return element.Fields.HasType<DelegateImplementation>(property);
     }
 
-    public object GetAttribute( /* Element */ object? obj, string? property)
+    public object? GetAttribute( /* Element */ object? obj, string? property)
     {
         ArgumentNullException.ThrowIfNull(obj);
         ArgumentNullException.ThrowIfNull(property);
@@ -283,7 +283,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         return questList.Count;
     }
 
-    public object ListItem( /* IQuestList */ object? list, int index)
+    public object? ListItem( /* IQuestList */ object? list, int index)
     {
         ArgumentNullException.ThrowIfNull(list);
 
@@ -337,19 +337,19 @@ internal class ExpressionOwner(WorldModel worldModel)
         }
     }
 
-    public Element GetObject(string? name)
+    public Element? GetObject(string? name)
     {
         ArgumentNullException.ThrowIfNull(name);
         return TryGetElement(ElementType.Object, name);
     }
 
-    public Element GetTimer(string? name)
+    public Element? GetTimer(string? name)
     {
         ArgumentNullException.ThrowIfNull(name);
         return TryGetElement(ElementType.Timer, name);
     }
 
-    private Element TryGetElement(ElementType type, string name)
+    private Element? TryGetElement(ElementType type, string name)
     {
         worldModel.Elements.TryGetValue(type, name, out var result);
         return result;
@@ -390,11 +390,11 @@ internal class ExpressionOwner(WorldModel worldModel)
         var cnt = 0;
         foreach (var p in parameters)
         {
-            paramValues.Add((string) impl.Definition.Fields[FieldDefinitions.ParamNames][cnt], p);
+            paramValues.Add((string) impl.Definition.Fields[FieldDefinitions.ParamNames]![cnt]!, p);
             cnt++;
         }
 
-        return await worldModel.RunDelegateScriptAsync(impl.Implementation.Fields[FieldDefinitions.Script], paramValues, element);
+        return await worldModel.RunDelegateScriptAsync(impl.Implementation.Fields[FieldDefinitions.Script]!, paramValues, element);
     }
 
     // ReSharper disable once InconsistentNaming
@@ -742,7 +742,7 @@ internal class ExpressionOwner(WorldModel worldModel)
 
     private QuestList<T> ListCombine<T>(QuestList<T>? list1, QuestList<T>? list2)
     {
-        return list1 == null ? new QuestList<T>(list2) : list1.MergeLists(list2);
+        return list1 == null ? new QuestList<T>(list2) : list1.MergeLists(list2!);
     }
 
     public QuestList<string> ListExclude(QuestList<string>? list, string? str)

--- a/src/Engine/GameLoader/AttributeLoaders.cs
+++ b/src/Engine/GameLoader/AttributeLoaders.cs
@@ -442,7 +442,7 @@ internal partial class GameLoader
 
         public override void Load(Element element, string attribute, string value)
         {
-            var result = new Dictionary<string, string>();
+            var result = new Dictionary<string, string?>();
 
             var values = Utility.ListSplit(value);
             foreach (var pair in values)

--- a/src/Engine/GameLoader/ElementLoaders.cs
+++ b/src/Engine/GameLoader/ElementLoaders.cs
@@ -451,7 +451,7 @@ internal partial class GameLoader
                 if (string.IsNullOrEmpty(currentElementType))
                 {
                     // the type property is the object type, so is not set for other element types.
-                    currentElementType = current.Fields.GetString("elementtype");
+                    currentElementType = current.Fields.GetString("elementtype")!;
                 }
 
                 type = GameLoader._implicitTypes.Get(currentElementType, attribute);
@@ -729,7 +729,7 @@ internal partial class GameLoader
                 throw new Exception("Current element is not set");
             }
 
-            current.Fields.LazyFields.AddType(reader.GetAttribute("name"));
+            current.Fields.LazyFields.AddType(reader.GetAttribute("name")!);
             return null;
         }
     }

--- a/src/Engine/GameLoader/ElementSavers.cs
+++ b/src/Engine/GameLoader/ElementSavers.cs
@@ -13,10 +13,10 @@ internal partial class GameSaver
         {
             writer.WriteStartElement("function");
             writer.WriteAttributeString("name", e.Name);
-            if (e.Fields[FieldDefinitions.ParamNames] != null && e.Fields[FieldDefinitions.ParamNames].Count > 0)
+            if (e.Fields[FieldDefinitions.ParamNames] is { Count: > 0 } paramNames)
             {
                 writer.WriteAttributeString("parameters",
-                    string.Join(", ", e.Fields[FieldDefinitions.ParamNames].ToArray()));
+                    string.Join(", ", paramNames.ToArray()));
             }
 
             if (!string.IsNullOrEmpty(e.Fields[FieldDefinitions.ReturnType]))
@@ -29,9 +29,9 @@ internal partial class GameSaver
                 writer.WriteAttributeString("folder", e.Fields[FieldDefinitions.EditorFolder]);
             }
 
-            if (e.Fields[FieldDefinitions.Script] != null)
+            if (e.Fields[FieldDefinitions.Script] is { } script)
             {
-                writer.WriteString(GameSaver.SaveScript(writer, e.Fields[FieldDefinitions.Script], 0));
+                writer.WriteString(GameSaver.SaveScript(writer, script, 0));
             }
 
             writer.WriteEndElement();
@@ -66,7 +66,7 @@ internal partial class GameSaver
             writer.WriteStartElement("delegate");
             writer.WriteAttributeString("name", e.Name);
             writer.WriteAttributeString("parameters",
-                string.Join(", ", e.Fields[FieldDefinitions.ParamNames].ToArray()));
+                string.Join(", ", e.Fields[FieldDefinitions.ParamNames]!.ToArray()));
             writer.WriteAttributeString("type", e.Fields[FieldDefinitions.ReturnType]);
             writer.WriteEndElement();
         }
@@ -80,7 +80,7 @@ internal partial class GameSaver
         {
             writer.WriteStartElement("template");
             writer.WriteAttributeString("name", e.Fields[FieldDefinitions.TemplateName]);
-            writer.WriteString(e.Fields[FieldDefinitions.Text]);
+            writer.WriteString(e.Fields[FieldDefinitions.Text]!);
             writer.WriteEndElement();
         }
     }
@@ -95,8 +95,8 @@ internal partial class GameSaver
             writer.WriteAttributeString("name", e.Name);
 
             writer.WriteString(GameSaver._worldModel.EditMode
-                ? e.Fields[FieldDefinitions.Text]
-                : e.Fields[FieldDefinitions.Function].Save());
+                ? e.Fields[FieldDefinitions.Text]!
+                : e.Fields[FieldDefinitions.Function]!.Save());
             writer.WriteEndElement();
         }
     }

--- a/src/Engine/GameLoader/FieldSaver.cs
+++ b/src/Engine/GameLoader/FieldSaver.cs
@@ -443,7 +443,7 @@ internal partial class FieldSaver
         {
             var impl = (DelegateImplementation) value;
             WriteAttribute(writer, element, attribute, impl.Definition.Name,
-                GameSaver.SaveScript(writer, impl.Implementation.Fields[FieldDefinitions.Script], 1));
+                GameSaver.SaveScript(writer, impl.Implementation.Fields[FieldDefinitions.Script]!, 1));
         }
     }
 

--- a/src/Engine/GameLoader/GameSaver.cs
+++ b/src/Engine/GameLoader/GameSaver.cs
@@ -164,9 +164,9 @@ internal partial class GameSaver
         _impliedTypes = new Dictionary<string, string>();
         foreach (var impliedType in _worldModel.Elements.GetElements(ElementType.ImpliedType))
         {
-            var element = impliedType.Fields[FieldDefinitions.Element];
-            var property = impliedType.Fields[FieldDefinitions.Property];
-            var type = impliedType.Fields[FieldDefinitions.Type];
+            var element = impliedType.Fields[FieldDefinitions.Element]!;
+            var property = impliedType.Fields[FieldDefinitions.Property]!;
+            var type = impliedType.Fields[FieldDefinitions.Type]!;
             _impliedTypes.Add(GetImpliedTypeKey(element, property), type);
         }
     }

--- a/src/Engine/GameLoader/ObjectSaver.cs
+++ b/src/Engine/GameLoader/ObjectSaver.cs
@@ -247,9 +247,9 @@ internal partial class GameSaver
                     writer.WriteAttributeString("alias", e.Fields[FieldDefinitions.Alias]);
                 }
 
-                if (e.Fields[FieldDefinitions.To] != null)
+                if (e.Fields[FieldDefinitions.To] is { } to)
                 {
-                    writer.WriteAttributeString("to", e.Fields[FieldDefinitions.To].Name);
+                    writer.WriteAttributeString("to", to.Name);
                 }
 
                 ObjectSaver.SaveFields(writer, e);

--- a/src/Engine/QuestDictionary.cs
+++ b/src/Engine/QuestDictionary.cs
@@ -1,20 +1,20 @@
-﻿#nullable disable
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace QuestViva.Engine;
 
 public interface IQuestDictionary
 {
-    void Add(object key, object value, int index);
+    void Add(object key, object? value, int index);
     void Remove(object key);
 }
 
 public class QuestDictionaryUpdatedEventArgs<T> : EventArgs
 {
-    public string Key { get; set; }
-    public T Item { get; set; }
+    public required string Key { get; set; }
+    public required T Item { get; set; }
     public int Index { get; set; }
     public UpdateSource Source { get; set; }
 }
@@ -22,13 +22,13 @@ public class QuestDictionaryUpdatedEventArgs<T> : EventArgs
 public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableField, IQuestDictionary
 {
     private readonly OrderedDictionary<string, T> _dictionary = new();
-    private UndoLogger _undoLog;
+    private UndoLogger? _undoLog;
 
     public QuestDictionary()
     {
     }
 
-    public QuestDictionary(IDictionary<string, T> dictionary)
+    public QuestDictionary(IDictionary<string, T>? dictionary)
     {
         if (dictionary != null)
         {
@@ -57,15 +57,15 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     #endregion
 
-    public event EventHandler<QuestDictionaryUpdatedEventArgs<T>> Added;
-    public event EventHandler<QuestDictionaryUpdatedEventArgs<T>> Removed;
+    public event EventHandler<QuestDictionaryUpdatedEventArgs<T>>? Added;
+    public event EventHandler<QuestDictionaryUpdatedEventArgs<T>>? Removed;
 
     private void UndoLogAdd(object key)
     {
         if (UndoLog != null)
         {
             // also set UndoLog property on added item, if it needs a reference to the undo logger
-            object value = _dictionary[(string) key];
+            object? value = _dictionary[(string) key];
             var mutableValue = value as IMutableField;
             if (mutableValue != null)
             {
@@ -106,10 +106,10 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     internal string SaveString()
     {
-        return SaveString(v => v.ToString());
+        return SaveString(v => v!.ToString());
     }
 
-    internal string SaveString(Func<T, string> converter)
+    internal string SaveString(Func<T, string?> converter)
     {
         var result = string.Empty;
         var count = 0;
@@ -151,12 +151,12 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     private class UndoDictionaryAdd : UndoLogger.IUndoAction
     {
-        private readonly object _addedItem;
+        private readonly object? _addedItem;
         private readonly object _addedKey;
         private readonly IQuestDictionary _appliesTo;
         private readonly int _index;
 
-        public UndoDictionaryAdd(IQuestDictionary appliesTo, object addedKey, object addedItem, int index)
+        public UndoDictionaryAdd(IQuestDictionary appliesTo, object addedKey, object? addedItem, int index)
         {
             _appliesTo = appliesTo;
             _addedKey = addedKey;
@@ -183,10 +183,10 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
     {
         private readonly IQuestDictionary _appliesTo;
         private readonly int _index;
-        private readonly object _removedItem;
+        private readonly object? _removedItem;
         private readonly object _removedKey;
 
-        public UndoDictionaryRemove(IQuestDictionary appliesTo, object removedKey, object removedItem, int index)
+        public UndoDictionaryRemove(IQuestDictionary appliesTo, object removedKey, object? removedItem, int index)
         {
             _appliesTo = appliesTo;
             _removedKey = removedKey;
@@ -211,9 +211,9 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     #region IMutableField Members
 
-    public Element Owner { get; set; }
+    public Element? Owner { get; set; }
 
-    public UndoLogger UndoLog
+    public UndoLogger? UndoLog
     {
         get => _undoLog;
         set
@@ -302,7 +302,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
         return _dictionary.Remove(key);
     }
 
-    public bool TryGetValue(string key, out T value)
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out T value)
     {
         return _dictionary.TryGetValue(key, out value);
     }
@@ -366,24 +366,24 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     #region IDictionary Members
 
-    public void Add(object key, object value)
+    public void Add(object key, object? value)
     {
         Add(key, value, _dictionary.Count);
     }
 
-    public void Add(object key, object value, int index)
+    public void Add(object key, object? value, int index)
     {
         CheckNotLocked();
         try
         {
-            _dictionary.Insert(index, (string) key, (T) value);
+            _dictionary.Insert(index, (string) key, (T) value!);
         }
         catch (Exception ex)
         {
             throw new Exception(string.Format("Error adding key '{0}' to dictionary: {1}", key, ex.Message), ex);
         }
 
-        ItemAdded((string) key, (T) value, UpdateSource.System, _dictionary.IndexOfKey((string) key));
+        ItemAdded((string) key, (T) value!, UpdateSource.System, _dictionary.IndexOfKey((string) key));
     }
 
     public bool Contains(object key)
@@ -410,10 +410,10 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     ICollection IDictionary.Values => (ICollection) _dictionary.Values;
 
-    public object this[object key]
+    public object? this[object key]
     {
         get => this[(string) key];
-        set => this[(string) key] = (T) value;
+        set => this[(string) key] = (T) value!;
     }
 
     #endregion
@@ -438,6 +438,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 // ****************************************************************************************************************
 
 public interface IOrderedDictionary<TKey, TValue> : IOrderedDictionary, IDictionary<TKey, TValue>
+    where TKey : notnull
 {
     /// <summary>
     ///     Gets or sets the value at the specified index.
@@ -482,18 +483,19 @@ public interface IOrderedDictionary<TKey, TValue> : IOrderedDictionary, IDiction
 }
 
 public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, TValue>
+    where TKey : notnull
 {
     private const int DefaultInitialCapacity = 0;
 
-    private static readonly string KeyTypeName = typeof(TKey).FullName;
-    private static readonly string ValueTypeName = typeof(TValue).FullName;
+    private static readonly string? KeyTypeName = typeof(TKey).FullName;
+    private static readonly string? ValueTypeName = typeof(TValue).FullName;
     private static readonly bool ValueTypeIsReferenceType = !typeof(ValueType).IsAssignableFrom(typeof(TValue));
-    private readonly IEqualityComparer<TKey> _comparer;
+    private readonly IEqualityComparer<TKey>? _comparer;
     private readonly int _initialCapacity;
 
-    private Dictionary<TKey, TValue> _dictionary;
-    private List<KeyValuePair<TKey, TValue>> _list;
-    private object _syncRoot;
+    private Dictionary<TKey, TValue>? _dictionary;
+    private List<KeyValuePair<TKey, TValue>>? _list;
+    private object? _syncRoot;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -529,7 +531,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     comparing keys, or <null /> to use the default
     ///     <see cref="EqualityComparer{TKey}">EqualityComparer&lt;TKey&gt;</see> for the type of the key.
     /// </param>
-    public OrderedDictionary(IEqualityComparer<TKey> comparer)
+    public OrderedDictionary(IEqualityComparer<TKey>? comparer)
         : this(DefaultInitialCapacity, comparer)
     {
     }
@@ -549,7 +551,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     <see cref="EqualityComparer{TKey}">EqualityComparer&lt;TKey&gt;</see> for the type of the key.
     /// </param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0</exception>
-    public OrderedDictionary(int capacity, IEqualityComparer<TKey> comparer)
+    public OrderedDictionary(int capacity, IEqualityComparer<TKey>? comparer)
     {
         if (0 > capacity)
         {
@@ -617,7 +619,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     {
         public DictionaryEntry Entry => new(inner.Current.Key, inner.Current.Value);
         public object Key => inner.Current.Key;
-        public object Value => inner.Current.Value;
+        public object? Value => inner.Current.Value;
         public object Current => Entry;
         public bool MoveNext() => inner.MoveNext();
         public void Reset() => inner.Reset();
@@ -695,7 +697,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     An element with the same key already exists in the
     ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see>.
     /// </exception>
-    void IOrderedDictionary.Insert(int index, object key, object value)
+    void IOrderedDictionary.Insert(int index, object key, object? value)
     {
         Insert(index, ConvertToKeyType(key), ConvertToValueType(value));
     }
@@ -772,7 +774,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> is not in the inheritance
     ///     hierarchy of <paramref name="valueObject" />.
     /// </exception>
-    object IOrderedDictionary.this[int index]
+    object? IOrderedDictionary.this[int index]
     {
         get => this[index];
 
@@ -860,7 +862,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     The value type of the <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> is not
     ///     in the inheritance hierarchy of <paramref name="value" />.
     /// </exception>
-    void IDictionary.Add(object key, object value)
+    void IDictionary.Add(object key, object? value)
     {
         Add(ConvertToKeyType(key), ConvertToValueType(value));
     }
@@ -1055,7 +1057,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     The value associated with the specified key. If the specified key is not found, attempting to get it returns
     ///     <null />, and attempting to set it creates a new element using the specified key.
     /// </value>
-    object IDictionary.this[object key]
+    object? IDictionary.this[object key]
     {
         get => this[ConvertToKeyType(key)];
         set => this[ConvertToKeyType(key)] = ConvertToValueType(value);
@@ -1116,7 +1118,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
                 Interlocked.CompareExchange(ref _syncRoot, new object(), null);
             }
 
-            return _syncRoot;
+            return _syncRoot!;
         }
     }
 
@@ -1151,7 +1153,7 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> contains an element with the
     ///     specified key; otherwise, <see langword="false" />.
     /// </returns>
-    public bool TryGetValue(TKey key, out TValue value)
+    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
     {
         return Dictionary.TryGetValue(key, out value);
     }
@@ -1281,13 +1283,13 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> is not in the inheritance
     ///     hierarchy of <paramref name="valueObject" />.
     /// </exception>
-    private static TValue ConvertToValueType(object value)
+    private static TValue ConvertToValueType(object? value)
     {
         if (null == value)
         {
             if (ValueTypeIsReferenceType)
             {
-                return default;
+                return default!;
             }
 
             throw new ArgumentNullException("value");

--- a/src/Engine/QuestList.cs
+++ b/src/Engine/QuestList.cs
@@ -1,23 +1,22 @@
-﻿#nullable disable
-using System.Collections;
+﻿using System.Collections;
 
 namespace QuestViva.Engine;
 
 public interface IQuestList
 {
-    object this[int index] { get; }
+    object? this[int index] { get; }
     int Count { get; }
-    void Add(object item);
-    void Add(object item, UpdateSource source);
-    void Add(object item, UpdateSource source, int index);
-    bool Remove(object item);
-    void Remove(object item, UpdateSource source, int index);
-    bool Contains(object item);
+    void Add(object? item);
+    void Add(object? item, UpdateSource source);
+    void Add(object? item, UpdateSource source, int index);
+    bool Remove(object? item);
+    void Remove(object? item, UpdateSource source, int index);
+    bool Contains(object? item);
 }
 
 public class QuestListUpdatedEventArgs<T> : EventArgs
 {
-    public T UpdatedItem { get; set; }
+    public required T UpdatedItem { get; set; }
     public int Index { get; set; }
     public UpdateSource Source { get; set; }
 }
@@ -25,14 +24,14 @@ public class QuestListUpdatedEventArgs<T> : EventArgs
 public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollection, IExtendableField
 {
     private readonly List<T> _list;
-    private UndoLogger _undoLog;
+    private UndoLogger? _undoLog;
 
     public QuestList()
     {
         _list = new List<T>();
     }
 
-    public QuestList(IEnumerable<T> collection)
+    public QuestList(IEnumerable<T>? collection)
     {
         if (collection == null)
         {
@@ -44,7 +43,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
         }
     }
 
-    public QuestList(IEnumerable<T> collection, bool extended)
+    public QuestList(IEnumerable<T>? collection, bool extended)
         : this(collection)
     {
         Extended = extended;
@@ -54,8 +53,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public IExtendableField Merge(IExtendableField parent)
     {
-        var parentList = parent as QuestList<T>;
-        return parentList.MergeLists(this);
+        return ((QuestList<T>) parent).MergeLists(this);
     }
 
     public void Add(T item)
@@ -87,7 +85,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     #endregion
 
-    public UndoLogger UndoLog
+    public UndoLogger? UndoLog
     {
         get => _undoLog;
         set
@@ -109,7 +107,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
         }
     }
 
-    public Element Owner { get; set; }
+    public Element? Owner { get; set; }
 
     public IMutableField Clone()
     {
@@ -120,39 +118,40 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public bool RequiresCloning => true;
 
-    public void Add(object item)
+    // Untyped IQuestList access: a null item is passed straight through when T is a reference type
+    public void Add(object? item)
     {
-        AddInternal((T) item, UpdateSource.System);
+        AddInternal((T) item!, UpdateSource.System);
     }
 
-    public void Add(object item, UpdateSource source)
+    public void Add(object? item, UpdateSource source)
     {
-        AddInternal((T) item, source);
+        AddInternal((T) item!, source);
     }
 
-    public void Add(object item, UpdateSource source, int index)
+    public void Add(object? item, UpdateSource source, int index)
     {
-        AddInternal((T) item, source, index);
+        AddInternal((T) item!, source, index);
     }
 
-    public bool Remove(object item)
+    public bool Remove(object? item)
     {
-        return RemoveInternal((T) item);
+        return RemoveInternal((T) item!);
     }
 
-    public void Remove(object item, UpdateSource source, int index)
+    public void Remove(object? item, UpdateSource source, int index)
     {
-        RemoveInternal((T) item, source, index);
+        RemoveInternal((T) item!, source, index);
     }
 
-    public bool Contains(object item)
+    public bool Contains(object? item)
     {
-        return _list.Contains((T) item);
+        return _list.Contains((T) item!);
     }
 
-    public object this[int index] => _list[index];
-    public event EventHandler<QuestListUpdatedEventArgs<T>> Added;
-    public event EventHandler<QuestListUpdatedEventArgs<T>> Removed;
+    public object? this[int index] => _list[index];
+    public event EventHandler<QuestListUpdatedEventArgs<T>>? Added;
+    public event EventHandler<QuestListUpdatedEventArgs<T>>? Removed;
 
     private void CheckNotLocked()
     {
@@ -219,7 +218,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
         RemoveInternal(_list[index], source, index);
     }
 
-    private void UndoLogAdd(object item, int index)
+    private void UndoLogAdd(object? item, int index)
     {
         if (UndoLog != null)
         {
@@ -234,7 +233,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
         }
     }
 
-    private void UndoLogRemove(object item, int index)
+    private void UndoLogRemove(object? item, int index)
     {
         if (UndoLog != null)
         {
@@ -266,7 +265,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     /// <param name="list1"></param>
     /// <param name="list2"></param>
     /// <returns></returns>
-    public static QuestList<T> operator +(QuestList<T> list1, QuestList<T> list2)
+    public static QuestList<T> operator +(QuestList<T>? list1, QuestList<T> list2)
     {
         if (list1 == null)
         {
@@ -285,7 +284,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public QuestList<T> Exclude(T element)
     {
-        var enumerable = this.Where(x => !x.Equals(element));
+        var enumerable = this.Where(x => !x!.Equals(element));
         return new QuestList<T>(enumerable);
     }
 
@@ -371,11 +370,11 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     private class UndoListAdd : UndoLogger.IUndoAction
     {
-        private readonly object _addedItem;
+        private readonly object? _addedItem;
         private readonly IQuestList _appliesTo;
         private readonly int _index;
 
-        public UndoListAdd(IQuestList appliesTo, object addedItem, int index)
+        public UndoListAdd(IQuestList appliesTo, object? addedItem, int index)
         {
             _appliesTo = appliesTo;
             _addedItem = addedItem;
@@ -401,9 +400,9 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     {
         private readonly IQuestList _appliesTo;
         private readonly int _index;
-        private readonly object _removedItem;
+        private readonly object? _removedItem;
 
-        public UndoListRemove(IQuestList appliesTo, object removedItem, int index)
+        public UndoListRemove(IQuestList appliesTo, object? removedItem, int index)
         {
             _appliesTo = appliesTo;
             _removedItem = removedItem;
@@ -454,7 +453,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public void RemoveAt(int index)
     {
-        RemoveInternal((T) this[index], UpdateSource.System, index);
+        RemoveInternal(_list[index], UpdateSource.System, index);
     }
 
     T IList<T>.this[int index]

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -282,9 +282,9 @@ public partial class WorldModel : IGame, IGameDebug
 
     public int ASLVersion => int.Parse(VersionString!);
 
-    public string Category => Game.Fields[FieldDefinitions.Category];
-    public string Description => Game.Fields[FieldDefinitions.Description];
-    public string Cover => Game.Fields[FieldDefinitions.Cover];
+    public string? Category => Game.Fields[FieldDefinitions.Category];
+    public string? Description => Game.Fields[FieldDefinitions.Description];
+    public string? Cover => Game.Fields[FieldDefinitions.Cover];
     public bool IsGamebook => Game.Fields[FieldDefinitions.EditorStyle] == "gamebook";
     public string? LanguageId => Template.GetText("LanguageId", false);
     public string? GetTemplateText(string name) => Template.GetText(name, false);
@@ -367,7 +367,7 @@ public partial class WorldModel : IGame, IGameDebug
                 }
                 else if (Version >= WorldModelVersion.v540)
                 {
-                    await PlayerUi.RunScriptAsync("loadHtml", [output.Fields.GetString("html")]);
+                    await PlayerUi.RunScriptAsync("loadHtml", [output.Fields.GetString("html")!]);
                     await PlayerUi.RunScriptAsync("markScrollPosition", null);
                     ScrollToEnd();
                 }
@@ -520,7 +520,7 @@ public partial class WorldModel : IGame, IGameDebug
             return;
         }
 
-        var parameters = new Parameters {{(string) handler.Fields[FieldDefinitions.ParamNames][0], param}};
+        var parameters = new Parameters {{(string) handler.Fields[FieldDefinitions.ParamNames]![0]!, param}};
 
         await RunProcedureAsync(eventName, parameters, false);
 
@@ -582,17 +582,18 @@ public partial class WorldModel : IGame, IGameDebug
         var result = new List<string>();
         foreach (var jsRef in Elements.GetElements(ElementType.Javascript))
         {
+            var src = jsRef.Fields[FieldDefinitions.Src]!;
             if (Version == WorldModelVersion.v500)
             {
                 // v500 games used Frame.js functions for static panel feature. This is now implemented natively
                 // in Player and WebPlayer.
-                if (jsRef.Fields[FieldDefinitions.Src].Equals("frame.js", StringComparison.CurrentCultureIgnoreCase))
+                if (src.Equals("frame.js", StringComparison.CurrentCultureIgnoreCase))
                 {
                     continue;
                 }
             }
 
-            result.Add(jsRef.Fields[FieldDefinitions.Src]);
+            result.Add(src);
         }
 
         return result;
@@ -697,7 +698,7 @@ public partial class WorldModel : IGame, IGameDebug
             : _gameData?.GetAdjacentFile(filename);
     }
 
-    public string GameID => Game.Fields[FieldDefinitions.GameID];
+    public string? GameID => Game.Fields[FieldDefinitions.GameID];
 
     IEnumerable<string> IGame.GetResourceNames()
     {
@@ -1101,8 +1102,8 @@ public partial class WorldModel : IGame, IGameDebug
             if (Version <= WorldModelVersion.v520 || !Elements.ContainsKey(ElementType.Function, "GetDisplayVerbs"))
             {
                 verbs = held.Contains(obj)
-                    ? obj.Fields[FieldDefinitions.InventoryVerbs]
-                    : obj.Fields[FieldDefinitions.DisplayVerbs];
+                    ? obj.Fields[FieldDefinitions.InventoryVerbs]!
+                    : obj.Fields[FieldDefinitions.DisplayVerbs]!;
             }
             else
             {
@@ -1129,12 +1130,12 @@ public partial class WorldModel : IGame, IGameDebug
             {
                 if (scope == "ScopeInventory")
                 {
-                    objects.Add(new ListData(await GetListDisplayAliasAsync(obj), obj.Fields[FieldDefinitions.InventoryVerbs],
+                    objects.Add(new ListData(await GetListDisplayAliasAsync(obj), obj.Fields[FieldDefinitions.InventoryVerbs]!,
                         obj.Name, await GetDisplayAliasAsync(obj)));
                 }
                 else
                 {
-                    objects.Add(new ListData(await GetListDisplayAliasAsync(obj), obj.Fields[FieldDefinitions.DisplayVerbs],
+                    objects.Add(new ListData(await GetListDisplayAliasAsync(obj), obj.Fields[FieldDefinitions.DisplayVerbs]!,
                         obj.Name, await GetDisplayAliasAsync(obj)));
                 }
             }
@@ -1203,7 +1204,7 @@ public partial class WorldModel : IGame, IGameDebug
             IEnumerable<string> verbs;
             if (Version <= WorldModelVersion.v520 || !Elements.ContainsKey(ElementType.Function, "GetDisplayVerbs"))
             {
-                verbs = exit.Fields[FieldDefinitions.DisplayVerbs];
+                verbs = exit.Fields[FieldDefinitions.DisplayVerbs]!;
             }
             else
             {
@@ -1437,25 +1438,26 @@ public partial class WorldModel : IGame, IGameDebug
             // would ignore this (but would usually still fail when the function was run, as the required
             // variable wouldn't exist). For Quest 5.3, an additional check if parameters is non-null but empty.
 
+            var paramNames = function.Fields[FieldDefinitions.ParamNames]!;
             var parametersInvalid = false;
             if (Version == WorldModelVersion.v520)
             {
-                parametersInvalid = parameters == null && function.Fields[FieldDefinitions.ParamNames].Count > 0;
+                parametersInvalid = parameters == null && paramNames.Count > 0;
             }
             else if (Version >= WorldModelVersion.v530)
             {
                 parametersInvalid = (parameters == null || parameters.Count == 0) &&
-                                    function.Fields[FieldDefinitions.ParamNames].Count > 0;
+                                    paramNames.Count > 0;
             }
 
             if (parametersInvalid)
             {
                 throw new Exception(string.Format("No parameters passed to {0} function - expected {1} parameters",
                     name,
-                    function.Fields[FieldDefinitions.ParamNames].Count));
+                    paramNames.Count));
             }
 
-            return await RunScriptAsync(function.Fields[FieldDefinitions.Script], parameters, expectResult);
+            return await RunScriptAsync(function.Fields[FieldDefinitions.Script]!, parameters, expectResult);
         }
 
         await PrintAsync($"Error - no such procedure '{name}'");
@@ -1614,7 +1616,7 @@ public partial class WorldModel : IGame, IGameDebug
         return result;
     }
 
-    internal void NotifyElementFieldUpdate(Element element, string attribute, object newValue, bool isUndo)
+    internal void NotifyElementFieldUpdate(Element element, string attribute, object? newValue, bool isUndo)
     {
         if (!element.Initialised)
         {
@@ -1624,7 +1626,7 @@ public partial class WorldModel : IGame, IGameDebug
         ElementFieldUpdated?.Invoke(this, new ElementFieldUpdatedEventArgs(element, attribute, newValue, isUndo));
     }
 
-    internal void NotifyElementMetaFieldUpdate(Element element, string attribute, object newValue, bool isUndo)
+    internal void NotifyElementMetaFieldUpdate(Element element, string attribute, object? newValue, bool isUndo)
     {
         if (!element.Initialised)
         {


### PR DESCRIPTION
First batch of the nullability cleanup: removes `#nullable disable` from Engine's core types — `Element`, `Elements`, `Fields` (incl. `LazyFields` and the undo actions), `QuestList` and `QuestDictionary` (incl. `OrderedDictionary`) — and fixes what that surfaces in already-nullable-enabled callers. Engine files still opted out: 61 → 56.

These went first because nearly everything else depends on them: annotating them honestly is what makes later batches' warnings meaningful.

## Annotation changes (compile-time only)
- **`Fields`**: `Get`, `GetAsType<T>`, `GetString`, `GetObject`, `GetCurrentType` and the typed `this[IField<…>]` indexers now return nullable — they always could return null for a missing attribute. `Set` accepts `object?`.
- **`Element`**: `Parent` and `Text` are nullable. `Name` stays non-null — `ObjectFactory` sets it immediately after construction, so the backing field uses a `null!` initialiser with a comment.
- **`Elements`**: `GetSingle` returns `Element?`; `TryGetValue` has `[MaybeNullWhen(false)]`; parent-index methods take `Element?` (null = root).
- **`IMutableField.UndoLog` / `Owner`** are nullable, matching what `ScriptBase` already declared.
- **`IGame.GameID`** is `string?` — Legacy's `V4Game` already returned `null`, and WebPlayer's `Game.razor` already guards with `IsNullOrEmpty`. Likewise `WorldModel.Category/Description/Cover`.
- **Expression functions** `GetString`, `GetAttribute`, `ListItem`, `GetObject`, `GetTimer` declare nullable returns (they already returned null in those cases).
- Event-args init members are `required`; events are nullable; `OrderedDictionary` gains `where TKey : notnull`; untyped `IQuestList`/`IDictionary` members take `object?`.

## Behaviour
No intended behaviour change. A few spots were restructured so the compiler can follow the null-state rather than adding `!` — equivalent code: `is { } x` / `is { Count: > 0 } x` patterns instead of repeated indexer lookups (`ElementSavers`, `ObjectSaver`, `Element.SetFieldAsync`), hoisted locals (`WorldModel.RunProcedureAsync`, `GetExternalScripts`), `Fields.Set` tracking the cloned `IMutableField` directly, and `ReplaceValue` called inline with `[NotNullWhen(true)]`.

Two technically-observable nits, both on paths that shouldn't happen: `QuestList.Merge` now casts its parent (`InvalidCastException` rather than `NullReferenceException` if it were ever handed a non-list), and the debugger's default formatter shows `""` rather than passing null through if a value's `ToString()` returns null.

`!` is used where an element type always carries a field set by the loader — function/delegate `paramnames` and `script`, javascript `src`, implied-type `element`/`property`/`type`, template `text`, dynamic template `function`, saved output `html`, object `displayverbs`/`inventoryverbs` — and in the untyped `IQuestList`/`IDictionary` adapters, where a null item is legitimately passed through for reference-type `T`.

## Latent null bugs surfaced (deliberately left as-is)
Kept behaviour-identical with `!` so this PR stays a pure refactor, and filed separately:
- #2240 — `ListCombine(list, null)` throws, while `ListCombine(null, list)` works
- #2241 — `<inherit>` with no `name` fails late at resolve with a confusing null-key error
- #2242 — saving a string dictionary containing a null value throws
- #2243 — `ListExclude` throws if the list contains a null item

An object-dictionary null value (`LazyFields.ConvertToObjectDictionary`) looked like another case but isn't reachable: the `string?` only comes from the shared dictionary loader's generic signature, and both object-dictionary loaders only ever store non-null strings.

## Test plan
- [x] `dotnet build --configuration Release`: clean (warnings as errors)
- [x] `dotnet test --configuration Release`: all 403 tests pass
- [x] BOM / CRLF preserved on every edited file (diff is annotation-only)
- [x] quest-e2e-tests corpus (58 games), golden snapshots diffed: `main` vs `main` gives 15 games that vary run-to-run (the known non-deterministic set); `main` vs this branch differs in exactly those same 15 and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)
