### PR TITLE
refactor(Engine): enable nullable reference types in Engine/Scripts

### DIFF
--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -72,7 +72,7 @@ public interface IPlayer
     void SetFont(string fontName);
     void SetFontSize(string fontSize);
     void Speak(string text);
-    void RequestSave(string html);
+    void RequestSave(string? html);
     void Show(string element);
     void Hide(string element);
     void SetCompassDirections(IEnumerable<string> dirs);

--- a/src/Engine/Fields.cs
+++ b/src/Engine/Fields.cs
@@ -1282,7 +1282,7 @@ public class LazyFields
             var newDictionary = new QuestDictionary<Element>();
             foreach (var kvp in objDictionary.Dictionary)
             {
-                newDictionary.Add(kvp.Key, _worldModel.Elements.Get(kvp.Value));
+                newDictionary.Add(kvp.Key, _worldModel.Elements.Get(kvp.Value!));
             }
 
             replacement = newDictionary;

--- a/src/Engine/Scripts/AskScript.cs
+++ b/src/Engine/Scripts/AskScript.cs
@@ -63,7 +63,7 @@ public class AskScript(
             var response = await _worldModel._questionTcs!.Task;
             resolved = true;
             _worldModel.SignalCallbackResolving();
-            c.Parameters["result"] = response;
+            c.Parameters!["result"] = response;
             await _worldModel.RunScriptAsync(callbackScript, c);
         }
         catch (OperationCanceledException) { }
@@ -81,7 +81,7 @@ public class AskScript(
         return SaveScript("ask", callbackScript, _caption.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -94,11 +94,11 @@ public class AskScript(
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         _caption = index switch
         {
-            0 => new Expression<string>((string) value, scriptContext),
+            0 => new Expression<string>((string) value!, scriptContext),
             1 =>
                 // any updates to the script should change the script itself - nothing should cause SetParameter to be triggered.
                 throw new InvalidOperationException(

--- a/src/Engine/Scripts/CommentScript.cs
+++ b/src/Engine/Scripts/CommentScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 public class CommentScriptConstructor : IScriptConstructor
 {
@@ -15,7 +14,7 @@ public class CommentScriptConstructor : IScriptConstructor
         set { }
     }
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 }
 
 public class CommentScript : ScriptBase
@@ -45,14 +44,14 @@ public class CommentScript : ScriptBase
             _comment.Split(new[] {"\n"}, StringSplitOptions.RemoveEmptyEntries));
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _comment;
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _comment = (string) value;
+        _comment = (string) value!;
     }
 
     public void AddLine(string line)

--- a/src/Engine/Scripts/Context.cs
+++ b/src/Engine/Scripts/Context.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections;
+﻿using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 
 namespace QuestViva.Engine.Scripts;
@@ -15,19 +14,19 @@ public class Context
         ReturnValue = new NoReturnValue();
     }
 
-    public Parameters Parameters { get; set; }
+    public Parameters? Parameters { get; set; }
     public object ReturnValue { get; set; }
     public bool IsReturned { get; set; }
 }
 
 [SuppressMessage("Microsoft.Usage", "CA2237:MarkISerializableTypesWithSerializable")]
-public class Parameters : Dictionary<string, object>
+public class Parameters : Dictionary<string, object?>
 {
     public Parameters()
     {
     }
 
-    public Parameters(string key, object value)
+    public Parameters(string key, object? value)
     {
         Add(key, value);
     }

--- a/src/Engine/Scripts/CreateScript.cs
+++ b/src/Engine/Scripts/CreateScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -12,7 +11,7 @@ public class CreateScriptConstructor : ScriptConstructorBase
         get { return new[] {1, 2}; }
     }
 
-    protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
+    protected override IScript? CreateInt(List<string> parameters, ScriptContext scriptContext)
     {
         switch (parameters.Count)
         {
@@ -32,7 +31,7 @@ public class CreateScript : ScriptBase
     private readonly ScriptContext _scriptContext;
     private readonly WorldModel _worldModel;
     private IFunction<string> _expr;
-    private IFunction<string> _type;
+    private IFunction<string>? _type;
 
     public CreateScript(ScriptContext scriptContext, IFunction<string> expr)
     {
@@ -82,7 +81,7 @@ public class CreateScript : ScriptBase
         return SaveScript("create", _expr.Save(), _type.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -95,12 +94,12 @@ public class CreateScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _expr = new Expression<string>((string) value, _scriptContext);
+                _expr = new Expression<string>((string) value!, _scriptContext);
                 break;
             case 1:
                 _type = value == null ? null : new Expression<string>((string) value, _scriptContext);
@@ -120,7 +119,7 @@ public class CreateExitScriptConstructor : ScriptConstructorBase
         get { return new[] {3, 4, 5}; }
     }
 
-    protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
+    protected override IScript? CreateInt(List<string> parameters, ScriptContext scriptContext)
     {
         switch (parameters.Count)
         {
@@ -150,8 +149,8 @@ public class CreateExitScript : ScriptBase
     private readonly ScriptContext _scriptContext;
     private readonly WorldModel _worldModel;
     private IFunction<Element> _from;
-    private IFunction<string> _id;
-    private IFunction<string> _initialType;
+    private IFunction<string>? _id;
+    private IFunction<string>? _initialType;
     private IFunction<string> _name;
     private IFunction<Element> _to;
 
@@ -219,7 +218,7 @@ public class CreateExitScript : ScriptBase
         return SaveScript("create exit", _id.Save(), _name.Save(), _from.Save(), _to.Save(), _initialType.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -238,7 +237,7 @@ public class CreateExitScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
@@ -246,13 +245,13 @@ public class CreateExitScript : ScriptBase
                 _id = value == null ? null : new Expression<string>((string) value, _scriptContext);
                 break;
             case 1:
-                _name = new Expression<string>((string) value, _scriptContext);
+                _name = new Expression<string>((string) value!, _scriptContext);
                 break;
             case 2:
-                _from = new Expression<Element>((string) value, _scriptContext);
+                _from = new Expression<Element>((string) value!, _scriptContext);
                 break;
             case 3:
-                _to = new Expression<Element>((string) value, _scriptContext);
+                _to = new Expression<Element>((string) value!, _scriptContext);
                 break;
             case 4:
                 _initialType = value == null ? null : new Expression<string>((string) value, _scriptContext);
@@ -309,14 +308,14 @@ public class CreateTimerScript : ScriptBase
         return SaveScript("create timer", _expr.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _expr.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _expr = new Expression<string>((string) value, _scriptContext);
+        _expr = new Expression<string>((string) value!, _scriptContext);
     }
 }
 
@@ -365,13 +364,13 @@ public class CreateTurnScript : ScriptBase
         return SaveScript("create turnscript", _expr.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _expr.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _expr = new Expression<string>((string) value, _scriptContext);
+        _expr = new Expression<string>((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/DelegateImplementation.cs
+++ b/src/Engine/Scripts/DelegateImplementation.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 internal class DelegateImplementation
 {
@@ -19,6 +18,6 @@ internal class DelegateImplementation
     public override string ToString()
     {
         var script = Implementation.Fields[FieldDefinitions.Script];
-        return script == null ? string.Empty : script.ToString();
+        return script?.ToString() ?? string.Empty;
     }
 }

--- a/src/Engine/Scripts/DestroyScript.cs
+++ b/src/Engine/Scripts/DestroyScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -58,13 +57,13 @@ public class DestroyScript : ScriptBase
         return SaveScript("destroy", _expr.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _expr.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _expr = new Expression<string>((string) value, _scriptContext);
+        _expr = new Expression<string>((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/DictionaryAddScript.cs
+++ b/src/Engine/Scripts/DictionaryAddScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections;
+﻿using System.Collections;
 using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
@@ -66,7 +65,7 @@ public class DictionaryAddScript : ScriptBase
         return SaveScript("dictionary add", _dictionary.Save(), _key.Save(), _value.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -81,18 +80,18 @@ public class DictionaryAddScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _dictionary = new ExpressionDynamic((string) value, _scriptContext);
+                _dictionary = new ExpressionDynamic((string) value!, _scriptContext);
                 break;
             case 1:
-                _key = new Expression<string>((string) value, _scriptContext);
+                _key = new Expression<string>((string) value!, _scriptContext);
                 break;
             case 2:
-                _value = new Expression<object>((string) value, _scriptContext);
+                _value = new Expression<object>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -158,7 +157,7 @@ public class DictionaryRemoveScript : ScriptBase
         return SaveScript("dictionary remove", _dictionary.Save(), _key.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -171,15 +170,15 @@ public class DictionaryRemoveScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _dictionary = new ExpressionDynamic((string) value, _scriptContext);
+                _dictionary = new ExpressionDynamic((string) value!, _scriptContext);
                 break;
             case 1:
-                _key = new Expression<string>((string) value, _scriptContext);
+                _key = new Expression<string>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/DoScript.cs
+++ b/src/Engine/Scripts/DoScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections;
+﻿using System.Collections;
 using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
@@ -10,7 +9,7 @@ public class DoScriptConstructor : ScriptConstructorBase
 
     public override string Keyword => "do";
 
-    protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
+    protected override IScript? CreateInt(List<string> parameters, ScriptContext scriptContext)
     {
         switch (parameters.Count)
         {
@@ -40,7 +39,7 @@ public class DoActionScript : ScriptBase
     private readonly WorldModel _worldModel;
     private IFunction<string> _action;
     private IFunction<Element> _obj;
-    private IFunction<IDictionary> _parameters;
+    private IFunction<IDictionary>? _parameters;
 
     public DoActionScript(ScriptContext scriptContext, IFunction<Element> obj, IFunction<string> action)
     {
@@ -51,7 +50,7 @@ public class DoActionScript : ScriptBase
     }
 
     public DoActionScript(ScriptContext scriptContext, IFunction<Element> obj, IFunction<string> action,
-        IFunction<IDictionary> parameters)
+        IFunction<IDictionary>? parameters)
         : this(scriptContext, obj, action)
     {
         _parameters = parameters;
@@ -68,7 +67,7 @@ public class DoActionScript : ScriptBase
     public override async Task ExecuteAsync(Context c)
     {
         var obj = await _obj.ExecuteAsync(c);
-        var action = obj.GetAction(await _action.ExecuteAsync(c));
+        var action = obj.GetAction(await _action.ExecuteAsync(c))!;
         if (_parameters == null)
         {
             await _worldModel.RunScriptAsync(action, obj);
@@ -84,13 +83,13 @@ public class DoActionScript : ScriptBase
         var parameters = _parameters == null ? null : _parameters.Save();
         if (!string.IsNullOrEmpty(parameters))
         {
-            return SaveScript("do", _obj.Save(), _action.Save(), _parameters.Save());
+            return SaveScript("do", _obj.Save(), _action.Save(), parameters);
         }
 
         return SaveScript("do", _obj.Save(), _action.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -105,18 +104,18 @@ public class DoActionScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _obj = new Expression<Element>((string) value, _scriptContext);
+                _obj = new Expression<Element>((string) value!, _scriptContext);
                 break;
             case 1:
-                _action = new Expression<string>((string) value, _scriptContext);
+                _action = new Expression<string>((string) value!, _scriptContext);
                 break;
             case 2:
-                _parameters = new Expression<IDictionary>((string) value, _scriptContext);
+                _parameters = new Expression<IDictionary>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/ErrorScript.cs
+++ b/src/Engine/Scripts/ErrorScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -53,13 +52,13 @@ public class ErrorScript : ScriptBase
         return SaveScript("error", _function.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _function.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _function = new ExpressionDynamic((string) value, _scriptContext);
+        _function = new ExpressionDynamic((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/FailedScript.cs
+++ b/src/Engine/Scripts/FailedScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 internal class FailedScript : ScriptBase
 {
@@ -27,17 +26,17 @@ internal class FailedScript : ScriptBase
         return _script;
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         if (index != 0)
         {
             throw new ArgumentOutOfRangeException();
         }
 
-        _script = (string) value;
+        _script = (string) value!;
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         if (index != 0)
         {

--- a/src/Engine/Scripts/FinishScript.cs
+++ b/src/Engine/Scripts/FinishScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 public class FinishScriptConstructor : ScriptConstructorBase
 {
@@ -43,12 +42,12 @@ public class FinishScript : ScriptBase
         return "finish";
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         throw new ArgumentOutOfRangeException();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         throw new ArgumentOutOfRangeException();
     }

--- a/src/Engine/Scripts/FirstTimeScript.cs
+++ b/src/Engine/Scripts/FirstTimeScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 internal interface IFirstTimeScript
 {
@@ -20,9 +19,9 @@ public class FirstTimeScriptConstructor : IScriptConstructor
         return new FirstTimeScript(WorldModel, ScriptFactory, firstTimeScript);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 
     public static void AddOtherwiseScript(IScript firstTimeScript, string script, IScriptFactory scriptFactory)
     {
@@ -40,7 +39,7 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
     private readonly IScriptFactory _scriptFactory;
     private readonly WorldModel _worldModel;
     private bool _hasRun;
-    private IScript _otherwiseScript;
+    private IScript? _otherwiseScript;
 
     public FirstTimeScript(WorldModel worldModel, IScriptFactory scriptFactory, IScript firstTimeScript)
     {
@@ -110,7 +109,7 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
         return _otherwiseScript.Save();
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -123,7 +122,7 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
@@ -132,7 +131,7 @@ public class FirstTimeScript : ScriptBase, IFirstTimeScript
                 throw new InvalidOperationException(
                     "Attempt to use SetParameter to change the script of a 'firsttime' script");
             case 1:
-                _otherwiseScript = (IScript) value;
+                _otherwiseScript = (IScript) value!;
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/ForEachScript.cs
+++ b/src/Engine/Scripts/ForEachScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections;
+﻿using System.Collections;
 using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
@@ -26,9 +25,9 @@ public class ForEachScriptConstructor : IScriptConstructor
             loopScript);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 }
 
 public class ForEachScript : ScriptBase
@@ -56,7 +55,7 @@ public class ForEachScript : ScriptBase
     public override async Task ExecuteAsync(Context c)
     {
         var result = await _list.ExecuteAsync(c);
-        IEnumerable resultList = null;
+        IEnumerable? resultList = null;
 
         // Cannot foreach over strings as of Quest 5.3, as the Char data type is not supported (retained functionality
         // for pre-5.3 to prevent breaking existing scripts)
@@ -81,7 +80,7 @@ public class ForEachScript : ScriptBase
 
         foreach (var variable in resultList)
         {
-            c.Parameters[_variable] = variable;
+            c.Parameters![_variable] = variable;
             await _loopScript.ExecuteAsync(c);
             if (c.IsReturned)
             {
@@ -95,7 +94,7 @@ public class ForEachScript : ScriptBase
         return SaveScript("foreach", _loopScript, _variable, _list.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -110,15 +109,15 @@ public class ForEachScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _variable = (string) value;
+                _variable = (string) value!;
                 break;
             case 1:
-                _list = new ExpressionDynamic((string) value, _scriptContext);
+                _list = new ExpressionDynamic((string) value!, _scriptContext);
                 break;
             case 2:
                 throw new InvalidOperationException(

--- a/src/Engine/Scripts/ForScript.cs
+++ b/src/Engine/Scripts/ForScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -35,9 +34,9 @@ public class ForScriptConstructor : IScriptConstructor
         throw new Exception(string.Format("'for' script should have 3 or 4 parameters: 'for ({0})'", param));
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 
     #endregion
 }
@@ -48,7 +47,7 @@ public class ForScript : ScriptBase
     private readonly ScriptContext _scriptContext;
     private readonly IScriptFactory _scriptFactory;
     private IFunction<int> _from;
-    private IFunction<int> _step;
+    private IFunction<int>? _step;
     private IFunction<int> _to;
     private string _variable;
     private WorldModel _worldModel;
@@ -66,7 +65,7 @@ public class ForScript : ScriptBase
     }
 
     public ForScript(ScriptContext scriptContext, IScriptFactory scriptFactory, string variable, IFunction<int> from,
-        IFunction<int> to, IFunction<int> step, IScript loopScript)
+        IFunction<int> to, IFunction<int>? step, IScript loopScript)
         : this(scriptContext, scriptFactory, variable, from, to, loopScript)
     {
         _step = step;
@@ -91,18 +90,18 @@ public class ForScript : ScriptBase
         var to = await _to.ExecuteAsync(c);
         var step = _step == null ? 1 : await _step.ExecuteAsync(c);
         int count;
-        c.Parameters[_variable] = 0;
+        c.Parameters![_variable] = 0;
 
         for (count = from; (step > 0 && count <= to) || (step < 0 && count >= to); count += step)
         {
-            c.Parameters[_variable] = count;
+            c.Parameters![_variable] = count;
             await _loopScript.ExecuteAsync(c);
             if (c.IsReturned)
             {
                 break;
             }
 
-            var newCount = c.Parameters[_variable];
+            var newCount = c.Parameters![_variable];
             if (newCount is int)
             {
                 count = (int) newCount;
@@ -125,7 +124,7 @@ public class ForScript : ScriptBase
         return SaveScript("for", _loopScript, _variable, _from.Save(), _to.Save(), _step.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -144,21 +143,21 @@ public class ForScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _variable = (string) value;
+                _variable = (string) value!;
                 break;
             case 1:
-                _from = new Expression<int>((string) value, _scriptContext);
+                _from = new Expression<int>((string) value!, _scriptContext);
                 break;
             case 2:
-                _to = new Expression<int>((string) value, _scriptContext);
+                _to = new Expression<int>((string) value!, _scriptContext);
                 break;
             case 3:
-                _step = new Expression<int>((string) value, _scriptContext);
+                _step = new Expression<int>((string) value!, _scriptContext);
                 break;
             case 4:
                 // any updates to the script should change the script itself - nothing should cause SetParameter to be triggered.

--- a/src/Engine/Scripts/FunctionCallParameters.cs
+++ b/src/Engine/Scripts/FunctionCallParameters.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 // We store the parameters internally as a QuestList<string>, so we can edit them in the Editor
@@ -10,7 +9,7 @@ namespace QuestViva.Engine.Scripts;
 // a game there is no mechanism for modifying a script command.
 internal class FunctionCallParameters
 {
-    public FunctionCallParameters(WorldModel worldModel, IList<IFunction<object>> parameters)
+    public FunctionCallParameters(WorldModel worldModel, IList<IFunction<object>>? parameters)
     {
         Parameters = parameters;
 
@@ -34,7 +33,7 @@ internal class FunctionCallParameters
         }
     }
 
-    public IList<IFunction<object>> Parameters { get; }
+    public IList<IFunction<object>>? Parameters { get; }
 
     public QuestList<string> ParametersAsQuestList { get; } = new();
 }

--- a/src/Engine/Scripts/FunctionCallScript.cs
+++ b/src/Engine/Scripts/FunctionCallScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -7,11 +6,11 @@ public class FunctionCallScriptConstructor : IScriptConstructor
 {
     public IScript Create(string script, ScriptContext scriptContext)
     {
-        List<IFunction<object>> paramExpressions = null;
+        List<IFunction<object>>? paramExpressions = null;
         string procName, afterParameter;
 
         var param = Utility.GetParameter(script, out afterParameter);
-        IScript paramScript = null;
+        IScript? paramScript = null;
 
         // Handle functions of the form
         //    SomeFunction (parameter) { script }
@@ -58,18 +57,18 @@ public class FunctionCallScriptConstructor : IScriptConstructor
         return new FunctionCallScript(WorldModel, procName, paramExpressions, paramScript);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 
-    public string Keyword => null;
+    public string? Keyword => null;
 }
 
 public class FunctionCallScript : ScriptBase, IFunctionCallScript
 {
     private readonly FunctionCallParameters _parameters;
     private readonly WorldModel _worldModel;
-    private IScript _paramFunction;
+    private IScript? _paramFunction;
     private string _procedure;
 
     public FunctionCallScript(WorldModel worldModel, string procedure)
@@ -77,8 +76,8 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
     {
     }
 
-    public FunctionCallScript(WorldModel worldModel, string procedure, IList<IFunction<object>> parameters,
-        IScript paramFunction)
+    public FunctionCallScript(WorldModel worldModel, string procedure, IList<IFunction<object>>? parameters,
+        IScript? paramFunction)
     {
         _worldModel = worldModel;
         _procedure = procedure;
@@ -89,7 +88,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         _parameters.ParametersAsQuestList.Removed += Parameters_Removed;
     }
 
-    public event EventHandler<ScriptUpdatedEventArgs> FunctionCallParametersUpdated;
+    public event EventHandler<ScriptUpdatedEventArgs>? FunctionCallParametersUpdated;
 
     public override async Task ExecuteAsync(Context c)
     {
@@ -100,11 +99,12 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         else
         {
             var paramValues = new Parameters();
-            var proc = _worldModel.Procedure(_procedure);
+            var proc = _worldModel.Procedure(_procedure)!;
 
-            var paramNames = proc.Fields[FieldDefinitions.ParamNames];
+            var paramNames = proc.Fields[FieldDefinitions.ParamNames]!;
 
-            var paramCount = _parameters.Parameters.Count;
+            var parameters = _parameters.Parameters!;
+            var paramCount = parameters.Count;
             if (_paramFunction != null)
             {
                 paramCount++;
@@ -132,15 +132,15 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
             }
 
             var cnt = 0;
-            foreach (var f in _parameters.Parameters)
+            foreach (var f in parameters)
             {
-                paramValues.Add((string) paramNames[cnt], await f.ExecuteAsync(c));
+                paramValues.Add((string) paramNames[cnt]!, await f.ExecuteAsync(c));
                 cnt++;
             }
 
             if (_paramFunction != null)
             {
-                paramValues.Add((string) paramNames[cnt], _paramFunction);
+                paramValues.Add((string) paramNames[cnt]!, _paramFunction);
             }
 
             await _worldModel.RunProcedureAsync(_procedure, paramValues, false);
@@ -159,7 +159,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
             //throw new Exception(string.Format("Unable to save call to function '{0}' - function does not exist", _procedure));
         }
 
-        if ((_parameters == null || _parameters.ParametersAsQuestList.Count == 0) && _paramFunction == null)
+        if (_parameters.ParametersAsQuestList.Count == 0 && _paramFunction == null)
         {
             return _procedure;
         }
@@ -183,7 +183,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         return SaveScript(_procedure + "()", _paramFunction);
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -196,7 +196,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         }
     }
 
-    public object GetFunctionCallParameter(int index)
+    public object? GetFunctionCallParameter(int index)
     {
         if (index >= _parameters.ParametersAsQuestList.Count)
         {
@@ -209,7 +209,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         return _parameters.ParametersAsQuestList[index];
     }
 
-    public void SetFunctionCallParameter(int index, object value)
+    public void SetFunctionCallParameter(int index, object? value)
     {
         if (index < _parameters.ParametersAsQuestList.Count)
         {
@@ -221,12 +221,12 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         _parameters.ParametersAsQuestList.Add(value, UpdateSource.User, index);
     }
 
-    public IScript GetFunctionCallParameterScript()
+    public IScript? GetFunctionCallParameterScript()
     {
         return _paramFunction;
     }
 
-    public void SetFunctionCallParameterScript(IScript script)
+    public void SetFunctionCallParameterScript(IScript? script)
     {
         _paramFunction = script;
     }
@@ -234,7 +234,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
     // Only an EditableScript wrapper - i.e. a script currently open in the editor - subscribes
     // to FunctionCallParametersUpdated, so both handlers below have to cope with there being no
     // subscriber at all.
-    private void Parameters_Added(object sender, QuestListUpdatedEventArgs<string> e)
+    private void Parameters_Added(object? sender, QuestListUpdatedEventArgs<string> e)
     {
         // the number of parameters in a function call cannot change. So, as QuestList doesn't
         // provide an Updated event (we simulate Updates with a Remove and an Add at the same
@@ -243,7 +243,7 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
         FunctionCallParametersUpdated?.Invoke(this, new ScriptUpdatedEventArgs(e.Index, e.UpdatedItem));
     }
 
-    private void Parameters_Removed(object sender, QuestListUpdatedEventArgs<string> e)
+    private void Parameters_Removed(object? sender, QuestListUpdatedEventArgs<string> e)
     {
         // the only time we care about a parameter being removed is if it's the first parameter being
         // deleted. Everything else should simply be a Remove followed by an Add, and we handle the
@@ -256,16 +256,16 @@ public class FunctionCallScript : ScriptBase, IFunctionCallScript
 
     protected override ScriptBase CloneScript()
     {
-        return new FunctionCallScript(_worldModel, _procedure, _parameters == null ? null : _parameters.Parameters,
+        return new FunctionCallScript(_worldModel, _procedure, _parameters.Parameters,
             _paramFunction);
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _procedure = (string) value;
+                _procedure = (string) value!;
                 break;
             case 1:
                 // any updates to the parameters should change the list itself - nothing should cause SetParameter to be triggered.

--- a/src/Engine/Scripts/GetInputScript.cs
+++ b/src/Engine/Scripts/GetInputScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 public class GetInputScriptConstructor : IScriptConstructor
 {
@@ -12,9 +11,9 @@ public class GetInputScriptConstructor : IScriptConstructor
         return new GetInputScript(scriptContext, ScriptFactory, callbackScript);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 }
 
 public class GetInputScript : ScriptBase
@@ -54,11 +53,11 @@ public class GetInputScript : ScriptBase
         var resolved = false;
         try
         {
-            var result = await _worldModel._commandInputTcs.Task;
+            var result = await _worldModel._commandInputTcs!.Task;
             resolved = true;
             _worldModel.SignalCallbackResolving();
             _worldModel._commandOverride = false;
-            c.Parameters["result"] = result;
+            c.Parameters!["result"] = result;
             await _worldModel.RunScriptAsync(_callbackScript, c);
         }
         catch (OperationCanceledException) { }
@@ -76,7 +75,7 @@ public class GetInputScript : ScriptBase
         return SaveScript("get input", _callbackScript);
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -87,7 +86,7 @@ public class GetInputScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {

--- a/src/Engine/Scripts/IScript.cs
+++ b/src/Engine/Scripts/IScript.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 public class ScriptUpdatedEventArgs : EventArgs
 {
@@ -8,7 +6,7 @@ public class ScriptUpdatedEventArgs : EventArgs
     {
     }
 
-    internal ScriptUpdatedEventArgs(IScript added, IScript removed)
+    internal ScriptUpdatedEventArgs(IScript? added, IScript? removed)
     {
         AddedScript = added;
         RemovedScript = removed;
@@ -20,14 +18,14 @@ public class ScriptUpdatedEventArgs : EventArgs
         Index = index;
     }
 
-    internal ScriptUpdatedEventArgs(int index, object newValue)
+    internal ScriptUpdatedEventArgs(int index, object? newValue)
     {
         Index = index;
         NewValue = newValue;
         IsParameterUpdate = true;
     }
 
-    internal ScriptUpdatedEventArgs(string id, object newValue)
+    internal ScriptUpdatedEventArgs(string id, object? newValue)
     {
         Id = id;
         NewValue = newValue;
@@ -53,32 +51,37 @@ public interface IScriptParent
 public interface IScript : IMutableField
 {
     string? Line { get; set; }
-    string Keyword { get; }
-    IScriptParent Parent { get; set; }
+    string? Keyword { get; }
+    IScriptParent? Parent { get; set; }
     Task ExecuteAsync(Context c);
     string Save();
-    void SetParameter(int index, object value);
-    void SetParameterSilent(int index, object value);
-    object GetParameter(int index);
+    void SetParameter(int index, object? value);
+    void SetParameterSilent(int index, object? value);
+    object? GetParameter(int index);
     event EventHandler<ScriptUpdatedEventArgs> ScriptUpdated;
     IEnumerable<string>? GetDefinedVariables();
 }
 
 public interface IFunctionCallScript : IScript
 {
-    object GetFunctionCallParameter(int index);
-    void SetFunctionCallParameter(int index, object value);
-    IScript GetFunctionCallParameterScript();
-    void SetFunctionCallParameterScript(IScript script);
+    object? GetFunctionCallParameter(int index);
+    void SetFunctionCallParameter(int index, object? value);
+    IScript? GetFunctionCallParameterScript();
+    void SetFunctionCallParameterScript(IScript? script);
     event EventHandler<ScriptUpdatedEventArgs> FunctionCallParametersUpdated;
 }
 
 public interface IScriptConstructor
 {
-    string Keyword { get; }
+    // Null for the function-call constructor, which ScriptFactory falls back to rather than matching by keyword
+    string? Keyword { get; }
+
+    // Both set by ScriptFactory straight after the constructor is created
     IScriptFactory ScriptFactory { set; }
     WorldModel WorldModel { get; set; }
-    IScript Create(string script, ScriptContext scriptContext);
+
+    // Returns null if the line isn't one this constructor handles, so ScriptFactory can try the next one
+    IScript? Create(string script, ScriptContext scriptContext);
 }
 
 public abstract class ScriptBase : IScript, IMutableField
@@ -97,27 +100,26 @@ public abstract class ScriptBase : IScript, IMutableField
         set => _line = value;
     }
 
-    public void SetParameter(int index, object value)
+    public void SetParameter(int index, object? value)
     {
         var oldValue = GetParameter(index);
         SetParameterSilent(index, value);
         UndoLog?.AddUndoAction(() => new UndoScriptChange(this, index, oldValue, value));
     }
 
-    public void SetParameterSilent(int index, object value)
+    public void SetParameterSilent(int index, object? value)
     {
         SetParameterInternal(index, value);
         NotifyUpdate(index, value);
     }
 
-    public abstract object GetParameter(int index);
+    public abstract object? GetParameter(int index);
 
-    public abstract string Keyword { get; }
+    public abstract string? Keyword { get; }
 
     public event EventHandler<ScriptUpdatedEventArgs>? ScriptUpdated;
 
-    [field: AllowNull, MaybeNull]
-    public IScriptParent Parent
+    public IScriptParent? Parent
     {
         get;
         set
@@ -154,12 +156,12 @@ public abstract class ScriptBase : IScript, IMutableField
         return result + " {" + Environment.NewLine + scriptString + Environment.NewLine + "}";
     }
 
-    protected void NotifyUpdate(int index, object newValue)
+    protected void NotifyUpdate(int index, object? newValue)
     {
         NotifyUpdate(new ScriptUpdatedEventArgs(index, newValue));
     }
 
-    protected void NotifyUpdate(IScript added, IScript removed)
+    protected void NotifyUpdate(IScript? added, IScript? removed)
     {
         NotifyUpdate(new ScriptUpdatedEventArgs(added, removed));
     }
@@ -169,7 +171,7 @@ public abstract class ScriptBase : IScript, IMutableField
         NotifyUpdate(new ScriptUpdatedEventArgs(inserted, index));
     }
 
-    protected void NotifyUpdate(string id, object newValue)
+    protected void NotifyUpdate(string id, object? newValue)
     {
         NotifyUpdate(new ScriptUpdatedEventArgs(id, newValue));
     }
@@ -184,13 +186,13 @@ public abstract class ScriptBase : IScript, IMutableField
 
     protected abstract ScriptBase CloneScript();
 
-    protected abstract void SetParameterInternal(int index, object value);
+    protected abstract void SetParameterInternal(int index, object? value);
 
     protected virtual void ParentUpdated()
     {
     }
 
-    private class UndoScriptChange(IScript appliesTo, int index, object oldValue, object newValue)
+    private class UndoScriptChange(IScript appliesTo, int index, object? oldValue, object? newValue)
         : UndoLogger.IUndoAction
     {
         public void DoUndo(WorldModel worldModel)

--- a/src/Engine/Scripts/IfScript.cs
+++ b/src/Engine/Scripts/IfScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
@@ -8,10 +7,10 @@ public interface IIfScript : IScript
 {
     IFunction<bool> Expression { get; }
     IScript ThenScript { get; set; }
-    IScript ElseScript { get; }
+    IScript? ElseScript { get; }
     IList<IElseIfScript> ElseIfScripts { get; }
     string ExpressionString { get; set; }
-    void SetElse(IScript elseScript);
+    void SetElse(IScript? elseScript);
     IElseIfScript AddElseIf(string expression, IScript script);
     IElseIfScript AddElseIf(IFunction<bool> expression, IScript script);
     event EventHandler<IfScriptUpdatedEventArgs> IfScriptUpdated;
@@ -77,9 +76,9 @@ public class IfScriptConstructor : IScriptConstructor
         return new IfScript(new Expression<bool>(expr, scriptContext), thenScript, scriptContext);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 
     #endregion
 }
@@ -99,7 +98,7 @@ public class IfScript : ScriptBase, IIfScript
     {
     }
 
-    public IfScript(IFunction<bool> expression, IScript thenScript, IScript elseScript, ScriptContext scriptContext)
+    public IfScript(IFunction<bool> expression, IScript thenScript, IScript? elseScript, ScriptContext scriptContext)
     {
         Expression = expression;
         ThenScript = thenScript;
@@ -108,9 +107,9 @@ public class IfScript : ScriptBase, IIfScript
         _worldModel = scriptContext.WorldModel;
     }
 
-    public event EventHandler<IfScriptUpdatedEventArgs> IfScriptUpdated;
+    public event EventHandler<IfScriptUpdatedEventArgs>? IfScriptUpdated;
 
-    public void SetElse(IScript elseScript)
+    public void SetElse(IScript? elseScript)
     {
         if (UndoLog != null)
         {
@@ -179,7 +178,7 @@ public class IfScript : ScriptBase, IIfScript
         get => Expression.Save();
         set
         {
-            UndoLog.AddUndoAction(() => new UndoChangeExpression(this, Expression.Save(), value));
+            UndoLog!.AddUndoAction(() => new UndoChangeExpression(this, Expression.Save(), value));
             SetExpressionSilent(value);
         }
     }
@@ -188,7 +187,7 @@ public class IfScript : ScriptBase, IIfScript
 
     public IScript ThenScript { get; set; }
 
-    public IScript ElseScript { get; private set; }
+    public IScript? ElseScript { get; private set; }
 
     protected override ScriptBase CloneScript()
     {
@@ -204,7 +203,7 @@ public class IfScript : ScriptBase, IIfScript
         return clone;
     }
 
-    private void SetElseSilent(IScript elseScript)
+    private void SetElseSilent(IScript? elseScript)
     {
         ElseScript = elseScript;
 
@@ -275,7 +274,7 @@ public class IfScript : ScriptBase, IIfScript
             get => Expression.Save();
             set
             {
-                _parent.UndoLog.AddUndoAction(() => new UndoChangeExpression(this, Expression.Save(), value));
+                _parent.UndoLog!.AddUndoAction(() => new UndoChangeExpression(this, Expression.Save(), value));
                 SetExpressionSilent(value);
             }
         }
@@ -294,10 +293,10 @@ public class IfScript : ScriptBase, IIfScript
 
     private class UndoChangeExpression : UndoLogger.IUndoAction
     {
-        private readonly ElseIfScript _elseIfScript;
+        private readonly ElseIfScript? _elseIfScript;
         private readonly string _newValue;
         private readonly string _oldValue;
-        private readonly IfScript _script;
+        private readonly IfScript? _script;
 
         private UndoChangeExpression(string oldValue, string newValue)
         {
@@ -351,12 +350,12 @@ public class IfScript : ScriptBase, IIfScript
     private class UndoSetElse : UndoLogger.IUndoAction
     {
         private readonly bool _newHasElse;
-        private readonly IScript _newValue;
+        private readonly IScript? _newValue;
         private readonly bool _oldHasElse;
-        private readonly IScript _oldValue;
+        private readonly IScript? _oldValue;
         private readonly IfScript _script;
 
-        public UndoSetElse(IfScript script, IScript oldValue, IScript newValue, bool oldHasElse, bool newHasElse)
+        public UndoSetElse(IfScript script, IScript? oldValue, IScript? newValue, bool oldHasElse, bool newHasElse)
         {
             _script = script;
             _oldValue = oldValue;
@@ -471,7 +470,7 @@ public class IfScript : ScriptBase, IIfScript
 
     public override string Keyword => "if";
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -486,7 +485,7 @@ public class IfScript : ScriptBase, IIfScript
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         throw new NotImplementedException();
     }
@@ -516,5 +515,5 @@ public class IfScriptUpdatedEventArgs : EventArgs
     }
 
     public IfScriptUpdatedEventType EventType { get; private set; }
-    public IElseIfScript Data { get; private set; }
+    public IElseIfScript? Data { get; private set; }
 }

--- a/src/Engine/Scripts/InsertScript.cs
+++ b/src/Engine/Scripts/InsertScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -73,13 +72,13 @@ public class InsertScript : ScriptBase
         return SaveScript("insert", _filename.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _filename.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _filename = new Expression<string>((string) value, _scriptContext);
+        _filename = new Expression<string>((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/InvokeScript.cs
+++ b/src/Engine/Scripts/InvokeScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections;
+﻿using System.Collections;
 using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
@@ -13,7 +12,7 @@ public class InvokeScriptConstructor : ScriptConstructorBase
         get { return new[] {1, 2}; }
     }
 
-    protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
+    protected override IScript? CreateInt(List<string> parameters, ScriptContext scriptContext)
     {
         switch (parameters.Count)
         {
@@ -32,7 +31,7 @@ public class InvokeScript : ScriptBase
 {
     private readonly ScriptContext _scriptContext;
     private readonly WorldModel _worldModel;
-    private IFunction<IDictionary> _parameters;
+    private IFunction<IDictionary>? _parameters;
     private IFunction<IScript> _script;
 
     public InvokeScript(ScriptContext scriptContext, IFunction<IScript> script)
@@ -42,7 +41,7 @@ public class InvokeScript : ScriptBase
         _script = script;
     }
 
-    public InvokeScript(ScriptContext scriptContext, IFunction<IScript> script, IFunction<IDictionary> parameters)
+    public InvokeScript(ScriptContext scriptContext, IFunction<IScript> script, IFunction<IDictionary>? parameters)
         : this(scriptContext, script)
     {
         _parameters = parameters;
@@ -79,7 +78,7 @@ public class InvokeScript : ScriptBase
         return SaveScript("invoke", _script.Save(), parameters);
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -92,15 +91,15 @@ public class InvokeScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _script = new Expression<IScript>((string) value, _scriptContext);
+                _script = new Expression<IScript>((string) value!, _scriptContext);
                 break;
             case 1:
-                _parameters = new Expression<IDictionary>((string) value, _scriptContext);
+                _parameters = new Expression<IDictionary>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/JSScript.cs
+++ b/src/Engine/Scripts/JSScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
@@ -13,7 +12,7 @@ public class JSScriptConstructor : IScriptConstructor
     {
         var param = Utility.GetParameter(script);
 
-        List<IFunctionDynamic> expressions = null;
+        List<IFunctionDynamic>? expressions = null;
 
         if (param != null)
         {
@@ -35,18 +34,18 @@ public class JSScriptConstructor : IScriptConstructor
         return new JSScript(scriptContext, functionName, expressions);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 }
 
 public class JSScript : ScriptBase
 {
     private readonly ScriptContext _scriptContext;
     private string _function;
-    private List<IFunctionDynamic> _parameters;
+    private List<IFunctionDynamic>? _parameters;
 
-    public JSScript(ScriptContext scriptContext, string function, List<IFunctionDynamic> parameters)
+    public JSScript(ScriptContext scriptContext, string function, List<IFunctionDynamic>? parameters)
     {
         _scriptContext = scriptContext;
         _function = function;
@@ -92,12 +91,12 @@ public class JSScript : ScriptBase
             _parameters == null ? new[] {string.Empty} : _parameters.Select(p => p.Save()).ToArray());
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         var constuctor = new JSScriptConstructor();
         try
         {
-            var newScript = (JSScript) constuctor.Create("JS." + (string) value, _scriptContext);
+            var newScript = (JSScript) constuctor.Create("JS." + (string) value!, _scriptContext);
             _function = newScript._function;
             _parameters = newScript._parameters;
         }
@@ -107,7 +106,7 @@ public class JSScript : ScriptBase
         }
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return Save().Substring(3);
     }

--- a/src/Engine/Scripts/LazyLoadScript.cs
+++ b/src/Engine/Scripts/LazyLoadScript.cs
@@ -1,17 +1,17 @@
-﻿#nullable disable
+﻿using System.Diagnostics.CodeAnalysis;
 using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
 public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
 {
-    private readonly IScriptConstructor _scriptConstructor;
+    private readonly IScriptConstructor? _scriptConstructor;
     private readonly ScriptContext _scriptContext;
     private readonly ScriptFactory _scriptFactory;
     private readonly WorldModel _worldModel;
-    private IScriptParent _parent;
-    private IScript _script;
-    private string _scriptString;
+    private IScriptParent? _parent;
+    private IScript? _script;
+    private string? _scriptString;
 
     public LazyLoadScript(ScriptFactory scriptFactory, string scriptString, ScriptContext scriptContext)
     {
@@ -51,7 +51,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         }
     }
 
-    public void SetElse(IScript elseScript)
+    public void SetElse(IScript? elseScript)
     {
         Initialise();
         ((IfScript) _script).SetElse(elseScript);
@@ -92,7 +92,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         }
     }
 
-    public IScript ElseScript
+    public IScript? ElseScript
     {
         get
         {
@@ -176,7 +176,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
             return _script.Clone();
         }
 
-        var result = new LazyLoadScript(_scriptFactory, _scriptString, _scriptContext);
+        var result = new LazyLoadScript(_scriptFactory, _scriptString!, _scriptContext);
         result.Line = _scriptString;
         result.Parent = _parent;
         return result;
@@ -202,7 +202,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         return _script.ExecuteAsync(c);
     }
 
-    public string Line
+    public string? Line
     {
         get
         {
@@ -231,25 +231,25 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         return _script.Save();
     }
 
-    public void SetParameter(int index, object value)
+    public void SetParameter(int index, object? value)
     {
         Initialise();
         _script.SetParameter(index, value);
     }
 
-    public void SetParameterSilent(int index, object value)
+    public void SetParameterSilent(int index, object? value)
     {
         Initialise();
         _script.SetParameterSilent(index, value);
     }
 
-    public object GetParameter(int index)
+    public object? GetParameter(int index)
     {
         Initialise();
         return _script.GetParameter(index);
     }
 
-    public string Keyword
+    public string? Keyword
     {
         get
         {
@@ -258,7 +258,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         }
     }
 
-    public IScriptParent Parent
+    public IScriptParent? Parent
     {
         get
         {
@@ -281,13 +281,13 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         }
     }
 
-    public IEnumerable<string> GetDefinedVariables()
+    public IEnumerable<string>? GetDefinedVariables()
     {
         Initialise();
         return _script.GetDefinedVariables();
     }
 
-    public UndoLogger UndoLog
+    public UndoLogger? UndoLog
     {
         get
         {
@@ -301,7 +301,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         }
     }
 
-    public Element Owner
+    public Element? Owner
     {
         get
         {
@@ -338,6 +338,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         }
     }
 
+    [MemberNotNull(nameof(_script))]
     private void Initialise()
     {
         if (_script != null)
@@ -345,16 +346,19 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
             return;
         }
 
+        // Only cleared at the end of this method, once _script has been created
+        var scriptString = _scriptString!;
+
         try
         {
             if (_scriptConstructor == null)
             {
-                _script = _scriptFactory.CreateScript(_scriptString, _scriptContext, false, false);
+                _script = _scriptFactory.CreateScript(scriptString, _scriptContext, false, false);
             }
             else
             {
-                _script = _scriptConstructor.Create(_scriptString, _scriptContext);
-                _script.Line = _scriptString;
+                _script = _scriptConstructor.Create(scriptString, _scriptContext)!;
+                _script.Line = scriptString;
             }
         }
         catch
@@ -364,7 +368,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
                 throw;
             }
 
-            _script = new FailedScript(_scriptString);
+            _script = new FailedScript(scriptString);
             if (_scriptConstructor == null)
             {
                 _script = new MultiScript(_scriptFactory.WorldModel, _script);
@@ -375,7 +379,7 @@ public class LazyLoadScript : IScript, IIfScript, IFirstTimeScript, IMultiScript
         _scriptString = null;
     }
 
-    public override string ToString()
+    public override string? ToString()
     {
         if (_script != null)
         {

--- a/src/Engine/Scripts/ListAddScript.cs
+++ b/src/Engine/Scripts/ListAddScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -61,7 +60,7 @@ public class ListAddScript : ScriptBase
         return SaveScript("list add", _list.Save(), _value.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -74,15 +73,15 @@ public class ListAddScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _list = new ExpressionDynamic((string) value, _scriptContext);
+                _list = new ExpressionDynamic((string) value!, _scriptContext);
                 break;
             case 1:
-                _value = new Expression<object>((string) value, _scriptContext);
+                _value = new Expression<object>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -148,7 +147,7 @@ public class ListRemoveScript : ScriptBase
         return SaveScript("list remove", _list.Save(), _value.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -161,15 +160,15 @@ public class ListRemoveScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _list = new ExpressionDynamic((string) value, _scriptContext);
+                _list = new ExpressionDynamic((string) value!, _scriptContext);
                 break;
             case 1:
-                _value = new Expression<object>((string) value, _scriptContext);
+                _value = new Expression<object>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/MsgScript.cs
+++ b/src/Engine/Scripts/MsgScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -53,13 +52,13 @@ public class MsgScript : ScriptBase
         return SaveScript("msg", _function.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _function.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _function = new ExpressionDynamic((string) value, _scriptContext);
+        _function = new ExpressionDynamic((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/MultiScript.cs
+++ b/src/Engine/Scripts/MultiScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 public interface IMultiScript : IScript
 {
@@ -15,7 +14,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
 {
     private readonly WorldModel _worldModel;
 
-    private ScriptFactory _scriptFactory;
+    private ScriptFactory? _scriptFactory;
     private List<IScript> _scripts;
 
     public MultiScript(WorldModel worldModel, params IScript[] scripts)
@@ -27,6 +26,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
     private MultiScript(WorldModel worldModel)
     {
         _worldModel = worldModel;
+        _scripts = [];
     }
 
     private ScriptFactory ScriptFactory
@@ -42,7 +42,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         }
     }
 
-    public override string Keyword => null;
+    public override string? Keyword => null;
 
     public void Add(params IScript[] scripts)
     {
@@ -127,7 +127,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         }
     }
 
-    public override string Line
+    public override string? Line
     {
         get
         {
@@ -159,7 +159,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         return result;
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         throw new NotImplementedException();
     }
@@ -232,7 +232,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
         NotifyUpdate(script, index);
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         throw new NotImplementedException();
     }

--- a/src/Engine/Scripts/OnReadyScript.cs
+++ b/src/Engine/Scripts/OnReadyScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 public class OnReadyScriptConstructor : IScriptConstructor
 {
@@ -12,9 +11,9 @@ public class OnReadyScriptConstructor : IScriptConstructor
         return new OnReadyScript(scriptContext, ScriptFactory, callbackScript);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 }
 
 public class OnReadyScript : ScriptBase
@@ -49,7 +48,7 @@ public class OnReadyScript : ScriptBase
         return SaveScript("on ready", _callbackScript);
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -60,7 +59,7 @@ public class OnReadyScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {

--- a/src/Engine/Scripts/PictureScript.cs
+++ b/src/Engine/Scripts/PictureScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -49,7 +48,7 @@ public class PictureScript : ScriptBase
         else
         {
             await _worldModel.PlayerUi.ShowPictureAsync(filename);
-            ((LegacyOutputLogger) _worldModel.OutputLogger).AddPicture(filename);
+            ((LegacyOutputLogger) _worldModel.OutputLogger!).AddPicture(filename);
         }
     }
 
@@ -58,13 +57,13 @@ public class PictureScript : ScriptBase
         return SaveScript("picture", _filename.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _filename.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _filename = new Expression<string>((string) value, _scriptContext);
+        _filename = new Expression<string>((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/PlaySoundScript.cs
+++ b/src/Engine/Scripts/PlaySoundScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -85,7 +84,7 @@ public class PlaySoundScript : ScriptBase
         return SaveScript("play sound", _filename.Save(), _synchronous.Save(), _loop.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -100,18 +99,18 @@ public class PlaySoundScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _filename = new Expression<string>((string) value, _scriptContext);
+                _filename = new Expression<string>((string) value!, _scriptContext);
                 break;
             case 1:
-                _synchronous = new Expression<bool>((string) value, _scriptContext);
+                _synchronous = new Expression<bool>((string) value!, _scriptContext);
                 break;
             case 2:
-                _loop = new Expression<bool>((string) value, _scriptContext);
+                _loop = new Expression<bool>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -161,12 +160,12 @@ public class StopSoundScript : ScriptBase
         return "stop sound";
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         throw new ArgumentOutOfRangeException();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         throw new ArgumentOutOfRangeException();
     }

--- a/src/Engine/Scripts/RequestSaveScript.cs
+++ b/src/Engine/Scripts/RequestSaveScript.cs
@@ -1,4 +1,3 @@
-#nullable disable
 
 
 /*
@@ -51,12 +50,12 @@ public class RequestSaveScript : ScriptBase
         return "requestsave";
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         throw new ArgumentOutOfRangeException();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         throw new ArgumentOutOfRangeException();
     }

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -84,7 +83,7 @@ public class RequestScript : ScriptBase
                 break;
             case Request.ClearScreen:
                 _worldModel.PlayerUi.ClearScreen();
-                _worldModel.OutputLogger.Clear();
+                _worldModel.OutputLogger!.Clear();
                 break;
             case Request.ShowPicture:
                 await _worldModel.PlayerUi.ShowPictureAsync(data);
@@ -148,7 +147,7 @@ public class RequestScript : ScriptBase
                 }
 
                 _worldModel.PlayerUi.SetFont(data);
-                ((LegacyOutputLogger) _worldModel.OutputLogger).SetFontName(data);
+                ((LegacyOutputLogger) _worldModel.OutputLogger!).SetFontName(data);
                 break;
             case Request.FontSize:
                 if (_worldModel.Version >= WorldModelVersion.v540)
@@ -158,7 +157,7 @@ public class RequestScript : ScriptBase
                 }
 
                 _worldModel.PlayerUi.SetFontSize(data);
-                ((LegacyOutputLogger) _worldModel.OutputLogger).SetFontSize(data);
+                ((LegacyOutputLogger) _worldModel.OutputLogger!).SetFontSize(data);
                 break;
             case Request.LinkForeground:
                 _worldModel.PlayerUi.SetLinkForeground(data);
@@ -224,7 +223,7 @@ public class RequestScript : ScriptBase
         return SaveScript("request", _request.ToString(), _data.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -237,15 +236,15 @@ public class RequestScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _request = (Request) Enum.Parse(typeof(Request), (string) value);
+                _request = (Request) Enum.Parse(typeof(Request), (string) value!);
                 break;
             case 1:
-                _data = new Expression<string>((string) value, _scriptContext);
+                _data = new Expression<string>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/RequestSpeakScript.cs
+++ b/src/Engine/Scripts/RequestSpeakScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 /*
  * This script command is an alternative to request (Speak, "some text"), and is added as part of deprecating
@@ -59,13 +58,13 @@ public class RequestSpeakScript : ScriptBase
         return SaveScript("requestspeak", _function.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _function.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _function = new ExpressionDynamic((string) value, _scriptContext);
+        _function = new ExpressionDynamic((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/ReturnScript.cs
+++ b/src/Engine/Scripts/ReturnScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -54,13 +53,13 @@ public class ReturnScript : ScriptBase
         return SaveScript("return", _returnValue.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _returnValue.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _returnValue = new ExpressionDynamic((string) value, _scriptContext);
+        _returnValue = new ExpressionDynamic((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/RunDelegateScript.cs
+++ b/src/Engine/Scripts/RunDelegateScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -19,26 +18,12 @@ public class RunDelegateScriptConstructor : ScriptConstructorBase
             throw new Exception("Expected at least 2 parameters in rundelegate call");
         }
 
+        var obj = new Expression<Element>(parameters[0], scriptContext);
+        var delegateName = new Expression<string>(parameters[1], scriptContext);
         var paramExpressions = new List<IFunction<object>>();
-        IFunction<Element> obj = null;
-        var cnt = 0;
-        IFunction<string> delegateName = null;
-
-        foreach (var param in parameters)
+        foreach (var param in parameters.Skip(2))
         {
-            cnt++;
-            switch (cnt)
-            {
-                case 1:
-                    obj = new Expression<Element>(param, scriptContext);
-                    break;
-                case 2:
-                    delegateName = new Expression<string>(param, scriptContext);
-                    break;
-                default:
-                    paramExpressions.Add(new Expression<object>(param, scriptContext));
-                    break;
-            }
+            paramExpressions.Add(new Expression<object>(param, scriptContext));
         }
 
         return new RunDelegateScript(scriptContext, obj, delegateName, paramExpressions);
@@ -67,7 +52,7 @@ public class RunDelegateScript : ScriptBase
 
     protected override ScriptBase CloneScript()
     {
-        return new RunDelegateScript(_scriptContext, _appliesTo.Clone(), _delegate.Clone(), _parameters.Parameters);
+        return new RunDelegateScript(_scriptContext, _appliesTo.Clone(), _delegate.Clone(), _parameters.Parameters!);
     }
 
     public override async Task ExecuteAsync(Context c)
@@ -90,13 +75,13 @@ public class RunDelegateScript : ScriptBase
         var paramValues = new Parameters();
 
         var cnt = 0;
-        foreach (var f in _parameters.Parameters)
+        foreach (var f in _parameters.Parameters!)
         {
-            paramValues.Add((string) impl.Definition.Fields[FieldDefinitions.ParamNames][cnt], await f.ExecuteAsync(c));
+            paramValues.Add((string) impl.Definition.Fields[FieldDefinitions.ParamNames]![cnt]!, await f.ExecuteAsync(c));
             cnt++;
         }
 
-        await _worldModel.RunScriptAsync(impl.Implementation.Fields[FieldDefinitions.Script], paramValues, obj);
+        await _worldModel.RunScriptAsync(impl.Implementation.Fields[FieldDefinitions.Script]!, paramValues, obj);
     }
 
     public override string Save()
@@ -112,7 +97,7 @@ public class RunDelegateScript : ScriptBase
         return SaveScript("rundelegate", saveParameters.ToArray());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -127,15 +112,15 @@ public class RunDelegateScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _appliesTo = new Expression<Element>((string) value, _scriptContext);
+                _appliesTo = new Expression<Element>((string) value!, _scriptContext);
                 break;
             case 1:
-                _delegate = new Expression<string>((string) value, _scriptContext);
+                _delegate = new Expression<string>((string) value!, _scriptContext);
                 break;
             case 2:
                 // any updates to the parameters should change the list itself - nothing should cause SetParameter to be triggered.

--- a/src/Engine/Scripts/ScriptConstructorBase.cs
+++ b/src/Engine/Scripts/ScriptConstructorBase.cs
@@ -1,11 +1,10 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Scripts;
+﻿namespace QuestViva.Engine.Scripts;
 
 public abstract class ScriptConstructorBase : IScriptConstructor
 {
     protected abstract int[] ExpectedParameters { get; }
 
-    protected abstract IScript CreateInt(List<string> parameters, ScriptContext scriptContext);
+    protected abstract IScript? CreateInt(List<string> parameters, ScriptContext scriptContext);
 
     private string FormatExpectedParameters()
     {
@@ -22,9 +21,9 @@ public abstract class ScriptConstructorBase : IScriptConstructor
 
     public abstract string Keyword { get; }
 
-    public IScript Create(string script, ScriptContext scriptContext)
+    public IScript? Create(string script, ScriptContext scriptContext)
     {
-        List<string> parameters = null;
+        List<string>? parameters = null;
         var param = Utility.GetParameter(script);
 
         int numParams;
@@ -47,12 +46,13 @@ public abstract class ScriptConstructorBase : IScriptConstructor
             }
         }
 
-        return CreateInt(parameters, scriptContext);
+        // Only null if the script had no parameter list at all, which ExpectedParameters has to allow
+        return CreateInt(parameters!, scriptContext);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 
     #endregion
 }

--- a/src/Engine/Scripts/SetFieldScript.cs
+++ b/src/Engine/Scripts/SetFieldScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -55,7 +54,7 @@ public class SetFieldScript : ScriptBase
         return SaveScript("set", _obj.Save(), _field.Save(), _value.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -70,18 +69,18 @@ public class SetFieldScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _obj = new Expression<Element>((string) value, _scriptContext);
+                _obj = new Expression<Element>((string) value!, _scriptContext);
                 break;
             case 1:
-                _field = new Expression<string>((string) value, _scriptContext);
+                _field = new Expression<string>((string) value!, _scriptContext);
                 break;
             case 2:
-                _value = new Expression<object>((string) value, _scriptContext);
+                _value = new Expression<object>((string) value!, _scriptContext);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Engine/Scripts/SetScript.cs
+++ b/src/Engine/Scripts/SetScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -7,7 +6,7 @@ public class SetScriptConstructor : IScriptConstructor
 {
     public string Keyword => "=";
 
-    public IScript Create(string script, ScriptContext scriptContext)
+    public IScript? Create(string script, ScriptContext scriptContext)
     {
         var isScript = false;
         var offset = 0;
@@ -76,11 +75,11 @@ public class SetScriptConstructor : IScriptConstructor
         return null;
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 
-    internal IFunction<Element> GetAppliesTo(ScriptContext scriptContext, string value, out string variable)
+    internal IFunction<Element>? GetAppliesTo(ScriptContext scriptContext, string value, out string variable)
     {
         value = value.Trim();
         var dotPos = value.LastIndexOf('.');
@@ -96,11 +95,12 @@ public class SetScriptConstructor : IScriptConstructor
 
 public abstract class SetScriptBase : ScriptBase
 {
-    private IFunction<Element> _appliesTo;
-    private string _property;
+    private IFunction<Element>? _appliesTo;
+    // Always assigned through Property in the constructor
+    private string _property = null!;
     protected ScriptContext _scriptContext;
 
-    internal SetScriptBase(SetScriptConstructor constructor, ScriptContext scriptContext, IFunction<Element> appliesTo,
+    internal SetScriptBase(SetScriptConstructor constructor, ScriptContext scriptContext, IFunction<Element>? appliesTo,
         string property)
     {
         Constructor = constructor;
@@ -110,7 +110,7 @@ public abstract class SetScriptBase : ScriptBase
         Property = property;
     }
 
-    protected IFunction<Element> AppliesTo
+    protected IFunction<Element>? AppliesTo
     {
         get => _appliesTo;
         private set
@@ -161,7 +161,7 @@ public abstract class SetScriptBase : ScriptBase
         return result;
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -174,24 +174,24 @@ public abstract class SetScriptBase : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
                 string variable;
-                AppliesTo = Constructor.GetAppliesTo(_scriptContext, (string) value, out variable);
+                AppliesTo = Constructor.GetAppliesTo(_scriptContext, (string) value!, out variable);
                 Property = variable;
                 break;
             case 1:
-                SetValue((string) value);
+                SetValue((string) value!);
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
         }
     }
 
-    public override IEnumerable<string> GetDefinedVariables()
+    public override IEnumerable<string>? GetDefinedVariables()
     {
         if (AppliesTo == null)
         {
@@ -212,7 +212,7 @@ public class SetExpressionScript : SetScriptBase
     private Expression<object> _expr;
 
     public SetExpressionScript(SetScriptConstructor constructor, ScriptContext scriptContext,
-        IFunction<Element> appliesTo, string property, Expression<object> expr)
+        IFunction<Element>? appliesTo, string property, Expression<object> expr)
         : base(constructor, scriptContext, appliesTo, property)
     {
         _expr = expr;
@@ -240,7 +240,7 @@ public class SetExpressionScript : SetScriptBase
         else
         {
             // we're setting a local variable
-            c.Parameters[Property] = result;
+            c.Parameters![Property] = result;
         }
     }
 
@@ -265,7 +265,7 @@ public class SetScriptScript : SetScriptBase
     private readonly IScriptFactory _scriptFactory;
     private IScript _script;
 
-    public SetScriptScript(SetScriptConstructor constructor, ScriptContext scriptContext, IFunction<Element> appliesTo,
+    public SetScriptScript(SetScriptConstructor constructor, ScriptContext scriptContext, IFunction<Element>? appliesTo,
         string property, IScript script)
         : base(constructor, scriptContext, appliesTo, property)
     {
@@ -294,7 +294,7 @@ public class SetScriptScript : SetScriptBase
         else
         {
             // we're setting a local variable
-            c.Parameters[Property] = _script;
+            c.Parameters![Property] = _script;
         }
     }
 

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -103,7 +103,7 @@ public class ShowMenuScript : ScriptBase
             _worldModel.SignalCallbackResolving();
             if (response != null)
                 await _worldModel.PrintAsync(" - " + optionsDictionary[response]);
-            c.Parameters["result"] = response;
+            c.Parameters!["result"] = response;
             await _worldModel.RunScriptAsync(_callbackScript, c);
         }
         catch (OperationCanceledException) { }
@@ -121,7 +121,7 @@ public class ShowMenuScript : ScriptBase
         return SaveScript("show menu", _callbackScript, _caption.Save(), _options.Save(), _allowCancel.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -138,18 +138,18 @@ public class ShowMenuScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _caption = new Expression<string>((string) value, _scriptContext);
+                _caption = new Expression<string>((string) value!, _scriptContext);
                 break;
             case 1:
-                _options = new ExpressionDynamic((string) value, _scriptContext);
+                _options = new ExpressionDynamic((string) value!, _scriptContext);
                 break;
             case 2:
-                _allowCancel = new Expression<bool>((string) value, _scriptContext);
+                _allowCancel = new Expression<bool>((string) value!, _scriptContext);
                 break;
             case 3:
                 throw new InvalidOperationException(

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -11,17 +10,17 @@ public class SwitchScriptConstructor : IScriptConstructor
     {
         string afterExpr;
         var param = Utility.GetParameter(script, out afterExpr);
-        IScript defaultScript;
+        IScript? defaultScript;
         var cases = ProcessCases(Utility.GetScript(afterExpr), out defaultScript, scriptContext);
 
         return new SwitchScript(scriptContext, new ExpressionDynamic(param, scriptContext), cases, defaultScript);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 
-    private Dictionary<IFunctionDynamic, IScript> ProcessCases(string cases, out IScript defaultScript,
+    private Dictionary<IFunctionDynamic, IScript> ProcessCases(string cases, out IScript? defaultScript,
         ScriptContext scriptContext)
     {
         var finished = false;
@@ -90,17 +89,18 @@ public class SwitchScript : ScriptBase
     private readonly IScript _default;
     private readonly ScriptContext _scriptContext;
     private readonly WorldModel _worldModel;
-    private SwitchCases _cases;
+    // Assigned straight after construction, by the public constructor and by CloneScript
+    private SwitchCases _cases = null!;
     private IFunctionDynamic _expr;
 
     public SwitchScript(ScriptContext scriptContext, IFunctionDynamic expression,
-        Dictionary<IFunctionDynamic, IScript> cases, IScript defaultScript)
+        Dictionary<IFunctionDynamic, IScript> cases, IScript? defaultScript)
         : this(scriptContext, expression, defaultScript)
     {
         _cases = new SwitchCases(this, cases);
     }
 
-    private SwitchScript(ScriptContext scriptContext, IFunctionDynamic expression, IScript defaultScript)
+    private SwitchScript(ScriptContext scriptContext, IFunctionDynamic expression, IScript? defaultScript)
     {
         _scriptContext = scriptContext;
         _worldModel = scriptContext.WorldModel;
@@ -142,7 +142,7 @@ public class SwitchScript : ScriptBase
         return result;
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -157,12 +157,12 @@ public class SwitchScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _expr = new ExpressionDynamic((string) value, _scriptContext);
+                _expr = new ExpressionDynamic((string) value!, _scriptContext);
                 break;
             case 1:
                 // any updates to the cases should change the scriptdictionary itself - nothing should cause SetParameter to be triggered.

--- a/src/Engine/Scripts/UndoScript.cs
+++ b/src/Engine/Scripts/UndoScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -44,12 +43,12 @@ public class UndoScript : ScriptBase
         return "undo";
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         throw new ArgumentOutOfRangeException();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         throw new ArgumentOutOfRangeException();
     }
@@ -100,13 +99,13 @@ public class StartTransactionScript : ScriptBase
         return SaveScript("start transaction", _command.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         return _command.Save();
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
-        _command = new Expression<string>((string) value, _scriptContext);
+        _command = new Expression<string>((string) value!, _scriptContext);
     }
 }

--- a/src/Engine/Scripts/WaitScript.cs
+++ b/src/Engine/Scripts/WaitScript.cs
@@ -1,4 +1,3 @@
-#nullable disable
 namespace QuestViva.Engine.Scripts;
 
 public class WaitScriptConstructor : IScriptConstructor
@@ -14,8 +13,8 @@ public class WaitScriptConstructor : IScriptConstructor
         return new WaitScript(WorldModel, ScriptFactory, callbackScript);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
-    public WorldModel WorldModel { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
+    public WorldModel WorldModel { get; set; } = null!;
 }
 
 public class WaitScript : ScriptBase
@@ -53,7 +52,7 @@ public class WaitScript : ScriptBase
         var resolved = false;
         try
         {
-            await _worldModel._waitTcs.Task;
+            await _worldModel._waitTcs!.Task;
             resolved = true;
             _worldModel.SignalCallbackResolving();
             if (_callbackScript != null)
@@ -74,7 +73,7 @@ public class WaitScript : ScriptBase
         return SaveScript("wait", _callbackScript);
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -85,7 +84,7 @@ public class WaitScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {

--- a/src/Engine/Scripts/WhileScript.cs
+++ b/src/Engine/Scripts/WhileScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Engine.Functions;
+﻿using QuestViva.Engine.Functions;
 
 namespace QuestViva.Engine.Scripts;
 
@@ -17,9 +16,9 @@ public class WhileScriptConstructor : IScriptConstructor
         return new WhileScript(scriptContext, ScriptFactory, new Expression<bool>(param, scriptContext), loopScript);
     }
 
-    public IScriptFactory ScriptFactory { get; set; }
+    public IScriptFactory ScriptFactory { get; set; } = null!;
 
-    public WorldModel WorldModel { get; set; }
+    public WorldModel WorldModel { get; set; } = null!;
 }
 
 public class WhileScript : ScriptBase
@@ -69,7 +68,7 @@ public class WhileScript : ScriptBase
         return SaveScript("while", _loopScript, _expression.Save());
     }
 
-    public override object GetParameter(int index)
+    public override object? GetParameter(int index)
     {
         switch (index)
         {
@@ -82,12 +81,12 @@ public class WhileScript : ScriptBase
         }
     }
 
-    protected override void SetParameterInternal(int index, object value)
+    protected override void SetParameterInternal(int index, object? value)
     {
         switch (index)
         {
             case 0:
-                _expression = new Expression<bool>((string) value, _scriptContext);
+                _expression = new Expression<bool>((string) value!, _scriptContext);
                 break;
             case 1:
                 // any updates to the script should change the script itself - nothing should cause SetParameter to be triggered.

--- a/src/Engine/Types/EditorCommandPattern.cs
+++ b/src/Engine/Types/EditorCommandPattern.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Types;
+﻿namespace QuestViva.Engine.Types;
 
 public class EditorCommandPattern
 {

--- a/src/Engine/Types/LazyObjectDictionary.cs
+++ b/src/Engine/Types/LazyObjectDictionary.cs
@@ -1,12 +1,11 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Types;
+﻿namespace QuestViva.Engine.Types;
 
 internal class LazyObjectDictionary
 {
-    public LazyObjectDictionary(IDictionary<string, string> dictionary)
+    public LazyObjectDictionary(IDictionary<string, string?> dictionary)
     {
         Dictionary = dictionary;
     }
 
-    public IDictionary<string, string> Dictionary { get; private set; }
+    public IDictionary<string, string?> Dictionary { get; private set; }
 }

--- a/src/Engine/Types/LazyObjectList.cs
+++ b/src/Engine/Types/LazyObjectList.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Types;
+﻿namespace QuestViva.Engine.Types;
 
 internal class LazyObjectList
 {

--- a/src/Engine/Types/LazyObjectReference.cs
+++ b/src/Engine/Types/LazyObjectReference.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Types;
+﻿namespace QuestViva.Engine.Types;
 
 internal class LazyObjectReference
 {

--- a/src/Engine/Types/LazyScript.cs
+++ b/src/Engine/Types/LazyScript.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Types;
+﻿namespace QuestViva.Engine.Types;
 
 internal class LazyScript
 {

--- a/src/Engine/Types/LazyScriptDictionary.cs
+++ b/src/Engine/Types/LazyScriptDictionary.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-namespace QuestViva.Engine.Types;
+﻿namespace QuestViva.Engine.Types;
 
 internal class LazyScriptDictionary
 {

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -832,7 +832,7 @@ public partial class WasmPlayerBridge
 
         void IPlayer.Speak(string text) { }
 
-        void IPlayer.RequestSave(string html) => JsRunScript("saveGame()");
+        void IPlayer.RequestSave(string? html) => JsRunScript("saveGame()");
 
         void IPlayer.Show(string element)
         {

--- a/src/WebPlayer/Player.cs
+++ b/src/WebPlayer/Player.cs
@@ -239,7 +239,7 @@ public class Player : IPlayerHelperUI
         // Do nothing
     }
 
-    void IPlayer.RequestSave(string html)
+    void IPlayer.RequestSave(string? html)
     {
         AddJavaScriptToBuffer("saveGame");
     }


### PR DESCRIPTION
Second nullability batch: removes `#nullable disable` from all 45 files in `Engine/Scripts` and `Engine/Types`, and fixes what that surfaces in already-nullable-enabled callers. Engine files still opted out: 56 → 11.

## Annotation changes (compile-time only)
- **`IScript` / `ScriptBase`**: `Parent` is `IScriptParent?` — `MultiScript` clears it when a script is removed, which was previously hidden behind `[field: AllowNull, MaybeNull]`. `Keyword` is `string?` (`MultiScript` and function calls have none). `GetParameter` / `SetParameter` / `SetParameterSilent` / `SetParameterInternal` use `object?`: optional parameters (`create exit` id and type, `for` step, `do`/`invoke` parameters) really do round-trip null through the editor and undo.
- **`IScriptConstructor`**: `Create` returns `IScript?` — `ScriptFactory` relies on this, falling back from a keyword constructor to `SetScriptConstructor` to the function-call constructor when one returns null — and `Keyword` is `string?`. Comments on the interface now say so, and that `ScriptFactory`/`WorldModel` are set straight after construction (hence `= null!` on implementers, matching `AskScript`/`ShowMenuScript`).
- **Optional script parts** are nullable: `IIfScript.ElseScript`/`SetElse`, `firsttime` otherwise, `for` step, `do`/`invoke` parameters, `create` type, `create exit` id/initial type, `JS.` parameters, `switch` default, and a function call's parameter list and parameter script.
- **`Context.Parameters`** is `Parameters?` (the expression evaluator already handles null), and `Parameters` values are `object?` — script variables can be null.
- **`IPlayer.RequestSave(string? html)`** — the `RequestSave` script, `request (RequestSave, ...)` and Legacy all pass null; the WebPlayer and WasmPlayer implementations ignore the argument.
- `LazyObjectDictionary` values are `string?`, matching the shared dictionary loader's signature.

## Behaviour
No intended behaviour change. A few equivalent restructures let the compiler follow the null-state instead of adding `!`: `LazyLoadScript.Initialise` is `[MemberNotNull(nameof(_script))]` and reads the pending script string into a local; `RunDelegateScriptConstructor` reads its first two parameters directly rather than looping with null placeholders; `MultiScript`'s private constructor initialises its script list; redundant null checks on `FunctionCallScript`'s always-set parameter holder are removed; `DoActionScript.Save` reuses the parameter string it had already computed.

The ~119 `!` fall into a few groups:
- `(string) value!` (57) in `SetParameterInternal`, for required parameters the editor always sets to a string
- `= null!` (29) on script constructors' `ScriptFactory`/`WorldModel` properties, plus `SwitchScript._cases` and `SetScriptBase._property`, all assigned straight after construction
- `c.Parameters!` (9) in scripts, which always run with parameters set by `WorldModel.RunScriptAsync`
- the rest: function/delegate `paramnames`/`script` (as in #2244), `OutputLogger` in the legacy request/picture scripts, and the pending `wait`/`get input` completion sources (matching `ShowMenuScript`)

## Latent null bugs surfaced (left as-is, filed separately)
1. #2245 — `do (obj, "action")` on an object with no such action passes a null script to `RunScriptAsync`, which logs a bare `NullReferenceException` (counting toward the script-error limit) rather than saying the action doesn't exist.
2. #2246 — A `rundelegate` line with no parameter list reaches `CreateInt` with null parameters (it's the only constructor whose `ExpectedParameters` is empty), so it fails with a `NullReferenceException` instead of its own "Expected at least 2 parameters" message.

## Test plan
- [x] `dotnet build --configuration Release`: clean (warnings as errors)
- [x] `dotnet test --configuration Release`: all 403 tests pass
- [x] BOM / line endings preserved on every edited file
- [x] e2e: the 22 scripts that exercise script editing (script adder, script editor rows/toolbar, `switch` cases, make-editable undo, code view, verbs, dialogue pages, library editor, …) all pass against local AppShell/WasmPlayer dev servers built from this branch
- [x] quest-e2e-tests corpus (58 games), golden snapshots diffed: `main` vs `main` gives 15 games that vary run-to-run; `main` vs this branch differs in 14 of those same games and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)
