### PR TITLE
refactor(Engine): enable nullable reference types in the remaining Engine files

### DIFF
--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -68,7 +68,7 @@ public interface IPlayer
     void SetBackground(string colour);
     void SetForeground(string colour);
     void SetLinkForeground(string colour);
-    Task RunScriptAsync(string function, object[]? parameters);
+    Task RunScriptAsync(string function, object?[]? parameters);
     void SetFont(string fontName);
     void SetFontSize(string fontSize);
     void Speak(string text);

--- a/src/Engine/Events.cs
+++ b/src/Engine/Events.cs
@@ -1,9 +1,8 @@
-#nullable disable
 namespace QuestViva.Engine;
 
 public class ElementFieldUpdatedEventArgs : EventArgs
 {
-    internal ElementFieldUpdatedEventArgs(Element element, string attribute, object newValue, bool isUndo)
+    internal ElementFieldUpdatedEventArgs(Element element, string attribute, object? newValue, bool isUndo)
     {
         Element = element;
         Attribute = attribute;
@@ -13,7 +12,7 @@ public class ElementFieldUpdatedEventArgs : EventArgs
 
     public Element Element { get; private set; }
     public string Attribute { get; private set; }
-    public object NewValue { get; private set; }
+    public object? NewValue { get; private set; }
     public bool IsUndo { get; private set; }
     public bool Refresh { get; private set; }
 }

--- a/src/Engine/Expressions/IExpressionEvaluator.cs
+++ b/src/Engine/Expressions/IExpressionEvaluator.cs
@@ -9,5 +9,5 @@ public interface IExpressionEvaluator<T>
 
 public interface IDynamicExpressionEvaluator
 {
-    Task<object> EvaluateAsync(Context c);
+    Task<object?> EvaluateAsync(Context c);
 }

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -35,7 +34,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         _nCalcExpression.EvaluateBinaryAsync += EvaluateBinaryAsync;
     }
 
-    async Task<object> IDynamicExpressionEvaluator.EvaluateAsync(Context c)
+    async Task<object?> IDynamicExpressionEvaluator.EvaluateAsync(Context c)
     {
         return await EvaluateAsync(c);
     }
@@ -52,7 +51,8 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
                 return (T) (object) (double) i;
             }
 
-            return (T) result;
+            // T is unconstrained, so a null result (e.g. for Expression<object>) is passed through as-is
+            return (T) result!;
         }
         catch (Exception ex)
         {
@@ -62,12 +62,14 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     }
 
     // NCalc returns Int64 for integer literals; coerce to Int32 to match engine expectations.
-    private static object CoerceLong(object value)
+    [return: NotNullIfNotNull(nameof(value))]
+    private static object? CoerceLong(object? value)
     {
         return value is long l ? (int) l : value;
     }
 
-    private Context _context;
+    // Set at the start of EvaluateAsync, before NCalc raises any of the evaluation events below
+    private Context _context = null!;
 
     // Set to true while evaluating cast()'s type argument so EvaluateParameter
     // returns the identifier name as a string rather than trying to resolve it as a variable.
@@ -77,7 +79,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     // because the attribute has never been assigned, e.g. "object.unsetattribute". EvaluateBinaryAsync
     // snapshots this right after evaluating each operand so a null-operand error can name the
     // actual unset attribute instead of just saying "this value".
-    private string _lastNullPropertyAccessDescription;
+    private string? _lastNullPropertyAccessDescription;
 
     private void EvaluateParameter(string name, ParameterEventArgs args)
     {
@@ -97,7 +99,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         args.Result = ResolveVariable(name);
     }
 
-    private object ResolveVariable(string name)
+    private object? ResolveVariable(string name)
     {
         if (name.Equals("null", StringComparison.InvariantCultureIgnoreCase)) return null;
 
@@ -144,7 +146,6 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         args.Result = await EvaluateAslFunctionAsync(name, args);
     }
 
-#nullable enable
     private static async Task<(bool handled, object? result)> EvaluateFunctionFromTypeAsync([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, object? instance,
         string name, FunctionData parameters)
     {
@@ -289,7 +290,6 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
         return (true, methodNoParams.Invoke(instance, evaluatedArgs));
     }
-#nullable disable
 
     // FLEE compiled expressions to IL so C# operator overloads (e.g. QuestList<T> - Element)
     // resolved automatically. NCalc evaluates at runtime and doesn't use operator overloads,
@@ -327,7 +327,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         {
             if (right is IDictionary dictionary)
             {
-                var contains = dictionary.Contains(left);
+                var contains = dictionary.Contains(left!);
                 args.Result = args.BinaryExpression.Type == BinaryExpressionType.In ? contains : !contains;
             }
 
@@ -337,8 +337,8 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         HandleBinaryResult(args, isEquality, operatorName, left, right, leftNullDescription, rightNullDescription);
     }
 
-    private static void HandleBinaryResult(BinaryEventArgs args, bool isEquality, string operatorName, object left,
-        object right, string leftNullDescription, string rightNullDescription)
+    private static void HandleBinaryResult(BinaryEventArgs args, bool isEquality, string? operatorName, object? left,
+        object? right, string? leftNullDescription, string? rightNullDescription)
     {
         // NCalc's internal equality logic calls Convert.ChangeType() which requires IConvertible.
         // Element doesn't implement IConvertible, so intercept equality/inequality for non-standard
@@ -392,7 +392,8 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         {
             // types exposed to scripts are rooted in ScriptDispatchRoots.cs
 #pragma warning disable IL2072
-            var method = TryFindOperatorOverload(declaringType, operatorName, leftType, rightType);
+            // operatorName is only null for equality, which is always handled above
+            var method = TryFindOperatorOverload(declaringType!, operatorName!, leftType, rightType);
 #pragma warning restore IL2072
             if (method != null)
             {
@@ -404,16 +405,16 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
     // '+' means concatenation as soon as either side is a string, so a null on the other side is
     // an empty string rather than an unset number - see the guard in HandleBinaryResult.
-    private static bool IsStringConcatenation(BinaryEventArgs args, object left, object right) =>
+    private static bool IsStringConcatenation(BinaryEventArgs args, object? left, object? right) =>
         args.BinaryExpression.Type == BinaryExpressionType.Plus && (left is string || right is string);
 
-    private static bool IsStandardNCalcType(object value) =>
+    private static bool IsStandardNCalcType(object? value) =>
         value is null or int or long or double or float or decimal or byte or short or uint or ulong or ushort or sbyte or bool or string;
 
-    private static bool IsIntegerType(object value) =>
+    private static bool IsIntegerType(object? value) =>
         value is int or long or byte or short or uint or ulong or ushort or sbyte;
 
-    private static MethodInfo TryFindOperatorOverload([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type declaringType, string operatorName, Type leftType, Type rightType)
+    private static MethodInfo? TryFindOperatorOverload([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type declaringType, string operatorName, Type? leftType, Type? rightType)
     {
         foreach (var method in declaringType.GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Where(m => m.Name == operatorName))
@@ -427,7 +428,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         return null;
     }
 
-    private static (bool handled, object result) EvaluateVariableFromType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type, string name)
+    private static (bool handled, object? result) EvaluateVariableFromType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type, string name)
     {
         var fields = type
             .GetFields(BindingFlags.Public | BindingFlags.Static)
@@ -444,7 +445,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         return (true, field.GetRawConstantValue());
     }
 
-    private async Task<object> EvaluateAslFunctionAsync(string name, FunctionEventArgs args)
+    private async Task<object?> EvaluateAslFunctionAsync(string name, FunctionEventArgs args)
     {
         if (name == "__Quest_MethodCall__")
         {
@@ -453,7 +454,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             var receiver = CoerceLong(await args.Parameters.EvaluateAsync(0));
             var methodName = await args.Parameters.EvaluateAsync(1) as string
                 ?? throw new Exception("__Quest_MethodCall__ second argument must be a string method name");
-            var methodArgs = new object[args.Parameters.Count - 2];
+            var methodArgs = new object?[args.Parameters.Count - 2];
             for (var i = 0; i < methodArgs.Length; i++)
                 methodArgs[i] = CoerceLong(await args.Parameters.EvaluateAsync(i + 2));
             return DispatchMethodCall(receiver, methodName, methodArgs);
@@ -496,7 +497,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
             var collection = await args.Parameters.EvaluateAsync(0);
             var key = CoerceLong(await args.Parameters.EvaluateAsync(1));
             if (collection is IQuestList)
-                return _expressionOwner.ListItem(collection, (int) key);
+                return _expressionOwner.ListItem(collection, (int) key!);
             return _expressionOwner.DictionaryItem(collection, key?.ToString());
         }
 
@@ -506,7 +507,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
                 throw new Exception("cast() expects 2 parameters: value and type");
             var value = CoerceLong(await args.Parameters.EvaluateAsync(0));
             _evaluatingCastType = true;
-            object typeArg;
+            object? typeArg;
             try { typeArg = await args.Parameters.EvaluateAsync(1); }
             finally { _evaluatingCastType = false; }
             var typeName = typeArg as string
@@ -530,14 +531,14 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
                 throw new Exception("IsDefined function expects 1 parameter");
             if (await args.Parameters.EvaluateAsync(0) is not string variableName)
                 throw new Exception("IsDefined function expects a string parameter");
-            return _context.Parameters.ContainsKey(variableName);
+            return _context.Parameters!.ContainsKey(variableName);
         }
 
         return await RunQuestProcedureAsync(name, args.Parameters.Count,
             i => args.Parameters.EvaluateAsync(i));
     }
 
-    private async Task<object> RunQuestProcedureAsync(string name, int argCount, Func<int, Task<object>> evaluateArgAsync)
+    private async Task<object?> RunQuestProcedureAsync(string name, int argCount, Func<int, Task<object?>> evaluateArgAsync)
     {
         var proc = _scriptContext.WorldModel.Procedure(name);
 
@@ -550,13 +551,13 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 
         for (var cnt = 0; cnt < argCount; cnt++)
         {
-            parameters.Add((string) proc.Fields[FieldDefinitions.ParamNames][cnt], await evaluateArgAsync(cnt));
+            parameters.Add((string) proc.Fields[FieldDefinitions.ParamNames]![cnt]!, await evaluateArgAsync(cnt));
         }
 
         return await _scriptContext.WorldModel.RunProcedureAsync(name, parameters, true);
     }
 
-    private static object DispatchMethodCall(object receiver, string methodName, object[] methodArgs)
+    private static object? DispatchMethodCall(object? receiver, string methodName, object?[] methodArgs)
     {
         var argTypes = methodArgs.Select(a => a?.GetType() ?? typeof(object)).ToArray();
         // script-accessible types are explicitly rooted in ScriptDispatchRoots.cs
@@ -592,7 +593,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         return method.Invoke(receiver, methodArgs);
     }
 
-    private static object CastValue(object value, string typeName) => typeName switch
+    private static object? CastValue(object? value, string typeName) => typeName switch
     {
         "boolean" => Convert.ToBoolean(value),
         "byte" => Convert.ToByte(value),

--- a/src/Engine/Functions/Expression.cs
+++ b/src/Engine/Functions/Expression.cs
@@ -69,7 +69,7 @@ public class ExpressionDynamic : ExpressionBase, IFunctionDynamic
         return new ExpressionDynamic(Expression, ScriptContext);
     }
 
-    public Task<object> ExecuteAsync(Context c)
+    public Task<object?> ExecuteAsync(Context c)
     {
         return _dynamicExpressionEvaluator.EvaluateAsync(c);
     }

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -27,7 +27,7 @@ internal class ExpressionOwner(WorldModel worldModel)
     public string Template(string? template)
     {
         ArgumentNullException.ThrowIfNull(template);
-        return worldModel.Template.GetText(template);
+        return worldModel.Template.GetText(template)!;
     }
 
     public Task<string> DynamicTemplate(string? template, params Element[] obj)
@@ -680,13 +680,13 @@ internal class ExpressionOwner(WorldModel worldModel)
         return _random.NextDouble();
     }
 
-    public Task<object> Eval(string? expression)
+    public Task<object?> Eval(string? expression)
     {
         ArgumentNullException.ThrowIfNull(expression);
         return Eval(expression, null);
     }
 
-    public Task<object> Eval(string? expression, /* IDictionary */ object? obj)
+    public Task<object?> Eval(string? expression, /* IDictionary */ object? obj)
     {
         ArgumentNullException.ThrowIfNull(expression);
         var parameters = obj == null ? null : GetParameter<IDictionary>(obj, "Eval", "dictionary");

--- a/src/Engine/Functions/IFunction.cs
+++ b/src/Engine/Functions/IFunction.cs
@@ -11,7 +11,7 @@ public interface IFunction<T>
 
 public interface IFunctionDynamic
 {
-    Task<object> ExecuteAsync(Context c);
+    Task<object?> ExecuteAsync(Context c);
     string Save();
     IFunctionDynamic Clone();
 }

--- a/src/Engine/GameLoader/ElementLoaders.cs
+++ b/src/Engine/GameLoader/ElementLoaders.cs
@@ -230,7 +230,7 @@ internal partial class GameLoader
 
         private void LoadTemplate(Element newCommand, string template)
         {
-            var pattern = WorldModel.Template.GetText(template);
+            var pattern = WorldModel.Template.GetText(template)!;
             if (WorldModel.EditMode)
             {
                 newCommand.Fields.Set(FieldDefinitions.Pattern.Property,
@@ -332,7 +332,7 @@ internal partial class GameLoader
         public override object? Load(XmlReader reader, ref Element? current)
         {
             var filename = GameLoader.GetTemplateAttribute(reader, "ref");
-            if (filename.Length == 0)
+            if (filename!.Length == 0)
             {
                 return null;
             }
@@ -535,8 +535,8 @@ internal partial class GameLoader
         public override object Load(XmlReader reader, ref Element? current)
         {
             return current != null
-                ? WorldModel.ObjectFactory.CreateObject(reader.GetAttribute("name"), current)
-                : WorldModel.ObjectFactory.CreateObject(reader.GetAttribute("name"));
+                ? WorldModel.ObjectFactory.CreateObject(reader.GetAttribute("name")!, current)
+                : WorldModel.ObjectFactory.CreateObject(reader.GetAttribute("name")!);
         }
     }
 
@@ -586,7 +586,7 @@ internal partial class GameLoader
 
         public override object Load(XmlReader reader, ref Element? current)
         {
-            return WorldModel.GetElementFactory(ElementType.ObjectType).Create(reader.GetAttribute("name"));
+            return WorldModel.GetElementFactory(ElementType.ObjectType).Create(reader.GetAttribute("name")!);
         }
     }
 
@@ -625,7 +625,7 @@ internal partial class GameLoader
 
         private Element AddVerbTemplate(string? c, string text)
         {
-            return WorldModel.Template.AddVerbTemplate(c, text, GameLoader._currentFile.Peek().Filename);
+            return WorldModel.Template.AddVerbTemplate(c!, text, GameLoader._currentFile.Peek().Filename);
         }
     }
 
@@ -869,7 +869,7 @@ internal partial class GameLoader
             var jsRef = WorldModel.GetElementFactory(ElementType.Javascript).Create();
             jsRef.Fields[FieldDefinitions.Anonymous] = true;
             var file = GameLoader.GetTemplateAttribute(reader, "src");
-            if (file.Length == 0)
+            if (file!.Length == 0)
             {
                 return null;
             }

--- a/src/Engine/GameLoader/GameLoader.cs
+++ b/src/Engine/GameLoader/GameLoader.cs
@@ -257,7 +257,7 @@ internal partial class GameLoader
         return loader;
     }
 
-    private string GetTemplateAttribute(XmlReader reader, string attribute)
+    private string? GetTemplateAttribute(XmlReader reader, string attribute)
     {
         return GetTemplate(reader.GetAttribute(attribute));
     }
@@ -267,7 +267,8 @@ internal partial class GameLoader
         return GetTemplate(reader.ReadElementContentAsString());
     }
 
-    private string GetTemplate(string? text)
+    [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(text))]
+    private string? GetTemplate(string? text)
     {
         return WorldModel.Template.ReplaceTemplateText(text);
     }

--- a/src/Engine/ObjectFactory.cs
+++ b/src/Engine/ObjectFactory.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Common;
+﻿using QuestViva.Common;
 
 namespace QuestViva.Engine;
 
@@ -19,9 +18,9 @@ public interface IElementFactory
 public abstract class ElementFactoryBase : IElementFactory
 {
     protected string FriendlyElementTypeName => ((ElementTypeInfo) typeof(ElementType)
-        .GetField(CreateElementType.ToString()).GetCustomAttributes(typeof(ElementTypeInfo), false)[0]).Name;
+        .GetField(CreateElementType.ToString())!.GetCustomAttributes(typeof(ElementTypeInfo), false)[0]).Name;
 
-    public event EventHandler<ObjectsUpdatedEventArgs> ObjectsUpdated;
+    public event EventHandler<ObjectsUpdatedEventArgs>? ObjectsUpdated;
 
     public abstract ElementType CreateElementType { get; }
 
@@ -46,7 +45,8 @@ public abstract class ElementFactoryBase : IElementFactory
         return CreateInternal(newElementName, true, null, elementToClone: elementToClone);
     }
 
-    public WorldModel WorldModel { get; set; }
+    // Set by WorldModel straight after the factory is created
+    public WorldModel WorldModel { get; set; } = null!;
 
     public void DestroyElement(string elementName)
     {
@@ -58,9 +58,9 @@ public abstract class ElementFactoryBase : IElementFactory
         DestroyElement(elementName, true);
     }
 
-    protected Element CreateInternal(string name, bool addToUndoLog, Action<Element> extraInitialisation,
-        IList<string> initialTypes = null, IDictionary<string, object> initialFields = null,
-        Element elementToClone = null)
+    protected Element CreateInternal(string name, bool addToUndoLog, Action<Element>? extraInitialisation,
+        IList<string>? initialTypes = null, IDictionary<string, object>? initialFields = null,
+        Element? elementToClone = null)
     {
         Element newElement;
 
@@ -267,14 +267,14 @@ public class ObjectFactory : ElementFactoryBase
         return CreateObject(objectName, type, true);
     }
 
-    public Element CreateObject(ObjectType type, IList<string> initialTypes, IDictionary<string, object> initialFields)
+    public Element CreateObject(ObjectType type, IList<string>? initialTypes, IDictionary<string, object>? initialFields)
     {
         var id = type == ObjectType.Exit ? WorldModel.GetUniqueId("exit") : WorldModel.GetUniqueId();
         return CreateObject(id, type, true, initialTypes, initialFields);
     }
 
     internal Element CreateObject(string objectName, ObjectType type, bool addToUndoLog,
-        IList<string> initialTypes = null, IDictionary<string, object> initialFields = null)
+        IList<string>? initialTypes = null, IDictionary<string, object>? initialFields = null)
     {
         var defaultType = WorldModel.DefaultTypeNames[type];
 
@@ -322,7 +322,7 @@ public class ObjectFactory : ElementFactoryBase
         return newCommand;
     }
 
-    public Element CreateTurnScript(string id, Element parent)
+    public Element CreateTurnScript(string? id, Element? parent)
     {
         var anonymous = false;
         if (string.IsNullOrEmpty(id))
@@ -342,12 +342,12 @@ public class ObjectFactory : ElementFactoryBase
         return newTurnScript;
     }
 
-    public Element CreateExit(string exitName, Element fromRoom, Element toRoom, string initialType)
+    public Element CreateExit(string? exitName, Element? fromRoom, Element? toRoom, string? initialType)
     {
         return CreateExit(null, exitName, fromRoom, toRoom, initialType);
     }
 
-    public Element CreateExit(string exitID, string exitName, Element fromRoom, Element toRoom, string initialType)
+    public Element CreateExit(string? exitID, string? exitName, Element? fromRoom, Element? toRoom, string? initialType)
     {
         var anonymous = false;
         if (string.IsNullOrEmpty(exitID))
@@ -380,21 +380,21 @@ public class ObjectFactory : ElementFactoryBase
         return newExit;
     }
 
-    public Element CreateExitLazy(string exitName, Element fromRoom, string toRoom)
+    public Element CreateExitLazy(string? exitName, Element? fromRoom, string? toRoom)
     {
         var newExit = CreateExit(exitName, fromRoom, null, null);
         InitLazyExit(newExit, toRoom);
         return newExit;
     }
 
-    public Element CreateExitLazy(string exitID, string exitName, Element fromRoom, string toRoom)
+    public Element CreateExitLazy(string? exitID, string? exitName, Element? fromRoom, string? toRoom)
     {
         var newExit = CreateExit(exitID, exitName, fromRoom, null, null);
         InitLazyExit(newExit, toRoom);
         return newExit;
     }
 
-    private void InitLazyExit(Element exit, string toRoom)
+    private void InitLazyExit(Element exit, string? toRoom)
     {
         if (toRoom != null)
         {

--- a/src/Engine/OutputLogger.cs
+++ b/src/Engine/OutputLogger.cs
@@ -1,12 +1,11 @@
-﻿#nullable disable
-using System.Text;
+﻿using System.Text;
 using System.Xml;
 
 namespace QuestViva.Engine;
 
 internal interface IOutputLogger
 {
-    void Save(string html);
+    void Save(string? html);
     void Clear();
 }
 
@@ -19,7 +18,7 @@ internal class OutputLogger : IOutputLogger
         _worldModel = worldModel;
     }
 
-    public void Save(string html)
+    public void Save(string? html)
     {
         var element = _worldModel.Elements.GetSingle(ElementType.Output) ??
                       _worldModel.GetElementFactory(ElementType.Output).Create();
@@ -49,7 +48,7 @@ internal class LegacyOutputLogger : IOutputLogger
         _anyText = false;
     }
 
-    public void Save(string html)
+    public void Save(string? html)
     {
         var element = _worldModel.Elements.GetSingle(ElementType.Output);
         if (element == null)
@@ -78,17 +77,17 @@ internal class LegacyOutputLogger : IOutputLogger
         _text.Append(string.Format("<output_picture filename=\"{0}\"/>", filename));
     }
 
-    public void SetFontName(string fontName)
+    public void SetFontName(string? fontName)
     {
         _text.Append(string.Format("<output_setfontname name=\"{0}\"/>", fontName));
     }
 
-    public void SetFontSize(string fontSize)
+    public void SetFontSize(string? fontSize)
     {
         _text.Append(string.Format("<output_setfontsize size=\"{0}\"/>", fontSize));
     }
 
-    public async Task DisplayOutputAsync(string text)
+    public async Task DisplayOutputAsync(string? text)
     {
         text = "<output>" + text + "</output>";
         var output = new StringBuilder();
@@ -127,8 +126,10 @@ internal class LegacyOutputLogger : IOutputLogger
                             }
 
                             var size = reader.GetAttribute("size");
-                            ((LegacyOutputLogger) _worldModel.OutputLogger).SetFontSize(size);
-                            _worldModel.PlayerUi.SetFontSize(size);
+                            // WorldModel's OutputLogger is this instance whenever legacy output is being replayed
+                            SetFontSize(size);
+                            // Written by SetFontSize above, so always present
+                            _worldModel.PlayerUi.SetFontSize(size!);
                             break;
                         case "output_setfontname":
                             if (output.Length > 0)
@@ -138,8 +139,8 @@ internal class LegacyOutputLogger : IOutputLogger
                             }
 
                             var name = reader.GetAttribute("name");
-                            ((LegacyOutputLogger) _worldModel.OutputLogger).SetFontName(name);
-                            _worldModel.PlayerUi.SetFont(name);
+                            SetFontName(name);
+                            _worldModel.PlayerUi.SetFont(name!);
                             break;
                         default:
                             output.Append("<" + reader.Name);

--- a/src/Engine/RegexCache.cs
+++ b/src/Engine/RegexCache.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace QuestViva.Engine;
 
@@ -9,7 +8,7 @@ internal class RegexCache
 
     public Regex GetRegex(string regex, string cacheID)
     {
-        Regex result;
+        Regex? result;
         if (_cache.TryGetValue(cacheID, out result))
         {
             return result;

--- a/src/Engine/ScriptFactory.cs
+++ b/src/Engine/ScriptFactory.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using QuestViva.Engine.Scripts;
 
 namespace QuestViva.Engine;
@@ -88,10 +87,10 @@ public partial class ScriptFactory : IScriptFactory
     {
         var result = new MultiScript(WorldModel);
         var finished = false;
-        IScript lastIf = null;
-        IScript lastComment = null;
-        IScript lastFirstTime = null;
-        IfScriptConstructor ifConstructor = null;
+        IScript? lastIf = null;
+        IScript? lastComment = null;
+        IScript? lastFirstTime = null;
+        IfScriptConstructor? ifConstructor = null;
 
         if (lazy)
         {
@@ -103,7 +102,7 @@ public partial class ScriptFactory : IScriptFactory
 
         while (!finished)
         {
-            string remainingScript;
+            string? remainingScript;
             try
             {
                 line = Utility.GetScript(line, out remainingScript);
@@ -119,14 +118,11 @@ public partial class ScriptFactory : IScriptFactory
                 throw;
             }
 
-            if (line != null)
-            {
-                line = line.Trim();
-            }
+            line = line.Trim();
 
             if (!string.IsNullOrEmpty(line))
             {
-                IScript newScript = null;
+                IScript? newScript = null;
                 var dontAdd = false;
                 var addedError = false;
 
@@ -138,13 +134,14 @@ public partial class ScriptFactory : IScriptFactory
                     }
                     else
                     {
+                        // ifConstructor is always set alongside lastIf
                         if (line.StartsWith("else if"))
                         {
-                            ifConstructor.AddElseIf(lastIf, line, scriptContext);
+                            ifConstructor!.AddElseIf(lastIf, line, scriptContext);
                         }
                         else
                         {
-                            ifConstructor.AddElse(lastIf, line, scriptContext);
+                            ifConstructor!.AddElse(lastIf, line, scriptContext);
                         }
                     }
 
@@ -252,17 +249,20 @@ public partial class ScriptFactory : IScriptFactory
                 }
             }
 
-            line = remainingScript;
-            if (string.IsNullOrEmpty(line))
+            if (string.IsNullOrEmpty(remainingScript))
             {
                 finished = true;
+            }
+            else
+            {
+                line = remainingScript;
             }
         }
 
         return result;
     }
 
-    public event EventHandler<AddErrorEventArgs> ErrorHandler;
+    public event EventHandler<AddErrorEventArgs>? ErrorHandler;
 
     private void AddConstructor(IScriptConstructor constructor)
     {
@@ -302,26 +302,26 @@ public partial class ScriptFactory : IScriptFactory
     [GeneratedRegex(@"^\W")]
     private static partial Regex NonWordCharacterRegex();
 
-    private IScriptConstructor GetScriptConstructor(string line)
+    private IScriptConstructor? GetScriptConstructor(string line)
     {
-        IScriptConstructor constructor = null;
+        IScriptConstructor? constructor = null;
         var strength = 0;
-        foreach (var c in _scriptConstructors.Values)
+        foreach (var (keyword, c) in _scriptConstructors)
         {
-            if (line.StartsWith(c.Keyword))
+            if (line.StartsWith(keyword))
             {
                 // The line must start with the script keyword, and then the following
                 // character must be a non-word character. For example "msgfunction" is not
                 // a match for "msg".
 
-                if (line.Length == c.Keyword.Length ||
-                    NonWordCharacterRegex().IsMatch(line.Substring(c.Keyword.Length)) ||
+                if (line.Length == keyword.Length ||
+                    NonWordCharacterRegex().IsMatch(line.Substring(keyword.Length)) ||
                     c is CommentScriptConstructor || c is JSScriptConstructor)
                 {
-                    if (c.Keyword.Length > strength)
+                    if (keyword.Length > strength)
                     {
                         constructor = c;
-                        strength = c.Keyword.Length;
+                        strength = keyword.Length;
                     }
                 }
             }
@@ -340,6 +340,6 @@ public partial class ScriptFactory : IScriptFactory
 
     public class AddErrorEventArgs : EventArgs
     {
-        public string Error { get; set; }
+        public required string Error { get; set; }
     }
 }

--- a/src/Engine/Scripts/AskScript.cs
+++ b/src/Engine/Scripts/AskScript.cs
@@ -9,9 +9,9 @@ public class AskScriptConstructor : IScriptConstructor
     public IScript Create(string script, ScriptContext scriptContext)
     {
         var param = Utility.GetParameter(script, out var afterExpr);
-        var callback = Utility.GetScript(afterExpr);
+        var callback = Utility.GetScript(afterExpr!);
 
-        var parameters = Utility.SplitParameter(param).ToArray();
+        var parameters = Utility.SplitParameter(param!).ToArray();
         if (parameters.Count() != 1)
         {
             throw new Exception($"'ask' script should have 1 parameter: 'ask ({param})'");

--- a/src/Engine/Scripts/Context.cs
+++ b/src/Engine/Scripts/Context.cs
@@ -15,7 +15,7 @@ public class Context
     }
 
     public Parameters? Parameters { get; set; }
-    public object ReturnValue { get; set; }
+    public object? ReturnValue { get; set; }
     public bool IsReturned { get; set; }
 }
 

--- a/src/Engine/Scripts/ForEachScript.cs
+++ b/src/Engine/Scripts/ForEachScript.cs
@@ -9,11 +9,11 @@ public class ForEachScriptConstructor : IScriptConstructor
 
     public IScript Create(string script, ScriptContext scriptContext)
     {
-        string afterExpr;
+        string? afterExpr;
         var param = Utility.GetParameter(script, out afterExpr);
-        var loop = Utility.GetScript(afterExpr);
+        var loop = Utility.GetScript(afterExpr!);
 
-        var parameters = Utility.SplitParameter(param).ToArray();
+        var parameters = Utility.SplitParameter(param!).ToArray();
         if (parameters.Count() != 2)
         {
             throw new Exception(string.Format("'foreach' script should have 2 parameters: 'foreach ({0})'", param));

--- a/src/Engine/Scripts/ForScript.cs
+++ b/src/Engine/Scripts/ForScript.cs
@@ -10,11 +10,11 @@ public class ForScriptConstructor : IScriptConstructor
 
     public IScript Create(string script, ScriptContext scriptContext)
     {
-        string afterExpr;
+        string? afterExpr;
         var param = Utility.GetParameter(script, out afterExpr);
-        var loop = Utility.GetScript(afterExpr);
+        var loop = Utility.GetScript(afterExpr!);
 
-        var parameters = Utility.SplitParameter(param).ToArray();
+        var parameters = Utility.SplitParameter(param!).ToArray();
         var loopScript = ScriptFactory.CreateScript(loop);
 
         if (parameters.Count() == 3)

--- a/src/Engine/Scripts/FunctionCallScript.cs
+++ b/src/Engine/Scripts/FunctionCallScript.cs
@@ -7,7 +7,8 @@ public class FunctionCallScriptConstructor : IScriptConstructor
     public IScript Create(string script, ScriptContext scriptContext)
     {
         List<IFunction<object>>? paramExpressions = null;
-        string procName, afterParameter;
+        string procName;
+        string? afterParameter;
 
         var param = Utility.GetParameter(script, out afterParameter);
         IScript? paramScript = null;

--- a/src/Engine/Scripts/IfScript.cs
+++ b/src/Engine/Scripts/IfScript.cs
@@ -60,10 +60,10 @@ public class IfScriptConstructor : IScriptConstructor
 
     public IScript Create(string script, ScriptContext scriptContext)
     {
-        string afterExpr;
+        string? afterExpr;
         var expr = Utility.GetParameter(script, out afterExpr);
 
-        if (afterExpr.StartsWith(")"))
+        if (afterExpr!.StartsWith(")"))
         {
             // We have a mismatch of brackets in the expression
             throw new Exception("Too many ')'");
@@ -73,7 +73,7 @@ public class IfScriptConstructor : IScriptConstructor
 
         var thenScript = ScriptFactory.CreateScript(then, scriptContext);
 
-        return new IfScript(new Expression<bool>(expr, scriptContext), thenScript, scriptContext);
+        return new IfScript(new Expression<bool>(expr!, scriptContext), thenScript, scriptContext);
     }
 
     public IScriptFactory ScriptFactory { get; set; } = null!;

--- a/src/Engine/Scripts/JSScript.cs
+++ b/src/Engine/Scripts/JSScript.cs
@@ -69,7 +69,7 @@ public class JSScript : ScriptBase
 
         if (_parameters != null)
         {
-            var paramValues = new object[_parameters.Count];
+            var paramValues = new object?[_parameters.Count];
             for (var i = 0; i < _parameters.Count; i++)
                 paramValues[i] = await _parameters[i].ExecuteAsync(c);
             await _scriptContext.WorldModel.PlayerUi.RunScriptAsync(_function, paramValues);

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -9,11 +9,11 @@ public class ShowMenuScriptConstructor : IScriptConstructor
 
     public IScript Create(string script, ScriptContext scriptContext)
     {
-        string afterExpr;
+        string? afterExpr;
         var param = Utility.GetParameter(script, out afterExpr);
-        var callback = Utility.GetScript(afterExpr);
+        var callback = Utility.GetScript(afterExpr!);
 
-        var parameters = Utility.SplitParameter(param).ToArray();
+        var parameters = Utility.SplitParameter(param!).ToArray();
         if (parameters.Count() != 3)
         {
             throw new Exception(string.Format("'show menu' script should have 3 parameters: 'show menu ({0})'", param));

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -8,12 +8,12 @@ public class SwitchScriptConstructor : IScriptConstructor
 
     public IScript Create(string script, ScriptContext scriptContext)
     {
-        string afterExpr;
+        string? afterExpr;
         var param = Utility.GetParameter(script, out afterExpr);
         IScript? defaultScript;
-        var cases = ProcessCases(Utility.GetScript(afterExpr), out defaultScript, scriptContext);
+        var cases = ProcessCases(Utility.GetScript(afterExpr!), out defaultScript, scriptContext);
 
-        return new SwitchScript(scriptContext, new ExpressionDynamic(param, scriptContext), cases, defaultScript);
+        return new SwitchScript(scriptContext, new ExpressionDynamic(param!, scriptContext), cases, defaultScript);
     }
 
     public IScriptFactory ScriptFactory { get; set; } = null!;
@@ -24,8 +24,8 @@ public class SwitchScriptConstructor : IScriptConstructor
         ScriptContext scriptContext)
     {
         var finished = false;
-        string remainingCases;
-        string afterExpr;
+        string? remainingCases;
+        string? afterExpr;
         var result = new Dictionary<IFunctionDynamic, IScript>();
         defaultScript = null;
 
@@ -33,18 +33,14 @@ public class SwitchScriptConstructor : IScriptConstructor
 
         while (!finished)
         {
-            cases = Utility.GetScript(cases, out remainingCases);
-            if (cases != null)
-            {
-                cases = cases.Trim();
-            }
+            cases = Utility.GetScript(cases, out remainingCases).Trim();
 
             if (!string.IsNullOrEmpty(cases))
             {
                 if (cases.StartsWith("case"))
                 {
-                    var expr = Utility.GetParameter(cases, out afterExpr);
-                    var caseScript = Utility.GetScript(afterExpr);
+                    var expr = Utility.GetParameter(cases, out afterExpr)!;
+                    var caseScript = Utility.GetScript(afterExpr!);
                     var script = ScriptFactory.CreateScript(caseScript, scriptContext);
 
                     // Case expression can have multiple values separated by commas. In Edit mode,
@@ -73,10 +69,13 @@ public class SwitchScriptConstructor : IScriptConstructor
                 }
             }
 
-            cases = remainingCases;
-            if (string.IsNullOrEmpty(cases))
+            if (string.IsNullOrEmpty(remainingCases))
             {
                 finished = true;
+            }
+            else
+            {
+                cases = remainingCases;
             }
         }
 

--- a/src/Engine/Scripts/WhileScript.cs
+++ b/src/Engine/Scripts/WhileScript.cs
@@ -8,12 +8,12 @@ public class WhileScriptConstructor : IScriptConstructor
 
     public IScript Create(string script, ScriptContext scriptContext)
     {
-        string afterExpr;
+        string? afterExpr;
         var param = Utility.GetParameter(script, out afterExpr);
-        var loop = Utility.GetScript(afterExpr);
+        var loop = Utility.GetScript(afterExpr!);
         var loopScript = ScriptFactory.CreateScript(loop);
 
-        return new WhileScript(scriptContext, ScriptFactory, new Expression<bool>(param, scriptContext), loopScript);
+        return new WhileScript(scriptContext, ScriptFactory, new Expression<bool>(param!, scriptContext), loopScript);
     }
 
     public IScriptFactory ScriptFactory { get; set; } = null!;

--- a/src/Engine/Templates.cs
+++ b/src/Engine/Templates.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using QuestViva.Engine.Functions;
 using QuestViva.Engine.Scripts;
@@ -15,15 +15,14 @@ public partial class Template
         _worldModel = worldModel;
     }
 
-    internal Element AddTemplate(string templateName, string text, bool isCommandTemplate, bool isBaseTemplate = false)
+    internal Element? AddTemplate(string templateName, string text, bool isCommandTemplate, bool isBaseTemplate = false)
     {
         // if a template is marked as IsBaseTemplate, it's from the base .aslx file so shouldn't be overwritten
         // by an equivalent library definition. But a later base-template definition (e.g. a second
         // <template> for the same name further down the same base file, as produced by old Quest 5.8
         // exports that inline a full library per language one after another) must still win over an
         // earlier one from the same scan - only non-base (library) definitions are blocked here.
-        Element existingTemplate;
-        if (_templateLookup.TryGetValue(templateName, out existingTemplate))
+        if (_templateLookup.TryGetValue(templateName, out var existingTemplate))
         {
             if (existingTemplate.Fields[FieldDefinitions.IsBaseTemplate] && !isBaseTemplate)
             {
@@ -49,7 +48,8 @@ public partial class Template
         return template;
     }
 
-    public string GetText(string t, bool throwException = true)
+    // Only returns null when throwException is false
+    public string? GetText(string t, bool throwException = true)
     {
         if (_templateLookup.TryGetValue(t, out var value))
         {
@@ -96,13 +96,13 @@ public partial class Template
     {
         if (!_worldModel.Elements.ContainsKey(ElementType.DynamicTemplate, t))
         {
-            return GetText(t);
+            return GetText(t)!;
         }
 
         var c = new Context();
         c.Parameters = parameters;
         var template = _worldModel.Elements.Get(ElementType.DynamicTemplate, t);
-        return await template.Fields[FieldDefinitions.Function].ExecuteAsync(c);
+        return await template.Fields[FieldDefinitions.Function]!.ExecuteAsync(c);
     }
 
     internal Element AddVerbTemplate(string c, string text, string filename)
@@ -111,7 +111,8 @@ public partial class Template
 
         if (!_templateLookup.ContainsKey(c))
         {
-            template = AddTemplate(c, "", true);
+            // Can't be blocked by an existing base template, as there's no existing template
+            template = AddTemplate(c, "", true)!;
         }
         else
         {
@@ -178,7 +179,8 @@ public partial class Template
     [GeneratedRegex(@"\[(?<name>.*?)\]")]
     private partial Regex TemplateRegex();
 
-    public string ReplaceTemplateText(string text)
+    [return: NotNullIfNotNull(nameof(text))]
+    public string? ReplaceTemplateText(string? text)
     {
         if (text == null)
         {

--- a/src/Engine/TimerRunner.cs
+++ b/src/Engine/TimerRunner.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using QuestViva.Engine.Scripts;
 
 namespace QuestViva.Engine;
@@ -7,7 +6,7 @@ namespace QuestViva.Engine;
 internal class TimerRunner
 {
     private readonly WorldModel _worldModel;
-    private Element _gameElement;
+    private Element? _gameElement;
 
     public TimerRunner(WorldModel worldModel, bool initialise)
     {
@@ -92,7 +91,7 @@ internal class TimerRunner
             if (TimeElapsed >= timer.Fields[FieldDefinitions.Trigger])
             {
                 Debug.Print("     - TRIGGER");
-                scripts.Add(timer, timer.Fields[FieldDefinitions.Script]);
+                scripts.Add(timer, timer.Fields[FieldDefinitions.Script]!);
                 timer.Fields[FieldDefinitions.Trigger] += timer.Fields[FieldDefinitions.Interval];
             }
         }

--- a/src/Engine/UndoLogger.cs
+++ b/src/Engine/UndoLogger.cs
@@ -1,12 +1,11 @@
-﻿#nullable disable
-namespace QuestViva.Engine;
+﻿namespace QuestViva.Engine;
 
 public class UndoLogger
 {
     private readonly Stack<Transaction> _redoTransactions = new();
     private readonly Stack<Transaction> _undoTransactions = new();
     private readonly WorldModel _worldModel;
-    private Transaction _currentTransaction;
+    private Transaction? _currentTransaction;
 
     private bool _logging;
 
@@ -15,8 +14,8 @@ public class UndoLogger
         _worldModel = worldModel;
     }
 
-    public event EventHandler TransactionsUpdated;
-    public event EventHandler TransactionCommitted;
+    public event EventHandler? TransactionsUpdated;
+    public event EventHandler? TransactionCommitted;
 
     public void StartTransaction(string command)
     {
@@ -26,7 +25,7 @@ public class UndoLogger
         }
 
         _logging = true;
-        Transaction previousTransaction = null;
+        Transaction? previousTransaction = null;
         if (_currentTransaction != null)
         {
             previousTransaction = _currentTransaction.Count > 0
@@ -41,7 +40,7 @@ public class UndoLogger
     public void EndTransaction()
     {
         _logging = false;
-        if (_currentTransaction.Count > 0)
+        if (_currentTransaction!.Count > 0)
         {
             _undoTransactions.Push(_currentTransaction);
             _redoTransactions.Clear();
@@ -76,7 +75,8 @@ public class UndoLogger
             return;
         }
 
-        _currentTransaction.AddUndoAction(getAction());
+        // _logging is only true between StartTransaction and EndTransaction
+        _currentTransaction!.AddUndoAction(getAction());
     }
 
     public async Task RollbackTransaction()
@@ -170,7 +170,7 @@ public class UndoLogger
 
         internal string Description { get; }
 
-        public Transaction PreviousTransaction { get; set; }
+        public Transaction? PreviousTransaction { get; set; }
 
         public void AddUndoAction(IUndoAction action)
         {

--- a/src/Engine/Utility.cs
+++ b/src/Engine/Utility.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -32,24 +31,22 @@ public static partial class Utility
 
     public static IList<string> ExpressionKeywords => Keywords.AsReadOnly();
 
-    public static string GetParameter(string script)
+    public static string? GetParameter(string script)
     {
-        string afterParameter;
-        return GetParameter(script, out afterParameter);
+        return GetParameter(script, out _);
     }
 
-    public static string GetParameter(string script, out string afterParameter)
+    public static string? GetParameter(string script, out string? afterParameter)
     {
         return GetParameterInt(script, '(', ')', out afterParameter);
     }
 
     public static string GetScript(string script)
     {
-        string afterScript;
-        return GetScript(script, out afterScript);
+        return GetScript(script, out _);
     }
 
-    public static string GetScript(string script, out string afterScript)
+    public static string GetScript(string script, out string? afterScript)
     {
         afterScript = null;
         var obscuredScript = ObscureStrings(script);
@@ -68,7 +65,8 @@ public static partial class Utility
         }
 
         var beforeBrace = script[..bracePos];
-        var insideBraces = GetParameterInt(script, '{', '}', out afterScript);
+        // Never null here, as the script is known to contain a '{'
+        var insideBraces = GetParameterInt(script, '{', '}', out afterScript)!;
 
         string result;
 
@@ -85,7 +83,7 @@ public static partial class Utility
         return result;
     }
 
-    private static string GetParameterInt(string text, char open, char close, out string afterParameter)
+    private static string? GetParameterInt(string text, char open, char close, out string? afterParameter)
     {
         afterParameter = null;
         var obscuredText = ObscureStrings(text);
@@ -417,7 +415,7 @@ public static partial class Utility
     // when the result is null - most commonly because it came from an attribute that was never
     // assigned a value. Use this instead wherever a script command converts an expression result
     // to a string, so the author gets a clear error rather than a leaked NRE.
-    public static string ExpressionResultToString(object value)
+    public static string ExpressionResultToString(object? value)
     {
         if (value is null)
         {
@@ -425,7 +423,7 @@ public static partial class Utility
                 "Cannot convert this value to a string because it has not been set - check whether an attribute or variable has been assigned a value before using it.");
         }
 
-        return value.ToString();
+        return value.ToString()!;
     }
 
     public static string[] ListSplit(string value)
@@ -542,7 +540,7 @@ public static partial class Utility
         return result;
     }
 
-    public static string ConvertVerbSimplePattern(string pattern, string separator)
+    public static string ConvertVerbSimplePattern(string pattern, string? separator)
     {
         // For verbs, we replace "eat; consume; munch" with
         // "^eat (?<object>.*)$|^consume (?<object>.*)$|^munch (?<object>.*)$"
@@ -552,7 +550,7 @@ public static partial class Utility
 
         var verbs = ListSplit(pattern);
         var result = string.Empty;
-        string separatorRegex = null;
+        string? separatorRegex = null;
 
         if (!string.IsNullOrEmpty(separator))
         {

--- a/src/Engine/Walkthrough.cs
+++ b/src/Engine/Walkthrough.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using QuestViva.Common;
+﻿using QuestViva.Common;
 
 namespace QuestViva.Engine;
 
@@ -48,7 +47,7 @@ public class Walkthrough : IWalkthrough
     private string[] ThisSteps()
     {
         var result = new List<string>();
-        IEnumerable<string> steps = _element.Fields[FieldDefinitions.Steps];
+        IEnumerable<string>? steps = _element.Fields[FieldDefinitions.Steps];
         if (steps != null)
         {
             result.AddRange(steps);

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -868,7 +868,7 @@ public partial class WorldModel : IGame, IGameDebug
 
     public Task PrintTemplateAsync(string t)
     {
-        return PrintAsync(Template.GetText(t));
+        return PrintAsync(Template.GetText(t)!);
     }
 
     public void Print(string text, bool linebreak = true)
@@ -1681,7 +1681,7 @@ public partial class WorldModel : IGame, IGameDebug
         return DefaultTypeNames.ContainsValue(typeName);
     }
 
-    public Element AddNewTemplate(string templateName)
+    public Element? AddNewTemplate(string templateName)
     {
         return Template.AddTemplate(templateName, string.Empty, false);
     }

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -783,7 +783,7 @@ public partial class WasmPlayerBridge
         // duration — e.g. RunWalkthrough's loop never awaits anything else between steps, so
         // without this the browser couldn't process input or DevTools protocol calls until the
         // entire walkthrough finished.
-        async Task IPlayer.RunScriptAsync(string function, object[]? parameters)
+        async Task IPlayer.RunScriptAsync(string function, object?[]? parameters)
         {
             // Strip newlines from string parameters — some games depend on this (matching WebPlayer behaviour)
             var processedParams = parameters?.Select(p =>

--- a/src/WebPlayer/Player.cs
+++ b/src/WebPlayer/Player.cs
@@ -215,7 +215,7 @@ public class Player : IPlayerHelperUI
         PlayerHelper.SetLinkForeground(colour);
     }
 
-    Task IPlayer.RunScriptAsync(string function, object[]? parameters)
+    Task IPlayer.RunScriptAsync(string function, object?[]? parameters)
     {
         // Clear text buffer before running custom JavaScript, otherwise text written
         // before now may appear after inserted HTML.


### PR DESCRIPTION
Third and final Engine nullability batch: removes `#nullable disable` from the last 11 files — `Utility`, `ScriptFactory`, `ObjectFactory`, `Templates`, `UndoLogger`, `OutputLogger`, `TimerRunner`, `Walkthrough`, `RegexCache`, `Events` and `Expressions/NcalcExpressionEvaluator` — and fixes what that surfaces in already-enabled callers. **The whole Engine project now has nullable reference types enabled** (Engine files still opted out: 11 → 0).

## Annotation changes (compile-time only)
- **`Utility`**: `GetParameter` returns `string?` (null when there's no parameter list) and its `afterParameter` / `GetScript`'s `afterScript` out-params are `string?`; `ConvertVerbSimplePattern` accepts a null separator; `ExpressionResultToString` accepts `object?` (it already throws a clear error for null).
- **Expression results are `object?`**: `IDynamicExpressionEvaluator.EvaluateAsync`, `IFunctionDynamic.ExecuteAsync`/`ExpressionDynamic`, `ExpressionOwner.Eval`, and `Context.ReturnValue` — expressions like `null` really do evaluate to null. Typed `Expression<T>` is unchanged; `NcalcExpressionEvaluator` passes a null result through at that boundary.
- **`ObjectFactory`**: exit and turn-script creation (`CreateExit`, `CreateExitLazy`, `CreateTurnScript`) take nullable id/name/room/type arguments, which they already null-check; initial types/fields are nullable.
- **`Templates`**: `GetText` returns `string?` (only null when `throwException` is false — `WorldModel.LanguageId` already declared it that way), `AddTemplate`/`WorldModel.AddNewTemplate` return `Element?` (null when blocked by a base template), and `ReplaceTemplateText` / `GameLoader.GetTemplate` are `[NotNullIfNotNull]`.
- **`IPlayer.RunScriptAsync(string, object?[]?)`** — `JS.` calls can pass null values; WebPlayer and WasmPlayer updated to match.
- `UndoLogger`'s current/previous transaction, `ScriptFactory.GetScriptConstructor`, the output loggers' `Save`/font/`DisplayOutputAsync` arguments, and `ElementFieldUpdatedEventArgs.NewValue` are nullable where null actually occurs.

## Behaviour
No intended behaviour change. Equivalent restructures so the compiler can follow the null-state: `ScriptFactory.GetScriptConstructor` iterates the keyword → constructor dictionary instead of re-reading each constructor's (nullable) `Keyword`; the script-splitting loops in `ScriptFactory` and `SwitchScriptConstructor` stop on a null/empty remainder rather than assigning it, and drop null checks on `GetScript` results that can't be null; `LegacyOutputLogger.DisplayOutputAsync` calls its own `SetFontSize`/`SetFontName` rather than casting `WorldModel.OutputLogger` back to itself (they're the same instance); `RegexCache`/`Templates` use `TryGetValue` with nullable out-values.

The ~48 `!` are mostly: keyword script constructors (`if`, `for`, `foreach`, `while`, `switch`, `ask`, `show menu`) relying on their line having a parameter list; `GetText` calls that use the default `throwException: true`; loader calls where the `name` attribute is required; function/dynamic-template/timer fields that element type always has (as in #2244); and fields assigned straight after construction.

## Latent null bugs surfaced (left as-is, filed separately)
1. #2248 — `IsDefined("x")` in an expression evaluated with no script parameters — e.g. `Eval("IsDefined(\"x\")")` without a dictionary, or a debugger assertion — dereferences a null `Context.Parameters` and throws, instead of returning false. (The rest of the evaluator already treats null parameters as "no variables".)
2. #2249 — A keyword script with no parameter list at all (e.g. a bare `for`, `while` or `switch` line) fails with a `NullReferenceException` instead of a clear syntax error — the same class of problem as #2246 for `rundelegate`.
3. #2250 — `x in dict` where `x` is null throws `ArgumentNullException` from the dictionary lookup.
4. #2251 — An `<include>` with no `ref`, or a `<javascript>` with no `src`, fails to load with a `NullReferenceException`.

## Test plan
- [x] `dotnet build --configuration Release`: clean (warnings as errors); Debug build also clean
- [x] `dotnet test --configuration Release`: all 403 tests pass
- [x] BOM / line endings preserved on every edited file
- [x] e2e: all 44 pass against local dev servers built from this branch — every `verify-wasmplayer-*` script (23, WasmPlayer) plus the 21 script-editing/undo AppShell scripts
- [x] quest-e2e-tests corpus (58 games), golden snapshots diffed: `main` vs `main` gives 15 games that vary run-to-run; `main` vs this branch differs in exactly those same 15 and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)
