### PR TITLE
refactor(PlayerCore): enable nullable reference types

### DIFF
--- a/src/PlayerCore/ChromeStrings.cs
+++ b/src/PlayerCore/ChromeStrings.cs
@@ -35,7 +35,7 @@ public static class ChromeStrings
         ["ShowPanesButton"] = "Show panels",
     };
 
-    public static Dictionary<string, string> Resolve(WorldModel worldModel)
+    public static Dictionary<string, string> Resolve(WorldModel? worldModel)
     {
         var result = new Dictionary<string, string>(Defaults);
         if (worldModel == null) return result;

--- a/src/PlayerCore/GameLauncher.cs
+++ b/src/PlayerCore/GameLauncher.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using QuestViva.Common;
+﻿using QuestViva.Common;
 using QuestViva.Engine;
 using QuestViva.Legacy;
 

--- a/src/PlayerCore/GameObjectInfo.cs
+++ b/src/PlayerCore/GameObjectInfo.cs
@@ -1,3 +1,3 @@
 namespace QuestViva.PlayerCore;
 
-public record GameObjectInfo(string Name, string Alias, string ParentName, string Description);
+public record GameObjectInfo(string Name, string? Alias, string? ParentName, string? Description);

--- a/src/PlayerCore/GameQuery.cs
+++ b/src/PlayerCore/GameQuery.cs
@@ -8,16 +8,16 @@ namespace QuestViva.PlayerCore;
 // disk via FileGameDataProvider); WasmEditorBridge's cover-art lookup runs in-browser with no
 // filesystem access, so it passes the game's already-read bytes and gets a ByteArrayGameDataProvider
 // instead — same GameData shape either way, just a different source stream.
-public class GameQuery(string filename, byte[] bytes = null)
+public class GameQuery(string filename, byte[]? bytes = null)
 {
     private readonly GameQueryUi _dummyUi = new();
     private readonly List<string> _errors = [];
-    private IGame _game;
-    private PlayerHelper _helper;
-    private V4Game _v4Game;
-    private WorldModel _v5Game;
+    private IGame? _game;
+    private PlayerHelper? _helper;
+    private V4Game? _v4Game;
+    private WorldModel? _v5Game;
 
-    public string GameName => _dummyUi.GameName;
+    public string? GameName => _dummyUi.GameName;
 
     public int ASLVersion
     {
@@ -55,9 +55,9 @@ public class GameQuery(string filename, byte[] bytes = null)
         }
     }
 
-    public string GameId => _game.GameID;
+    public string? GameId => _game!.GameID;
 
-    public string Category
+    public string? Category
     {
         get
         {
@@ -75,7 +75,7 @@ public class GameQuery(string filename, byte[] bytes = null)
         }
     }
 
-    public string Description
+    public string? Description
     {
         get
         {
@@ -93,7 +93,7 @@ public class GameQuery(string filename, byte[] bytes = null)
         }
     }
 
-    public string CoverResourceName
+    public string? CoverResourceName
     {
         get
         {
@@ -116,7 +116,7 @@ public class GameQuery(string filename, byte[] bytes = null)
     ///     Returns null for V4 games and for V5 games that don't set the LanguageId template.
     ///     When null, callers can use <see cref="GameName" /> and <see cref="Description" /> for language detection.
     /// </summary>
-    public string LanguageId
+    public string? LanguageId
     {
         get
         {
@@ -139,7 +139,7 @@ public class GameQuery(string filename, byte[] bytes = null)
     ///     Intended for use with language detection when <see cref="LanguageId" /> is null.
     ///     Returns null for V4 games.
     /// </summary>
-    public string GameTextSample
+    public string? GameTextSample
     {
         get
         {
@@ -153,9 +153,9 @@ public class GameQuery(string filename, byte[] bytes = null)
                 var parts = new List<string>();
                 foreach (var obj in _v5Game.Objects)
                 {
-                    if (obj.Fields.HasString("description"))
+                    if (obj.Fields.GetString("description") is { } description)
                     {
-                        parts.Add(obj.Fields.GetString("description"));
+                        parts.Add(description);
                     }
                 }
 
@@ -170,7 +170,7 @@ public class GameQuery(string filename, byte[] bytes = null)
     ///     All rooms and objects defined in the game itself, excluding anything inherited from Core libraries.
     ///     Returns null for V4 games.
     /// </summary>
-    public IReadOnlyList<GameObjectInfo> GameObjects
+    public IReadOnlyList<GameObjectInfo>? GameObjects
     {
         get
         {
@@ -218,7 +218,7 @@ public class GameQuery(string filename, byte[] bytes = null)
         _game = gameLauncher.GetGame(gameData, null);
         _v4Game = _game as V4Game;
         _v5Game = _game as WorldModel;
-        _helper = new PlayerHelper(_game, _dummyUi);
+        _helper = new PlayerHelper(_game!, _dummyUi);
 
         try
         {
@@ -240,17 +240,17 @@ public class GameQuery(string filename, byte[] bytes = null)
 
     public IEnumerable<string> GetResourceNames()
     {
-        return _game.GetResourceNames();
+        return _game!.GetResourceNames();
     }
 
-    public Stream GetResource(string resourceName)
+    public Stream? GetResource(string resourceName)
     {
-        return _game.GetResourceStream(resourceName);
+        return _game!.GetResourceStream(resourceName);
     }
 
     private class GameQueryUi : IPlayerHelperUI
     {
-        public string GameName { get; private set; }
+        public string? GameName { get; private set; }
 
         public void OutputText(string text)
         {
@@ -344,7 +344,7 @@ public class GameQuery(string filename, byte[] bytes = null)
         {
         }
 
-        public Task RunScriptAsync(string function, object[] parameters)
+        public Task RunScriptAsync(string function, object?[]? parameters)
         {
             return Task.CompletedTask;
         }
@@ -361,7 +361,7 @@ public class GameQuery(string filename, byte[] bytes = null)
         {
         }
 
-        public void RequestSave(string html)
+        public void RequestSave(string? html)
         {
             throw new NotImplementedException();
         }
@@ -390,7 +390,7 @@ public class GameQuery(string filename, byte[] bytes = null)
         {
         }
 
-        public string GetUIOption(UIOption option)
+        public string? GetUIOption(UIOption option)
         {
             return null;
         }

--- a/src/PlayerCore/ListHandler.cs
+++ b/src/PlayerCore/ListHandler.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using QuestViva.Common;
 
 namespace QuestViva.PlayerCore;

--- a/src/PlayerCore/PlayerCore.csproj
+++ b/src/PlayerCore/PlayerCore.csproj
@@ -5,6 +5,7 @@
         <RootNamespace>QuestViva.PlayerCore</RootNamespace>
         <PackageId>QuestViva.PlayerCore</PackageId>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
         <IsAotCompatible>true</IsAotCompatible>
         <Description>Game player runtime for Quest Viva — load and query .aslx text adventure game files.</Description>

--- a/src/PlayerCore/PlayerHelper.cs
+++ b/src/PlayerCore/PlayerHelper.cs
@@ -63,8 +63,8 @@ public class PlayerHelper
     public bool UseGameColours { get; set; }
     public bool UseGameFont { get; set; }
 
-    public string PlayerOverrideForeground { get; set; }
-    public string PlayerOverrideFontFamily { get; set; }
+    public string PlayerOverrideForeground { get; set; } = "";
+    public string PlayerOverrideFontFamily { get; set; } = "";
     public float PlayerOverrideFontSize { get; set; }
 
     public async Task<(bool, IEnumerable<string>)> Initialise(IPlayer player)
@@ -75,7 +75,7 @@ public class PlayerHelper
             return (false, Game.Errors);
         }
 
-        var errors = result ? null : new List<string> {"Unable to initialise game"};
+        IEnumerable<string> errors = result ? Array.Empty<string>() : new List<string> {"Unable to initialise game"};
         return (result, errors);
     }
 
@@ -92,7 +92,7 @@ public class PlayerHelper
         var currentCommand = "";
         var currentHref = "";
         var currentLinkColour = "";
-        string currentOnClick = null;
+        string? currentOnClick = null;
         var generatingLink = false;
         var settings = new XmlReaderSettings();
         settings.IgnoreWhitespace = false;
@@ -144,13 +144,13 @@ public class PlayerHelper
                             WriteText("<u>");
                             break;
                         case "color":
-                            _foregroundOverride = reader.GetAttribute("color");
+                            _foregroundOverride = reader.GetAttribute("color")!;
                             break;
                         case "font":
-                            _fontSizeOverride = reader.GetAttribute("size");
+                            _fontSizeOverride = reader.GetAttribute("size")!;
                             break;
                         case "align":
-                            _playerUI.SetAlignment(reader.GetAttribute("align"));
+                            _playerUI.SetAlignment(reader.GetAttribute("align")!);
                             break;
                         case "a":
                             generatingLink = true;
@@ -288,7 +288,7 @@ public class PlayerHelper
         return GetCurrentFormat(null);
     }
 
-    private string GetCurrentFormat(string linkForeground)
+    private string GetCurrentFormat(string? linkForeground)
     {
         var style = "";
         if (UseGameFont)
@@ -351,7 +351,7 @@ public class PlayerHelper
         return style;
     }
 
-    private void AddLink(string text, string command, string verbs, string colour, string elementId)
+    private void AddLink(string text, string? command, string? verbs, string? colour, string? elementId)
     {
         var onclick = string.Empty;
         _linkCount++;
@@ -359,7 +359,7 @@ public class PlayerHelper
 
         if (string.IsNullOrEmpty(verbs))
         {
-            onclick = string.Format(" onclick=\"sendCommand('{0}')\"", command.Replace("'", @"\'"));
+            onclick = string.Format(" onclick=\"sendCommand('{0}')\"", command!.Replace("'", @"\'"));
         }
 
         WriteText(string.Format("<a id=\"{0}\" style=\"{1}\" class=\"cmdlink\"{2}>{3}</a>",
@@ -374,11 +374,12 @@ public class PlayerHelper
         if (!string.IsNullOrEmpty(verbs))
         {
             _playerUI.OutputText(ClearBuffer());
-            _playerUI.BindMenu(linkid, verbs, text, elementId);
+            // Only object links have verbs, and they always carry an id
+            _playerUI.BindMenu(linkid, verbs, text, elementId!);
         }
     }
 
-    private void AddExternalLink(string text, string href, string colour, string onclick)
+    private void AddExternalLink(string text, string? href, string? colour, string? onclick)
     {
         WriteText(string.Format("<a style=\"{0}\" class=\"cmdlink\" onclick=\"{1}\">{2}</a>",
             GetCurrentFormat(colour ?? _linkForeground),
@@ -433,13 +434,13 @@ public class PlayerHelper
         WriteText(FormatText(text) + "<br />");
     }
 
-    private static Stream GetUiResource(string name)
+    private static Stream? GetUiResource(string name)
     {
         return Assembly.GetExecutingAssembly()
             .GetManifestResourceStream($"QuestViva.PlayerCore.Resources.{name}");
     }
 
-    public static string GetUiResourceString(string name)
+    public static string? GetUiResourceString(string name)
     {
         using var stream = GetUiResource(name);
         if (stream == null)
@@ -451,7 +452,7 @@ public class PlayerHelper
         return reader.ReadToEnd();
     }
 
-    public static byte[] GetUiResourceBytes(string name)
+    public static byte[]? GetUiResourceBytes(string name)
     {
         using var stream = GetUiResource(name);
         if (stream == null)
@@ -511,14 +512,14 @@ public class PlayerHelper
 
     public static string GetContentType(string filename)
     {
-        string result;
+        string? result;
         return MimeTypes.TryGetValue(Path.GetExtension(filename).ToLower(), out result) ? result : "";
     }
 
     public class CommandData
     {
-        public string Command { get; set; }
-        public IDictionary<string, string> Metadata { get; set; }
+        public string? Command { get; set; }
+        public IDictionary<string, string>? Metadata { get; set; }
     }
 }
 

--- a/src/PlayerCore/WalkthroughRunner.cs
+++ b/src/PlayerCore/WalkthroughRunner.cs
@@ -10,7 +10,7 @@ public class WalkthroughRunner(IGameDebug game, string walkthrough)
 
     private readonly IGame _game = (IGame) game;
     private bool _cancelled;
-    private IDictionary<string, string> _menuOptions;
+    private IDictionary<string, string>? _menuOptions;
     private bool _pausing;
     private bool _showingMenu;
     private bool _showingQuestion;
@@ -18,9 +18,9 @@ public class WalkthroughRunner(IGameDebug game, string walkthrough)
 
     public int Steps => game.Walkthroughs.Walkthroughs[walkthrough].Steps.Length;
 
-    public event OutputEventHandler Output;
+    public event OutputEventHandler? Output;
 
-    public event ClearBufferEventHandler ClearBuffer;
+    public event ClearBufferEventHandler? ClearBuffer;
 
     public async Task Run()
     {
@@ -125,7 +125,7 @@ public class WalkthroughRunner(IGameDebug game, string walkthrough)
             _showingMenu = false;
             var menuResponse = response[5..];
             WriteLine("  - " + menuResponse);
-            if (_menuOptions.ContainsKey(menuResponse))
+            if (_menuOptions!.ContainsKey(menuResponse))
             {
                 await _game.SetMenuResponse(menuResponse);
             }

--- a/src/WebPlayer/Components/Game.razor
+++ b/src/WebPlayer/Components/Game.razor
@@ -57,7 +57,7 @@
     [Parameter] public required Func<GameData, IResourceUrlProvider> ResourceUrlProvider { get; set; }
     [Parameter] public required bool EnableDebug { get; set; }
     [Parameter] public bool EnableSave { get; set; } = true;
-    private static MarkupString UiHtml => (MarkupString) PlayerHelper.GetUiResourceString("playercore.htm");
+    private static MarkupString UiHtml => (MarkupString) PlayerHelper.GetUiResourceString("playercore.htm")!;
     private Player? Player { get; set; }
     private GameData? gameData;
     private IGame? game;

--- a/tests/PlayerCoreTests/GameQueryTests.cs
+++ b/tests/PlayerCoreTests/GameQueryTests.cs
@@ -108,6 +108,7 @@ public class GameQueryTests
         Assert.IsTrue(resources.Contains("ta.png"));
 
         var stream = query.GetResource("aw.jpg");
+        Assert.IsNotNull(stream);
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms);
         var bytes = ms.ToArray();


### PR DESCRIPTION
Enables nullable reference types for the whole PlayerCore project (`<Nullable>enable</Nullable>` in the csproj — it previously had no setting, so everything except the two files carrying `#nullable enable` was oblivious), and removes those now-redundant per-file directives.

## Annotation changes (compile-time only)
- **`GameQuery`**: `GameName`, `GameId`, `Category`, `Description`, `CoverResourceName`, `LanguageId`, `GameTextSample`, `GameObjects` and `GetResource` return nullable — they're documented to return null for V4 games (or when unset), and `GameLauncher.GetGame` / `IGame.GetResourceStream` were already annotated as nullable. `GameObjectInfo`'s `Alias`/`ParentName`/`Description` are nullable. The optional `bytes` constructor parameter is `byte[]?`.
- **`PlayerHelper`**: `GetUiResourceString`/`GetUiResourceBytes` return nullable (null for a missing resource); `CommandData.Command`/`Metadata` are nullable; link-building helpers take nullable command/verbs/colour/element id/href/onclick, since text markup attributes can be absent.
- **`ChromeStrings.Resolve(WorldModel?)`** — its doc comment already describes `Resolve(null)` for legacy games, and both WasmPlayer and WebPlayer call it with `game as WorldModel`.
- `GameQuery`'s dummy UI now matches the `IPlayer` signatures (`RunScriptAsync(object?[]?)`, `RequestSave(string?)`, `GetUIOption` → `string?`); `WalkthroughRunner`'s events and pending menu options are nullable.

## Behaviour
No intended behaviour change:
- `PlayerHelper.Initialise` now returns an empty error list rather than null on success, so its errors are non-null for every caller — they're only ever read when initialisation fails (in `GameQuery`, WasmPlayer and WebPlayer), so this just removes the need for `!` at each call site.
- `PlayerOverrideForeground` / `PlayerOverrideFontFamily` default to `""` instead of null. They're never set anywhere, and are only read when `UseGameColours` / `UseGameFont` is false, which no caller does.
- `GameTextSample` uses a single `GetString(...) is { } description` lookup instead of `HasString` + `GetString`.

The 11 `!` are: `GameQuery` members that are only valid after `Initialise` (as before, they'd throw if called first); `WalkthroughRunner`'s menu options, always set before a menu response is expected; the embedded `playercore.htm` resource in WebPlayer's `Game.razor`; `BindMenu`'s element id, which object links (the only links with verbs) always carry; and three text-markup attributes (below). `GameQueryTests` now asserts the resource stream is non-null rather than relying on it.

## Latent null edge noted (not filed)
In `PlayerHelper.PrintText`, a `<color>` with no `color` attribute or a `<font>` with no `size` attribute stores null into the current override, which the next formatted text dereferences; an `<align>` with no `align` attribute passes null to the UI; and an `<object>` link with empty `verbs` would call `command.Replace` on a null command. None of this is reachable from engine output: the only built-in emitter of `<color>`/`<font>`/`<align>` is Legacy's `TextFormatter`, which always writes the attribute, and nothing in Engine, Core or Legacy emits `<object>`/`<command>` link markup — so only hand-written malformed markup could hit it. Kept as-is.

## Test plan
- [x] `dotnet build --configuration Release`: clean (warnings as errors); Debug build also clean
- [x] `dotnet test --configuration Release`: all 403 tests pass
- [x] BOM / line endings preserved on every edited file
- [x] e2e: all 23 `verify-wasmplayer-*` scripts (WasmPlayer uses `PlayerHelper` for all game output) plus 8 AppShell scripts touching cover/game loading pass against local dev servers built from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
