### PR TITLE
refactor(EditorCore): enable nullable reference types (except EditorController)

### DIFF
--- a/src/EditorCore/EditableDataWrapper.cs
+++ b/src/EditorCore/EditableDataWrapper.cs
@@ -1,6 +1,7 @@
 ﻿namespace QuestViva.EditorCore;
 
 internal class EditableDataWrapper<TSource, TWrapped>
+    where TSource : notnull
 {
     private readonly Func<EditorController, TSource, TWrapped> _getNewWrappedInstance;
     private readonly Dictionary<TSource, TWrapped> _instances = new();
@@ -12,13 +13,12 @@ internal class EditableDataWrapper<TSource, TWrapped>
 
     public TWrapped GetInstance(EditorController controller, TSource source)
     {
-        TWrapped instance;
-        if (_instances.TryGetValue(source, out instance))
+        if (_instances.TryGetValue(source, out var existing))
         {
-            return instance;
+            return existing;
         }
 
-        instance = _getNewWrappedInstance(controller, source);
+        var instance = _getNewWrappedInstance(controller, source);
         _instances.Add(source, instance);
         return instance;
     }

--- a/src/EditorCore/EditableDictionary.cs
+++ b/src/EditorCore/EditableDictionary.cs
@@ -39,8 +39,8 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
         throw new NotImplementedException();
     }
 
-    public event EventHandler<EditableListUpdatedEventArgs<T>> Added;
-    public event EventHandler<EditableListUpdatedEventArgs<T>> Removed;
+    public event EventHandler<EditableListUpdatedEventArgs<T>>? Added;
+    public event EventHandler<EditableListUpdatedEventArgs<T>>? Removed;
 
     // currently unused - we currently only use EditableDictionary<string>, and we don't
     // use the Updated event as the same behaviour is implemented with a combination of Added and Removed.
@@ -61,7 +61,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
             foreach (var item in _wrappedItems)
             {
                 // TO DO: We will need some kind of projection function for non-string T's
-                result.Add(item.Key, item.Value.Value as string);
+                result.Add(item.Key, (item.Value.Value as string)!);
             }
 
             return result;
@@ -70,7 +70,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
 
     public void Add(string key, T value)
     {
-        string undoEntry = null;
+        string? undoEntry = null;
         if (typeof(T) == typeof(string))
         {
             undoEntry = string.Format("Add '{0}={1}'", key, value as string);
@@ -88,7 +88,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
 
     public void Remove(params string[] keys)
     {
-        string undoEntry = null;
+        string? undoEntry = null;
         if (typeof(T) == typeof(string))
         {
             undoEntry = string.Format("Remove '{0}'", string.Join(",", keys));
@@ -138,7 +138,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
         return result;
     }
 
-    public string Owner
+    public string? Owner
     {
         get
         {
@@ -194,12 +194,12 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
         }
     }
 
-    private void OnSourceAdded(object sender, QuestDictionaryUpdatedEventArgs<T> e)
+    private void OnSourceAdded(object? sender, QuestDictionaryUpdatedEventArgs<T> e)
     {
         AddWrappedItem(e.Key, e.Item, (EditorUpdateSource) e.Source, e.Index);
     }
 
-    private void OnSourceRemoved(object sender, QuestDictionaryUpdatedEventArgs<T> e)
+    private void OnSourceRemoved(object? sender, QuestDictionaryUpdatedEventArgs<T> e)
     {
         RemoveWrappedItem(_wrappedItems[e.Key], (EditorUpdateSource) e.Source, e.Index);
     }
@@ -209,7 +209,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
         var newSource = (QuestDictionary<T>) _source.Clone();
         newSource.Locked = false;
         parent.Fields.Set(attribute, newSource);
-        newSource = (QuestDictionary<T>) parent.Fields.Get(attribute);
+        newSource = (QuestDictionary<T>) parent.Fields.Get(attribute)!;
         return GetNewInstance(_controller, newSource);
     }
 

--- a/src/EditorCore/EditableIfScript.cs
+++ b/src/EditorCore/EditableIfScript.cs
@@ -9,7 +9,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
     private readonly IIfScript _ifScript;
     private readonly EditableScripts _thenScript;
-    private EditableScripts _elseScript;
+    private EditableScripts? _elseScript;
 
     internal EditableIfScript(EditorController controller, IIfScript script, UndoLogger undoLogger)
         : base(controller, script, undoLogger)
@@ -44,16 +44,16 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
     public IEditableScripts ThenScript => _thenScript;
 
-    public IEditableScripts ElseScript => _elseScript;
+    public IEditableScripts? ElseScript => _elseScript;
 
     public IEnumerable<EditableElseIf> ElseIfScripts => _elseIfScripts.Values;
 
-    public override string DisplayString(int index, object newValue)
+    public override string DisplayString(int index, object? newValue)
     {
         // if index is 0 then we're editing, and newValue is the entire new script, so just return it straight away.
         if (index == 0)
         {
-            return (string) newValue;
+            return (string) newValue!;
         }
 
         // if index is not 0, then this is a request for the DisplayString based on the stored data, so generate it.
@@ -67,12 +67,12 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
     }
 
     // these should probably not be on the interface...
-    public override object GetParameter(string index)
+    public override object? GetParameter(string index)
     {
         throw new NotImplementedException();
     }
 
-    public override void SetParameter(string index, object value)
+    public override void SetParameter(string index, object? value)
     {
         throw new NotImplementedException();
     }
@@ -85,9 +85,9 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
         remove { }
     }
 
-    public string Name => null;
+    public string? Name => null;
 
-    public object GetAttribute(string attribute)
+    public object? GetAttribute(string attribute)
     {
         if (attribute == "expression")
         {
@@ -97,11 +97,11 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
         throw new ArgumentOutOfRangeException("attribute", "Unrecognised 'if' attribute");
     }
 
-    public ValidationResult SetAttribute(string attribute, object value)
+    public ValidationResult SetAttribute(string attribute, object? value)
     {
         if (attribute == "expression")
         {
-            _ifScript.ExpressionString = (string) value;
+            _ifScript.ExpressionString = (string) value!;
         }
         else
         {
@@ -111,12 +111,12 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
         return new ValidationResult {Valid = true};
     }
 
-    public IEnumerable<string> GetAffectedRelatedAttributes(string attribute)
+    public IEnumerable<string>? GetAffectedRelatedAttributes(string attribute)
     {
         return null;
     }
 
-    public string GetSelectedFilter(string filterGroup)
+    public string? GetSelectedFilter(string filterGroup)
     {
         return null;
     }
@@ -129,17 +129,17 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
     public bool IsDirectlySaveable => true;
 
-    public event EventHandler AddedElse;
-    public event EventHandler RemovedElse;
-    public event EventHandler<ElseIfEventArgs> AddedElseIf;
-    public event EventHandler<ElseIfEventArgs> RemovedElseIf;
+    public event EventHandler? AddedElse;
+    public event EventHandler? RemovedElse;
+    public event EventHandler<ElseIfEventArgs>? AddedElseIf;
+    public event EventHandler<ElseIfEventArgs>? RemovedElseIf;
 
-    private void OnIfScriptUpdated(object sender, IfScriptUpdatedEventArgs e)
+    private void OnIfScriptUpdated(object? sender, IfScriptUpdatedEventArgs e)
     {
         switch (e.EventType)
         {
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.AddedElse:
-                _elseScript = EditableScripts.GetInstance(Controller, _ifScript.ElseScript);
+                _elseScript = EditableScripts.GetInstance(Controller, _ifScript.ElseScript!);
                 _elseScript.Updated += nestedScript_Updated;
                 if (AddedElse != null)
                 {
@@ -148,7 +148,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
                 break;
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.RemovedElse:
-                _elseScript.Updated -= nestedScript_Updated;
+                _elseScript!.Updated -= nestedScript_Updated;
                 _elseScript = null;
                 if (RemovedElse != null)
                 {
@@ -157,7 +157,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
                 break;
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.AddedElseIf:
-                var editableNewScript = EditableScripts.GetInstance(Controller, e.Data.Script);
+                var editableNewScript = EditableScripts.GetInstance(Controller, e.Data!.Script);
                 editableNewScript.Updated += nestedScript_Updated;
 
                 // Wrap the newly created elseif in an EditableElseIf and add it to our internal dictionary
@@ -172,7 +172,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
                 break;
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.RemovedElseIf:
-                EditableScripts.GetInstance(Controller, e.Data.Script).Updated -= nestedScript_Updated;
+                EditableScripts.GetInstance(Controller, e.Data!.Script).Updated -= nestedScript_Updated;
                 if (RemovedElseIf != null)
                 {
                     RemovedElseIf(this, new ElseIfEventArgs(_elseIfScripts[e.Data.Script]));
@@ -187,12 +187,12 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
         RaiseUpdated(new EditableScriptUpdatedEventArgs(DisplayString()));
     }
 
-    private void nestedScript_Updated(object sender, EditableScriptsUpdatedEventArgs e)
+    private void nestedScript_Updated(object? sender, EditableScriptsUpdatedEventArgs e)
     {
         RaiseUpdateForNestedScriptChange(e);
     }
 
-    public string DisplayString(IEditableScripts modifiedSection, int index, string newValue)
+    public string DisplayString(IEditableScripts? modifiedSection, int index, string newValue)
     {
         // If we've updated the "then" script, then we need to get an updated "then" script where attribute "index" has been updated to "newValue"
         var result = modifiedSection == ThenScript
@@ -232,7 +232,7 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 
     private string ElseDisplayStringFragment(int index, string newValue)
     {
-        return string.Format(", Else ({0})", index == 1 ? newValue : ElseScript.DisplayString());
+        return string.Format(", Else ({0})", index == 1 ? newValue : ElseScript!.DisplayString());
     }
 
     public void AddElse()
@@ -296,9 +296,9 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
             remove { }
         }
 
-        public string Name => null;
+        public string? Name => null;
 
-        public object GetAttribute(string attribute)
+        public object? GetAttribute(string attribute)
         {
             if (attribute == "expression")
             {
@@ -308,11 +308,11 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
             throw new ArgumentOutOfRangeException("attribute", "Unrecognised 'else if' attribute");
         }
 
-        public ValidationResult SetAttribute(string attribute, object value)
+        public ValidationResult SetAttribute(string attribute, object? value)
         {
             if (attribute == "expression")
             {
-                Expression = (string) value;
+                Expression = (string) value!;
             }
             else
             {
@@ -322,12 +322,12 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
             return new ValidationResult {Valid = true};
         }
 
-        public IEnumerable<string> GetAffectedRelatedAttributes(string attribute)
+        public IEnumerable<string>? GetAffectedRelatedAttributes(string attribute)
         {
             return null;
         }
 
-        public string GetSelectedFilter(string filterGroup)
+        public string? GetSelectedFilter(string filterGroup)
         {
             return null;
         }
@@ -353,7 +353,7 @@ public class IfExpressionControlDefinition : IEditorControl
 
     public string ControlType => "textbox";
 
-    public string Caption => null;
+    public string? Caption => null;
 
     public int? Height => null;
 
@@ -363,7 +363,7 @@ public class IfExpressionControlDefinition : IEditorControl
 
     public bool Expand => false;
 
-    public string GetString(string tag)
+    public string? GetString(string tag)
     {
         if (tag == "usetemplates")
         {
@@ -413,9 +413,9 @@ public class IfExpressionControlDefinition : IEditorControl
         return true;
     }
 
-    public IEditorDefinition Parent => null;
+    public IEditorDefinition? Parent => null;
 
     public bool IsControlVisibleInSimpleMode => true;
 
-    public string Id => null;
+    public string? Id => null;
 }

--- a/src/EditorCore/EditableList.cs
+++ b/src/EditorCore/EditableList.cs
@@ -40,14 +40,14 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         throw new NotImplementedException();
     }
 
-    public event EventHandler<EditableListUpdatedEventArgs<T>> Added;
-    public event EventHandler<EditableListUpdatedEventArgs<T>> Removed;
+    public event EventHandler<EditableListUpdatedEventArgs<T>>? Added;
+    public event EventHandler<EditableListUpdatedEventArgs<T>>? Removed;
 
     public IDictionary<string, IEditableListItem<T>> Items => _wrappedItems;
 
     public void Add(T item)
     {
-        string undoEntry = null;
+        string? undoEntry = null;
         if (typeof(T) == typeof(string))
         {
             undoEntry = string.Format("Add '{0}'", item as string);
@@ -65,7 +65,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
 
     public void Remove(params string[] keys)
     {
-        string undoEntry = null;
+        string? undoEntry = null;
         if (typeof(T) == typeof(string))
         {
             undoEntry = "Remove items from list";
@@ -88,7 +88,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
 
     public void Update(int index, T item)
     {
-        string undoEntry = null;
+        string? undoEntry = null;
         if (typeof(T) == typeof(string))
         {
             undoEntry = string.Format("Update '{0}'", item as string);
@@ -119,7 +119,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
             foreach (var item in _wrappedItems)
             {
                 // TO DO: We will need some kind of projection function for non-string T's
-                result.Add(item.Key, item.Value.Value as string);
+                result.Add(item.Key, (item.Value.Value as string)!);
             }
 
             return result;
@@ -154,7 +154,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         return _wrappedItemsList.GetEnumerator();
     }
 
-    public string Owner
+    public string? Owner
     {
         get
         {
@@ -168,7 +168,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
     }
 
     public IEnumerable<IEditableListItem<T>> ItemsList => _wrappedItemsList;
-    public event NotifyCollectionChangedEventHandler CollectionChanged;
+    public event NotifyCollectionChangedEventHandler? CollectionChanged;
 
     private void PopulateWrappedItems()
     {
@@ -233,12 +233,12 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         }
     }
 
-    private void OnSourceAdded(object sender, QuestListUpdatedEventArgs<T> e)
+    private void OnSourceAdded(object? sender, QuestListUpdatedEventArgs<T> e)
     {
         AddWrappedItem(e.UpdatedItem, (EditorUpdateSource) e.Source, e.Index);
     }
 
-    private void OnSourceRemoved(object sender, QuestListUpdatedEventArgs<T> e)
+    private void OnSourceRemoved(object? sender, QuestListUpdatedEventArgs<T> e)
     {
         RemoveWrappedItem(_wrappedItems[_wrappedItemKeys[e.Index]], (EditorUpdateSource) e.Source, e.Index);
     }
@@ -248,7 +248,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         var newSource = (QuestList<T>) _source.Clone();
         newSource.Locked = false;
         parent.Fields.Set(attribute, newSource);
-        newSource = (QuestList<T>) parent.Fields.Get(attribute);
+        newSource = (QuestList<T>) parent.Fields.Get(attribute)!;
         return GetNewInstance(_controller, newSource);
     }
 

--- a/src/EditorCore/EditableObjectReference.cs
+++ b/src/EditorCore/EditableObjectReference.cs
@@ -7,7 +7,7 @@ public class EditableObjectReference : IEditableObjectReference
     private readonly string _attribute;
     private readonly EditorController _controller;
     private readonly Element _parent;
-    private Element _object;
+    private Element? _object;
 
     public EditableObjectReference(EditorController controller, Element obj, Element parent, string attribute)
     {
@@ -23,19 +23,19 @@ public class EditableObjectReference : IEditableObjectReference
         remove { }
     }
 
-    public object GetUnderlyingValue()
+    public object? GetUnderlyingValue()
     {
         return _object;
     }
 
     public string DisplayString()
     {
-        return "Object: " + _object.Name;
+        return "Object: " + _object!.Name;
     }
 
     public string Reference
     {
-        get => _object.Name;
+        get => _object!.Name;
         set
         {
             _object = string.IsNullOrEmpty(value) ? null : _controller.WorldModel.Elements.Get(value);

--- a/src/EditorCore/EditableScript.cs
+++ b/src/EditorCore/EditableScript.cs
@@ -15,19 +15,20 @@ public class EditableScript : EditableScriptBase, IEditableScript
     internal EditableScript(EditorController controller, IScript script, UndoLogger undoLogger)
         : base(controller, script, undoLogger)
     {
-        _editorName = Script.Keyword;
+        // An editable script always wraps a single script command, which has a keyword
+        _editorName = Script.Keyword!;
     }
 
-    internal string DisplayTemplate { get; set; }
+    internal string? DisplayTemplate { get; set; }
 
-    public override string DisplayString(int index, object newValue)
+    public override string DisplayString(int index, object? newValue)
     {
         // This version of DisplayString is used while we are editing an attribute value
         // as we don't want to save updates for every keypress
 
         if (string.IsNullOrEmpty(DisplayTemplate))
         {
-            return Script == null ? null : Script.Save();
+            return Script.Save();
         }
 
         var result = DisplayTemplate;
@@ -39,7 +40,7 @@ public class EditableScript : EditableScriptBase, IEditableScript
             var attributeNum = int.Parse(m.Groups["attribute"].Value);
             string attributeValue;
 
-            object value;
+            object? value;
             if (attributeNum == index)
             {
                 value = newValue;
@@ -95,22 +96,22 @@ public class EditableScript : EditableScriptBase, IEditableScript
         set => _editorName = value;
     }
 
-    public override object GetParameter(string index)
+    public override object? GetParameter(string index)
     {
         if (EditorName.StartsWith("(function)"))
         {
             if (index == "script")
             {
-                return FunctionCallScript.GetFunctionCallParameterScript();
+                return FunctionCallScript!.GetFunctionCallParameterScript();
             }
 
-            return FunctionCallScript.GetFunctionCallParameter(int.Parse(index));
+            return FunctionCallScript!.GetFunctionCallParameter(int.Parse(index));
         }
 
         return Script.GetParameter(int.Parse(index));
     }
 
-    public override void SetParameter(string index, object value)
+    public override void SetParameter(string index, object? value)
     {
         var valueToSet = value;
         var wrappedValue = value as IDataWrapper;
@@ -123,12 +124,12 @@ public class EditableScript : EditableScriptBase, IEditableScript
         {
             if (index == "script")
             {
-                FunctionCallScript.SetFunctionCallParameterScript(valueToSet as IScript);
+                FunctionCallScript!.SetFunctionCallParameterScript(valueToSet as IScript);
                 RaiseUpdated(new EditableScriptUpdatedEventArgs {IsNestedScriptUpdate = true});
                 return;
             }
 
-            FunctionCallScript.SetFunctionCallParameter(int.Parse(index), valueToSet);
+            FunctionCallScript!.SetFunctionCallParameter(int.Parse(index), valueToSet);
             return;
         }
 
@@ -146,7 +147,7 @@ public class EditableScript : EditableScriptBase, IEditableScript
         }
     }
 
-    private void nestedScript_Updated(object sender, EditableScriptsUpdatedEventArgs e)
+    private void nestedScript_Updated(object? sender, EditableScriptsUpdatedEventArgs e)
     {
         RaiseUpdateForNestedScriptChange(e);
     }

--- a/src/EditorCore/EditableScriptBase.cs
+++ b/src/EditorCore/EditableScriptBase.cs
@@ -7,7 +7,8 @@ public abstract class EditableScriptBase : IEditableScript
 {
     private static int _count;
 
-    private IScript _script;
+    // Assigned through Script in the constructor
+    private IScript _script = null!;
 
     public EditableScriptBase(EditorController controller, IScript script, UndoLogger undoLogger)
     {
@@ -48,31 +49,32 @@ public abstract class EditableScriptBase : IEditableScript
         }
     }
 
-    internal IFunctionCallScript FunctionCallScript => _script as IFunctionCallScript;
+    internal IFunctionCallScript? FunctionCallScript => _script as IFunctionCallScript;
 
     protected EditorController Controller { get; }
 
-    public event EventHandler<EditableScriptUpdatedEventArgs> Updated;
+    public event EventHandler<EditableScriptUpdatedEventArgs>? Updated;
 
     public virtual string DisplayString()
     {
         return DisplayString(-1, string.Empty);
     }
 
-    public abstract string DisplayString(int index, object newValue);
+    public abstract string DisplayString(int index, object? newValue);
     public abstract string EditorName { get; set; }
-    public abstract object GetParameter(string index);
-    public abstract void SetParameter(string index, object value);
+    public abstract object? GetParameter(string index);
+    public abstract void SetParameter(string index, object? value);
     public abstract ScriptType Type { get; }
 
     public string Id { get; }
 
     public IEnumerable<string> GetVariablesInScope()
     {
-        return Script.Parent.GetVariablesInScope();
+        // Editable scripts always live inside a MultiScript
+        return Script.Parent!.GetVariablesInScope();
     }
 
-    protected void ScriptUpdated(object sender, ScriptUpdatedEventArgs e)
+    protected void ScriptUpdated(object? sender, ScriptUpdatedEventArgs e)
     {
         if (Updated != null)
         {
@@ -82,7 +84,7 @@ public abstract class EditableScriptBase : IEditableScript
             }
             else if (e != null && e.IsNamedParameterUpdate)
             {
-                Updated(this, new EditableScriptUpdatedEventArgs(e.Id, (string) e.NewValue));
+                Updated(this, new EditableScriptUpdatedEventArgs(e.Id, (string?) e.NewValue));
             }
             else
             {
@@ -91,11 +93,11 @@ public abstract class EditableScriptBase : IEditableScript
         }
     }
 
-    private void FunctionCallParametersUpdated(object sender, ScriptUpdatedEventArgs e)
+    private void FunctionCallParametersUpdated(object? sender, ScriptUpdatedEventArgs e)
     {
         if (EditorName.StartsWith("(function)"))
         {
-            Updated(this, new EditableScriptUpdatedEventArgs(e.Index, Controller.WrapValue(e.NewValue)));
+            Updated!(this, new EditableScriptUpdatedEventArgs(e.Index, Controller.WrapValue(e.NewValue)));
         }
     }
 

--- a/src/EditorCore/EditableScriptFactory.cs
+++ b/src/EditorCore/EditableScriptFactory.cs
@@ -6,13 +6,14 @@ namespace QuestViva.EditorCore;
 
 public class EditableScriptData
 {
-    private readonly Expression<bool> _visibilityExpression;
+    private readonly Expression<bool>? _visibilityExpression;
 
     public EditableScriptData(Element editor, WorldModel worldModel, int order)
     {
         Order = order;
         DisplayString = editor.Fields.GetString("display");
-        Category = editor.Fields.GetString("category");
+        // Only created for editors that have a category - see EditableScriptFactory.IsScriptEditor
+        Category = editor.Fields.GetString("category")!;
         CreateString = editor.Fields.GetString("create");
         AdderDisplayString = editor.Fields.GetString("add");
         IsVisibleInSimpleMode = !editor.Fields.GetAsType<bool>("advanced");
@@ -25,12 +26,12 @@ public class EditableScriptData
         }
     }
 
-    public string DisplayString { get; }
+    public string? DisplayString { get; }
     public string Category { get; }
-    public string CreateString { get; private set; }
-    public string AdderDisplayString { get; private set; }
+    public string? CreateString { get; private set; }
+    public string? AdderDisplayString { get; private set; }
     public bool IsVisibleInSimpleMode { get; }
-    public string CommonButton { get; private set; }
+    public string? CommonButton { get; private set; }
     public int Order { get; private set; }
 
     public async Task<bool> IsVisible()
@@ -56,7 +57,8 @@ internal class EditableScriptFactory
         foreach (var editor in worldModel.Elements.GetElements(ElementType.Editor).Where(IsScriptEditor))
         {
             var appliesTo = editor.Fields.GetString("appliesto");
-            ScriptData.Add(appliesTo, new EditableScriptData(editor, worldModel, order++));
+            // Script editors always name the script command they apply to
+            ScriptData.Add(appliesTo!, new EditableScriptData(editor, worldModel, order++));
         }
     }
 
@@ -75,12 +77,12 @@ internal class EditableScriptFactory
 
     internal EditableScriptBase CreateEditableScript(IScript script)
     {
-        EditableScriptBase newScript;
-
-        if (_cache.TryGetValue(script, out newScript))
+        if (_cache.TryGetValue(script, out var cachedScript))
         {
-            return newScript;
+            return cachedScript;
         }
+
+        EditableScriptBase newScript;
 
         if (script.Keyword == "if")
         {
@@ -89,9 +91,9 @@ internal class EditableScriptFactory
         else
         {
             var newEditableScript = new EditableScript(_controller, script, _worldModel.UndoLogger);
-            if (ScriptData.ContainsKey(script.Keyword))
+            if (script.Keyword != null && ScriptData.TryGetValue(script.Keyword, out var scriptData))
             {
-                newEditableScript.DisplayTemplate = ScriptData[script.Keyword].DisplayString;
+                newEditableScript.DisplayTemplate = scriptData.DisplayString;
             }
 
             newScript = newEditableScript;

--- a/src/EditorCore/EditableScripts.cs
+++ b/src/EditorCore/EditableScripts.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using QuestViva.Engine.Scripts;
 
@@ -11,7 +12,8 @@ public class EditableScripts : IEditableScripts, IDataWrapper
 
     private readonly List<IEditableScript> _scripts;
     private bool _replacingScripts;
-    private IMultiScript _underlyingScript;
+    // Set by InitialiseScript, which every constructor path calls
+    private IMultiScript _underlyingScript = null!;
 
     static EditableScripts()
     {
@@ -30,8 +32,8 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         InitialiseScript(script);
     }
 
-    public event EventHandler<EditableScriptsUpdatedEventArgs> Updated;
-    public event EventHandler<DataWrapperUpdatedEventArgs> UnderlyingValueUpdated;
+    public event EventHandler<EditableScriptsUpdatedEventArgs>? Updated;
+    public event EventHandler<DataWrapperUpdatedEventArgs>? UnderlyingValueUpdated;
 
     #region IDataWrapper Members
 
@@ -122,13 +124,13 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         var clonedScript = (IScript) _underlyingScript.Clone();
         var parentElement = _controller.WorldModel.Elements.Get(parent);
         parentElement.Fields.Set(attribute, clonedScript);
-        clonedScript = (IScript) parentElement.Fields.Get(attribute);
+        clonedScript = (IScript) parentElement.Fields.Get(attribute)!;
         var result = new EditableScripts(_controller, clonedScript);
 
         return result;
     }
 
-    public string Owner
+    public string? Owner
     {
         get
         {
@@ -210,6 +212,7 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
     }
 
+    [MemberNotNull(nameof(_underlyingScript))]
     private void InitialiseMultiScript(IMultiScript script)
     {
         if (_underlyingScript != null)
@@ -222,7 +225,7 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         _underlyingScript.UndoLog = _controller.WorldModel.UndoLogger;
     }
 
-    private void multiScript_ScriptUpdated(object sender, ScriptUpdatedEventArgs e)
+    private void multiScript_ScriptUpdated(object? sender, ScriptUpdatedEventArgs e)
     {
         if (_adding)
         {
@@ -257,7 +260,7 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         {
             _replacingScripts = true;
             _scripts.Clear();
-            foreach (var script in ((MultiScript) sender).Scripts)
+            foreach (var script in ((MultiScript) sender!).Scripts)
             {
                 Add(_controller.ScriptFactory.CreateEditableScript(script), true);
             }
@@ -278,11 +281,11 @@ public class EditableScripts : IEditableScripts, IDataWrapper
         Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
     }
 
-    private void script_Updated(object sender, EditableScriptUpdatedEventArgs e)
+    private void script_Updated(object? sender, EditableScriptUpdatedEventArgs e)
     {
         if (Updated != null)
         {
-            Updated(this, new EditableScriptsUpdatedEventArgs((IEditableScript) sender, e));
+            Updated(this, new EditableScriptsUpdatedEventArgs((IEditableScript) sender!, e));
         }
 
         if (UnderlyingValueUpdated != null)

--- a/src/EditorCore/EditableWrappedItemDictionary.cs
+++ b/src/EditorCore/EditableWrappedItemDictionary.cs
@@ -46,10 +46,10 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         return string.Format("(Script Dictionary: {0} items)", _source.Count);
     }
 
-    public event EventHandler<EditableListUpdatedEventArgs<TWrapped>> Added;
-    public event EventHandler<EditableListUpdatedEventArgs<TWrapped>> Removed;
+    public event EventHandler<EditableListUpdatedEventArgs<TWrapped>>? Added;
+    public event EventHandler<EditableListUpdatedEventArgs<TWrapped>>? Removed;
 
-    public event EventHandler<EditableListUpdatedEventArgs<TWrapped>> Updated;
+    public event EventHandler<EditableListUpdatedEventArgs<TWrapped>>? Updated;
 
     public IDictionary<string, IEditableListItem<TWrapped>> Items => _wrappedItems;
 
@@ -72,8 +72,7 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     public void Add(string key, TWrapped value)
     {
-        string undoEntry = null;
-        undoEntry = string.Format("Add '{0}={1}'", key, value == null ? string.Empty : value.DisplayString());
+        var undoEntry = string.Format("Add '{0}={1}'", key, value == null ? string.Empty : value.DisplayString());
 
         _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
         _source.Add(key, UnwrapValue(value), UpdateSource.User);
@@ -82,8 +81,7 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
 
     public void Remove(params string[] keys)
     {
-        string undoEntry = null;
-        undoEntry = string.Format("Remove '{0}'", string.Join(",", keys));
+        var undoEntry = string.Format("Remove '{0}'", string.Join(",", keys));
 
         _controller.WorldModel.UndoLogger.StartTransaction(undoEntry);
         foreach (var key in keys)
@@ -149,7 +147,7 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
     //    return EditableWrappedItemDictionary<TSource, TWrapped>.GetNewInstance(_controller, newSource);
     //}
 
-    public string Owner
+    public string? Owner
     {
         get
         {
@@ -181,14 +179,15 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         return (TWrapped) _controller.WrapValue(source);
     }
 
-    private TSource UnwrapValue(TWrapped wrapped)
+    private TSource UnwrapValue(TWrapped? wrapped)
     {
         if (wrapped == null)
         {
-            return null;
+            // Stored as a null value in the underlying dictionary
+            return null!;
         }
 
-        return (TSource) wrapped.GetUnderlyingValue();
+        return (TSource) wrapped.GetUnderlyingValue()!;
     }
 
     private void AddWrappedItem(string key, TWrapped value, EditorUpdateSource source, int index)
@@ -218,12 +217,12 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         }
     }
 
-    private void WrappedUnderlyingValueUpdated(object sender, DataWrapperUpdatedEventArgs e)
+    private void WrappedUnderlyingValueUpdated(object? sender, DataWrapperUpdatedEventArgs e)
     {
         if (Updated != null)
         {
             // sender will be the underlying wrapped value that has been updated. e.g. an IEditableScripts item
-            var updatedItem = (TWrapped) sender;
+            var updatedItem = (TWrapped) sender!;
 
             Updated(this, new EditableListUpdatedEventArgs<TWrapped>
             {
@@ -233,12 +232,12 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         }
     }
 
-    private void OnSourceAdded(object sender, QuestDictionaryUpdatedEventArgs<TSource> e)
+    private void OnSourceAdded(object? sender, QuestDictionaryUpdatedEventArgs<TSource> e)
     {
         AddWrappedItem(e.Key, WrapValue(e.Item), (EditorUpdateSource) e.Source, e.Index);
     }
 
-    private void OnSourceRemoved(object sender, QuestDictionaryUpdatedEventArgs<TSource> e)
+    private void OnSourceRemoved(object? sender, QuestDictionaryUpdatedEventArgs<TSource> e)
     {
         RemoveWrappedItem(_wrappedItems[e.Key], (EditorUpdateSource) e.Source, e.Index);
     }

--- a/src/EditorCore/EditorControl.cs
+++ b/src/EditorCore/EditorControl.cs
@@ -36,35 +36,36 @@ internal class EditorControl : IEditorControl
         IsControlVisibleInSimpleMode = !source.Fields.GetAsType<bool>("advanced");
         Id = source.Name;
 
-        if (source.Fields.HasString("filtergroup"))
+        if (source.Fields.GetString("filtergroup") is { } filterGroup)
         {
-            parent.RegisterFilter(source.Fields.GetString("filtergroup"), source.Fields.GetString("filter"), Attribute);
+            // A control in a filter group always names its filter and attribute
+            parent.RegisterFilter(filterGroup, source.Fields.GetString("filter")!, Attribute!);
         }
     }
 
-    public string ControlType { get; }
+    public string? ControlType { get; }
 
-    public string Caption { get; }
+    public string? Caption { get; }
 
     public int? Height { get; }
 
     public int? Width { get; }
 
-    public string Attribute { get; }
+    public string? Attribute { get; }
 
     public bool Expand { get; }
 
-    public string GetString(string tag)
+    public string? GetString(string tag)
     {
         return _source.Fields.GetString(tag);
     }
 
-    public IEnumerable<string> GetListString(string tag)
+    public IEnumerable<string>? GetListString(string tag)
     {
         return _source.Fields.GetAsType<QuestList<string>>(tag);
     }
 
-    public IDictionary<string, string> GetDictionary(string tag)
+    public IDictionary<string, string>? GetDictionary(string tag)
     {
         return _source.Fields.GetAsType<QuestDictionary<string>>(tag);
     }

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿#nullable disable
+using System.Collections;
 using System.Text.RegularExpressions;
 using System.Xml;
 using QuestViva.Common;

--- a/src/EditorCore/EditorCore.csproj
+++ b/src/EditorCore/EditorCore.csproj
@@ -4,6 +4,7 @@
         <OutputType>Library</OutputType>
         <RootNamespace>QuestViva.EditorCore</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
         <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>

--- a/src/EditorCore/EditorData.cs
+++ b/src/EditorCore/EditorData.cs
@@ -5,7 +5,7 @@ namespace QuestViva.EditorCore;
 
 internal class EditorAttributeData : IEditorAttributeData
 {
-    public EditorAttributeData(string attributeName, bool isInherited, string source, bool isDefaultType)
+    public EditorAttributeData(string attributeName, bool isInherited, string? source, bool isDefaultType)
     {
         AttributeName = attributeName;
         IsInherited = isInherited;
@@ -17,7 +17,7 @@ internal class EditorAttributeData : IEditorAttributeData
 
     public bool IsInherited { get; }
 
-    public string Source { get; set; }
+    public string? Source { get; set; }
 
     public bool IsDefaultType { get; set; }
 }
@@ -37,11 +37,11 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
         element.Fields.AttributeChangedSilent += Fields_AttributeChanged;
     }
 
-    public event EventHandler Changed;
+    public event EventHandler? Changed;
 
     public string Name => _element.Name;
 
-    public object GetAttribute(string attribute)
+    public object? GetAttribute(string attribute)
     {
         if (attribute == "name" && _element.Fields[FieldDefinitions.Anonymous])
         {
@@ -51,7 +51,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
         return _controller.WrapValue(_element.Fields.Get(attribute), _element, attribute);
     }
 
-    public ValidationResult SetAttribute(string attribute, object value)
+    public ValidationResult SetAttribute(string attribute, object? value)
     {
         if (attribute == "name")
         {
@@ -85,7 +85,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
             value = wrapper.GetUnderlyingValue();
         }
 
-        string oldName = null;
+        string? oldName = null;
         if (attribute == "name")
         {
             oldName = _element.Name;
@@ -95,7 +95,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
 
         if (attribute == "name")
         {
-            _controller.UpdateDictionariesReferencingRenamedObject(oldName, (string) value);
+            _controller.UpdateDictionariesReferencingRenamedObject(oldName, (string) value!);
         }
 
         return new ValidationResult {Valid = true};
@@ -103,7 +103,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
 
     // When the "anonymous" field is updated, that affects how the "name" attribute is displayed.
 
-    public IEnumerable<string> GetAffectedRelatedAttributes(string attribute)
+    public IEnumerable<string>? GetAffectedRelatedAttributes(string attribute)
     {
         if (attribute == "anonymous")
         {
@@ -113,10 +113,9 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
         return null;
     }
 
-    public string GetSelectedFilter(string filterGroup)
+    public string? GetSelectedFilter(string filterGroup)
     {
-        string result;
-        _filters.TryGetValue(filterGroup, out result);
+        _filters.TryGetValue(filterGroup, out var result);
         return result;
     }
 
@@ -154,7 +153,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
 
     public bool IsLibraryElement => _element.MetaFields[MetaFieldDefinitions.Library];
 
-    public string Filename => _element.MetaFields[MetaFieldDefinitions.Filename];
+    public string? Filename => _element.MetaFields[MetaFieldDefinitions.Filename];
 
     public void MakeElementLocal()
     {
@@ -173,14 +172,14 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
         set { }
     }
 
-    public IEnumerable<string> GetVariablesInScope()
+    public IEnumerable<string>? GetVariablesInScope()
     {
         return null;
     }
 
     public bool IsDirectlySaveable => true;
 
-    private void Fields_AttributeChanged(object sender, AttributeChangedEventArgs e)
+    private void Fields_AttributeChanged(object? sender, AttributeChangedEventArgs e)
     {
         if (Changed != null)
         {

--- a/src/EditorCore/EditorDefinition.cs
+++ b/src/EditorCore/EditorDefinition.cs
@@ -37,17 +37,17 @@ internal class EditorDefinition : IEditorDefinition
         }
     }
 
-    public string AppliesTo { get; }
+    public string? AppliesTo { get; }
 
-    public string Pattern { get; }
+    public string? Pattern { get; }
 
-    public string Create { get; }
+    public string? Create { get; }
 
-    public string ExpressionType { get; }
+    public string? ExpressionType { get; }
 
-    public string OriginalPattern { get; }
+    public string? OriginalPattern { get; }
 
-    public string Description { get; }
+    public string? Description { get; }
 
     public IDictionary<string, IEditorTab> Tabs => _tabs;
 

--- a/src/EditorCore/EditorTab.cs
+++ b/src/EditorCore/EditorTab.cs
@@ -33,9 +33,9 @@ internal class EditorTab : IEditorTab
         _source = source;
     }
 
-    public string Caption { get; }
+    public string? Caption { get; }
 
-    public string HelpUrl { get; }
+    public string? HelpUrl { get; }
 
     public IEnumerable<IEditorControl> Controls => _controls.Values;
 

--- a/src/EditorCore/EditorVisibilityHelper.cs
+++ b/src/EditorCore/EditorVisibilityHelper.cs
@@ -7,18 +7,18 @@ namespace QuestViva.EditorCore;
 internal class EditorVisibilityHelper
 {
     private readonly bool _alwaysVisible = true;
-    private readonly string _filter;
-    private readonly string _filterGroup;
-    private readonly IList<string> _notVisibleIfElementInheritsType;
+    private readonly string? _filter;
+    private readonly string? _filterGroup;
+    private readonly IList<string>? _notVisibleIfElementInheritsType;
     private readonly EditorDefinition _parent;
-    private readonly string _relatedAttribute;
+    private readonly string? _relatedAttribute;
     private readonly bool _relatedAttributeNegate;
-    private readonly Expression<bool> _visibilityExpression;
-    private readonly IList<string> _visibleIfElementInheritsType;
-    private readonly string _visibleIfRelatedAttributeIsType;
+    private readonly Expression<bool>? _visibilityExpression;
+    private readonly IList<string>? _visibleIfElementInheritsType;
+    private readonly string? _visibleIfRelatedAttributeIsType;
     private readonly WorldModel _worldModel;
-    private List<Element> _notVisibleIfElementInheritsTypeElement;
-    private List<Element> _visibleIfElementInheritsTypeElement;
+    private List<Element>? _notVisibleIfElementInheritsTypeElement;
+    private List<Element>? _visibleIfElementInheritsTypeElement;
 
     public EditorVisibilityHelper(EditorDefinition parent, WorldModel worldModel, Element source)
     {
@@ -66,7 +66,8 @@ internal class EditorVisibilityHelper
         {
             // evaluate <onlydisplayif> expression, with "this" as the current element
             var context = new Context();
-            context.Parameters = new Parameters("this", _worldModel.Elements.Get(data.Name));
+            // Visibility is only evaluated for element editors, whose data is always named
+            context.Parameters = new Parameters("this", _worldModel.Elements.Get(data.Name!));
             var result = false;
             try
             {
@@ -115,7 +116,7 @@ internal class EditorVisibilityHelper
 
             // if the element does inherit any of the "forbidden" types, then this control is not visible
 
-            var element = _worldModel.Elements.Get(data.Name);
+            var element = _worldModel.Elements.Get(data.Name!);
 
             foreach (var forbiddenType in _notVisibleIfElementInheritsTypeElement)
             {
@@ -161,7 +162,7 @@ internal class EditorVisibilityHelper
 
             // if the element does inherit any of the types, then this control is visible
 
-            var element = _worldModel.Elements.Get(data.Name);
+            var element = _worldModel.Elements.Get(data.Name!);
 
             foreach (var type in _visibleIfElementInheritsTypeElement)
             {

--- a/src/EditorCore/ExpressionTemplateEditorData.cs
+++ b/src/EditorCore/ExpressionTemplateEditorData.cs
@@ -13,23 +13,24 @@ internal class ExpressionTemplateEditorData : IEditorData
         // We create the parameter dictionary in the same way as the command parser, so
         // we end up with a dictionary like "object=myobject".
 
-        _parameters = Engine.Utility.Populate(definition.Pattern, expression);
-        _originalPattern = definition.OriginalPattern;
+        // Expression template editors always define a pattern and its original form
+        _parameters = Engine.Utility.Populate(definition.Pattern!, expression);
+        _originalPattern = definition.OriginalPattern!;
         _parentData = parentData;
     }
 
-    public event EventHandler Changed;
+    public event EventHandler? Changed;
 
     public string Name => throw new NotImplementedException();
 
-    public object GetAttribute(string attribute)
+    public object? GetAttribute(string attribute)
     {
         return _parameters[attribute];
     }
 
-    public ValidationResult SetAttribute(string attribute, object value)
+    public ValidationResult SetAttribute(string attribute, object? value)
     {
-        _parameters[attribute] = (string) value;
+        _parameters[attribute] = (string) value!;
         if (Changed != null)
         {
             Changed(this, new EventArgs());
@@ -38,12 +39,12 @@ internal class ExpressionTemplateEditorData : IEditorData
         return new ValidationResult {Valid = true};
     }
 
-    public IEnumerable<string> GetAffectedRelatedAttributes(string attribute)
+    public IEnumerable<string>? GetAffectedRelatedAttributes(string attribute)
     {
         throw new NotImplementedException();
     }
 
-    public string GetSelectedFilter(string filterGroup)
+    public string? GetSelectedFilter(string filterGroup)
     {
         throw new NotImplementedException();
     }
@@ -55,7 +56,7 @@ internal class ExpressionTemplateEditorData : IEditorData
 
     public bool ReadOnly { get; set; }
 
-    public IEnumerable<string> GetVariablesInScope()
+    public IEnumerable<string>? GetVariablesInScope()
     {
         return _parentData.GetVariablesInScope();
     }

--- a/src/EditorCore/IDataWrapper.cs
+++ b/src/EditorCore/IDataWrapper.cs
@@ -7,6 +7,6 @@ public class DataWrapperUpdatedEventArgs : EventArgs
 public interface IDataWrapper
 {
     event EventHandler<DataWrapperUpdatedEventArgs> UnderlyingValueUpdated;
-    object GetUnderlyingValue();
+    object? GetUnderlyingValue();
     string DisplayString();
 }

--- a/src/EditorCore/IEditableList.cs
+++ b/src/EditorCore/IEditableList.cs
@@ -4,7 +4,7 @@ namespace QuestViva.EditorCore;
 
 public class EditableListUpdatedEventArgs<T> : EventArgs
 {
-    public IEditableListItem<T> UpdatedItem { get; set; }
+    public required IEditableListItem<T> UpdatedItem { get; set; }
     public int Index { get; set; }
     public EditorUpdateSource Source { get; set; }
 }
@@ -14,7 +14,7 @@ public interface IEditableList<T> : IEnumerable
     IDictionary<string, IEditableListItem<T>> Items { get; }
     IEnumerable<KeyValuePair<string, string>> DisplayItems { get; }
     bool Locked { get; }
-    string Owner { get; }
+    string? Owner { get; }
     IEnumerable<IEditableListItem<T>> ItemsList { get; }
     event EventHandler<EditableListUpdatedEventArgs<T>> Added;
     event EventHandler<EditableListUpdatedEventArgs<T>> Removed;
@@ -39,7 +39,7 @@ public interface IEditableDictionary<T>
     IEnumerable<KeyValuePair<string, string>> DisplayItems { get; }
     T this[string key] { get; }
     bool Locked { get; }
-    string Owner { get; }
+    string? Owner { get; }
     event EventHandler<EditableListUpdatedEventArgs<T>> Added;
     event EventHandler<EditableListUpdatedEventArgs<T>> Removed;
     event EventHandler<EditableListUpdatedEventArgs<T>> Updated;

--- a/src/EditorCore/IEditableScript.cs
+++ b/src/EditorCore/IEditableScript.cs
@@ -7,29 +7,29 @@ public class EditableScriptUpdatedEventArgs : EventArgs
         Index = -1;
     }
 
-    internal EditableScriptUpdatedEventArgs(int index, object newValue)
+    internal EditableScriptUpdatedEventArgs(int index, object? newValue)
     {
         Index = index;
         NewValue = newValue;
         IsParameterUpdate = true;
     }
 
-    internal EditableScriptUpdatedEventArgs(string id, object newValue)
+    internal EditableScriptUpdatedEventArgs(string? id, object? newValue)
     {
         Id = id;
         NewValue = newValue;
         IsNamedParameterUpdate = true;
     }
 
-    internal EditableScriptUpdatedEventArgs(object newValue)
+    internal EditableScriptUpdatedEventArgs(object? newValue)
     {
         NewValue = newValue;
         IsWholeScriptUpdate = true;
     }
 
     public int Index { get; private set; }
-    public string Id { get; private set; }
-    public object NewValue { get; private set; }
+    public string? Id { get; private set; }
+    public object? NewValue { get; private set; }
     public bool IsParameterUpdate { get; private set; }
     public bool IsNamedParameterUpdate { get; private set; }
     public bool IsWholeScriptUpdate { get; private set; }
@@ -48,9 +48,9 @@ public interface IEditableScript
     string EditorName { get; set; }
     ScriptType Type { get; }
     string DisplayString();
-    string DisplayString(int index, object newValue);
-    object GetParameter(string index);
-    void SetParameter(string index, object value);
+    string DisplayString(int index, object? newValue);
+    object? GetParameter(string index);
+    void SetParameter(string index, object? value);
     event EventHandler<EditableScriptUpdatedEventArgs> Updated;
     IEnumerable<string> GetVariablesInScope();
 }

--- a/src/EditorCore/IEditableScripts.cs
+++ b/src/EditorCore/IEditableScripts.cs
@@ -12,8 +12,8 @@ public class EditableScriptsUpdatedEventArgs : EventArgs
         UpdatedScriptEventArgs = args;
     }
 
-    public IEditableScript UpdatedScript { get; private set; }
-    public EditableScriptUpdatedEventArgs UpdatedScriptEventArgs { get; private set; }
+    public IEditableScript? UpdatedScript { get; private set; }
+    public EditableScriptUpdatedEventArgs? UpdatedScriptEventArgs { get; private set; }
 }
 
 public interface IEditableScripts : IDataWrapper
@@ -21,7 +21,7 @@ public interface IEditableScripts : IDataWrapper
     IEnumerable<IEditableScript> Scripts { get; }
     IEditableScript this[int index] { get; }
     int Count { get; }
-    string Owner { get; }
+    string? Owner { get; }
     string Code { get; set; }
     void AddNew(string keyword, string elementName);
     event EventHandler<EditableScriptsUpdatedEventArgs> Updated;

--- a/src/EditorCore/IEditorControl.cs
+++ b/src/EditorCore/IEditorControl.cs
@@ -2,18 +2,18 @@
 
 public interface IEditorControl
 {
-    string ControlType { get; }
-    string Caption { get; }
+    string? ControlType { get; }
+    string? Caption { get; }
     int? Height { get; }
     int? Width { get; }
-    string Attribute { get; }
+    string? Attribute { get; }
     bool Expand { get; }
-    IEditorDefinition Parent { get; }
+    IEditorDefinition? Parent { get; }
     bool IsControlVisibleInSimpleMode { get; }
-    string Id { get; }
-    string GetString(string tag);
-    IEnumerable<string> GetListString(string tag);
-    IDictionary<string, string> GetDictionary(string tag);
+    string? Id { get; }
+    string? GetString(string tag);
+    IEnumerable<string>? GetListString(string tag);
+    IDictionary<string, string>? GetDictionary(string tag);
     int? GetInt(string tag);
     double? GetDouble(string tag);
     bool GetBool(string tag);

--- a/src/EditorCore/IEditorData.cs
+++ b/src/EditorCore/IEditorData.cs
@@ -4,25 +4,25 @@ public interface IEditorAttributeData
 {
     string AttributeName { get; }
     bool IsInherited { get; }
-    string Source { get; }
+    string? Source { get; }
     bool IsDefaultType { get; }
 }
 
 public interface IEditorData
 {
-    string Name { get; }
+    string? Name { get; }
     bool ReadOnly { get; set; }
 
     // Usually set to True, but set to false for ExpressionTemplateEditorData as any update
     // to an expression template parameter can only be persisted by saving the entire parent
     // expression.
     bool IsDirectlySaveable { get; }
-    object GetAttribute(string attribute);
-    ValidationResult SetAttribute(string attribute, object value);
-    IEnumerable<string> GetAffectedRelatedAttributes(string attribute);
-    string GetSelectedFilter(string filterGroup);
+    object? GetAttribute(string attribute);
+    ValidationResult SetAttribute(string attribute, object? value);
+    IEnumerable<string>? GetAffectedRelatedAttributes(string attribute);
+    string? GetSelectedFilter(string filterGroup);
     void SetSelectedFilter(string filterGroup, string filter);
-    IEnumerable<string> GetVariablesInScope();
+    IEnumerable<string>? GetVariablesInScope();
 
     event EventHandler Changed;
 }
@@ -30,7 +30,7 @@ public interface IEditorData
 public interface IEditorDataExtendedAttributeInfo : IEditorData
 {
     bool IsLibraryElement { get; }
-    string Filename { get; }
+    string? Filename { get; }
     IEnumerable<IEditorAttributeData> GetAttributeData();
     IEditorAttributeData GetAttributeData(string attribute);
     void RemoveAttribute(string attribute);

--- a/src/EditorCore/IEditorDefinition.cs
+++ b/src/EditorCore/IEditorDefinition.cs
@@ -7,11 +7,11 @@ public interface IEditorDefinition
     /// ("msg", "(function)OutputTextNoBr") or element type ("object") this
     /// editor definition describes.
     /// </summary>
-    string AppliesTo { get; }
+    string? AppliesTo { get; }
 
     IDictionary<string, IEditorTab> Tabs { get; }
     IEnumerable<IEditorControl> Controls { get; }
-    string Description { get; }
-    string OriginalPattern { get; }
+    string? Description { get; }
+    string? OriginalPattern { get; }
     string GetDefaultFilterName(string filterGroupName, IEditorData data);
 }

--- a/src/EditorCore/IEditorTab.cs
+++ b/src/EditorCore/IEditorTab.cs
@@ -2,16 +2,14 @@
 
 public interface IEditorTab
 {
-    string Caption { get; }
+    string? Caption { get; }
 
     /// <summary>
     /// The tab's &lt;helpurl&gt;, if it has one: a site-relative path into the
     /// documentation (e.g. "/howto/world/exits/"). Null when the tab has no
     /// help target, in which case no help affordance is offered for it.
-    /// (Unannotated because EditorCore doesn't enable nullable reference
-    /// types, matching Caption and the rest of this interface.)
     /// </summary>
-    string HelpUrl { get; }
+    string? HelpUrl { get; }
     IEnumerable<IEditorControl> Controls { get; }
     bool IsTabVisibleInSimpleMode { get; }
     Task<bool> IsTabVisible(IEditorData data);

--- a/src/EditorCore/ScriptCommandEditorData.cs
+++ b/src/EditorCore/ScriptCommandEditorData.cs
@@ -13,28 +13,28 @@ public class ScriptCommandEditorData : IEditorData
         _script.Updated += OnScriptUpdated;
     }
 
-    public event EventHandler Changed;
+    public event EventHandler? Changed;
 
-    public string Name => null;
+    public string? Name => null;
 
-    public object GetAttribute(string attribute)
+    public object? GetAttribute(string attribute)
     {
         return _controller.WrapValue(_script.GetParameter(attribute));
     }
 
-    public ValidationResult SetAttribute(string attribute, object value)
+    public ValidationResult SetAttribute(string attribute, object? value)
     {
         _script.SetParameter(attribute, value);
 
         return new ValidationResult {Valid = true};
     }
 
-    public IEnumerable<string> GetAffectedRelatedAttributes(string attribute)
+    public IEnumerable<string>? GetAffectedRelatedAttributes(string attribute)
     {
         return null;
     }
 
-    public string GetSelectedFilter(string filterGroup)
+    public string? GetSelectedFilter(string filterGroup)
     {
         return null;
     }
@@ -45,14 +45,14 @@ public class ScriptCommandEditorData : IEditorData
 
     public bool ReadOnly { get; set; }
 
-    public IEnumerable<string> GetVariablesInScope()
+    public IEnumerable<string>? GetVariablesInScope()
     {
         return _script.GetVariablesInScope();
     }
 
     public bool IsDirectlySaveable => true;
 
-    private void OnScriptUpdated(object sender, EditableScriptUpdatedEventArgs e)
+    private void OnScriptUpdated(object? sender, EditableScriptUpdatedEventArgs e)
     {
         if (Changed != null)
         {

--- a/src/EditorCore/SubEditorControlData.cs
+++ b/src/EditorCore/SubEditorControlData.cs
@@ -26,9 +26,9 @@ public class AttributeSubEditorControlData : IEditorControl
 
     public string Attribute { get; }
 
-    public string Caption => null;
+    public string? Caption => null;
 
-    public string ControlType => null;
+    public string? ControlType => null;
 
     public bool Expand => false;
 
@@ -37,7 +37,7 @@ public class AttributeSubEditorControlData : IEditorControl
         return false;
     }
 
-    public IDictionary<string, string> GetDictionary(string tag)
+    public IDictionary<string, string>? GetDictionary(string tag)
     {
         if (tag == "types")
         {
@@ -67,7 +67,7 @@ public class AttributeSubEditorControlData : IEditorControl
         throw new NotImplementedException();
     }
 
-    public virtual string GetString(string tag)
+    public virtual string? GetString(string tag)
     {
         switch (tag)
         {
@@ -99,7 +99,7 @@ public class AttributeSubEditorControlData : IEditorControl
 
     public int? Width => null;
 
-    public IEditorDefinition Parent => null;
+    public IEditorDefinition? Parent => null;
 
     public bool IsControlVisibleInSimpleMode => true;
 

--- a/src/EditorCore/Utility.cs
+++ b/src/EditorCore/Utility.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 
 namespace QuestViva.EditorCore;
 
@@ -6,7 +7,8 @@ public static class EditorUtility
 {
     private static readonly Regex ContainsUnescapedQuote = new("^\"|[^\\\\]\\\"");
 
-    public static string FormatAsOneLine(string input)
+    [return: NotNullIfNotNull(nameof(input))]
+    public static string? FormatAsOneLine(string? input)
     {
         if (input == null)
         {
@@ -69,20 +71,20 @@ public static class EditorUtility
         do
         {
             i++;
-            newFilename = Path.Combine(directory, baseFilename + " " + i + extension);
+            newFilename = Path.Combine(directory!, baseFilename + " " + i + extension);
         } while (File.Exists(newFilename));
 
         return newFilename;
     }
 
-    public static string GetDisplayString(object value)
+    public static string GetDisplayString(object? value)
     {
         var scriptValue = value as IEditableScripts;
         var listStringValue = value as IEditableList<string>;
         var dictionaryStringValue = value as IEditableDictionary<string>;
         var dictionaryScriptValue = value as IEditableDictionary<IEditableScripts>;
         var wrappedValue = value as IDataWrapper;
-        string result = null;
+        string result;
 
         if (scriptValue != null)
         {
@@ -110,7 +112,7 @@ public static class EditorUtility
         }
         else
         {
-            result = value.ToString();
+            result = value.ToString() ?? string.Empty;
         }
 
         return FormatAsOneLine(result);

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -183,7 +183,7 @@ internal record AttributeDataItem(
     string Name,
     string? Value,
     bool IsInherited,
-    string Source,
+    string? Source,
     bool IsDefaultType,
     string Type);
 
@@ -1468,13 +1468,13 @@ public partial class WasmEditorBridge
     {
         foreach (var ctrl in controls.Where(c => c.ControlType == "dropdowntypes"))
         {
-            attrs[ctrl.Id] = _controller!.GetSelectedDropDownType(ctrl, elementKey);
+            attrs[ctrl.Id!] = _controller!.GetSelectedDropDownType(ctrl, elementKey);
         }
 
         foreach (var ctrl in controls.Where(c => c.ControlType == "multi" && c.Attribute != null))
         {
             var val = data.GetAttribute(ctrl.Attribute!);
-            attrs[ctrl.Id] = val switch
+            attrs[ctrl.Id!] = val switch
             {
                 null => "null",
                 string => "string",
@@ -1507,8 +1507,8 @@ public partial class WasmEditorBridge
                 continue;
             }
 
-            attrs[ctrl.Id] = data.GetSelectedFilter(filterGroupName)
-                ?? ctrl.Parent.GetDefaultFilterName(filterGroupName, data);
+            attrs[ctrl.Id!] = data.GetSelectedFilter(filterGroupName)
+                ?? ctrl.Parent!.GetDefaultFilterName(filterGroupName, data);
         }
 
         // Matches the old Quest 5 desktop editor's RichTextControl.Populate: show real linebreaks
@@ -2284,8 +2284,8 @@ public partial class WasmEditorBridge
                 var increment = isNumeric ? GetNumericHint(ctrl, "increment") : null;
 
                 return new ExpressionTemplateControlData(
-                    ctrl.Attribute ?? ctrl.Id,
-                    ctrl.ControlType,
+                    (ctrl.Attribute ?? ctrl.Id)!,
+                    ctrl.ControlType!,
                     ctrl.Caption,
                     paramValue,
                     simpleEditor,
@@ -2300,8 +2300,8 @@ public partial class WasmEditorBridge
 
         return JsonSerializer.Serialize(
             new ExpressionTemplateData(
-                definition.Description,
-                definition.OriginalPattern,
+                definition.Description!,
+                definition.OriginalPattern!,
                 controls
             ),
             WasmEditorJsonContext.Default.ExpressionTemplateData
@@ -2534,8 +2534,8 @@ public partial class WasmEditorBridge
             return JsonSerializer.Serialize(empty, WasmEditorJsonContext.Default.ExitsData);
         }
 
-        var directions = exitsControl.GetListString("compass").ToList();
-        var types = exitsControl.GetDictionary("compasstypes");
+        var directions = exitsControl.GetListString("compass")!.ToList();
+        var types = exitsControl.GetDictionary("compasstypes")!;
 
         var compass = directions.Select((d, i) => new CompassDirectionInfo(
             d, types[d], directions[OppositeDirs[i]], types[directions[OppositeDirs[i]]],
@@ -2583,8 +2583,8 @@ public partial class WasmEditorBridge
             return "error:No exits control found";
         }
 
-        var directions = exitsControl.GetListString("compass").ToList();
-        var types = exitsControl.GetDictionary("compasstypes");
+        var directions = exitsControl.GetListString("compass")!.ToList();
+        var types = exitsControl.GetDictionary("compasstypes")!;
         var dirIndex = directions.IndexOf(direction);
         if (dirIndex < 0)
         {
@@ -2638,7 +2638,7 @@ public partial class WasmEditorBridge
             return "error:No exits control found";
         }
 
-        var types = exitsControl.GetDictionary("compasstypes");
+        var types = exitsControl.GetDictionary("compasstypes")!;
         if (!types.TryGetValue(direction, out var type))
         {
             return "error:Unknown direction";
@@ -4138,7 +4138,7 @@ public partial class WasmEditorBridge
         var increment = isNumericSimpleEditor ? GetNumericHint(ctrl, "increment") : null;
 
         return new ScriptControlData(
-            ctrl.ControlType,
+            ctrl.ControlType!,
             ctrl.Caption,
             ctrl.Attribute,
             value,
@@ -4357,7 +4357,7 @@ public partial class WasmEditorBridge
         var nullable = ctrl.GetBool("nullable");
         var sameRow = ctrl.GetBool("samerow");
 
-        return new ControlInfo(attribute, ctrl.ControlType, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
+        return new ControlInfo(attribute, ctrl.ControlType!, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
             null, null, textProcessorCommands, addPrompt, Source: source,
             Advanced: !ctrl.IsControlVisibleInSimpleMode,
             KeyPrompt: keyPrompt, ValuePrompt: valuePrompt, SourceExclude: sourceExclude, SourceType: sourceType,


### PR DESCRIPTION
Enables nullable reference types for the EditorCore project (`<Nullable>enable</Nullable>` in the csproj — it previously had no setting), covering everything except `EditorController.cs`, which is temporarily opted out with `#nullable disable`.

Turning it on for the whole project surfaced 350 warnings, 143 of them in `EditorController.cs` alone (3,268 lines). Splitting keeps both halves reviewable: this PR covers the editable-data wrappers (`Editable*`), `EditorData`, the editor definition/control/tab/visibility types and their callers in WasmEditor; a follow-up removes the `EditorController` opt-out.

## Annotation changes (compile-time only)
- **`IEditorData`**: `Name`, `GetAttribute`, the value passed to `SetAttribute`, `GetAffectedRelatedAttributes`, `GetSelectedFilter` and `GetVariablesInScope` are nullable — several implementations (script/if/else-if data, `EditorData`) return null for them. `IEditorDataExtendedAttributeInfo.Filename` and `IEditorAttributeData.Source` are nullable.
- **`IEditorControl`**: `ControlType`, `Caption`, `Attribute`, `Parent`, `Id` and `GetString`/`GetListString`/`GetDictionary` are nullable — they come from optional editor-definition fields, and the if-expression and attribute sub-editor controls return null for several. **`IEditorTab`**'s `Caption`/`HelpUrl` and **`IEditorDefinition`**'s `AppliesTo`/`Description`/`OriginalPattern` likewise (and `IEditorTab`'s doc comment no longer says it's unannotated because EditorCore lacks nullable).
- **Editable wrappers**: `IDataWrapper.GetUnderlyingValue` returns `object?`; `IEditableScript` parameters and `EditableScriptUpdatedEventArgs.Id`/`NewValue` are `object?`/`string?`, matching the Engine script APIs they wrap; the `Owner` of editable scripts/lists/dictionaries is `string?`; `EditableIfScript.ElseScript` is nullable; `EditableScriptData`'s optional display/create/add/common strings are nullable; `EditableListUpdatedEventArgs.UpdatedItem` is `required`.
- **WasmEditor**: `AttributeDataItem.Source` is `string?`, since it comes straight from Common's `DebugDataItem.Source` (JSON output unchanged).

## Behaviour
No intended behaviour change. Small equivalent restructures: single `TryGetValue` lookups in `EditableScriptFactory`, `EditableDataWrapper` (now `where TSource : notnull`) and `EditorData.GetSelectedFilter`; `EditorControl` registers its filter from one `GetString("filtergroup") is { }` lookup; `EditableScripts.InitialiseMultiScript` is `[MemberNotNull]`; `EditableScript.DisplayString` drops a null check on its always-set `Script`. Two technically-observable nits on paths that don't occur: a script with no keyword now skips the display-template lookup in `EditableScriptFactory` rather than throwing (only `MultiScript` has no keyword, and it's never wrapped as an editable script), and `EditorUtility.GetDisplayString` shows `""` if a value's `ToString()` returns null.

The ~57 `!` are mostly: event-handler `sender` casts; `FunctionCallScript` access in `(function)` editors; required-parameter casts; element editor data always being named; values editor definitions always supply (control ids/types/parents, the exits control's compass lists, expression templates' description and pattern, a script editor's category and `appliesto`); and fields assigned straight after construction.

## Test plan
- [x] `dotnet build --configuration Release`: clean (warnings as errors); Debug build also clean
- [x] `dotnet test --configuration Release`: all 403 tests pass (incl. 47 EditorCoreTests)
- [x] BOM / line endings preserved on every edited file
- [x] e2e: all 60 `verify-appshell-*` scripts run against a local AppShell dev server with a WasmEditor build from this branch — 59 pass; the remaining one, `verify-appshell-server-mode-no-create`, needs a dev server started with `PUBLIC_HAS_SERVER=true` (it checks the textadventures.co.uk `/open` page copy) and so can't pass against a default dev server; it doesn't exercise EditorCore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
