### PR TITLE
refactor(Engine): remove unreferenced Engine and PlayerCore API

### DIFF
--- a/src/Engine/Element.cs
+++ b/src/Engine/Element.cs
@@ -186,11 +186,6 @@ public class Element : IComparable
         return MapObjectTypeStringsToElementType[typeString];
     }
 
-    internal static string GetTypeStringForElementType(ElementType type)
-    {
-        return ElemTypeStrings[type];
-    }
-
     internal static string GetTypeStringForObjectType(ObjectType type)
     {
         return TypeStrings[type];
@@ -265,11 +260,6 @@ public class Element : IComparable
     internal void SetTextFromFields(string? text)
     {
         _text = text;
-    }
-
-    internal void AddType(Element addType)
-    {
-        Fields.AddType(addType);
     }
 
     internal DebugData GetDebugData()

--- a/src/Engine/Elements.cs
+++ b/src/Engine/Elements.cs
@@ -229,11 +229,6 @@ public class Elements
         return _elements[t].Count;
     }
 
-    public int Count()
-    {
-        return _allElements.Count;
-    }
-
     public Element? GetSingle(ElementType t)
     {
         foreach (var e in _elements[t].Values)

--- a/src/Engine/Events.cs
+++ b/src/Engine/Events.cs
@@ -14,7 +14,6 @@ public class ElementFieldUpdatedEventArgs : EventArgs
     public string Attribute { get; private set; }
     public object? NewValue { get; private set; }
     public bool IsUndo { get; private set; }
-    public bool Refresh { get; private set; }
 }
 
 public class ElementRefreshEventArgs : EventArgs

--- a/src/Engine/Fields.cs
+++ b/src/Engine/Fields.cs
@@ -118,7 +118,6 @@ public static class FieldDefinitions
     public static IField<bool> IsBaseTemplate = new FieldDef<bool>("isbasetemplate");
     public static IField<string> DisplayVerb = new FieldDef<string>("displayverb");
     public static IField<string> Cover = new FieldDef<string>("cover");
-    public static IField<string> PublishFileExtensions = new FieldDef<string>("publishfileextensions");
     public static IField<string> EditorStyle = new FieldDef<string>("_editorstyle");
 }
 
@@ -459,17 +458,6 @@ public class Fields
         }
     }
 
-    public Type? GetCurrentType(string attribute)
-    {
-        var value = Get(attribute);
-        if (value == null)
-        {
-            return null;
-        }
-
-        return value.GetType();
-    }
-
     public object? Get(string attribute)
     {
         return Get(attribute, false).Value;
@@ -592,35 +580,6 @@ public class Fields
         }
 
         return field.Merge(parent);
-    }
-
-    internal DebugDataItem GetDebugDataItem(string attribute)
-    {
-        var result = new DebugDataItem(FormatDebugData(Get(attribute)));
-
-        string? source = null;
-        var isInherited = false;
-
-        if (_attributes.ContainsKey(attribute))
-        {
-            source = _element.Name;
-        }
-        else
-        {
-            foreach (var type in _types)
-            {
-                if (type.Fields.Exists(attribute, true))
-                {
-                    source = type.Name;
-                    isInherited = true;
-                    break;
-                }
-            }
-        }
-
-        result.IsInherited = isInherited;
-        result.Source = source;
-        return result;
     }
 
     internal bool Exists(string attribute, bool includeExtendableFields)
@@ -783,30 +742,6 @@ public class Fields
     public bool HasString(string attribute)
     {
         return HasType<string>(attribute);
-    }
-
-    public Element? GetObject(string attribute)
-    {
-        return GetAsType<Element>(attribute);
-    }
-
-    public bool HasObject(string attribute)
-    {
-        return HasType<Element>(attribute);
-    }
-
-    public Dictionary<string, object?> GetAllAttributes()
-    {
-        // return a clone of the attributes dictionary as we don't
-        // want external code changing any.
-        var result = new Dictionary<string, object?>();
-        foreach (var key in _attributes.Keys)
-        {
-            // ok so it's not strictly a clone for things like Lists
-            result.Add(key, _attributes[key]);
-        }
-
-        return result;
     }
 
     internal void DoUndoAddRemoveType(Stack<Element> newValue)
@@ -982,12 +917,6 @@ public class Fields
     public IFunction<string>? this[IField<IFunction<string>> field]
     {
         get => GetAsType<IFunction<string>>(field.Property);
-        set => Set(field.Property, value);
-    }
-
-    public QuestList<object>? this[IField<QuestList<object>> field]
-    {
-        get => GetAsType<QuestList<object>>(field.Property);
         set => Set(field.Property, value);
     }
 

--- a/src/Engine/ObjectFactory.cs
+++ b/src/Engine/ObjectFactory.cs
@@ -11,7 +11,6 @@ public interface IElementFactory
     Element Create(string name);
     Element Create();
     void DestroyElement(string elementName);
-    void DestroyElementSilent(string elementName);
     Element CloneElement(Element elementToClone, string newElementName);
 }
 
@@ -51,11 +50,6 @@ public abstract class ElementFactoryBase : IElementFactory
     public void DestroyElement(string elementName)
     {
         DestroyElement(elementName, false);
-    }
-
-    public void DestroyElementSilent(string elementName)
-    {
-        DestroyElement(elementName, true);
     }
 
     protected Element CreateInternal(string name, bool addToUndoLog, Action<Element>? extraInitialisation,
@@ -309,12 +303,6 @@ public class ObjectFactory : ElementFactoryBase
         return newObject;
     }
 
-    public Element CreateCommand()
-    {
-        var id = WorldModel.GetUniqueId();
-        return CreateCommand(id);
-    }
-
     public Element CreateCommand(string id)
     {
         var newCommand = CreateObject(id, ObjectType.Command);
@@ -468,20 +456,6 @@ internal class TemplateFactory : ElementFactoryBase
 internal class DynamicTemplateFactory : ElementFactoryBase
 {
     public override ElementType CreateElementType => ElementType.DynamicTemplate;
-}
-
-internal abstract class SingleElementFactory : ElementFactoryBase
-{
-    public override Element Create(string name)
-    {
-        if (WorldModel.Elements.Count(CreateElementType) >= 1)
-        {
-            throw new InvalidOperationException(string.Format("There can only be one '{0}' element",
-                FriendlyElementTypeName));
-        }
-
-        return base.Create(name);
-    }
 }
 
 internal class WalkthroughFactory : ElementFactoryBase

--- a/src/Engine/QuestDictionary.cs
+++ b/src/Engine/QuestDictionary.cs
@@ -509,36 +509,6 @@ public sealed class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, T
     /// <summary>
     ///     Initializes a new instance of the
     ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> class using the specified
-    ///     initial capacity.
-    /// </summary>
-    /// <param name="capacity">
-    ///     The initial number of elements that the
-    ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> can contain.
-    /// </param>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0</exception>
-    public OrderedDictionary(int capacity)
-        : this(capacity, null)
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of the
-    ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> class using the specified
-    ///     comparer.
-    /// </summary>
-    /// <param name="comparer">
-    ///     The <see cref="IEqualityComparer{TKey}">IEqualityComparer&lt;TKey&gt;</see> to use when
-    ///     comparing keys, or <null /> to use the default
-    ///     <see cref="EqualityComparer{TKey}">EqualityComparer&lt;TKey&gt;</see> for the type of the key.
-    /// </param>
-    public OrderedDictionary(IEqualityComparer<TKey>? comparer)
-        : this(DefaultInitialCapacity, comparer)
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of the
-    ///     <see cref="OrderedDictionary{TKey,TValue}">OrderedDictionary&lt;TKey,TValue&gt;</see> class using the specified
     ///     initial capacity and comparer.
     /// </summary>
     /// <param name="capacity">

--- a/src/Engine/Utility.cs
+++ b/src/Engine/Utility.cs
@@ -8,10 +8,6 @@ namespace QuestViva.Engine;
 [SuppressMessage("Microsoft.Usage", "CA2237:MarkISerializableTypesWithSerializable")]
 public class MismatchingQuotesException : Exception
 {
-    public MismatchingQuotesException() : base("Missing quote character (\")")
-    {
-    }
-
     public MismatchingQuotesException(string message) : base(message)
     {
     }

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -31,8 +31,6 @@ public partial class WorldModel : IGame, IGameDebug
     };
 
     private static readonly Dictionary<Type, string> TypesToTypeNames = new();
-
-    private static List<string>? _functionNames;
     private readonly List<string> _attributeNames = [];
     private readonly Dictionary<string, ElementType> _debuggerElementTypes = new();
     private readonly Dictionary<string, ObjectType> _debuggerObjectTypes = new();
@@ -1227,11 +1225,6 @@ public partial class WorldModel : IGame, IGameDebug
         return Elements.Get(el).Fields.GetInheritedTypesDebugData();
     }
 
-    public DebugDataItem GetDebugDataItem(string el, string attribute)
-    {
-        return Elements.Get(el).Fields.GetDebugDataItem(attribute);
-    }
-
     internal void SignalTurnSuspended(bool scroll = true)
     {
         if (scroll && Version >= WorldModelVersion.v540)
@@ -1406,14 +1399,6 @@ public partial class WorldModel : IGame, IGameDebug
     public Element AddProcedure(string name)
     {
         var proc = GetElementFactory(ElementType.Function).Create(name);
-        return proc;
-    }
-
-    public Element AddProcedure(string name, IScript script, string[] parameters)
-    {
-        var proc = AddProcedure(name);
-        proc.Fields[FieldDefinitions.Script] = script;
-        proc.Fields[FieldDefinitions.ParamNames] = new QuestList<string>(parameters);
         return proc;
     }
 
@@ -1618,11 +1603,6 @@ public partial class WorldModel : IGame, IGameDebug
         return Element.GetObjectTypeForTypeString(typeString);
     }
 
-    public static string GetTypeStringForElementType(ElementType type)
-    {
-        return Element.GetTypeStringForElementType(type);
-    }
-
     public static string GetTypeStringForObjectType(ObjectType type)
     {
         return Element.GetTypeStringForObjectType(type);
@@ -1721,38 +1701,18 @@ public partial class WorldModel : IGame, IGameDebug
         return packager.CreatePackage(filename, includeWalkthrough, out error, includeFiles, outputStream);
     }
 
-    public IEnumerable<string> GetBuiltInFunctionNames()
-    {
-        if (_functionNames != null)
-        {
-            return _functionNames.AsReadOnly();
-        }
-
-        var methods = typeof(ExpressionOwner).GetMethods();
-        var stringMethods = typeof(StringFunctions).GetMethods();
-        var dateTimeMethods = typeof(DateTimeFunctions).GetMethods();
-
-        var allMethods = methods.Union(stringMethods).Union(dateTimeMethods);
-
-        _functionNames = new List<string>(allMethods.Select(m => m.Name));
-
-        return _functionNames.AsReadOnly();
-    }
-
     // Signatures (name + parameter names) for the built-in expression functions, reflected from
-    // the same classes GetBuiltInFunctionNames() draws from — used to power the editor's
+    // ExpressionOwner, StringFunctions and DateTimeFunctions — used to power the editor's
     // expression-insert helper. DeclaredOnly + !IsSpecialName excludes inherited object members
-    // (ToString/Equals/...) and property accessors, which GetBuiltInFunctionNames() above doesn't
-    // filter out (harmless there since only the name list is used, but would show up as bogus
-    // zero-arg "functions" here).
+    // (ToString/Equals/...) and property accessors, which would otherwise show up as bogus
+    // zero-arg "functions".
     public IEnumerable<(string Name, string[] Parameters)> GetBuiltInFunctionSignatures()
     {
         const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
                                     BindingFlags.DeclaredOnly;
 
         // Each GetMethods() call is made directly on a typeof(...) constant (rather than via a
-        // lambda over a Type variable) so the trimmer can see which type's members to preserve —
-        // matching GetBuiltInFunctionNames() above.
+        // lambda over a Type variable) so the trimmer can see which type's members to preserve.
         var methods = typeof(ExpressionOwner).GetMethods(flags)
             .Concat(typeof(StringFunctions).GetMethods(flags))
             .Concat(typeof(DateTimeFunctions).GetMethods(flags));

--- a/src/PlayerCore/PlayerHelper.cs
+++ b/src/PlayerCore/PlayerHelper.cs
@@ -429,11 +429,6 @@ public class PlayerHelper
         _fontSize = fontSize;
     }
 
-    public void AppendText(string text)
-    {
-        WriteText(FormatText(text) + "<br />");
-    }
-
     private static Stream? GetUiResource(string name)
     {
         return Assembly.GetExecutingAssembly()
@@ -486,40 +481,10 @@ public class PlayerHelper
         return string.Join("/", verbs);
     }
 
-    public static CommandData GetCommandData(string data)
-    {
-        var result = new CommandData();
-
-        using var doc = JsonDocument.Parse(data);
-        var root = doc.RootElement;
-
-        if (root.TryGetProperty("command", out var commandEl))
-            result.Command = commandEl.GetString();
-
-        if (root.TryGetProperty("metadata", out var metadataEl))
-        {
-            var metadataString = metadataEl.GetString();
-            if (metadataString != null)
-            {
-                using var metaDoc = JsonDocument.Parse(metadataString);
-                result.Metadata = metaDoc.RootElement.EnumerateObject()
-                    .ToDictionary(p => p.Name, p => p.Value.GetString() ?? "");
-            }
-        }
-
-        return result;
-    }
-
     public static string GetContentType(string filename)
     {
         string? result;
         return MimeTypes.TryGetValue(Path.GetExtension(filename).ToLower(), out result) ? result : "";
-    }
-
-    public class CommandData
-    {
-        public string? Command { get; set; }
-        public IDictionary<string, string>? Metadata { get; set; }
     }
 }
 


### PR DESCRIPTION
Removes Engine and PlayerCore API that nothing references. This follows #2259, which did the same for EditorCore; the QuestViva.* NuGet packages are still in beta, so breaking public API is fine.

## How it was found
The same Roslyn `SymbolFinder.FindReferencesAsync` audit as #2259, run on every type and member declared in Engine, Common and PlayerCore and searching the whole solution. After the removals it was re-run until nothing more turned up.

The audit can't see every kind of use, so each candidate was also checked against:
- **WebPlayer's `.razor` components**, whose references the audit turned out not to see.
- **AppShell and PlayerCore JS/TS.**
- **Reflection and by-name use:** expression functions, operator overloads, `Enum.TryParse`.
- **textadventures.co.uk**, which consumes `QuestViva.PlayerCore`.

## Removed
- **`WorldModel`:**
  - `GetBuiltInFunctionNames` and its cache, superseded by `GetBuiltInFunctionSignatures`;
  - `GetDebugDataItem`, and `Fields.GetDebugDataItem` behind it;
  - `GetTypeStringForElementType`, and `Element.GetTypeStringForElementType` behind it;
  - the three-argument `AddProcedure` overload, unused since Quest 5.0.
- **`Fields`:** `GetCurrentType`, `GetObject`, `HasObject`, `GetAllAttributes`, the `QuestList<object>` indexer, and `FieldDefinitions.PublishFileExtensions`. Nothing has read the `publishfileextensions` attribute since the Quest 5 packager code went in #1855; AppShell decides which assets go into a `.quest` itself. Core's default value for the attribute is left in place, since existing games carry it.
- **Element factories:** `IElementFactory.DestroyElementSilent` and its implementation, the parameterless `ObjectFactory.CreateCommand()`, and the unused `SingleElementFactory` base class.
- **Misc Engine:** `Element.AddType`, `Elements.Count()`, `ElementFieldUpdatedEventArgs.Refresh` (never set), two unused `OrderedDictionary` constructors, and `MismatchingQuotesException`'s parameterless constructor.
- **PlayerCore:** `PlayerHelper.AppendText`, and `PlayerHelper.GetCommandData` with its `CommandData` type.

## Kept despite having no C# references
- **Expression functions:** `ExpressionOwner`, `StringFunctions` and `DateTimeFunctions` (112 methods). Game expressions call them by name.
- **`QuestList<T>`'s `+`, `-` and `*` operators:** the expression evaluator looks them up by name (`op_Addition` etc.) for list arithmetic in game code.
- **`UIOption` values** (`OverrideForeground`, `OverrideFontName`, …): `ExpressionOwner.GetUIOption` parses option names from game code with `Enum.TryParse`.
- **`GameQuery` and `GameObjectInfo`:** textadventures.co.uk uses `GameQuery` for game uploads (`ASLVersion`, `IsGamebook`, `GameId`, `GetResourceNames`, …), and WebPlayer's Dev Query page uses the rest.
- **`UrlGameDataProvider`, `FileDirectoryGameDataProvider` and `PlayerHelper.GetUiResourceString`:** used from WebPlayer `.razor` components.
- **Interface implementations** (`IDictionary`/`IOrderedDictionary` members, `IComparable`, `IEqualityComparer.GetHashCode`, the NCalc expression factory overload): required by their interfaces.
- **`GameLauncher`'s private zip helpers:** scaffolding for the `.zip` TODO in `GetGame`.
- **Test-only members:** `WorldModel()`, `Fields.Resolve`, `Elements.Count(ElementType)`.

No behaviour change: everything removed was unreachable.

## Test plan
- [x] `dotnet build --configuration Release`: clean (warnings as errors); Debug build also clean
- [x] `dotnet test --configuration Release`: all 403 tests pass
- [x] Re-ran the find-references audit after removal: nothing new unreferenced; the 45 remaining unreferenced or test-only members are the ones kept above
- [x] BOM / line endings preserved on every edited file
- [x] e2e: all 23 `verify-wasmplayer-*` scripts against a local WasmPlayer dev server, and all 60 `verify-appshell-*` scripts against a local AppShell dev server, both built from this branch — 82 of 83 pass; the remaining one, `verify-appshell-server-mode-no-create`, needs `PUBLIC_HAS_SERVER=true` and so can't pass against a default dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
