### PR TITLE
refactor: enable nullable reference types in the remaining test projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ EditorCore ───────────────────────
 - **AppShell** (`src/AppShell/`) — SvelteKit SPA (adapter-static) frontend for the game editor; talks to WasmEditor over the JS/WASM boundary and to `FileAdapter` implementations (`src/lib/filesystem/`) for storage (FSA, OPFS local drafts, server, Electron). Also serves the Play/Create Home landing page at root when `PUBLIC_SHOW_HOME=true` (play.questviva.com, Electron) — root shows a game catalog (Play tab, fetched from textadventures.co.uk's `api/Catalog`) or the editor canvas once a game is loaded; `/open` (Create tab) is unchanged; `/play/[id]` is a new game-detail route. Unset (textadventures.co.uk) keeps the previous editor-only root behavior. See `docs/appshell-wasm-svelte.md` and `docs/deployment-domains.md`
 - **ElectronApp** (`src/ElectronApp/`) — Electron main-process shell (desktop app) wrapping the AppShell SPA over a local loopback HTTP server; no Svelte/UI code of its own. See `docs/electron-desktop-app.md`
 
-**Test projects in `tests/`:** EngineTests, PlayerCoreTests, EditorCoreTests, UtilityTests, LegacyTests
+**Test projects in `tests/`:** EngineTests, PlayerCoreTests, EditorCoreTests, LegacyTests, WebPlayerTests
 
 ## Core Library Semantics (Core.aslx and friends)
 

--- a/tests/EditorCoreTests/EditableListTests.cs
+++ b/tests/EditorCoreTests/EditableListTests.cs
@@ -5,13 +5,13 @@ namespace QuestViva.EditorCoreTests;
 [TestClass]
 public class EditableListTests : EditorControllerTestBase
 {
-    private IEditableList<string> _list;
-    private object _listattr;
+    private IEditableList<string> _list = null!;
+    private object _listattr = null!;
 
     public override void DoExtraInitialisation()
     {
-        _listattr = Controller.GetEditorData("testobj").GetAttribute("listattr");
-        _list = _listattr as IEditableList<string>;
+        _listattr = Controller.GetEditorData("testobj")!.GetAttribute("listattr")!;
+        _list = (IEditableList<string>) _listattr;
     }
 
     private string GetItemListString(IEditableList<string> list)

--- a/tests/EditorCoreTests/EditableScriptTests.cs
+++ b/tests/EditorCoreTests/EditableScriptTests.cs
@@ -8,7 +8,7 @@ public class EditableScriptTests : EditorControllerTestBase
     private void TestUndoRedo(string initialScript, string initialDisplayString, string transactionDescription,
         Action<IEditableScript> changeValue, string newDisplayString)
     {
-        EditableScriptsUpdatedEventArgs updatedEventArgs = null;
+        EditableScriptsUpdatedEventArgs? updatedEventArgs = null;
 
         // Nothing in the undo/redo lists to start with
         Assert.AreEqual(0, UndoList.Count);
@@ -18,7 +18,7 @@ public class EditableScriptTests : EditorControllerTestBase
         var newScripts = Controller.CreateNewEditableScripts("game", "somescript", initialScript, true);
 
         // When the Updated event fires, store the event arguments locally
-        newScripts.Updated += delegate(object sender, EditableScriptsUpdatedEventArgs e) { updatedEventArgs = e; };
+        newScripts.Updated += delegate(object? sender, EditableScriptsUpdatedEventArgs e) { updatedEventArgs = e; };
 
         // We should now have one script, and the undo list should have one item
         Assert.AreEqual(1, newScripts.Scripts.Count());
@@ -110,7 +110,7 @@ public class EditableScriptTests : EditorControllerTestBase
         newElseIf.EditableScripts.AddNew("msg (\"test\")", "game");
 
         // Capture update events
-        EditableScriptsUpdatedEventArgs lastArgs = null;
+        EditableScriptsUpdatedEventArgs? lastArgs = null;
         newScripts.Updated += (sender, e) => { lastArgs = e; };
 
         // Check the initial display string is correct
@@ -127,7 +127,7 @@ public class EditableScriptTests : EditorControllerTestBase
         var newExpectedDisplayString =
             "If (someExpression) Then (Print \"Then script\"), Else If (newElseIfExpression) Then (Print \"test\")";
         Assert.AreEqual(newExpectedDisplayString, newScripts.DisplayString());
-        Assert.AreEqual("newElseIfExpression", lastArgs.UpdatedScriptEventArgs.NewValue);
+        Assert.AreEqual("newElseIfExpression", lastArgs!.UpdatedScriptEventArgs!.NewValue);
 
         // Now undo and redo, and check the display strings update correctly
         Controller.Undo();

--- a/tests/EditorCoreTests/EditorControllerRoomsAndPagesTests.cs
+++ b/tests/EditorCoreTests/EditorControllerRoomsAndPagesTests.cs
@@ -55,7 +55,7 @@ public class EditorControllerRoomsAndPagesTests
         controller.CreateNewObject("box", "game", "A Box");
         controller.CreateNewObject("innerThing", "box", "Inner Thing");
 
-        var parents = controller.GetPossibleNewObjectParentsForCurrentSelection("innerThing").ToArray();
+        var parents = controller.GetPossibleNewObjectParentsForCurrentSelection("innerThing")!.ToArray();
 
         CollectionAssert.AreEqual(new[] { "game", "box", "innerThing" }, parents);
 
@@ -74,7 +74,7 @@ public class EditorControllerRoomsAndPagesTests
 
         controller.CreateNewRoom("aRoom", "game", "A Room");
 
-        var parents = controller.GetPossibleNewObjectParentsForCurrentSelection("aRoom").ToArray();
+        var parents = controller.GetPossibleNewObjectParentsForCurrentSelection("aRoom")!.ToArray();
 
         CollectionAssert.AreEqual(new[] { "game", "aRoom" }, parents);
 

--- a/tests/EditorCoreTests/EditorControllerTestBase.cs
+++ b/tests/EditorCoreTests/EditorControllerTestBase.cs
@@ -9,7 +9,7 @@ public abstract class EditorControllerTestBase
 {
     private readonly EditorTreeData _tree = new();
 
-    protected EditorController Controller { get; private set; }
+    protected EditorController Controller { get; private set; } = null!;
 
     protected List<string> UndoList { get; private set; } = new();
 
@@ -48,32 +48,32 @@ public abstract class EditorControllerTestBase
         Controller.Dispose();
     }
 
-    private void OnControllerClearTree(object sender, EventArgs e)
+    private void OnControllerClearTree(object? sender, EventArgs e)
     {
         _tree.Clear();
     }
 
-    private void OnControllerBeginTreeUpdate(object sender, EventArgs e)
+    private void OnControllerBeginTreeUpdate(object? sender, EventArgs e)
     {
         _tree.BeginUpdate();
     }
 
-    private void OnControllerEndTreeUpdate(object sender, EventArgs e)
+    private void OnControllerEndTreeUpdate(object? sender, EventArgs e)
     {
         _tree.EndUpdate();
     }
 
-    private void OnControllerAddedNode(object sender, EditorController.AddedNodeEventArgs e)
+    private void OnControllerAddedNode(object? sender, EditorController.AddedNodeEventArgs e)
     {
         _tree.Add(e.Key, e.Text, e.Parent);
     }
 
-    private void OnControllerUndoListUpdated(object sender, EditorController.UpdateUndoListEventArgs e)
+    private void OnControllerUndoListUpdated(object? sender, EditorController.UpdateUndoListEventArgs e)
     {
         UndoList = new List<string>(e.UndoList);
     }
 
-    private void OnControllerRedoListUpdated(object sender, EditorController.UpdateUndoListEventArgs e)
+    private void OnControllerRedoListUpdated(object? sender, EditorController.UpdateUndoListEventArgs e)
     {
         RedoList = new List<string>(e.UndoList);
     }

--- a/tests/EditorCoreTests/EditorCoreTests.csproj
+++ b/tests/EditorCoreTests/EditorCoreTests.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>disable</Nullable>
+        <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/tests/EditorCoreTests/EditorTreeData.cs
+++ b/tests/EditorCoreTests/EditorTreeData.cs
@@ -2,9 +2,9 @@
 
 public class EditorTreeItem
 {
-    public string Key;
-    public EditorTreeItem Parent;
-    public string Text;
+    public required string Key;
+    public EditorTreeItem? Parent;
+    public required string Text;
 }
 
 public class EditorTreeData
@@ -17,7 +17,7 @@ public class EditorTreeData
         _items.Clear();
     }
 
-    public void Add(string key, string text, string parent)
+    public void Add(string key, string text, string? parent)
     {
         var parentItem = parent == null ? null : _items[parent];
         var newItem = new EditorTreeItem {Key = key, Parent = parentItem, Text = text};

--- a/tests/EditorCoreTests/FunctionFolderTests.cs
+++ b/tests/EditorCoreTests/FunctionFolderTests.cs
@@ -359,7 +359,7 @@ public class FunctionFolderTests
         controller.Uninitialise();
     }
 
-    private static string GetFolder(EditorController controller, string key) =>
+    private static string? GetFolder(EditorController controller, string key) =>
         controller.WorldModel.Elements.Get(key).Fields[FieldDefinitions.EditorFolder];
 
     private static int GetSortIndex(EditorController controller, string key) =>

--- a/tests/EditorCoreTests/IncludedLibraryTests.cs
+++ b/tests/EditorCoreTests/IncludedLibraryTests.cs
@@ -52,7 +52,7 @@ public class IncludedLibraryTests
         var savedBytes = Encoding.UTF8.GetBytes(savedXml);
 
         var reloadController = new EditorController();
-        string errorMessage = null;
+        string? errorMessage = null;
         reloadController.ShowMessage += (_, e) => errorMessage = e.Message;
 
         var ok = await reloadController.Initialise(new ByteArrayGameDataProvider(savedBytes, "test.aslx"));
@@ -91,7 +91,7 @@ public class IncludedLibraryTests
     private static async Task AssertBuiltInLibrariesProtected(string templateName, params string[] libraryFilenames)
     {
         var keysByText = new Dictionary<string, string>();
-        void OnAddedNode(object sender, EditorController.AddedNodeEventArgs e) => keysByText[e.Text] = e.Key;
+        void OnAddedNode(object? sender, EditorController.AddedNodeEventArgs e) => keysByText[e.Text] = e.Key;
 
         var controller = await LoadTemplateController(templateName, c => c.AddedNode += OnAddedNode);
 
@@ -107,7 +107,7 @@ public class IncludedLibraryTests
     }
 
     private static async Task<EditorController> LoadTemplateController(string templateName,
-        Action<EditorController> attachExtraEvents = null)
+        Action<EditorController>? attachExtraEvents = null)
     {
         var templates = EditorController.GetAvailableTemplates();
         var template = templates.Values.Single(t => t.TemplateName == templateName);

--- a/tests/EditorCoreTests/MakeScriptEditableTests.cs
+++ b/tests/EditorCoreTests/MakeScriptEditableTests.cs
@@ -34,7 +34,7 @@ public class MakeScriptEditableTests
         controller.CreateNewRoom("aRoom", "game", "A Room");
 
         var undoCountBefore = controller.GetUndoItems().Count();
-        var scripts = (IEditableScripts) controller.GetEditorData("aRoom").GetAttribute(attribute);
+        var scripts = (IEditableScripts) controller.GetEditorData("aRoom")!.GetAttribute(attribute)!;
         Assert.AreEqual("defaultobject", scripts.Owner, $"'{attribute}' should start out inherited");
 
         controller.StartTransaction($"Copy {attribute} script to aRoom");
@@ -55,9 +55,9 @@ public class MakeScriptEditableTests
         controller.Uninitialise();
     }
 
-    private static string GetScriptOwner(EditorController controller, string attribute)
+    private static string? GetScriptOwner(EditorController controller, string attribute)
     {
-        return ((IEditableScripts) controller.GetEditorData("aRoom").GetAttribute(attribute)).Owner;
+        return ((IEditableScripts) controller.GetEditorData("aRoom")!.GetAttribute(attribute)!).Owner;
     }
 
     // Mirrors IncludedLibraryTests / EditorControllerRoomsAndPagesTests - the shared test.aslx

--- a/tests/EditorCoreTests/TemplateTests.cs
+++ b/tests/EditorCoreTests/TemplateTests.cs
@@ -32,7 +32,7 @@ public class TemplateTests
             controller.Uninitialise();
             continue;
 
-            void OnControllerOnShowMessage(object _, EditorController.ShowMessageEventArgs e)
+            void OnControllerOnShowMessage(object? _, EditorController.ShowMessageEventArgs e)
             {
                 errorsRaised += e.Message;
             }

--- a/tests/EngineTests/AsyncScriptTests.cs
+++ b/tests/EngineTests/AsyncScriptTests.cs
@@ -7,10 +7,10 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class AsyncScriptTests
 {
-    private WorldModel _worldModel;
-    private ScriptContext _scriptContext;
-    private ScriptFactory _scriptFactory;
-    private Element _obj;
+    private WorldModel _worldModel = null!;
+    private ScriptContext _scriptContext = null!;
+    private ScriptFactory _scriptFactory = null!;
+    private Element _obj = null!;
 
     [TestInitialize]
     public void Setup()
@@ -29,7 +29,7 @@ public class AsyncScriptTests
         function.Fields[FieldDefinitions.Script] = _scriptFactory.CreateScript(script, _scriptContext);
     }
 
-    private async Task<object> CallAsync(string name, Parameters parameters = null)
+    private async Task<object?> CallAsync(string name, Parameters? parameters = null)
     {
         return await _worldModel.RunProcedureAsync(name, parameters, true);
     }

--- a/tests/EngineTests/CallbackTests.cs
+++ b/tests/EngineTests/CallbackTests.cs
@@ -19,7 +19,7 @@ internal sealed class GameDriver
 {
     private readonly WorldModel _worldModel;
     private List<string> _batch = [];
-    private Exception _scriptError;
+    private Exception? _scriptError;
     public List<int> RequestedTimerTicks { get; } = [];
     public GameState State => _worldModel.State;
     public WorldModel Model => _worldModel;

--- a/tests/EngineTests/CloneTests.cs
+++ b/tests/EngineTests/CloneTests.cs
@@ -9,9 +9,9 @@ public class CloneTests
     private const string AttributeValue = "attributevalue";
     private const string ListAttributeName = "listattribute";
     private readonly List<string> _listAttributeValue = new() {"one", "two", "three"};
-    private Element _original;
+    private Element _original = null!;
 
-    private WorldModel _worldModel;
+    private WorldModel _worldModel = null!;
 
     [TestInitialize]
     public void Setup()
@@ -21,9 +21,9 @@ public class CloneTests
         _original = _worldModel.GetElementFactory(ElementType.Object).Create("original");
         _original.Fields.Set(AttributeName, AttributeValue);
         _original.Fields.Set(ListAttributeName, new QuestList<string>(_listAttributeValue));
-        _original.Fields.Resolve(null);
+        _original.Fields.Resolve(null!);
         Assert.AreEqual(AttributeValue, _original.Fields.GetString(AttributeName));
-        Assert.AreEqual(3, _original.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
+        Assert.AreEqual(3, _original.Fields.GetAsType<QuestList<string>>(ListAttributeName)!.Count);
     }
 
     [TestMethod]
@@ -36,7 +36,7 @@ public class CloneTests
 
         // Attribute values must be the same
         Assert.AreEqual(AttributeValue, clone.Fields.GetString(AttributeName));
-        Assert.AreEqual(3, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
+        Assert.AreEqual(3, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName)!.Count);
 
         // Names must not match
         Assert.AreNotEqual(_original.Name, clone.Name);
@@ -99,19 +99,19 @@ public class CloneTests
         var clone = _original.Clone();
 
         _worldModel.UndoLogger.StartTransaction("Change attribute");
-        clone.Fields.GetAsType<QuestList<string>>(ListAttributeName).Add("newvalue");
+        clone.Fields.GetAsType<QuestList<string>>(ListAttributeName)!.Add("newvalue");
         _worldModel.UndoLogger.EndTransaction();
 
         // Cloned's field value is changed
-        Assert.AreEqual(4, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
+        Assert.AreEqual(4, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName)!.Count);
 
         // Original's field value is not changed
-        Assert.AreEqual(3, _original.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
+        Assert.AreEqual(3, _original.Fields.GetAsType<QuestList<string>>(ListAttributeName)!.Count);
 
         await _worldModel.UndoLogger.Undo();
 
         // Cloned's field value is back to original value
-        Assert.AreEqual(3, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName).Count);
+        Assert.AreEqual(3, clone.Fields.GetAsType<QuestList<string>>(ListAttributeName)!.Count);
     }
 
     [TestMethod]

--- a/tests/EngineTests/ComplexTypesTests.cs
+++ b/tests/EngineTests/ComplexTypesTests.cs
@@ -5,8 +5,8 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class ComplexTypesTests
 {
-    private Element _object;
-    private WorldModel _worldModel;
+    private Element _object = null!;
+    private WorldModel _worldModel = null!;
 
     [TestInitialize]
     public void Setup()
@@ -18,7 +18,7 @@ public class ComplexTypesTests
         var dictionary = new QuestDictionary<object> {{"key1", "nested string"}};
         list.Add(dictionary);
         _object.Fields.Set("list", list);
-        _object.Fields.Resolve(null);
+        _object.Fields.Resolve(null!);
     }
 
     [TestMethod]
@@ -39,7 +39,7 @@ public class ComplexTypesTests
     public void TestAddListItemUndoRedo()
     {
         var obj = _worldModel.Elements.Get("object");
-        var list = obj.Fields.GetAsType<QuestList<object>>("list");
+        var list = obj.Fields.GetAsType<QuestList<object>>("list")!;
         Assert.AreEqual(2, list.Count);
 
         _worldModel.UndoLogger.StartTransaction("Add list item");
@@ -56,8 +56,8 @@ public class ComplexTypesTests
     public void TestNestedDictionaryAddUndoRedo()
     {
         var obj = _worldModel.Elements.Get("object");
-        var list = obj.Fields.GetAsType<QuestList<object>>("list");
-        var dictionary = list[1] as QuestDictionary<object>;
+        var list = obj.Fields.GetAsType<QuestList<object>>("list")!;
+        var dictionary = (QuestDictionary<object>) list[1]!;
         Assert.AreEqual(1, dictionary.Count);
 
         _worldModel.UndoLogger.StartTransaction("Add dictionary item");

--- a/tests/EngineTests/ElementsTests.cs
+++ b/tests/EngineTests/ElementsTests.cs
@@ -5,7 +5,7 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class ElementsTests
 {
-    private WorldModel _worldModel;
+    private WorldModel _worldModel = null!;
 
     [TestInitialize]
     public void Setup()

--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>disable</Nullable>
+        <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -31,12 +31,12 @@ public class ExpressionTests
     private const bool BoolAttributeValue = true;
 
     private const string DictAttributeName = "dictattribute";
-    private Element _child;
-    private Element _object;
-    private ScriptContext _scriptContext;
-    private ScriptFactory _scriptFactory;
+    private Element _child = null!;
+    private Element _object = null!;
+    private ScriptContext _scriptContext = null!;
+    private ScriptFactory _scriptFactory = null!;
 
-    private WorldModel _worldModel;
+    private WorldModel _worldModel = null!;
 
     [TestInitialize]
     public void Setup()
@@ -87,7 +87,7 @@ public class ExpressionTests
         return expr.ExecuteAsync(c);
     }
 
-    private Task<object> RunExpressionGeneric(string expression)
+    private Task<object?> RunExpressionGeneric(string expression)
     {
         var expr = new ExpressionDynamic(expression, _scriptContext);
         var c = new Context();
@@ -336,7 +336,7 @@ public class ExpressionTests
     public async Task TestGetDouble()
     {
         var result = await RunExpressionGeneric($"GetDouble({ObjectName}, \"{DoubleAttributeName}\")");
-        ((double)result).ShouldBe(DoubleAttributeValue, 0.000001);
+        ((double)result!).ShouldBe(DoubleAttributeValue, 0.000001);
     }
 
     [DataTestMethod]
@@ -366,7 +366,7 @@ public class ExpressionTests
     public async Task TestCallingNewStringListFunction()
     {
         var result = await RunExpressionGeneric("NewStringList()");
-        var resultList = result.ShouldBeAssignableTo<QuestList<string>>();
+        var resultList = result.ShouldBeAssignableTo<QuestList<string>>()!;
         resultList.Count.ShouldBe(0);
     }
 
@@ -374,7 +374,7 @@ public class ExpressionTests
     public async Task TestCustomStringListFunction()
     {
         var result = await RunExpressionGeneric("CustomStringListFunction(\"a\", \"b\")");
-        var resultList = result.ShouldBeAssignableTo<QuestList<string>>();
+        var resultList = result.ShouldBeAssignableTo<QuestList<string>>()!;
         resultList.Count.ShouldBe(2);
         resultList[0].ShouldBe("a");
         resultList[1].ShouldBe("b");
@@ -455,7 +455,7 @@ public class ExpressionTests
     public async Task TestSplitFunction()
     {
         var result = await RunExpressionGeneric("Split(\"a,b,c\", \",\")");
-        var resultList = result.ShouldBeAssignableTo<QuestList<string>>();
+        var resultList = result.ShouldBeAssignableTo<QuestList<string>>()!;
         resultList.Count.ShouldBe(3);
         resultList[0].ShouldBe("a");
         resultList[1].ShouldBe("b");
@@ -506,7 +506,7 @@ public class ExpressionTests
     public async Task TestCallingAllObjectsFunction()
     {
         var result = await RunExpressionGeneric("AllObjects()");
-        var resultList = result.ShouldBeAssignableTo<QuestList<Element>>();
+        var resultList = result.ShouldBeAssignableTo<QuestList<Element>>()!;
         resultList.Count.ShouldBe(3);
     }
 
@@ -595,7 +595,7 @@ public class ExpressionTests
         var list = new QuestList<Element>([_object, _child]);
         var expr = new ExpressionDynamic("mylist - myobj", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "mylist", list }, { "myobj", _object } } };
-        var result = (await expr.ExecuteAsync(c)).ShouldBeAssignableTo<QuestList<Element>>();
+        var result = (await expr.ExecuteAsync(c)).ShouldBeAssignableTo<QuestList<Element>>()!;
         result.Count.ShouldBe(1);
         result[0].ShouldBe(_child);
     }
@@ -606,7 +606,7 @@ public class ExpressionTests
         var list = new QuestList<Element>([_object]);
         var expr = new ExpressionDynamic("mylist + myobj", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "mylist", list }, { "myobj", _child } } };
-        var result = (await expr.ExecuteAsync(c)).ShouldBeAssignableTo<QuestList<Element>>();
+        var result = (await expr.ExecuteAsync(c)).ShouldBeAssignableTo<QuestList<Element>>()!;
         result.Count.ShouldBe(2);
     }
 
@@ -627,7 +627,7 @@ public class ExpressionTests
         var list = new QuestList<Element>([_child]);
         var expr = new ExpressionDynamic("myobj + mylist", _scriptContext);
         var c = new Context { Parameters = new Parameters { { "mylist", list }, { "myobj", _object } } };
-        var result = (await expr.ExecuteAsync(c)).ShouldBeAssignableTo<QuestList<Element>>();
+        var result = (await expr.ExecuteAsync(c)).ShouldBeAssignableTo<QuestList<Element>>()!;
         result.Count.ShouldBe(2);
         result[0].ShouldBe(_object);
         result[1].ShouldBe(_child);

--- a/tests/EngineTests/FieldExtensionTests.cs
+++ b/tests/EngineTests/FieldExtensionTests.cs
@@ -20,7 +20,7 @@ public class FieldExtensionTests
         obj.Fields.AddType(type1);
         obj.Fields.AddType(type2);
 
-        var result = obj.Fields.GetAsType<QuestList<string>>("listfield");
+        var result = obj.Fields.GetAsType<QuestList<string>>("listfield")!;
 
         Assert.AreEqual(2, result.Count);
         Assert.IsTrue(result.Contains("a"));
@@ -42,7 +42,7 @@ public class FieldExtensionTests
         var obj = worldModel.GetElementFactory(ElementType.Object).Create("object");
         obj.Fields.AddType(type2);
 
-        var result = obj.Fields.GetAsType<QuestList<string>>("listfield");
+        var result = obj.Fields.GetAsType<QuestList<string>>("listfield")!;
 
         Assert.AreEqual(2, result.Count);
         Assert.IsTrue(result.Contains("a"));
@@ -67,7 +67,7 @@ public class FieldExtensionTests
         var obj = worldModel.GetElementFactory(ElementType.Object).Create("object");
         obj.Fields.AddType(type3);
 
-        var result = obj.Fields.GetAsType<QuestList<string>>("listfield");
+        var result = obj.Fields.GetAsType<QuestList<string>>("listfield")!;
 
         Assert.AreEqual(2, result.Count);
         Assert.IsTrue(result.Contains("a"));

--- a/tests/EngineTests/FieldsTests.cs
+++ b/tests/EngineTests/FieldsTests.cs
@@ -17,12 +17,12 @@ public class FieldsTests
     private const string AttributeDefinedByDefault2Name = "otherdefaultattribute";
     private const string AttributeDefinedByDefault2Value = "otherdefaultvalue";
     private const string AttributeDefinedByDefault2OverriddenValue = "overriddendefaultvalue";
-    private Element _defaultType;
-    private Element _object;
-    private Element _objectType;
-    private Element _subType;
+    private Element _defaultType = null!;
+    private Element _object = null!;
+    private Element _objectType = null!;
+    private Element _subType = null!;
 
-    private WorldModel _worldModel;
+    private WorldModel _worldModel = null!;
 
     [TestInitialize]
     public void Setup()
@@ -46,7 +46,7 @@ public class FieldsTests
         _objectType.Fields.AddType(_subType);
 
         _object = _worldModel.GetElementFactory(ElementType.Object).Create("object");
-        _object.Fields.Resolve(null);
+        _object.Fields.Resolve(null!);
         _object.Fields.AddType(_objectType);
     }
 
@@ -125,7 +125,7 @@ public class FieldsTests
         obj.Fields.AddType(type);
         obj.Fields.AddType(type2);
         obj.Fields.Set("attrfromobj", "fromobjvalue");
-        obj.Fields.Resolve(null);
+        obj.Fields.Resolve(null!);
 
         // Test initial values are correct first
         Assert.AreEqual("fromobjvalue", obj.Fields.GetString("attrfromobj"));

--- a/tests/EngineTests/Helpers.cs
+++ b/tests/EngineTests/Helpers.cs
@@ -10,7 +10,7 @@ internal static class Helpers
         return new WorldModel();
     }
 
-    public static WorldModel CreateWorldModel(GameData gameData)
+    public static WorldModel CreateWorldModel(GameData? gameData)
     {
         return new WorldModel(gameData, null);
     }

--- a/tests/EngineTests/MultiScriptTests.cs
+++ b/tests/EngineTests/MultiScriptTests.cs
@@ -7,7 +7,7 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class MultiScriptTests
 {
-    private WorldModel _worldModel;
+    private WorldModel _worldModel = null!;
 
     [TestInitialize]
     public void Setup()

--- a/tests/EngineTests/QuestListTest.cs
+++ b/tests/EngineTests/QuestListTest.cs
@@ -5,8 +5,8 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class QuestListTest
 {
-    private Element _a, _b, _c;
-    private WorldModel _worldModel;
+    private Element _a = null!, _b = null!, _c = null!;
+    private WorldModel _worldModel = null!;
 
     [TestInitialize]
     public void Setup()

--- a/tests/EngineTests/RegistrationTests.cs
+++ b/tests/EngineTests/RegistrationTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections;
 using System.Reflection;
 using QuestViva.Engine;

--- a/tests/EngineTests/SwitchScriptConstructorTest.cs
+++ b/tests/EngineTests/SwitchScriptConstructorTest.cs
@@ -6,11 +6,11 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class SwitchScriptConstructorTest
 {
-    private SwitchScriptConstructor _constructor;
-    private ScriptFactory _scriptFactory;
-    private WorldModel _worldModel;
+    private SwitchScriptConstructor _constructor = null!;
+    private ScriptFactory _scriptFactory = null!;
+    private WorldModel _worldModel = null!;
 
-    private ScriptContext _scriptContext;
+    private ScriptContext _scriptContext = null!;
 
     [TestInitialize]
     public void Setup()
@@ -34,7 +34,7 @@ public class SwitchScriptConstructorTest
             }
             }";
         var script = _constructor.Create(text, _scriptContext);
-        var actualCases = (QuestDictionary<IScript>) script.GetParameter(1);
+        var actualCases = (QuestDictionary<IScript>) script.GetParameter(1)!;
 
         Assert.AreEqual(1, actualCases.Count);
         Assert.IsTrue(actualCases.Contains("1"));
@@ -45,7 +45,7 @@ public class SwitchScriptConstructorTest
             }
             }";
         script = _constructor.Create(text, _scriptContext);
-        actualCases = (QuestDictionary<IScript>) script.GetParameter(1);
+        actualCases = (QuestDictionary<IScript>) script.GetParameter(1)!;
 
         Assert.AreEqual(2, actualCases.Count);
         Assert.AreSame(actualCases["StringListItem(myStringList, 0)"],

--- a/tests/EngineTests/TemplateTests.cs
+++ b/tests/EngineTests/TemplateTests.cs
@@ -7,7 +7,7 @@ namespace QuestViva.EngineTests;
 [TestClass]
 public class TemplateTests
 {
-    private WorldModel _worldModel;
+    private WorldModel _worldModel = null!;
 
     [TestInitialize]
     public void Init()

--- a/tests/LegacyTests/LegacyBlockingTests.cs
+++ b/tests/LegacyTests/LegacyBlockingTests.cs
@@ -12,7 +12,7 @@ namespace QuestViva.LegacyTests;
 public class LegacyBlockingTests
 {
     private readonly TestPlayer _player = new();
-    private IGame _game;
+    private IGame _game = null!;
 
     [TestInitialize]
     public async Task Init()

--- a/tests/LegacyTests/LegacyTests.csproj
+++ b/tests/LegacyTests/LegacyTests.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>disable</Nullable>
+        <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/tests/LegacyTests/TestPlayer.cs
+++ b/tests/LegacyTests/TestPlayer.cs
@@ -8,11 +8,11 @@ internal class TestPlayer : IPlayer
 
     public int BufferLength => _output.Count;
 
-    public MenuData LatestMenu { get; set; }
+    public MenuData? LatestMenu { get; set; }
 
     public bool IsWaiting { get; set; }
 
-    public string QuestionData { get; set; }
+    public string? QuestionData { get; set; }
 
     public string Location { get; private set; } = string.Empty;
 
@@ -99,7 +99,7 @@ internal class TestPlayer : IPlayer
         Foreground = colour;
     }
 
-    public Task RunScriptAsync(string function, object[] parameters)
+    public Task RunScriptAsync(string function, object?[]? parameters)
     {
         return Task.CompletedTask;
     }
@@ -118,7 +118,7 @@ internal class TestPlayer : IPlayer
     {
     }
 
-    public void RequestSave(string html)
+    public void RequestSave(string? html)
     {
     }
 
@@ -159,7 +159,7 @@ internal class TestPlayer : IPlayer
     {
     }
 
-    public string GetUIOption(UIOption option)
+    public string? GetUIOption(UIOption option)
     {
         return null;
     }

--- a/tests/LegacyTests/V4GameTests.cs
+++ b/tests/LegacyTests/V4GameTests.cs
@@ -7,7 +7,7 @@ namespace QuestViva.LegacyTests;
 public class V4GameTests
 {
     private readonly TestPlayer _player = new();
-    private IGame _game;
+    private IGame _game = null!;
 
     [TestInitialize]
     public async Task Init()
@@ -62,7 +62,7 @@ public class V4GameTests
         await _game.SendCommand("x twin");
         Assert.AreEqual("- <i>Please select which twin you mean:</i>", _player.Buffer(1));
         Assert.AreEqual(2, _player.BufferLength, "Expected nothing else in the output buffer after menu displayed");
-        Assert.AreNotEqual(null, _player.LatestMenu);
+        Assert.IsNotNull(_player.LatestMenu);
         Assert.AreEqual(2, _player.LatestMenu.Options.Count);
         Assert.AreEqual("Twin 1", _player.LatestMenu.Options.ElementAt(0).Value);
         Assert.AreEqual("Twin 2", _player.LatestMenu.Options.ElementAt(1).Value);


### PR DESCRIPTION
Enables nullable reference types in EngineTests, EditorCoreTests and LegacyTests: `<Nullable>enable</Nullable>` in each csproj, replacing `disable`. PlayerCoreTests and WebPlayerTests already had it, so every test project is now nullable-enabled.

This completes the nullability work: every project in the solution now has nullable enabled except Legacy, which deliberately stays disabled (see the comment in `Legacy.csproj`).

Turning it on surfaced 123 warnings (EngineTests 77, EditorCoreTests 36, LegacyTests 10).

## Changes (test code only)
- **Fields set in `[TestInitialize]`/setup** are declared `= null!` (38 of the 70 `!`).
- **Event handler `sender` parameters** are `object?`. **Locals and optional parameters that start as or default to null** are nullable.
- **`Helpers.CreateWorldModel`** takes `GameData?`, matching the `WorldModel` constructor it forwards to, so callers can pass `FileGameDataProvider.GetData()`'s result straight through.
- **LegacyTests' `TestPlayer`** matches `IPlayer`'s nullable signatures (`RunScriptAsync`, `RequestSave`, `GetUIOption`), and its captured `LatestMenu`/`QuestionData` are nullable.
- **EditorCoreTests' `EditorTreeItem`**: `Key`/`Text` are `required` and `Parent` is nullable (top-level nodes have none).
- **The remaining `!`** are on lookups the test knows succeed: `GetAsType`, `GetEditorData`, `GetParameter`, Shouldly's `ShouldBeAssignableTo`, and similar.
- **`Fields.Resolve(null)` → `Resolve(null!)`** in four tests. The Engine parameter stays non-nullable: a null factory only works when the element has no lazy scripts, which is true for these tests but isn't the method's contract.
- **Small equivalent tidies:**
  - `Assert.AreNotEqual(null, x)` → `Assert.IsNotNull(x)`;
  - two `x as T` followed by a dereference become casts;
  - `RegistrationTests.cs` drops its now-redundant `#nullable enable`.

No production code changes. CLAUDE.md's test project list also drops `UtilityTests`, which no longer exists, and adds `WebPlayerTests`.

## Test plan
- [x] `dotnet build --no-incremental`: 0 warnings; `dotnet build --configuration Release`: clean (warnings as errors)
- [x] `dotnet test --configuration Release`: all 403 tests pass
- [x] BOM / line endings preserved on every edited file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
