### PR TITLE
refactor: enforce event invoke, collection expression and pattern matching style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,30 @@ root = true
 # EnforceCodeStyleInBuild (Directory.Build.props) + TreatWarningsAsErrors.
 dotnet_diagnostic.IDE1006.severity = warning
 
+# Code style rules, also enforced at build time. Most can be auto-fixed with e.g.
+#   dotnet format style QuestViva.sln --diagnostics IDE0028 IDE1005
+# Raise events with ?.Invoke rather than an explicit null check
+csharp_style_conditional_delegate_call = true
+dotnet_diagnostic.IDE1005.severity = warning
+
+# Collection initializers and collection expressions ([]). Only when the declared type is the
+# type being created: for an interface target (IEnumerable<T> etc.) a collection expression can
+# produce a different runtime type, which would break code that casts it back and mutates it.
+dotnet_style_collection_initializer = true
+dotnet_style_prefer_collection_expression = when_types_exactly_match
+dotnet_diagnostic.IDE0028.severity = warning
+dotnet_diagnostic.IDE0300.severity = warning
+dotnet_diagnostic.IDE0301.severity = warning
+dotnet_diagnostic.IDE0302.severity = warning
+dotnet_diagnostic.IDE0303.severity = warning
+
+# Pattern matching instead of "as" + null check, or "is" + cast
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+dotnet_diagnostic.IDE0019.severity = warning
+dotnet_diagnostic.IDE0020.severity = warning
+dotnet_diagnostic.IDE0038.severity = warning
+
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 dotnet_naming_style.camel_case.capitalization = camel_case
 dotnet_naming_style.underscore_camel_case.capitalization = camel_case
@@ -55,3 +79,16 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[src/Legacy/**.cs]
+# Legacy is frozen Quest 4 compatibility code (see Legacy.csproj), so only the naming rules
+# above apply there, not the code style rules.
+dotnet_diagnostic.IDE1005.severity = none
+dotnet_diagnostic.IDE0028.severity = none
+dotnet_diagnostic.IDE0300.severity = none
+dotnet_diagnostic.IDE0301.severity = none
+dotnet_diagnostic.IDE0302.severity = none
+dotnet_diagnostic.IDE0303.severity = none
+dotnet_diagnostic.IDE0019.severity = none
+dotnet_diagnostic.IDE0020.severity = none
+dotnet_diagnostic.IDE0038.severity = none

--- a/src/Common/IGameDebug.cs
+++ b/src/Common/IGameDebug.cs
@@ -72,7 +72,7 @@ public class DebugData
 {
     public static readonly DebugData Empty = new();
 
-    public Dictionary<string, DebugDataItem> Data { get; set; } = new();
+    public Dictionary<string, DebugDataItem> Data { get; set; } = [];
 }
 
 public interface IWalkthroughs

--- a/src/EditorCore/EditableDataWrapper.cs
+++ b/src/EditorCore/EditableDataWrapper.cs
@@ -4,7 +4,7 @@ internal class EditableDataWrapper<TSource, TWrapped>
     where TSource : notnull
 {
     private readonly Func<EditorController, TSource, TWrapped> _getNewWrappedInstance;
-    private readonly Dictionary<TSource, TWrapped> _instances = new();
+    private readonly Dictionary<TSource, TWrapped> _instances = [];
 
     public EditableDataWrapper(Func<EditorController, TSource, TWrapped> instanceCreator)
     {

--- a/src/EditorCore/EditableDictionary.cs
+++ b/src/EditorCore/EditableDictionary.cs
@@ -8,7 +8,7 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
     private readonly EditorController _controller;
 
     private readonly QuestDictionary<T> _source;
-    private readonly Dictionary<string, IEditableListItem<T>> _wrappedItems = new();
+    private readonly Dictionary<string, IEditableListItem<T>> _wrappedItems = [];
 
     public EditableDictionary(EditorController controller, QuestDictionary<T> source)
     {
@@ -136,20 +136,14 @@ public class EditableDictionary<T> : IEditableDictionary<T>, IDataWrapper
         IEditableListItem<T> wrappedValue = new EditableListItem<T>(key, value);
         _wrappedItems.Add(key, wrappedValue);
 
-        if (Added != null)
-        {
-            Added(this,
-                new EditableListUpdatedEventArgs<T> {UpdatedItem = wrappedValue, Index = index, Source = source});
-        }
+        Added?.Invoke(this,
+    new EditableListUpdatedEventArgs<T> { UpdatedItem = wrappedValue, Index = index, Source = source });
     }
 
     private void RemoveWrappedItem(IEditableListItem<T> item, EditorUpdateSource source, int index)
     {
         _wrappedItems.Remove(item.Key);
-        if (Removed != null)
-        {
-            Removed(this, new EditableListUpdatedEventArgs<T> {UpdatedItem = item, Index = index, Source = source});
-        }
+        Removed?.Invoke(this, new EditableListUpdatedEventArgs<T> { UpdatedItem = item, Index = index, Source = source });
     }
 
     private void OnSourceAdded(object? sender, QuestDictionaryUpdatedEventArgs<T> e)

--- a/src/EditorCore/EditableIfScript.cs
+++ b/src/EditorCore/EditableIfScript.cs
@@ -5,7 +5,7 @@ namespace QuestViva.EditorCore;
 
 public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
 {
-    private readonly Dictionary<IScript, EditableElseIf> _elseIfScripts = new();
+    private readonly Dictionary<IScript, EditableElseIf> _elseIfScripts = [];
 
     private readonly IIfScript _ifScript;
     private readonly EditableScripts _thenScript;
@@ -132,19 +132,13 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.AddedElse:
                 _elseScript = EditableScripts.GetInstance(Controller, _ifScript.ElseScript!);
                 _elseScript.Updated += nestedScript_Updated;
-                if (AddedElse != null)
-                {
-                    AddedElse(this, new EventArgs());
-                }
+                AddedElse?.Invoke(this, new EventArgs());
 
                 break;
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.RemovedElse:
                 _elseScript!.Updated -= nestedScript_Updated;
                 _elseScript = null;
-                if (RemovedElse != null)
-                {
-                    RemovedElse(this, new EventArgs());
-                }
+                RemovedElse?.Invoke(this, new EventArgs());
 
                 break;
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.AddedElseIf:
@@ -156,18 +150,12 @@ public class EditableIfScript : EditableScriptBase, IEditableScript, IEditorData
                 _elseIfScripts.Add(e.Data.Script, newEditableElseIf);
 
                 // Raise the update to display in the UI
-                if (AddedElseIf != null)
-                {
-                    AddedElseIf(this, new ElseIfEventArgs(newEditableElseIf));
-                }
+                AddedElseIf?.Invoke(this, new ElseIfEventArgs(newEditableElseIf));
 
                 break;
             case IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.RemovedElseIf:
                 EditableScripts.GetInstance(Controller, e.Data!.Script).Updated -= nestedScript_Updated;
-                if (RemovedElseIf != null)
-                {
-                    RemovedElseIf(this, new ElseIfEventArgs(_elseIfScripts[e.Data.Script]));
-                }
+                RemovedElseIf?.Invoke(this, new ElseIfEventArgs(_elseIfScripts[e.Data.Script]));
 
                 _elseIfScripts.Remove(e.Data.Script);
                 break;

--- a/src/EditorCore/EditableList.cs
+++ b/src/EditorCore/EditableList.cs
@@ -9,9 +9,9 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
     private readonly EditorController _controller;
 
     private readonly QuestList<T> _source;
-    private readonly List<string> _wrappedItemKeys = new();
-    private readonly Dictionary<string, IEditableListItem<T>> _wrappedItems = new();
-    private readonly List<IEditableListItem<T>> _wrappedItemsList = new();
+    private readonly List<string> _wrappedItemKeys = [];
+    private readonly Dictionary<string, IEditableListItem<T>> _wrappedItems = [];
+    private readonly List<IEditableListItem<T>> _wrappedItemsList = [];
     private int _nextId;
 
     public EditableList(EditorController controller, QuestList<T> source)
@@ -157,17 +157,11 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         _wrappedItemsList.Insert(index, wrappedValue);
         _wrappedItemKeys.Insert(index, key);
 
-        if (Added != null)
-        {
-            Added(this,
-                new EditableListUpdatedEventArgs<T> {UpdatedItem = wrappedValue, Index = index, Source = source});
-        }
+        Added?.Invoke(this,
+    new EditableListUpdatedEventArgs<T> { UpdatedItem = wrappedValue, Index = index, Source = source });
 
-        if (CollectionChanged != null)
-        {
-            CollectionChanged(this,
-                new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, wrappedValue, index));
-        }
+        CollectionChanged?.Invoke(this,
+    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, wrappedValue, index));
     }
 
     private string GetUniqueId()
@@ -181,16 +175,10 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
         _wrappedItems.Remove(item.Key);
         _wrappedItemsList.Remove(item);
         _wrappedItemKeys.Remove(item.Key);
-        if (Removed != null)
-        {
-            Removed(this, new EditableListUpdatedEventArgs<T> {UpdatedItem = item, Index = index, Source = source});
-        }
+        Removed?.Invoke(this, new EditableListUpdatedEventArgs<T> { UpdatedItem = item, Index = index, Source = source });
 
-        if (CollectionChanged != null)
-        {
-            CollectionChanged(this,
-                new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
-        }
+        CollectionChanged?.Invoke(this,
+    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
     }
 
     private void OnSourceAdded(object? sender, QuestListUpdatedEventArgs<T> e)

--- a/src/EditorCore/EditableScript.cs
+++ b/src/EditorCore/EditableScript.cs
@@ -9,7 +9,7 @@ namespace QuestViva.EditorCore;
 public class EditableScript : EditableScriptBase, IEditableScript
 {
     private static readonly Regex AttributeRegex = new("#(?<attribute>\\d+)");
-    private readonly List<EditableScripts> _watchedNestedScripts = new();
+    private readonly List<EditableScripts> _watchedNestedScripts = [];
     private string _editorName;
 
     internal EditableScript(EditorController controller, IScript script, UndoLogger undoLogger)
@@ -55,21 +55,17 @@ public class EditableScript : EditableScriptBase, IEditableScript
                 value = ((IDataWrapper) value).GetUnderlyingValue();
             }
 
-            var scriptValue = value as IScript;
-            var stringValue = value as string;
-            var collectionValue = value as ICollection;
-
-            if (stringValue != null)
+            if (value is string stringValue)
             {
                 attributeValue = stringValue.Length == 0 ? "?" : stringValue;
             }
-            else if (scriptValue != null)
+            else if (value is IScript scriptValue)
             {
                 var editableScripts = EditableScripts.GetInstance(Controller, scriptValue);
                 RegisterNestedScriptForUpdates(editableScripts);
                 attributeValue = editableScripts.Count == 0 ? "(nothing)" : editableScripts.DisplayString();
             }
-            else if (collectionValue != null)
+            else if (value is ICollection collectionValue)
             {
                 attributeValue = collectionValue.Count.ToString();
             }
@@ -114,8 +110,7 @@ public class EditableScript : EditableScriptBase, IEditableScript
     public override void SetParameter(string index, object? value)
     {
         var valueToSet = value;
-        var wrappedValue = value as IDataWrapper;
-        if (wrappedValue != null)
+        if (value is IDataWrapper wrappedValue)
         {
             valueToSet = wrappedValue.GetUnderlyingValue();
         }

--- a/src/EditorCore/EditableScriptBase.cs
+++ b/src/EditorCore/EditableScriptBase.cs
@@ -103,10 +103,7 @@ public abstract class EditableScriptBase : IEditableScript
 
     protected void RaiseUpdated(EditableScriptUpdatedEventArgs e)
     {
-        if (Updated != null)
-        {
-            Updated(this, e);
-        }
+        Updated?.Invoke(this, e);
     }
 
     protected void RaiseUpdateForNestedScriptChange(EditableScriptsUpdatedEventArgs e)

--- a/src/EditorCore/EditableScriptFactory.cs
+++ b/src/EditorCore/EditableScriptFactory.cs
@@ -42,7 +42,7 @@ public class EditableScriptData
 
 internal class EditableScriptFactory
 {
-    private readonly Dictionary<IScript, EditableScriptBase> _cache = new();
+    private readonly Dictionary<IScript, EditableScriptBase> _cache = [];
     private readonly EditorController _controller;
     private readonly ScriptFactory _scriptFactory;
     private readonly WorldModel _worldModel;
@@ -62,7 +62,7 @@ internal class EditableScriptFactory
         }
     }
 
-    internal Dictionary<string, EditableScriptData> ScriptData { get; } = new();
+    internal Dictionary<string, EditableScriptData> ScriptData { get; } = [];
 
     private bool IsScriptEditor(Element editor)
     {

--- a/src/EditorCore/EditableScripts.cs
+++ b/src/EditorCore/EditableScripts.cs
@@ -23,7 +23,7 @@ public class EditableScripts : IEditableScripts, IDataWrapper
     private EditableScripts(EditorController controller)
     {
         _controller = controller;
-        _scripts = new List<IEditableScript>();
+        _scripts = [];
     }
 
     private EditableScripts(EditorController controller, IScript script)
@@ -268,30 +268,18 @@ public class EditableScripts : IEditableScripts, IDataWrapper
             _replacingScripts = false;
         }
 
-        if (Updated != null)
-        {
-            Updated(this, new EditableScriptsUpdatedEventArgs());
-        }
+        Updated?.Invoke(this, new EditableScriptsUpdatedEventArgs());
 
-        if (UnderlyingValueUpdated != null)
-        {
-            UnderlyingValueUpdated(this, new DataWrapperUpdatedEventArgs());
-        }
+        UnderlyingValueUpdated?.Invoke(this, new DataWrapperUpdatedEventArgs());
 
         Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
     }
 
     private void script_Updated(object? sender, EditableScriptUpdatedEventArgs e)
     {
-        if (Updated != null)
-        {
-            Updated(this, new EditableScriptsUpdatedEventArgs((IEditableScript) sender!, e));
-        }
+        Updated?.Invoke(this, new EditableScriptsUpdatedEventArgs((IEditableScript)sender!, e));
 
-        if (UnderlyingValueUpdated != null)
-        {
-            UnderlyingValueUpdated(this, new DataWrapperUpdatedEventArgs());
-        }
+        UnderlyingValueUpdated?.Invoke(this, new DataWrapperUpdatedEventArgs());
 
         Debug.Assert(_underlyingScript.Scripts.Count() == _scripts.Count);
     }

--- a/src/EditorCore/EditableWrappedItemDictionary.cs
+++ b/src/EditorCore/EditableWrappedItemDictionary.cs
@@ -14,8 +14,8 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
     private readonly EditorController _controller;
 
     private readonly QuestDictionary<TSource> _source;
-    private readonly Dictionary<string, IEditableListItem<TWrapped>> _wrappedItems = new();
-    private readonly Dictionary<TWrapped, IEditableListItem<TWrapped>> _wrappedItemsLookup = new();
+    private readonly Dictionary<string, IEditableListItem<TWrapped>> _wrappedItems = [];
+    private readonly Dictionary<TWrapped, IEditableListItem<TWrapped>> _wrappedItemsLookup = [];
 
     public EditableWrappedItemDictionary(EditorController controller, QuestDictionary<TSource> source)
     {
@@ -144,12 +144,9 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         _wrappedItemsLookup.Add(value, wrappedValue);
         value.UnderlyingValueUpdated += WrappedUnderlyingValueUpdated;
 
-        if (Added != null)
-        {
-            Added(this,
-                new EditableListUpdatedEventArgs<TWrapped>
-                    {UpdatedItem = wrappedValue, Index = index, Source = source});
-        }
+        Added?.Invoke(this,
+    new EditableListUpdatedEventArgs<TWrapped>
+    { UpdatedItem = wrappedValue, Index = index, Source = source });
     }
 
     private void RemoveWrappedItem(IEditableListItem<TWrapped> item, EditorUpdateSource source, int index)
@@ -157,11 +154,8 @@ public class EditableWrappedItemDictionary<TSource, TWrapped> : IEditableDiction
         _wrappedItems[item.Key].Value.UnderlyingValueUpdated -= WrappedUnderlyingValueUpdated;
         _wrappedItemsLookup.Remove(_wrappedItems[item.Key].Value);
         _wrappedItems.Remove(item.Key);
-        if (Removed != null)
-        {
-            Removed(this,
-                new EditableListUpdatedEventArgs<TWrapped> {UpdatedItem = item, Index = index, Source = source});
-        }
+        Removed?.Invoke(this,
+    new EditableListUpdatedEventArgs<TWrapped> { UpdatedItem = item, Index = index, Source = source });
     }
 
     private void WrappedUnderlyingValueUpdated(object? sender, DataWrapperUpdatedEventArgs e)

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -95,8 +95,8 @@ public sealed class EditorController : IDisposable
         {ValidationMessage.MismatchingQuotes, "Missing quote character (\")"}
     };
 
-    private readonly List<ElementType> _advancedTypes = new()
-    {
+    private readonly List<ElementType> _advancedTypes =
+    [
         ElementType.DynamicTemplate,
         ElementType.Function,
         ElementType.IncludedLibrary,
@@ -105,20 +105,20 @@ public sealed class EditorController : IDisposable
         ElementType.Template,
         ElementType.Timer,
         ElementType.Walkthrough
-    };
+    ];
 
-    private readonly Dictionary<string, EditorDefinition> _editorDefinitions = new();
-    private readonly Dictionary<string, EditorDefinition> _expressionDefinitions = new();
+    private readonly Dictionary<string, EditorDefinition> _editorDefinitions = [];
+    private readonly Dictionary<string, EditorDefinition> _expressionDefinitions = [];
 
-    private readonly List<ElementType> _ignoredTypes = new()
-    {
+    private readonly List<ElementType> _ignoredTypes =
+    [
         ElementType.ImpliedType,
         ElementType.Delegate,
         ElementType.Editor,
         ElementType.EditorTab,
         ElementType.EditorControl,
         ElementType.Resource
-    };
+    ];
 
     private readonly Regex _startsWithNumberRegex = new(@"^\d");
 
@@ -167,10 +167,7 @@ public sealed class EditorController : IDisposable
             {
                 _simpleMode = value;
                 UpdateTree();
-                if (SimpleModeChanged != null)
-                {
-                    SimpleModeChanged(this, new EventArgs());
-                }
+                SimpleModeChanged?.Invoke(this, new EventArgs());
             }
         }
     }
@@ -288,10 +285,7 @@ public sealed class EditorController : IDisposable
 
     private void OnWorldModelLoadStatus(object? sender, Engine.LoadStatusEventArgs e)
     {
-        if (LoadStatus != null)
-        {
-            LoadStatus(this, new LoadStatusEventArgs(e.Status));
-        }
+        LoadStatus?.Invoke(this, new LoadStatusEventArgs(e.Status));
     }
 
     private void Elements_ElementRenamed(object? sender, NameChangedEventArgs e)
@@ -300,23 +294,14 @@ public sealed class EditorController : IDisposable
         var newName = e.Element.Name;
 
         RenamedNode!(this, new RenamedNodeEventArgs {OldName = oldName, NewName = newName});
-        if (ElementsUpdated != null)
-        {
-            ElementsUpdated(this, EventArgs.Empty);
-        }
+        ElementsUpdated?.Invoke(this, EventArgs.Empty);
     }
 
     private void UndoLogger_TransactionsUpdated(object? sender, EventArgs e)
     {
-        if (UndoListUpdated != null)
-        {
-            UndoListUpdated(this, new UpdateUndoListEventArgs(WorldModel.UndoLogger.UndoList()));
-        }
+        UndoListUpdated?.Invoke(this, new UpdateUndoListEventArgs(WorldModel.UndoLogger.UndoList()));
 
-        if (RedoListUpdated != null)
-        {
-            RedoListUpdated(this, new UpdateUndoListEventArgs(WorldModel.UndoLogger.RedoList()));
-        }
+        RedoListUpdated?.Invoke(this, new UpdateUndoListEventArgs(WorldModel.UndoLogger.RedoList()));
     }
 
     private void OnWorldModelElementFieldUpdated(object? sender, ElementFieldUpdatedEventArgs e)
@@ -326,12 +311,9 @@ public sealed class EditorController : IDisposable
             return;
         }
 
-        if (ElementUpdated != null)
-        {
-            ElementUpdated(this,
-                new ElementUpdatedEventArgs(e.Element.Name, e.Attribute, WrapValue(e.NewValue, e.Element, e.Attribute),
-                    e.IsUndo));
-        }
+        ElementUpdated?.Invoke(this,
+    new ElementUpdatedEventArgs(e.Element.Name, e.Attribute, WrapValue(e.NewValue, e.Element, e.Attribute),
+        e.IsUndo));
 
         if (e.Attribute == "parent")
         {
@@ -339,10 +321,7 @@ public sealed class EditorController : IDisposable
             RemoveElementAndSubElementsFromTree(e.Element);
             AddElementAndSubElementsToTree(e.Element);
             EndTreeUpdate!(this, new EventArgs());
-            if (ElementsUpdated != null)
-            {
-                ElementsUpdated(this, new EventArgs());
-            }
+            ElementsUpdated?.Invoke(this, new EventArgs());
         }
 
         if (e.Attribute == "anonymous" || e.Attribute == "alias"
@@ -361,10 +340,7 @@ public sealed class EditorController : IDisposable
                 // element name might be null if we're undoing an element add
                 RetitledNode!(this,
                     new RetitledNodeEventArgs {Key = e.Element.Name, NewTitle = GetDisplayName(e.Element)});
-                if (ElementsUpdated != null)
-                {
-                    ElementsUpdated(this, EventArgs.Empty);
-                }
+                ElementsUpdated?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -383,10 +359,7 @@ public sealed class EditorController : IDisposable
 
         if (e.Element.ElemType == ElementType.IncludedLibrary && e.Attribute == "filename")
         {
-            if (LibrariesUpdated != null)
-            {
-                LibrariesUpdated(this, new LibrariesUpdatedEventArgs());
-            }
+            LibrariesUpdated?.Invoke(this, new LibrariesUpdatedEventArgs());
         }
     }
 
@@ -403,10 +376,7 @@ public sealed class EditorController : IDisposable
         {
             RemovedNode!(this, new RemovedNodeEventArgs {Key = e.Element.Name});
             AddElementAndSubElementsToTree(e.Element, GetElementPosition(e.Element));
-            if (ElementMoved != null)
-            {
-                ElementMoved(this, new ElementMovedEventArgs {Key = e.Element.Name});
-            }
+            ElementMoved?.Invoke(this, new ElementMovedEventArgs { Key = e.Element.Name });
         }
 
         if (e.Attribute == "library")
@@ -466,10 +436,7 @@ public sealed class EditorController : IDisposable
     {
         if (_initialised)
         {
-            if (ElementRefreshed != null)
-            {
-                ElementRefreshed(this, new ElementRefreshedEventArgs(e.Element.Name));
-            }
+            ElementRefreshed?.Invoke(this, new ElementRefreshedEventArgs(e.Element.Name));
         }
     }
 
@@ -486,15 +453,12 @@ public sealed class EditorController : IDisposable
             RemovedNode!(this, new RemovedNodeEventArgs {Key = args.Removed});
         }
 
-        if (ElementsUpdated != null)
-        {
-            ElementsUpdated(this, new EventArgs());
-        }
+        ElementsUpdated?.Invoke(this, new EventArgs());
     }
 
     private void InitialiseTreeStructure()
     {
-        _elementTreeStructure = new Dictionary<ElementType, TreeHeader>();
+        _elementTreeStructure = [];
 
         AddTreeHeader(EditorStyle.TextAdventure, ElementType.Object, "_objects", "Objects", null, false);
         AddTreeHeader(EditorStyle.GameBook, ElementType.Object, "_objects", "Pages", null, false);
@@ -1265,8 +1229,7 @@ public sealed class EditorController : IDisposable
             // verbElements only includes verbs with a property
             var verbProperty = verb.Fields[FieldDefinitions.Property]!;
             var pattern = verb.Fields.Get(FieldDefinitions.Pattern.Property);
-            var simplePattern = pattern as EditorCommandPattern;
-            var displayName = simplePattern != null ? simplePattern.Pattern : verbProperty;
+            var displayName = pattern is EditorCommandPattern simplePattern ? simplePattern.Pattern : verbProperty;
             result[verbProperty] = FriendlyVerbDisplayName(displayName);
         }
 
@@ -1275,7 +1238,7 @@ public sealed class EditorController : IDisposable
 
     private string FriendlyVerbDisplayName(string input)
     {
-        var verbs = input.Split(new[] {";", "; "}, StringSplitOptions.None);
+        var verbs = input.Split([";", "; "], StringSplitOptions.None);
         var result = string.Empty;
         foreach (var verb in verbs)
         {
@@ -1415,7 +1378,7 @@ public sealed class EditorController : IDisposable
     {
         if (to == null && lookonly)
         {
-            return CreateNewAnonymousObject(parent, "exit", ObjectType.Exit, new List<string> {type},
+            return CreateNewAnonymousObject(parent, "exit", ObjectType.Exit, [type],
                 new Dictionary<string, object>
                 {
                     {"to", WorldModel.Elements.Get(parent)},
@@ -1425,7 +1388,7 @@ public sealed class EditorController : IDisposable
                 }, useTransaction);
         }
 
-        return CreateNewAnonymousObject(parent, "exit", ObjectType.Exit, new List<string> {type},
+        return CreateNewAnonymousObject(parent, "exit", ObjectType.Exit, [type],
             new Dictionary<string, object>
             {
                 // Only a look-only exit can be created without a destination
@@ -1458,7 +1421,7 @@ public sealed class EditorController : IDisposable
     public string CreateNewVerb(string? parent, bool useTransaction)
     {
         return CreateNewAnonymousObject(parent, "command", ObjectType.Command,
-            new List<string> {"defaultverb"},
+            ["defaultverb"],
             new Dictionary<string, object> {{"isverb", true}},
             useTransaction);
     }
@@ -1713,8 +1676,10 @@ public sealed class EditorController : IDisposable
         if (elementType != ElementType.Object || currentSelection.Type == ObjectType.Object ||
             currentSelection.Type == ObjectType.Game)
         {
-            var result = new List<string>();
-            result.Add(elementKey);
+            var result = new List<string>
+            {
+                elementKey
+            };
 
             var thisElement = currentSelection;
             while (thisElement.Parent != null)
@@ -2075,11 +2040,8 @@ public sealed class EditorController : IDisposable
 
     internal void SetClipboardScript(IEnumerable<IScript> script)
     {
-        _clipboardScripts = new List<IScript>(script);
-        if (ScriptClipboardUpdated != null)
-        {
-            ScriptClipboardUpdated(this, new ScriptClipboardUpdateEventArgs {HasScript = _clipboardScripts.Count > 0});
-        }
+        _clipboardScripts = [.. script];
+        ScriptClipboardUpdated?.Invoke(this, new ScriptClipboardUpdateEventArgs { HasScript = _clipboardScripts.Count > 0 });
     }
 
     internal IEnumerable<IScript> GetClipboardScript()
@@ -2782,14 +2744,12 @@ public sealed class EditorController : IDisposable
                     if (element.Fields.Get(ctl.Attribute!) is IDictionary dictionary && dictionary.Contains(oldName))
                     {
                         var wrappedValue = WrapValue(dictionary);
-                        var editableStringDictionary = wrappedValue as IEditableDictionary<string>;
-                        var editableScriptDictionary = wrappedValue as IEditableDictionary<IEditableScripts>;
-                        if (editableStringDictionary != null)
+                        if (wrappedValue is IEditableDictionary<string> editableStringDictionary)
                         {
                             editableStringDictionary.ChangeKey(oldName, newName);
                         }
 
-                        if (editableScriptDictionary != null)
+                        if (wrappedValue is IEditableDictionary<IEditableScripts> editableScriptDictionary)
                         {
                             editableScriptDictionary.ChangeKey(oldName, newName);
                         }

--- a/src/EditorCore/EditorData.cs
+++ b/src/EditorCore/EditorData.cs
@@ -26,7 +26,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
 {
     private readonly EditorController _controller;
     private readonly Element _element;
-    private readonly Dictionary<string, string> _filters = new();
+    private readonly Dictionary<string, string> _filters = [];
 
     public EditorData(Element element, EditorController controller)
     {
@@ -79,8 +79,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
             return new ValidationResult {Valid = false, Message = ValidationMessage.InvalidAttributeName};
         }
 
-        var wrapper = value as IDataWrapper;
-        if (wrapper != null)
+        if (value is IDataWrapper wrapper)
         {
             value = wrapper.GetUnderlyingValue();
         }
@@ -110,10 +109,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
     public void SetSelectedFilter(string filterGroup, string filter)
     {
         _filters[filterGroup] = filter;
-        if (Changed != null)
-        {
-            Changed(this, new EventArgs());
-        }
+        Changed?.Invoke(this, new EventArgs());
     }
 
     public IEnumerable<IEditorAttributeData> GetAttributeData()
@@ -155,10 +151,7 @@ internal class EditorData : IEditorDataExtendedAttributeInfo
 
     private void Fields_AttributeChanged(object? sender, AttributeChangedEventArgs e)
     {
-        if (Changed != null)
-        {
-            Changed(this, new EventArgs());
-        }
+        Changed?.Invoke(this, new EventArgs());
     }
 
     private IEnumerable<IEditorAttributeData> ConvertDebugDataToEditorAttributeData(DebugData data)

--- a/src/EditorCore/EditorDefinition.cs
+++ b/src/EditorCore/EditorDefinition.cs
@@ -5,14 +5,14 @@ namespace QuestViva.EditorCore;
 internal class EditorDefinition : IEditorDefinition
 {
     private readonly Dictionary<string, IEditorControl> _controls;
-    private readonly Dictionary<string, FilterGroup> _filterGroups = new();
+    private readonly Dictionary<string, FilterGroup> _filterGroups = [];
 
     private readonly Dictionary<string, IEditorTab> _tabs;
 
     public EditorDefinition(WorldModel worldModel, Element source)
     {
-        _tabs = new Dictionary<string, IEditorTab>();
-        _controls = new Dictionary<string, IEditorControl>();
+        _tabs = [];
+        _controls = [];
         AppliesTo = source.Fields.GetString("appliesto");
         Pattern = source.Fields.GetString("pattern");
         OriginalPattern = source.Fields.GetString(FieldDefinitions.OriginalPattern.Property);
@@ -105,7 +105,7 @@ internal class EditorDefinition : IEditorDefinition
             Name = name;
         }
 
-        public List<string> Attributes { get; } = new();
+        public List<string> Attributes { get; } = [];
 
         public string Name { get; }
     }
@@ -117,7 +117,7 @@ internal class EditorDefinition : IEditorDefinition
             Name = name;
         }
 
-        public Dictionary<string, Filter> Filters { get; } = new();
+        public Dictionary<string, Filter> Filters { get; } = [];
 
         public string Name { get; }
     }

--- a/src/EditorCore/EditorTab.cs
+++ b/src/EditorCore/EditorTab.cs
@@ -10,7 +10,7 @@ internal class EditorTab : IEditorTab
 
     public EditorTab(EditorDefinition parent, WorldModel worldModel, Element source)
     {
-        _controls = new Dictionary<string, IEditorControl>();
+        _controls = [];
         Caption = source.Fields.GetString("caption");
         // Editor definitions live in <library type="editor">, which GameSaver
         // excludes from both package and editor saves - so unlike Core.aslx

--- a/src/EditorCore/EditorVisibilityHelper.cs
+++ b/src/EditorCore/EditorVisibilityHelper.cs
@@ -109,9 +109,7 @@ internal class EditorVisibilityHelper
             if (_notVisibleIfElementInheritsTypeElement == null)
             {
                 // convert "mustnotinherit" type names list into a list of type elements
-                _notVisibleIfElementInheritsTypeElement = new List<Element>(
-                    _notVisibleIfElementInheritsType.Select(t => _worldModel.Elements.Get(ElementType.ObjectType, t))
-                );
+                _notVisibleIfElementInheritsTypeElement = [.. _notVisibleIfElementInheritsType.Select(t => _worldModel.Elements.Get(ElementType.ObjectType, t))];
             }
 
             // if the element does inherit any of the "forbidden" types, then this control is not visible
@@ -155,9 +153,7 @@ internal class EditorVisibilityHelper
             if (_visibleIfElementInheritsTypeElement == null)
             {
                 // convert "mustinherit" type names list into a list of type elements
-                _visibleIfElementInheritsTypeElement = new List<Element>(
-                    _visibleIfElementInheritsType.Select(t => _worldModel.Elements.Get(ElementType.ObjectType, t))
-                );
+                _visibleIfElementInheritsTypeElement = [.. _visibleIfElementInheritsType.Select(t => _worldModel.Elements.Get(ElementType.ObjectType, t))];
             }
 
             // if the element does inherit any of the types, then this control is visible

--- a/src/EditorCore/ExpressionTemplateEditorData.cs
+++ b/src/EditorCore/ExpressionTemplateEditorData.cs
@@ -31,10 +31,7 @@ internal class ExpressionTemplateEditorData : IEditorData
     public ValidationResult SetAttribute(string attribute, object? value)
     {
         _parameters[attribute] = (string) value!;
-        if (Changed != null)
-        {
-            Changed(this, new EventArgs());
-        }
+        Changed?.Invoke(this, new EventArgs());
 
         return new ValidationResult {Valid = true};
     }

--- a/src/EditorCore/FilterOptions.cs
+++ b/src/EditorCore/FilterOptions.cs
@@ -2,7 +2,7 @@
 
 public class FilterOptions
 {
-    private readonly List<string> _filters = new();
+    private readonly List<string> _filters = [];
 
     public void Set(string filter, bool value)
     {

--- a/src/EditorCore/FontsManager.cs
+++ b/src/EditorCore/FontsManager.cs
@@ -11,8 +11,8 @@ internal class FontsManager
 {
     private static readonly HttpClient Client = new();
 
-    private readonly List<string> _basefonts = new()
-    {
+    private readonly List<string> _basefonts =
+    [
         "Georgia, serif",
         "'Palatino Linotype', 'Book Antiqua', Palatino, serif",
         "'Times New Roman', Times, serif",
@@ -26,9 +26,9 @@ internal class FontsManager
         "Verdana, Geneva, sans-serif",
         "'Courier New', Courier, monospace",
         "'Lucida Console', Monaco, monospace"
-    };
+    ];
 
-    private List<string> _webFonts = new() { string.Empty };
+    private List<string> _webFonts = [string.Empty];
 
     public FontsManager()
     {
@@ -44,7 +44,7 @@ internal class FontsManager
             var result = JsonSerializer.Deserialize(json, FontsManagerJsonContext.Default.WebFontsResult);
             if (result?.items != null)
             {
-                _webFonts = new List<string>(result.items.Select(i => i.family));
+                _webFonts = [.. result.items.Select(i => i.family)];
                 _webFonts.Insert(0, string.Empty);
             }
         }
@@ -59,13 +59,13 @@ internal class FontsManager
     {
         public string kind { get; set; } = string.Empty;
         public string family { get; set; } = string.Empty;
-        public List<string> variants { get; set; } = new();
-        public List<string> subsets { get; set; } = new();
+        public List<string> variants { get; set; } = [];
+        public List<string> subsets { get; set; } = [];
     }
 
     internal class WebFontsResult
     {
         public string kind { get; set; } = string.Empty;
-        public List<WebFontResult> items { get; set; } = new();
+        public List<WebFontResult> items { get; set; } = [];
     }
 }

--- a/src/EditorCore/ScriptCommandEditorData.cs
+++ b/src/EditorCore/ScriptCommandEditorData.cs
@@ -45,9 +45,6 @@ public class ScriptCommandEditorData : IEditorData
 
     private void OnScriptUpdated(object? sender, EditableScriptUpdatedEventArgs e)
     {
-        if (Changed != null)
-        {
-            Changed(this, new EventArgs());
-        }
+        Changed?.Invoke(this, new EventArgs());
     }
 }

--- a/src/Engine/Element.cs
+++ b/src/Engine/Element.cs
@@ -65,20 +65,22 @@ public class Element : IComparable
 
     static Element()
     {
-        TypeStrings = new Dictionary<ObjectType, string>();
-        TypeStrings.Add(ObjectType.Object, "object");
-        TypeStrings.Add(ObjectType.Exit, "exit");
-        TypeStrings.Add(ObjectType.Command, "command");
-        TypeStrings.Add(ObjectType.Game, "game");
-        TypeStrings.Add(ObjectType.TurnScript, "turnscript");
+        TypeStrings = new Dictionary<ObjectType, string>
+        {
+            { ObjectType.Object, "object" },
+            { ObjectType.Exit, "exit" },
+            { ObjectType.Command, "command" },
+            { ObjectType.Game, "game" },
+            { ObjectType.TurnScript, "turnscript" }
+        };
 
-        MapObjectTypeStringsToElementType = new Dictionary<string, ObjectType>();
+        MapObjectTypeStringsToElementType = [];
         foreach (var item in TypeStrings)
         {
             MapObjectTypeStringsToElementType.Add(item.Value, item.Key);
         }
 
-        ElemTypeStrings = new Dictionary<ElementType, string>();
+        ElemTypeStrings = [];
         foreach (ElementType t in Enum.GetValues<ElementType>())
         {
             ElemTypeStrings.Add(t,
@@ -86,7 +88,7 @@ public class Element : IComparable
                     .GetCustomAttributes(typeof(ElementTypeInfo), false)[0]).Name);
         }
 
-        MapElemTypeStringsToElementType = new Dictionary<string, ElementType>();
+        MapElemTypeStringsToElementType = [];
         foreach (var item in ElemTypeStrings)
         {
             MapElemTypeStringsToElementType.Add(item.Value, item.Key);

--- a/src/Engine/Elements.cs
+++ b/src/Engine/Elements.cs
@@ -4,35 +4,35 @@ namespace QuestViva.Engine;
 
 public class Elements
 {
-    private readonly Dictionary<string, Element> _allElements = new();
-    private readonly Dictionary<ElementType, Dictionary<string, Element>> _elements = new();
-    private readonly Dictionary<ElementType, List<Element>> _elementsLists = new();
+    private readonly Dictionary<string, Element> _allElements = [];
+    private readonly Dictionary<ElementType, Dictionary<string, Element>> _elements = [];
+    private readonly Dictionary<ElementType, List<Element>> _elementsLists = [];
 
     // Index of parent -> direct children, kept in sync by Add/Remove/UpdateParentIndex so that
     // GetDirectChildren doesn't need to do a full scan of every element in the game.
-    private readonly List<Element> _rootElements = new();
-    private readonly Dictionary<Element, List<Element>> _childrenByParent = new();
+    private readonly List<Element> _rootElements = [];
+    private readonly Dictionary<Element, List<Element>> _childrenByParent = [];
 
     // Elements that have completed at least one Add() call, and so are eligible to have their
     // parent-index entry moved by UpdateParentIndex. Elements being cloned have "parent" copied
     // onto them (via Fields.Clone) before they've been added, so that early parent assignment
     // must not touch the index - Add() below performs the baseline registration instead.
-    private readonly HashSet<Element> _indexedElements = new();
+    private readonly HashSet<Element> _indexedElements = [];
 
     // Per-parent counters backing UpdateElementSortOrder, so assigning a new child's SortIndex
     // doesn't need to scan all existing siblings to find the current max. SortIndex is only ever
     // used for relative ordering (OrderBy) or pairwise swapping of two already-issued values, so
     // a monotonically increasing counter per parent is safe even though it doesn't reclaim gaps
     // left by removed elements.
-    private readonly Dictionary<Element, int> _nextSortIndexByParent = new();
+    private readonly Dictionary<Element, int> _nextSortIndexByParent = [];
     private int _nextRootSortIndex;
 
     internal Elements()
     {
         foreach (ElementType t in Enum.GetValues<ElementType>())
         {
-            _elements.Add(t, new Dictionary<string, Element>());
-            _elementsLists.Add(t, new List<Element>());
+            _elements.Add(t, []);
+            _elementsLists.Add(t, []);
         }
     }
 
@@ -99,10 +99,7 @@ public class Elements
         _allElements.Add(e.Element.Name, e.Element);
         _elements[e.Element.ElemType].Add(e.Element.Name, e.Element);
 
-        if (ElementRenamed != null)
-        {
-            ElementRenamed(this, e);
-        }
+        ElementRenamed?.Invoke(this, e);
     }
 
     internal void Remove(ElementType t, string key)
@@ -143,7 +140,7 @@ public class Elements
 
         if (!_childrenByParent.TryGetValue(parent, out var children))
         {
-            children = new List<Element>();
+            children = [];
             _childrenByParent[parent] = children;
         }
 

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -167,7 +167,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         return (handled, result);
     }
 
-    private static readonly Dictionary<(Type, string), MethodBase[]?> MethodCache = new();
+    private static readonly Dictionary<(Type, string), MethodBase[]?> MethodCache = [];
 
     private static MethodBase[]? GetPublicMethodsByName([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string name)
     {
@@ -397,7 +397,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
 #pragma warning restore IL2072
             if (method != null)
             {
-                args.Result = method.Invoke(null, new[] { left, right });
+                args.Result = method.Invoke(null, [left, right]);
                 return;
             }
         }

--- a/src/Engine/Fields.cs
+++ b/src/Engine/Fields.cs
@@ -160,20 +160,20 @@ public class Fields
     // dictionaries, scripts etc. have no simple literal syntax to write back,
     // so there's deliberately no entry for them here — an override textbox
     // for those would just be a dead end.
-    private static readonly HashSet<Type> OverridableValueTypes = new()
-    {
+    private static readonly HashSet<Type> OverridableValueTypes =
+    [
         typeof(bool), typeof(string), typeof(Element),
         typeof(int), typeof(double), typeof(long), typeof(float), typeof(decimal), typeof(short)
-    };
+    ];
 
     private static bool CanOverrideValue(object? value)
     {
         return value == null || OverridableValueTypes.Contains(value.GetType());
     }
 
-    private readonly Dictionary<string, object?> _attributes = new();
+    private readonly Dictionary<string, object?> _attributes = [];
     private readonly Element _element;
-    private readonly Dictionary<string, IExtendableField> _extendableFields = new();
+    private readonly Dictionary<string, IExtendableField> _extendableFields = [];
     private readonly bool _isMeta;
     private readonly WorldModel _worldModel;
     private Stack<Element> _types = new();
@@ -363,9 +363,7 @@ public class Fields
 
         if (changed && cloneClonableValues)
         {
-            var mutableOldValue = oldValue as IMutableField;
-            var mutableNewValue = value as IMutableField;
-            if (mutableOldValue != null)
+            if (oldValue is IMutableField mutableOldValue)
             {
                 if (_worldModel.EditMode || mutableOldValue.RequiresCloning)
                 {
@@ -373,7 +371,7 @@ public class Fields
                 }
             }
 
-            if (mutableNewValue != null)
+            if (value is IMutableField mutableNewValue)
             {
                 if (_worldModel.EditMode || mutableNewValue.RequiresCloning)
                 {
@@ -507,10 +505,9 @@ public class Fields
     private AttributeData GetMergedResult(string attribute, AttributeData baseField)
     {
         var source = new List<string>();
-        var extendableBaseField = baseField.Value as IExtendableField;
         var mergedResult = GetExtendableField(attribute, source);
 
-        if (extendableBaseField == null)
+        if (baseField.Value is not IExtendableField extendableBaseField)
         {
             return new AttributeData
             {
@@ -622,10 +619,7 @@ public class Fields
         AddType(addType);
         var newValue = CloneStack(_types);
         _worldModel.UndoLogger.AddUndoAction(() => new UndoAddRemoveType(_element.Name, oldValue, newValue));
-        if (AttributeChangedSilent != null)
-        {
-            AttributeChangedSilent(this, new AttributeChangedEventArgs(true));
-        }
+        AttributeChangedSilent?.Invoke(this, new AttributeChangedEventArgs(true));
     }
 
     public void RemoveTypeUndoable(Element removeType)
@@ -634,10 +628,7 @@ public class Fields
         _types = CloneStackAndDelete(_types, removeType);
         var newValue = CloneStack(_types);
         _worldModel.UndoLogger.AddUndoAction(() => new UndoAddRemoveType(_element.Name, oldValue, newValue));
-        if (AttributeChangedSilent != null)
-        {
-            AttributeChangedSilent(this, new AttributeChangedEventArgs(true));
-        }
+        AttributeChangedSilent?.Invoke(this, new AttributeChangedEventArgs(true));
     }
 
     private string FormatDebugData(object? value)
@@ -747,10 +738,7 @@ public class Fields
     internal void DoUndoAddRemoveType(Stack<Element> newValue)
     {
         _types = newValue;
-        if (AttributeChangedSilent != null)
-        {
-            AttributeChangedSilent(this, new AttributeChangedEventArgs(true));
-        }
+        AttributeChangedSilent?.Invoke(this, new AttributeChangedEventArgs(true));
     }
 
     private Stack<Element> CloneStack(Stack<Element> input)
@@ -806,8 +794,7 @@ public class Fields
 
         foreach (var attribute in _attributes)
         {
-            var elementValue = attribute.Value as Element;
-            if (elementValue != null)
+            if (attribute.Value is Element elementValue)
             {
                 if (elementValue == e)
                 {
@@ -817,8 +804,7 @@ public class Fields
                 continue;
             }
 
-            var listValue = attribute.Value as QuestList<Element>;
-            if (listValue != null)
+            if (attribute.Value is QuestList<Element> listValue)
             {
                 while (listValue.Contains(e))
                 {
@@ -828,8 +814,7 @@ public class Fields
                 continue;
             }
 
-            var dictionaryValue = attribute.Value as QuestDictionary<Element>;
-            if (dictionaryValue != null)
+            if (attribute.Value is QuestDictionary<Element> dictionaryValue)
             {
                 var keysToRemove = new List<string>();
                 foreach (var item in dictionaryValue)
@@ -927,15 +912,15 @@ public class LazyFields
 {
     private readonly Fields _fields;
     private readonly WorldModel _worldModel;
-    private List<Action> _actions = new();
-    private List<string> _defaultTypes = new();
-    private Dictionary<string, IDictionary<string, string?>> _objectDictionaries = new();
-    private Dictionary<string, string> _objectFields = new();
-    private Dictionary<string, IEnumerable<string>> _objectLists = new();
+    private List<Action> _actions = [];
+    private List<string> _defaultTypes = [];
+    private Dictionary<string, IDictionary<string, string?>> _objectDictionaries = [];
+    private Dictionary<string, string> _objectFields = [];
+    private Dictionary<string, IEnumerable<string>> _objectLists = [];
     private bool _resolved;
-    private Dictionary<string, IDictionary<string, string>> _scriptDictionaries = new();
-    private Dictionary<string, string> _scripts = new();
-    private List<string> _types = new();
+    private Dictionary<string, IDictionary<string, string>> _scriptDictionaries = [];
+    private Dictionary<string, string> _scripts = [];
+    private List<string> _types = [];
 
     internal LazyFields(WorldModel worldModel, Fields fields)
     {
@@ -1057,14 +1042,12 @@ public class LazyFields
         foreach (var field in _fields.FieldNames)
         {
             var attribute = _fields.Get(field);
-            var objectList = attribute as QuestList<object>;
-            if (objectList != null)
+            if (attribute is QuestList<object> objectList)
             {
                 ResolveObjectList(objectList, scriptFactory);
             }
 
-            var objectDictionary = attribute as QuestDictionary<object>;
-            if (objectDictionary != null)
+            if (attribute is QuestDictionary<object> objectDictionary)
             {
                 ResolveObjectDictionary(objectDictionary, scriptFactory);
             }
@@ -1177,36 +1160,31 @@ public class LazyFields
     {
         replacement = null;
 
-        var genericList = value as QuestList<object>;
-        if (genericList != null)
+        if (value is QuestList<object> genericList)
         {
             ResolveObjectList(genericList, scriptFactory);
             return false;
         }
 
-        var genericDictionary = value as QuestDictionary<object>;
-        if (genericDictionary != null)
+        if (value is QuestDictionary<object> genericDictionary)
         {
             ResolveObjectDictionary(genericDictionary, scriptFactory);
             return false;
         }
 
-        var objRef = value as LazyObjectReference;
-        if (objRef != null)
+        if (value is LazyObjectReference objRef)
         {
             replacement = _worldModel.Elements.Get(objRef.ObjectName);
             return true;
         }
 
-        var objList = value as LazyObjectList;
-        if (objList != null)
+        if (value is LazyObjectList objList)
         {
             replacement = new QuestList<Element>(objList.Objects.Select(o => _worldModel.Elements.Get(o)));
             return true;
         }
 
-        var objDictionary = value as LazyObjectDictionary;
-        if (objDictionary != null)
+        if (value is LazyObjectDictionary objDictionary)
         {
             var newDictionary = new QuestDictionary<Element>();
             foreach (var kvp in objDictionary.Dictionary)
@@ -1218,15 +1196,13 @@ public class LazyFields
             return true;
         }
 
-        var script = value as LazyScript;
-        if (script != null)
+        if (value is LazyScript script)
         {
             replacement = scriptFactory.CreateScript(script.Script);
             return true;
         }
 
-        var scriptDictionary = value as LazyScriptDictionary;
-        if (scriptDictionary != null)
+        if (value is LazyScriptDictionary scriptDictionary)
         {
             replacement = ConvertToScriptDictionary(scriptDictionary.Dictionary, scriptFactory);
             return true;

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -151,7 +151,7 @@ internal class ExpressionOwner(WorldModel worldModel)
     {
         ArgumentNullException.ThrowIfNull(obj);
         var element = GetParameter<Element>(obj, "GetAttributeNames", "object");
-        return new QuestList<string>(element.Fields.GetAttributeNames(includeInheritedAttributes));
+        return [.. element.Fields.GetAttributeNames(includeInheritedAttributes)];
     }
 
     public string? GetExitByLink( /* Element */ object? from, /* Element */ object? to)
@@ -186,37 +186,37 @@ internal class ExpressionOwner(WorldModel worldModel)
 
     public QuestList<Element> NewObjectList()
     {
-        return new QuestList<Element>();
+        return [];
     }
 
     public QuestList<string> NewStringList()
     {
-        return new QuestList<string>();
+        return [];
     }
 
     public QuestList<object> NewList()
     {
-        return new QuestList<object>();
+        return [];
     }
 
     public QuestDictionary<string> NewStringDictionary()
     {
-        return new QuestDictionary<string>();
+        return [];
     }
 
     public QuestDictionary<Element> NewObjectDictionary()
     {
-        return new QuestDictionary<Element>();
+        return [];
     }
 
     public QuestDictionary<IScript> NewScriptDictionary()
     {
-        return new QuestDictionary<IScript>();
+        return [];
     }
 
     public QuestDictionary<object> NewDictionary()
     {
-        return new QuestDictionary<object>();
+        return [];
     }
 
     public bool ListContains( /* IQuestList */ object? list, object? item)
@@ -378,9 +378,8 @@ internal class ExpressionOwner(WorldModel worldModel)
         ArgumentNullException.ThrowIfNull(obj);
         ArgumentNullException.ThrowIfNull(del);
         var element = GetParameter<Element>(obj, "RunDelegateFunction", "object");
-        var impl = element.Fields.Get(del) as DelegateImplementation;
 
-        if (impl == null)
+        if (element.Fields.Get(del) is not DelegateImplementation impl)
         {
             throw new Exception($"Object '{element.Name}' has no delegate implementation '{del}'");
         }
@@ -525,7 +524,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         ArgumentNullException.ThrowIfNull(caption);
         ArgumentNullException.ThrowIfNull(options);
         var optionsDict = options.ToDictionary(o => o);
-        return await ShowMenu(caption, new QuestDictionary<string>(optionsDict), allowCancel);
+        return await ShowMenu(caption, [.. optionsDict], allowCancel);
     }
 
     public bool DictionaryContains( /* IDictionary */ object? obj, string? key)
@@ -742,7 +741,7 @@ internal class ExpressionOwner(WorldModel worldModel)
 
     private QuestList<T> ListCombine<T>(QuestList<T>? list1, QuestList<T>? list2)
     {
-        return list1 == null ? new QuestList<T>(list2) : list1.MergeLists(list2!);
+        return list1 == null ? [.. list2 ?? []] : list1.MergeLists(list2!);
     }
 
     public QuestList<string> ListExclude(QuestList<string>? list, string? str)
@@ -819,9 +818,8 @@ internal class ExpressionOwner(WorldModel worldModel)
     {
         ArgumentNullException.ThrowIfNull(obj);
         var element = GetParameter<Element>(obj, "GetDirectChildren", "object");
-        return new QuestList<Element>(
-            worldModel.Elements.GetDirectChildren(element)
-                .Where(e => e.ElemType == ElementType.Object && e.Type == ObjectType.Object));
+        return [.. worldModel.Elements.GetDirectChildren(element)
+                .Where(e => e.ElemType == ElementType.Object && e.Type == ObjectType.Object)];
     }
 
     public bool IsGameRunning()
@@ -840,28 +838,28 @@ internal class ExpressionOwner(WorldModel worldModel)
             result = result.ThenBy(e => e.Fields.Get(attribute[idx]));
         }
 
-        return new QuestList<Element>(result);
+        return [.. result];
     }
 
     public QuestList<Element> ObjectListSortDescending( /* QuestList<Element> */ object? obj, params string[] attribute)
     {
         ArgumentNullException.ThrowIfNull(obj);
         var list = GetParameter<QuestList<Element>>(obj, "ObjectListSortDescending", "objectlist");
-        return new QuestList<Element>(ObjectListSort(list, attribute).Reverse());
+        return [.. ObjectListSort(list, attribute).Reverse()];
     }
 
     public QuestList<string> StringListSort( /* QuestList<string> */ object? obj)
     {
         ArgumentNullException.ThrowIfNull(obj);
         var list = GetParameter<QuestList<string>>(obj, "StringListSort", "objectlist");
-        return new QuestList<string>(list.OrderBy(item => item));
+        return [.. list.OrderBy(item => item)];
     }
 
     public QuestList<string> StringListSortDescending( /* QuestList<string> */ object? obj)
     {
         ArgumentNullException.ThrowIfNull(obj);
         var list = GetParameter<QuestList<string>>(obj, "StringListSortDescending", "objectlist");
-        return new QuestList<string>(StringListSort(list).Reverse());
+        return [.. StringListSort(list).Reverse()];
     }
 
     public string? GetUiOption(string? optionName)

--- a/src/Engine/Functions/StringFunctions.cs
+++ b/src/Engine/Functions/StringFunctions.cs
@@ -86,13 +86,13 @@ public static class StringFunctions
     {
         ArgumentNullException.ThrowIfNull(input);
         ArgumentNullException.ThrowIfNull(splitChar);
-        return new QuestList<string>(input.Split([splitChar], StringSplitOptions.None));
+        return [.. input.Split([splitChar], StringSplitOptions.None)];
     }
 
     public static QuestList<string> Split(string? input)
     {
         ArgumentNullException.ThrowIfNull(input);
-        return new QuestList<string>(input.Split([";"], StringSplitOptions.None));
+        return [.. input.Split([";"], StringSplitOptions.None)];
     }
 
     public static string Join(IEnumerable<string>? input, string? joinChar)

--- a/src/Engine/GameLoader/AttributeLoaders.cs
+++ b/src/Engine/GameLoader/AttributeLoaders.cs
@@ -9,7 +9,7 @@ namespace QuestViva.Engine.GameLoader;
 
 internal partial class GameLoader
 {
-    private readonly Dictionary<string, IValueLoader> _valueLoaders = new();
+    private readonly Dictionary<string, IValueLoader> _valueLoaders = [];
 
     private void AddLoaders(LoadMode mode)
     {

--- a/src/Engine/GameLoader/ElementLoaders.cs
+++ b/src/Engine/GameLoader/ElementLoaders.cs
@@ -9,11 +9,11 @@ namespace QuestViva.Engine.GameLoader;
 
 internal partial class GameLoader
 {
-    private readonly Dictionary<string, IXmlLoader> _xmlLoaders = new();
+    private readonly Dictionary<string, IXmlLoader> _xmlLoaders = [];
     private IXmlLoader _defaultXmlLoader = null!;
 
-    private Dictionary<string, IAttributeLoader> AttributeLoaders { get; } = new();
-    private Dictionary<string, IExtendedAttributeLoader> ExtendedAttributeLoaders { get; } = new();
+    private Dictionary<string, IAttributeLoader> AttributeLoaders { get; } = [];
+    private Dictionary<string, IExtendedAttributeLoader> ExtendedAttributeLoaders { get; } = [];
 
     private WorldModel WorldModel { get; }
     private ScriptFactory ScriptFactory { get; }
@@ -684,7 +684,7 @@ internal partial class GameLoader
                 }
             }
 
-            proc.Fields[FieldDefinitions.ParamNames] = new QuestList<string>(paramNames);
+            proc.Fields[FieldDefinitions.ParamNames] = [.. paramNames ?? []];
             if (returns != null)
             {
                 proc.Fields[FieldDefinitions.ReturnType] = WorldModel.ConvertTypeToTypeName(returns);

--- a/src/Engine/GameLoader/FieldSaver.cs
+++ b/src/Engine/GameLoader/FieldSaver.cs
@@ -10,7 +10,7 @@ namespace QuestViva.Engine.GameLoader;
 internal partial class FieldSaver
 {
     private readonly GameSaver _saver;
-    private readonly Dictionary<Type, IFieldSaver> _savers = new();
+    private readonly Dictionary<Type, IFieldSaver> _savers = [];
 
     public FieldSaver(GameSaver saver)
     {

--- a/src/Engine/GameLoader/GameLoader.cs
+++ b/src/Engine/GameLoader/GameLoader.cs
@@ -387,7 +387,7 @@ internal partial class GameLoader
     {
         public RequiredAttributes(params RequiredAttribute[] attribs)
         {
-            Attributes = new List<RequiredAttribute>(attribs);
+            Attributes = [.. attribs];
         }
 
         public RequiredAttributes(bool canUseTemplates, params string[] attribs)
@@ -404,7 +404,7 @@ internal partial class GameLoader
 
     private class ImplicitTypes
     {
-        private readonly Dictionary<string, string> _implicitTypes = new();
+        private readonly Dictionary<string, string> _implicitTypes = [];
 
         public void Add(string element, string property, string type)
         {

--- a/src/Engine/GameLoader/GameSaver.cs
+++ b/src/Engine/GameLoader/GameSaver.cs
@@ -12,8 +12,8 @@ public enum SaveMode
 
 internal partial class GameSaver
 {
-    private readonly Dictionary<ElementType, IElementSaver> _elementSavers = new();
-    private readonly Dictionary<ElementType, IElementsSaver> _elementsSavers = new();
+    private readonly Dictionary<ElementType, IElementSaver> _elementSavers = [];
+    private readonly Dictionary<ElementType, IElementsSaver> _elementsSavers = [];
     private readonly WorldModel _worldModel;
     private Dictionary<string, string>? _impliedTypes;
     private SaveMode _mode;
@@ -161,7 +161,7 @@ internal partial class GameSaver
 
     private void UpdateImpliedTypesCache()
     {
-        _impliedTypes = new Dictionary<string, string>();
+        _impliedTypes = [];
         foreach (var impliedType in _worldModel.Elements.GetElements(ElementType.ImpliedType))
         {
             var element = impliedType.Fields[FieldDefinitions.Element]!;

--- a/src/Engine/GameLoader/ObjectSaver.cs
+++ b/src/Engine/GameLoader/ObjectSaver.cs
@@ -45,7 +45,7 @@ internal partial class GameSaver
 
     private class ObjectSaver : ElementSaverBase
     {
-        private readonly Dictionary<ObjectType, IObjectSaver> _savers = new();
+        private readonly Dictionary<ObjectType, IObjectSaver> _savers = [];
 
         public ObjectSaver()
         {

--- a/src/Engine/ObjectFactory.cs
+++ b/src/Engine/ObjectFactory.cs
@@ -91,10 +91,7 @@ public abstract class ElementFactoryBase : IElementFactory
             newElement.Type = elementToClone.Type;
         }
 
-        if (extraInitialisation != null)
-        {
-            extraInitialisation.Invoke(newElement);
-        }
+        extraInitialisation?.Invoke(newElement);
 
         if (initialTypes != null)
         {
@@ -123,18 +120,12 @@ public abstract class ElementFactoryBase : IElementFactory
 
     protected void NotifyAddedElement(string elementName)
     {
-        if (ObjectsUpdated != null)
-        {
-            ObjectsUpdated(this, new ObjectsUpdatedEventArgs {Added = elementName});
-        }
+        ObjectsUpdated?.Invoke(this, new ObjectsUpdatedEventArgs { Added = elementName });
     }
 
     protected void NotifyRemovedElement(string elementName)
     {
-        if (ObjectsUpdated != null)
-        {
-            ObjectsUpdated(this, new ObjectsUpdatedEventArgs {Removed = elementName});
-        }
+        ObjectsUpdated?.Invoke(this, new ObjectsUpdatedEventArgs { Removed = elementName });
     }
 
     private void DestroyElement(string elementName, bool silent)
@@ -278,7 +269,7 @@ public class ObjectFactory : ElementFactoryBase
             {
                 if (initialTypes == null)
                 {
-                    initialTypes = new List<string>();
+                    initialTypes = [];
                 }
 
                 initialTypes.Insert(0, defaultType);

--- a/src/Engine/QuestDictionary.cs
+++ b/src/Engine/QuestDictionary.cs
@@ -21,7 +21,7 @@ public class QuestDictionaryUpdatedEventArgs<T> : EventArgs
 
 public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableField, IQuestDictionary
 {
-    private readonly OrderedDictionary<string, T> _dictionary = new();
+    private readonly OrderedDictionary<string, T> _dictionary = [];
     private UndoLogger? _undoLog;
 
     public QuestDictionary()
@@ -66,8 +66,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
         {
             // also set UndoLog property on added item, if it needs a reference to the undo logger
             object? value = _dictionary[(string) key];
-            var mutableValue = value as IMutableField;
-            if (mutableValue != null)
+            if (value is IMutableField mutableValue)
             {
                 mutableValue.UndoLog = UndoLog;
             }
@@ -131,22 +130,16 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
     {
         UndoLogAdd(key);
 
-        if (Added != null)
-        {
-            Added(this,
-                new QuestDictionaryUpdatedEventArgs<T> {Key = key, Item = value, Index = index, Source = source});
-        }
+        Added?.Invoke(this,
+    new QuestDictionaryUpdatedEventArgs<T> { Key = key, Item = value, Index = index, Source = source });
     }
 
     private void ItemRemoved(string key, T value, UpdateSource source, int index)
     {
         UndoLogRemove(key);
 
-        if (Removed != null)
-        {
-            Removed(this,
-                new QuestDictionaryUpdatedEventArgs<T> {Key = key, Item = value, Index = index, Source = source});
-        }
+        Removed?.Invoke(this,
+    new QuestDictionaryUpdatedEventArgs<T> { Key = key, Item = value, Index = index, Source = source });
     }
 
     private class UndoDictionaryAdd : UndoLogger.IUndoAction
@@ -226,8 +219,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
             _undoLog = value;
             foreach (var item in Values)
             {
-                var mutableValue = item as IMutableField;
-                if (mutableValue != null)
+                if (item is IMutableField mutableValue)
                 {
                     mutableValue.UndoLog = value;
                 }
@@ -241,10 +233,9 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
         foreach (var kvp in _dictionary)
         {
             var newValue = kvp.Value;
-            var clonableValue = newValue as IMutableField;
-            if (clonableValue != null)
+            if (newValue is IMutableField clonableValue)
             {
-                newValue = (T) clonableValue.Clone();
+                newValue = (T)clonableValue.Clone();
             }
 
             result.Add(kvp.Key, newValue);

--- a/src/Engine/QuestList.cs
+++ b/src/Engine/QuestList.cs
@@ -28,18 +28,18 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public QuestList()
     {
-        _list = new List<T>();
+        _list = [];
     }
 
     public QuestList(IEnumerable<T>? collection)
     {
         if (collection == null)
         {
-            _list = new List<T>();
+            _list = [];
         }
         else
         {
-            _list = new List<T>(collection);
+            _list = [.. collection];
         }
     }
 
@@ -98,8 +98,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
             _undoLog = value;
             foreach (var item in this)
             {
-                var mutableValue = item as IMutableField;
-                if (mutableValue != null)
+                if (item is IMutableField mutableValue)
                 {
                     mutableValue.UndoLog = value;
                 }
@@ -223,8 +222,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
         if (UndoLog != null)
         {
             // also set UndoLog property on added item, if it needs a reference to the undo logger
-            var mutableValue = item as IMutableField;
-            if (mutableValue != null)
+            if (item is IMutableField mutableValue)
             {
                 mutableValue.UndoLog = UndoLog;
             }
@@ -245,18 +243,12 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     {
         UndoLogAdd(item, index);
 
-        if (Added != null)
-        {
-            Added(this, new QuestListUpdatedEventArgs<T> {UpdatedItem = item, Index = index, Source = source});
-        }
+        Added?.Invoke(this, new QuestListUpdatedEventArgs<T> { UpdatedItem = item, Index = index, Source = source });
     }
 
     private void ItemRemoved(T item, UpdateSource source, int index)
     {
-        if (Removed != null)
-        {
-            Removed(this, new QuestListUpdatedEventArgs<T> {UpdatedItem = item, Index = index, Source = source});
-        }
+        Removed?.Invoke(this, new QuestListUpdatedEventArgs<T> { UpdatedItem = item, Index = index, Source = source });
     }
 
     /// <summary>
@@ -269,7 +261,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     {
         if (list1 == null)
         {
-            return new QuestList<T>(list2);
+            return [.. list2];
         }
 
         return list1.MergeLists(list2);
@@ -285,13 +277,13 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     public QuestList<T> Exclude(T element)
     {
         var enumerable = this.Where(x => !x!.Equals(element));
-        return new QuestList<T>(enumerable);
+        return [.. enumerable];
     }
 
     public QuestList<T> Exclude(QuestList<T> excludeList)
     {
         var enumerable = this.Where(x => !excludeList.Contains(x));
-        return new QuestList<T>(enumerable);
+        return [.. enumerable];
     }
 
     /// <summary>
@@ -302,8 +294,10 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     /// <returns></returns>
     public static QuestList<T> operator +(QuestList<T> list, T element)
     {
-        var result = new QuestList<T>(list);
-        result.Add(element);
+        var result = new QuestList<T>(list)
+        {
+            element
+        };
         return result;
     }
 
@@ -315,8 +309,10 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
     /// <returns></returns>
     public static QuestList<T> operator +(T element, QuestList<T> list)
     {
-        var result = new QuestList<T>();
-        result.Add(element);
+        var result = new QuestList<T>
+        {
+            element
+        };
         result.AddRange(list);
         return result;
     }

--- a/src/Engine/RegexCache.cs
+++ b/src/Engine/RegexCache.cs
@@ -4,7 +4,7 @@ namespace QuestViva.Engine;
 
 internal class RegexCache
 {
-    private readonly Dictionary<string, Regex> _cache = new();
+    private readonly Dictionary<string, Regex> _cache = [];
 
     public Regex GetRegex(string regex, string cacheID)
     {

--- a/src/Engine/ScriptFactory.cs
+++ b/src/Engine/ScriptFactory.cs
@@ -15,7 +15,7 @@ public partial class ScriptFactory : IScriptFactory
     private readonly bool _lazyLoadingEnabled = true;
     private readonly FunctionCallScriptConstructor _procConstructor;
 
-    private readonly Dictionary<string, IScriptConstructor> _scriptConstructors = new();
+    private readonly Dictionary<string, IScriptConstructor> _scriptConstructors = [];
     private readonly SetScriptConstructor _setConstructor;
 
     public ScriptFactory(WorldModel worldModel)
@@ -332,10 +332,7 @@ public partial class ScriptFactory : IScriptFactory
 
     private void AddError(string error)
     {
-        if (ErrorHandler != null)
-        {
-            ErrorHandler(this, new AddErrorEventArgs {Error = error});
-        }
+        ErrorHandler?.Invoke(this, new AddErrorEventArgs { Error = error });
     }
 
     public class AddErrorEventArgs : EventArgs

--- a/src/Engine/Scripts/CommentScript.cs
+++ b/src/Engine/Scripts/CommentScript.cs
@@ -41,7 +41,7 @@ public class CommentScript : ScriptBase
     public override string Save()
     {
         return "// " + string.Join(Environment.NewLine + "// ",
-            _comment.Split(new[] {"\n"}, StringSplitOptions.RemoveEmptyEntries));
+            _comment.Split(["\n"], StringSplitOptions.RemoveEmptyEntries));
     }
 
     public override object? GetParameter(int index)

--- a/src/Engine/Scripts/CreateScript.cs
+++ b/src/Engine/Scripts/CreateScript.cs
@@ -8,7 +8,7 @@ public class CreateScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1, 2}; }
+        get { return [1, 2]; }
     }
 
     protected override IScript? CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -67,7 +67,7 @@ public class CreateScript : ScriptBase
         else
         {
             _worldModel.ObjectFactory.CreateObject(await _expr.ExecuteAsync(c), ObjectType.Object, true,
-                new List<string> {await _type.ExecuteAsync(c)});
+                [await _type.ExecuteAsync(c)]);
         }
     }
 
@@ -116,7 +116,7 @@ public class CreateExitScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {3, 4, 5}; }
+        get { return [3, 4, 5]; }
     }
 
     protected override IScript? CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -268,7 +268,7 @@ public class CreateTimerScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -325,7 +325,7 @@ public class CreateTurnScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/DestroyScript.cs
+++ b/src/Engine/Scripts/DestroyScript.cs
@@ -8,7 +8,7 @@ public class DestroyScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/DictionaryAddScript.cs
+++ b/src/Engine/Scripts/DictionaryAddScript.cs
@@ -9,7 +9,7 @@ public class DictionaryAddScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {3}; }
+        get { return [3]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -48,9 +48,7 @@ public class DictionaryAddScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await _dictionary.ExecuteAsync(c) as IDictionary;
-
-        if (result != null)
+        if (await _dictionary.ExecuteAsync(c) is IDictionary result)
         {
             result.Add(await _key.ExecuteAsync(c), await _value.ExecuteAsync(c));
         }
@@ -105,7 +103,7 @@ public class DictionaryRemoveScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {2}; }
+        get { return [2]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -140,9 +138,7 @@ public class DictionaryRemoveScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await _dictionary.ExecuteAsync(c) as IDictionary;
-
-        if (result != null)
+        if (await _dictionary.ExecuteAsync(c) is IDictionary result)
         {
             result.Remove(await _key.ExecuteAsync(c));
         }

--- a/src/Engine/Scripts/DoScript.cs
+++ b/src/Engine/Scripts/DoScript.cs
@@ -27,7 +27,7 @@ public class DoScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {2, 3}; }
+        get { return [2, 3]; }
     }
 
     #endregion

--- a/src/Engine/Scripts/ErrorScript.cs
+++ b/src/Engine/Scripts/ErrorScript.cs
@@ -15,7 +15,7 @@ public class ErrorScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     #endregion

--- a/src/Engine/Scripts/FinishScript.cs
+++ b/src/Engine/Scripts/FinishScript.cs
@@ -6,7 +6,7 @@ public class FinishScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {0}; }
+        get { return [0]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/ForEachScript.cs
+++ b/src/Engine/Scripts/ForEachScript.cs
@@ -62,8 +62,7 @@ public class ForEachScript : ScriptBase
 
         if (_scriptContext.WorldModel.Version < WorldModelVersion.v530 || !(result is string))
         {
-            var resultDictionary = result as IDictionary;
-            if (resultDictionary != null)
+            if (result is IDictionary resultDictionary)
             {
                 resultList = resultDictionary.Keys;
             }

--- a/src/Engine/Scripts/FunctionCallParameters.cs
+++ b/src/Engine/Scripts/FunctionCallParameters.cs
@@ -35,5 +35,5 @@ internal class FunctionCallParameters
 
     public IList<IFunction<object>>? Parameters { get; }
 
-    public QuestList<string> ParametersAsQuestList { get; } = new();
+    public QuestList<string> ParametersAsQuestList { get; } = [];
 }

--- a/src/Engine/Scripts/FunctionCallScript.cs
+++ b/src/Engine/Scripts/FunctionCallScript.cs
@@ -35,7 +35,7 @@ public class FunctionCallScriptConstructor : IScriptConstructor
             {
                 var parameters = Utility.SplitParameter(param);
                 procName = script.Substring(0, script.IndexOf('(')).Trim();
-                paramExpressions = new List<IFunction<object>>();
+                paramExpressions = [];
                 if (param.Trim().Length > 0)
                 {
                     foreach (var s in parameters)
@@ -46,7 +46,7 @@ public class FunctionCallScriptConstructor : IScriptConstructor
             }
             else
             {
-                procName = script.Substring(0, script.IndexOfAny(new[] {'{', ' '}));
+                procName = script.Substring(0, script.IndexOfAny(['{', ' ']));
             }
         }
 

--- a/src/Engine/Scripts/IScript.cs
+++ b/src/Engine/Scripts/IScript.cs
@@ -178,10 +178,7 @@ public abstract class ScriptBase : IScript, IMutableField
 
     protected void NotifyUpdate(ScriptUpdatedEventArgs args)
     {
-        if (ScriptUpdated != null)
-        {
-            ScriptUpdated(this, args);
-        }
+        ScriptUpdated?.Invoke(this, args);
     }
 
     protected abstract ScriptBase CloneScript();

--- a/src/Engine/Scripts/IfScript.cs
+++ b/src/Engine/Scripts/IfScript.cs
@@ -85,7 +85,7 @@ public class IfScriptConstructor : IScriptConstructor
 
 public class IfScript : ScriptBase, IIfScript
 {
-    private readonly List<IElseIfScript> _elseIfScript = new();
+    private readonly List<IElseIfScript> _elseIfScript = [];
     private readonly ScriptContext _scriptContext;
 
     private bool _hasElse;
@@ -227,24 +227,18 @@ public class IfScript : ScriptBase, IIfScript
     {
         _elseIfScript.Add(elseIfScript);
 
-        if (IfScriptUpdated != null)
-        {
-            IfScriptUpdated(this,
-                new IfScriptUpdatedEventArgs(IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.AddedElseIf,
-                    elseIfScript));
-        }
+        IfScriptUpdated?.Invoke(this,
+    new IfScriptUpdatedEventArgs(IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.AddedElseIf,
+        elseIfScript));
     }
 
     private void RemoveElseIfSilent(IElseIfScript elseIfScript)
     {
         _elseIfScript.Remove(elseIfScript);
 
-        if (IfScriptUpdated != null)
-        {
-            IfScriptUpdated(this,
-                new IfScriptUpdatedEventArgs(IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.RemovedElseIf,
-                    elseIfScript));
-        }
+        IfScriptUpdated?.Invoke(this,
+    new IfScriptUpdatedEventArgs(IfScriptUpdatedEventArgs.IfScriptUpdatedEventType.RemovedElseIf,
+        elseIfScript));
     }
 
     private void SetExpressionSilent(string newValue)

--- a/src/Engine/Scripts/InsertScript.cs
+++ b/src/Engine/Scripts/InsertScript.cs
@@ -8,7 +8,7 @@ public class InsertScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/InvokeScript.cs
+++ b/src/Engine/Scripts/InvokeScript.cs
@@ -9,7 +9,7 @@ public class InvokeScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1, 2}; }
+        get { return [1, 2]; }
     }
 
     protected override IScript? CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/JSScript.cs
+++ b/src/Engine/Scripts/JSScript.cs
@@ -20,7 +20,7 @@ public class JSScriptConstructor : IScriptConstructor
             if (parameters.Count != 1 || parameters[0].Trim().Length != 0)
             {
                 expressions =
-                    new List<IFunctionDynamic>(parameters.Select(p => new ExpressionDynamic(p, scriptContext)));
+                    [.. parameters.Select(p => new ExpressionDynamic(p, scriptContext))];
             }
         }
 
@@ -57,7 +57,7 @@ public class JSScript : ScriptBase
     protected override ScriptBase CloneScript()
     {
         return new JSScript(_scriptContext, _function,
-            _parameters == null ? null : new List<IFunctionDynamic>(_parameters));
+            _parameters == null ? null : [.. _parameters]);
     }
 
     public override async Task ExecuteAsync(Context c)
@@ -88,7 +88,7 @@ public class JSScript : ScriptBase
         }
 
         return SaveScript("JS." + _function,
-            _parameters == null ? new[] {string.Empty} : _parameters.Select(p => p.Save()).ToArray());
+            _parameters == null ? [string.Empty] : _parameters.Select(p => p.Save()).ToArray());
     }
 
     protected override void SetParameterInternal(int index, object? value)

--- a/src/Engine/Scripts/ListAddScript.cs
+++ b/src/Engine/Scripts/ListAddScript.cs
@@ -8,7 +8,7 @@ public class ListAddScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {2}; }
+        get { return [2]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -43,9 +43,7 @@ public class ListAddScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await _list.ExecuteAsync(c) as IQuestList;
-
-        if (result != null)
+        if (await _list.ExecuteAsync(c) is IQuestList result)
         {
             result.Add(await _value.ExecuteAsync(c));
         }
@@ -95,7 +93,7 @@ public class ListRemoveScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {2}; }
+        get { return [2]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -130,9 +128,7 @@ public class ListRemoveScript : ScriptBase
 
     public override async Task ExecuteAsync(Context c)
     {
-        var result = await _list.ExecuteAsync(c) as IQuestList;
-
-        if (result != null)
+        if (await _list.ExecuteAsync(c) is IQuestList result)
         {
             result.Remove(await _value.ExecuteAsync(c));
         }

--- a/src/Engine/Scripts/MsgScript.cs
+++ b/src/Engine/Scripts/MsgScript.cs
@@ -15,7 +15,7 @@ public class MsgScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     #endregion

--- a/src/Engine/Scripts/MultiScript.cs
+++ b/src/Engine/Scripts/MultiScript.cs
@@ -20,7 +20,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
     public MultiScript(WorldModel worldModel, params IScript[] scripts)
         : this(worldModel)
     {
-        _scripts = new List<IScript>(scripts);
+        _scripts = [.. scripts];
     }
 
     private MultiScript(WorldModel worldModel)
@@ -200,7 +200,7 @@ public class MultiScript : ScriptBase, IScriptParent, IMultiScript
     protected override ScriptBase CloneScript()
     {
         var clone = new MultiScript(_worldModel);
-        clone._scripts = new List<IScript>();
+        clone._scripts = [];
         foreach (var script in _scripts)
         {
             var clonedScript = (IScript) script.Clone();

--- a/src/Engine/Scripts/PictureScript.cs
+++ b/src/Engine/Scripts/PictureScript.cs
@@ -8,7 +8,7 @@ public class PictureScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/PlaySoundScript.cs
+++ b/src/Engine/Scripts/PlaySoundScript.cs
@@ -8,7 +8,7 @@ public class PlaySoundScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {3}; }
+        get { return [3]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -124,7 +124,7 @@ public class StopSoundScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {0}; }
+        get { return [0]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/RequestSaveScript.cs
+++ b/src/Engine/Scripts/RequestSaveScript.cs
@@ -14,7 +14,7 @@ public class RequestSaveScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {0}; }
+        get { return [0]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/RequestScript.cs
+++ b/src/Engine/Scripts/RequestScript.cs
@@ -37,7 +37,7 @@ public class RequestScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {2}; }
+        get { return [2]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/RequestSpeakScript.cs
+++ b/src/Engine/Scripts/RequestSpeakScript.cs
@@ -21,7 +21,7 @@ public class RequestSpeakScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     #endregion

--- a/src/Engine/Scripts/ReturnScript.cs
+++ b/src/Engine/Scripts/ReturnScript.cs
@@ -8,7 +8,7 @@ public class ReturnScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/RunDelegateScript.cs
+++ b/src/Engine/Scripts/RunDelegateScript.cs
@@ -8,7 +8,7 @@ public class RunDelegateScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new int[] { }; }
+        get { return []; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -64,9 +64,8 @@ public class RunDelegateScript : ScriptBase
 
         var obj = await _appliesTo.ExecuteAsync(c);
         var delName = await _delegate.ExecuteAsync(c);
-        var impl = obj.Fields.Get(delName) as DelegateImplementation;
 
-        if (impl == null)
+        if (obj.Fields.Get(delName) is not DelegateImplementation impl)
         {
             throw new Exception(
                 string.Format("Object '{0}' has no delegate implementation '{1}'", obj.Name, _delegate));
@@ -86,9 +85,11 @@ public class RunDelegateScript : ScriptBase
 
     public override string Save()
     {
-        var saveParameters = new List<string>();
-        saveParameters.Add(_appliesTo.Save());
-        saveParameters.Add(_delegate.Save());
+        var saveParameters = new List<string>
+        {
+            _appliesTo.Save(),
+            _delegate.Save()
+        };
         foreach (var p in _parameters.ParametersAsQuestList)
         {
             saveParameters.Add(p);

--- a/src/Engine/Scripts/SetFieldScript.cs
+++ b/src/Engine/Scripts/SetFieldScript.cs
@@ -8,7 +8,7 @@ public class SetFieldScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {3}; }
+        get { return [3]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -179,7 +179,7 @@ public class SwitchScript : ScriptBase
     private class SwitchCases
     {
         private readonly SwitchScript _parent;
-        private Dictionary<string, IFunctionDynamic> _compiledExpressions = new();
+        private Dictionary<string, IFunctionDynamic> _compiledExpressions = [];
 
         public SwitchCases(SwitchScript parent, Dictionary<IFunctionDynamic, IScript> cases)
             : this(parent)
@@ -209,13 +209,13 @@ public class SwitchScript : ScriptBase
             }
         }
 
-        public QuestDictionary<IScript> CasesAsQuestDictionary { get; private set; } = new();
+        public QuestDictionary<IScript> CasesAsQuestDictionary { get; private set; } = [];
 
         internal SwitchCases Clone(SwitchScript newParent)
         {
             var clone = new SwitchCases(newParent);
             clone.CasesAsQuestDictionary = (QuestDictionary<IScript>) CasesAsQuestDictionary.Clone();
-            clone._compiledExpressions = new Dictionary<string, IFunctionDynamic>();
+            clone._compiledExpressions = [];
             foreach (var compiledExpression in _compiledExpressions)
             {
                 clone._compiledExpressions.Add(compiledExpression.Key, compiledExpression.Value);

--- a/src/Engine/Scripts/UndoScript.cs
+++ b/src/Engine/Scripts/UndoScript.cs
@@ -8,7 +8,7 @@ public class UndoScriptConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {0}; }
+        get { return [0]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)
@@ -60,7 +60,7 @@ public class StartTransactionConstructor : ScriptConstructorBase
 
     protected override int[] ExpectedParameters
     {
-        get { return new[] {1}; }
+        get { return [1]; }
     }
 
     protected override IScript CreateInt(List<string> parameters, ScriptContext scriptContext)

--- a/src/Engine/Templates.cs
+++ b/src/Engine/Templates.cs
@@ -7,7 +7,7 @@ namespace QuestViva.Engine;
 
 public partial class Template
 {
-    private readonly Dictionary<string, Element> _templateLookup = new();
+    private readonly Dictionary<string, Element> _templateLookup = [];
     private readonly WorldModel _worldModel;
 
     public Template(WorldModel worldModel)
@@ -78,7 +78,7 @@ public partial class Template
         }
         else
         {
-            parameters = new Parameters();
+            parameters = [];
             for (var i = 0; i < obj.Length; i++)
             {
                 parameters.Add("object" + (i + 1), obj[i]);

--- a/src/Engine/UndoLogger.cs
+++ b/src/Engine/UndoLogger.cs
@@ -62,10 +62,7 @@ public class UndoLogger
 
     private void OnTransactionsUpdated()
     {
-        if (TransactionsUpdated != null)
-        {
-            TransactionsUpdated(this, new EventArgs());
-        }
+        TransactionsUpdated?.Invoke(this, new EventArgs());
     }
 
     internal void AddUndoAction(Func<IUndoAction> getAction)
@@ -159,7 +156,7 @@ public class UndoLogger
 
     private class Transaction
     {
-        private readonly List<IUndoAction> _attributes = new();
+        private readonly List<IUndoAction> _attributes = [];
 
         public Transaction(string command)
         {

--- a/src/Engine/Utility.cs
+++ b/src/Engine/Utility.cs
@@ -18,12 +18,12 @@ public static partial class Utility
     private const string SpaceReplacementString = "___SPACE___";
 
     public static readonly string[] DisallowedAttributes =
-        {"object", "command", "turnscript", "game", "exit", "type", "finish"};
+        ["object", "command", "turnscript", "game", "exit", "type", "finish"];
 
-    private static readonly List<string> Keywords = new() {"and", "or", "xor", "not", "if", "in"};
-    private static readonly HashSet<string> KeywordsSet = new(Keywords);
+    private static readonly List<string> Keywords = ["and", "or", "xor", "not", "if", "in"];
+    private static readonly HashSet<string> KeywordsSet = [.. Keywords];
 
-    private static readonly string[] ListSplitDelimiters = new[] {"; ", ";"};
+    private static readonly string[] ListSplitDelimiters = ["; ", ";"];
 
     public static IList<string> ExpressionKeywords => Keywords.AsReadOnly();
 
@@ -378,7 +378,7 @@ public static partial class Utility
     private static string RemoveCommentsMultiLine(string input, bool onlyRemoveMidLineComments)
     {
         var output = new List<string>();
-        foreach (var inputLine in input.Split(new[] {"\n"}, StringSplitOptions.None))
+        foreach (var inputLine in input.Split(["\n"], StringSplitOptions.None))
         {
             output.Add(RemoveComments(inputLine, onlyRemoveMidLineComments));
         }
@@ -388,7 +388,7 @@ public static partial class Utility
 
     public static List<string> SplitIntoLines(string text)
     {
-        var lines = new List<string>(text.Split(new[] {"\n"}, StringSplitOptions.RemoveEmptyEntries));
+        var lines = new List<string>(text.Split(["\n"], StringSplitOptions.RemoveEmptyEntries));
         var result = new List<string>();
         foreach (var line in lines)
         {

--- a/src/Engine/Walkthrough.cs
+++ b/src/Engine/Walkthrough.cs
@@ -4,7 +4,7 @@ namespace QuestViva.Engine;
 
 public sealed class Walkthroughs : IWalkthroughs
 {
-    private readonly Dictionary<string, IWalkthrough> _walkthroughs = new();
+    private readonly Dictionary<string, IWalkthrough> _walkthroughs = [];
 
     public Walkthroughs(WorldModel worldModel)
     {

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -30,13 +30,13 @@ public partial class WorldModel : IGame, IGameDebug
         {"list", typeof(QuestList<object>)}
     };
 
-    private static readonly Dictionary<Type, string> TypesToTypeNames = new();
+    private static readonly Dictionary<Type, string> TypesToTypeNames = [];
     private readonly List<string> _attributeNames = [];
-    private readonly Dictionary<string, ElementType> _debuggerElementTypes = new();
-    private readonly Dictionary<string, ObjectType> _debuggerObjectTypes = new();
-    private readonly Dictionary<ElementType, IElementFactory> _elementFactories = new();
+    private readonly Dictionary<string, ElementType> _debuggerElementTypes = [];
+    private readonly Dictionary<string, ObjectType> _debuggerObjectTypes = [];
+    private readonly Dictionary<ElementType, IElementFactory> _elementFactories = [];
     private readonly GameData? _gameData;
-    private readonly Dictionary<string, int> _nextUniqueId = new();
+    private readonly Dictionary<string, int> _nextUniqueId = [];
     private readonly Stream? _saveData;
 
     internal bool _commandOverride;
@@ -872,10 +872,7 @@ public partial class WorldModel : IGame, IGameDebug
     public void Print(string text, bool linebreak = true)
     {
         if (EditMode) return;
-        if (PrintText != null)
-        {
-            PrintText(linebreak ? "<output>" + text + "</output>" : "<output nobr=\"true\">" + text + "</output>");
-        }
+        PrintText?.Invoke(linebreak ? "<output>" + text + "</output>" : "<output nobr=\"true\">" + text + "</output>");
         _legacyOutputLogger?.AddText(text, linebreak);
     }
 
@@ -912,14 +909,14 @@ public partial class WorldModel : IGame, IGameDebug
 
     internal QuestList<Element> GetAllObjects()
     {
-        return new QuestList<Element>(Elements.Objects);
+        return [.. Elements.Objects];
     }
 
     private async Task<QuestList<Element>> GetObjectsInScopeAsync(string scopeFunction)
     {
         if (Elements.ContainsKey(ElementType.Function, scopeFunction))
         {
-            return (QuestList<Element>?) await RunProcedureAsync(scopeFunction, null, true) ?? new QuestList<Element>();
+            return (QuestList<Element>?) await RunProcedureAsync(scopeFunction, null, true) ?? [];
         }
 
         throw new Exception($"No function '{scopeFunction}'");
@@ -1085,7 +1082,7 @@ public partial class WorldModel : IGame, IGameDebug
 
         var visibleNotHeld = Elements.ContainsKey(ElementType.Function, "ScopeVisibleNotHeld")
             ? await GetObjectsInScopeAsync("ScopeVisibleNotHeld")
-            : new QuestList<Element>();
+            : [];
 
         var objects = new List<ListData>();
         var seen = new HashSet<Element>();
@@ -1157,10 +1154,7 @@ public partial class WorldModel : IGame, IGameDebug
 
     private async Task UpdateExitsListAsync()
     {
-        if (UpdateList != null)
-        {
-            UpdateList(ListType.ExitsList, await GetExitsListDataAsync());
-        }
+        UpdateList?.Invoke(ListType.ExitsList, await GetExitsListDataAsync());
     }
 
     private async Task<string> GetListDisplayAliasAsync(Element obj)
@@ -1324,7 +1318,7 @@ public partial class WorldModel : IGame, IGameDebug
         Element? thisElement = null)
     {
         var c = new Context();
-        parameters ??= new Parameters();
+        parameters ??= [];
         if (thisElement != null)
         {
             parameters.Add("this", thisElement);

--- a/src/PlayerCore/ListHandler.cs
+++ b/src/PlayerCore/ListHandler.cs
@@ -5,7 +5,7 @@ namespace QuestViva.PlayerCore;
 public class ListHandler(Action<string, object?[]?> addJavaScriptToBuffer)
 {
     private readonly ListDataComparer _comparer = new();
-    private readonly Dictionary<ListType, List<ListData>> _lists = new();
+    private readonly Dictionary<ListType, List<ListData>> _lists = [];
     private Action<string, object?[]?> AddJavaScriptToBuffer { get; } = addJavaScriptToBuffer;
 
     public void UpdateList(ListType listType, List<ListData> items)

--- a/src/PlayerCore/PlayerHelper.cs
+++ b/src/PlayerCore/PlayerHelper.cs
@@ -20,7 +20,7 @@ public interface IPlayerHelperUI : IPlayer
 /// </summary>
 public class PlayerHelper
 {
-    private static readonly Dictionary<string, string> MimeTypes = new();
+    private static readonly Dictionary<string, string> MimeTypes = [];
     private readonly IPlayerHelperUI _playerUI;
 
     private string _font = "";

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -828,7 +828,7 @@ public partial class WasmEditorBridge
     // AddPublishAsset/PendingPublishAssets stage assets for CreatePublishPackage below.
     // Initialise/SetGameXml consume and clear this before constructing their
     // ByteArrayGameDataProvider, regardless of whether the load succeeds.
-    private static readonly Dictionary<string, byte[]> PendingAdjacentFiles = new();
+    private static readonly Dictionary<string, byte[]> PendingAdjacentFiles = [];
 
     [JSExport]
     public static void AddAdjacentFile(string filename, byte[] data)
@@ -1041,8 +1041,7 @@ public partial class WasmEditorBridge
 
         try
         {
-            var existing = data.GetAttribute(attribute) as IEditableList<string>;
-            if (existing == null)
+            if (data.GetAttribute(attribute) is not IEditableList<string> existing)
             {
                 _controller.CreateNewEditableList(elementKey, attribute, value, true);
             }
@@ -1080,8 +1079,7 @@ public partial class WasmEditorBridge
             return "error";
         }
 
-        var list = data.GetAttribute(attribute) as IEditableList<string>;
-        if (list == null)
+        if (data.GetAttribute(attribute) is not IEditableList<string> list)
         {
             return "error";
         }
@@ -1112,8 +1110,7 @@ public partial class WasmEditorBridge
             return "error";
         }
 
-        var list = data.GetAttribute(attribute) as IEditableList<string>;
-        if (list == null)
+        if (data.GetAttribute(attribute) is not IEditableList<string> list)
         {
             return "error";
         }
@@ -3462,8 +3459,7 @@ public partial class WasmEditorBridge
         _controller.StartTransaction($"Set {attribute}");
         try
         {
-            var cmd = data.GetAttribute(attribute) as IEditableCommandPattern;
-            if (cmd != null)
+            if (data.GetAttribute(attribute) is IEditableCommandPattern cmd)
             {
                 cmd.Pattern = pattern;
             }
@@ -3500,8 +3496,7 @@ public partial class WasmEditorBridge
 
         try
         {
-            var existing = data.GetAttribute(attribute) as IEditableDictionary<string>;
-            if (existing == null)
+            if (data.GetAttribute(attribute) is not IEditableDictionary<string> existing)
             {
                 _controller.CreateNewEditableStringDictionary(elementKey, attribute, key, value, true);
             }
@@ -3539,8 +3534,7 @@ public partial class WasmEditorBridge
             return "error";
         }
 
-        var dict = data.GetAttribute(attribute) as IEditableDictionary<string>;
-        if (dict == null)
+        if (data.GetAttribute(attribute) is not IEditableDictionary<string> dict)
         {
             return "error";
         }
@@ -3571,8 +3565,7 @@ public partial class WasmEditorBridge
             return "error";
         }
 
-        var dict = data.GetAttribute(attribute) as IEditableDictionary<string>;
-        if (dict == null)
+        if (data.GetAttribute(attribute) is not IEditableDictionary<string> dict)
         {
             return "error";
         }
@@ -3665,8 +3658,7 @@ public partial class WasmEditorBridge
 
         try
         {
-            var existing = data.GetAttribute(attribute) as IEditableDictionary<IEditableScripts>;
-            if (existing == null)
+            if (data.GetAttribute(attribute) is not IEditableDictionary<IEditableScripts> existing)
             {
                 var emptyScript = _controller.CreateNewEditableScripts(null!, null!, null!, false);
                 _controller.CreateNewEditableScriptDictionary(elementKey, attribute, key, emptyScript, true);
@@ -3705,8 +3697,7 @@ public partial class WasmEditorBridge
             return "error";
         }
 
-        var dict = data.GetAttribute(attribute) as IEditableDictionary<IEditableScripts>;
-        if (dict == null)
+        if (data.GetAttribute(attribute) is not IEditableDictionary<IEditableScripts> dict)
         {
             return "error";
         }
@@ -3736,8 +3727,7 @@ public partial class WasmEditorBridge
             return "error";
         }
 
-        var dict = data.GetAttribute(attribute) as IEditableDictionary<IEditableScripts>;
-        if (dict == null)
+        if (data.GetAttribute(attribute) is not IEditableDictionary<IEditableScripts> dict)
         {
             return "error";
         }
@@ -3827,8 +3817,7 @@ public partial class WasmEditorBridge
         {
             var attrName = attribute[..bracketIdx];
             var key = attribute[(bracketIdx + 1)..^1];
-            var dict = data.GetAttribute(attrName) as IEditableDictionary<IEditableScripts>;
-            if (dict == null || !dict.Items.TryGetValue(key, out var item))
+            if (data.GetAttribute(attrName) is not IEditableDictionary<IEditableScripts> dict || !dict.Items.TryGetValue(key, out var item))
             {
                 return null;
             }
@@ -4199,9 +4188,7 @@ public partial class WasmEditorBridge
     {
         try
         {
-            var data =
-                _controller!.GetElementDataAttribute("_RichTextControl_TextProcessorCommands", "data") as IEnumerable;
-            if (data == null)
+            if (_controller!.GetElementDataAttribute("_RichTextControl_TextProcessorCommands", "data") is not IEnumerable data)
             {
                 return null;
             }

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -63,7 +63,7 @@ public partial class WasmPlayerBridge
     // here, one at a time ([JSExport] can't marshal an array of blobs in one call — mirrors
     // WasmEditorBridge's identical AddAdjacentFile), before every Initialise/InitialiseWithSave
     // call (including a restart), which consumes and clears this regardless of outcome.
-    private static readonly Dictionary<string, byte[]> PendingAdjacentFiles = new();
+    private static readonly Dictionary<string, byte[]> PendingAdjacentFiles = [];
 
     [JSExport]
     public static void AddAdjacentFile(string filename, byte[] data)
@@ -217,9 +217,9 @@ public partial class WasmPlayerBridge
     {
         if (_game == null || _ui == null || _ui.IsFinished) return;
         IDictionary<string, string> metadata = string.IsNullOrEmpty(metadataJson)
-            ? new Dictionary<string, string>()
+            ? []
             : JsonSerializer.Deserialize(metadataJson, WasmJsonContext.Default.DictionaryStringString)
-              ?? new Dictionary<string, string>();
+              ?? [];
         await _game.SendCommand(command, tickCount, metadata);
         await _ui.FlushBufferAndYieldAsync();
     }
@@ -481,7 +481,7 @@ public partial class WasmPlayerBridge
         private PlayerHelper? _helper;
 
         // Buffered JS calls — flushed at turn end or before any interactive call.
-        private readonly List<Action> _uiBuffer = new();
+        private readonly List<Action> _uiBuffer = [];
         // Only the last requestNextTimerTick per turn matters; older ones are stale.
         private int? _pendingTimerTick = null;
 

--- a/src/WebPlayer/LocalResources.cs
+++ b/src/WebPlayer/LocalResources.cs
@@ -4,7 +4,7 @@ namespace QuestViva.WebPlayer;
 
 public static class LocalResources
 {
-    private static readonly Dictionary<string, Func<string, Stream?>> ResourceStreamProviders = new();
+    private static readonly Dictionary<string, Func<string, Stream?>> ResourceStreamProviders = [];
 
     public static void AddResourceStreamProvider(string resourcesId, Func<string, Stream?> resourceStreamProvider)
     {

--- a/tests/EditorCoreTests/EditorControllerTestBase.cs
+++ b/tests/EditorCoreTests/EditorControllerTestBase.cs
@@ -11,9 +11,9 @@ public abstract class EditorControllerTestBase
 
     protected EditorController Controller { get; private set; } = null!;
 
-    protected List<string> UndoList { get; private set; } = new();
+    protected List<string> UndoList { get; private set; } = [];
 
-    protected List<string> RedoList { get; private set; } = new();
+    protected List<string> RedoList { get; private set; } = [];
 
     [TestInitialize]
     public async Task Init()
@@ -70,11 +70,11 @@ public abstract class EditorControllerTestBase
 
     private void OnControllerUndoListUpdated(object? sender, EditorController.UpdateUndoListEventArgs e)
     {
-        UndoList = new List<string>(e.UndoList);
+        UndoList = [.. e.UndoList];
     }
 
     private void OnControllerRedoListUpdated(object? sender, EditorController.UpdateUndoListEventArgs e)
     {
-        RedoList = new List<string>(e.UndoList);
+        RedoList = [.. e.UndoList];
     }
 }

--- a/tests/EditorCoreTests/EditorTreeData.cs
+++ b/tests/EditorCoreTests/EditorTreeData.cs
@@ -9,7 +9,7 @@ public class EditorTreeItem
 
 public class EditorTreeData
 {
-    private readonly Dictionary<string, EditorTreeItem> _items = new();
+    private readonly Dictionary<string, EditorTreeItem> _items = [];
     private bool _frozen = true;
 
     public void Clear()

--- a/tests/EngineTests/AsyncScriptTests.cs
+++ b/tests/EngineTests/AsyncScriptTests.cs
@@ -25,7 +25,7 @@ public class AsyncScriptTests
     private void AddFunction(string name, string script, params string[] paramNames)
     {
         var function = _worldModel.GetElementFactory(ElementType.Function).Create(name);
-        function.Fields[FieldDefinitions.ParamNames] = new QuestList<string>(paramNames);
+        function.Fields[FieldDefinitions.ParamNames] = [.. paramNames];
         function.Fields[FieldDefinitions.Script] = _scriptFactory.CreateScript(script, _scriptContext);
     }
 

--- a/tests/EngineTests/CloneTests.cs
+++ b/tests/EngineTests/CloneTests.cs
@@ -8,7 +8,7 @@ public class CloneTests
     private const string AttributeName = "attribute";
     private const string AttributeValue = "attributevalue";
     private const string ListAttributeName = "listattribute";
-    private readonly List<string> _listAttributeValue = new() {"one", "two", "three"};
+    private readonly List<string> _listAttributeValue = ["one", "two", "three"];
     private Element _original = null!;
 
     private WorldModel _worldModel = null!;

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -76,7 +76,7 @@ public class ExpressionTests
     {
         var function = _worldModel.GetElementFactory(ElementType.Function).Create(name);
         function.Fields[FieldDefinitions.ReturnType] = returnType;
-        function.Fields[FieldDefinitions.ParamNames] = new QuestList<string>(parameters);
+        function.Fields[FieldDefinitions.ParamNames] = [.. parameters];
         function.Fields[FieldDefinitions.Script] = _scriptFactory.CreateScript(script, _scriptContext);
     }
 
@@ -498,7 +498,7 @@ public class ExpressionTests
         var c = new Context { Parameters = new Parameters { { "myvar", 42 } } };
         (await expr.ExecuteAsync(c)).ShouldBeTrue();
 
-        var c2 = new Context { Parameters = new Parameters() };
+        var c2 = new Context { Parameters = [] };
         (await expr.ExecuteAsync(c2)).ShouldBeFalse();
     }
 

--- a/tests/EngineTests/QuestDictionaryTests.cs
+++ b/tests/EngineTests/QuestDictionaryTests.cs
@@ -16,11 +16,13 @@ public class QuestDictionaryTests
     [TestMethod]
     public void Foreach_AfterRemoveAndReAdd_PreservesTrueInsertionOrder()
     {
-        var dict = new QuestDictionary<string>();
-        dict.Add("a", "1");
-        dict.Add("b", "2");
-        dict.Add("c", "3");
-        dict.Add("d", "4");
+        var dict = new QuestDictionary<string>
+        {
+            { "a", "1" },
+            { "b", "2" },
+            { "c", "3" },
+            { "d", "4" }
+        };
         dict.Remove("b");
         dict.Add("e", "5");
 

--- a/tests/LegacyTests/TestPlayer.cs
+++ b/tests/LegacyTests/TestPlayer.cs
@@ -4,7 +4,7 @@ namespace QuestViva.LegacyTests;
 
 internal class TestPlayer : IPlayer
 {
-    private readonly List<string> _output = new();
+    private readonly List<string> _output = [];
 
     public int BufferLength => _output.Count;
 


### PR DESCRIPTION
Applies three mechanical C# style rules across the codebase and enforces them at build time, the same way #2238 enforces the naming conventions: `.editorconfig` severity `warning`, plus `EnforceCodeStyleInBuild` and `TreatWarningsAsErrors`. The point is consistency. New code, including AI-written code, can't drift back to the old patterns.

| Rule | What it does | Sites |
|---|---|---|
| IDE1005 | `if (Changed != null) { Changed(this, e); }` → `Changed?.Invoke(this, e);` | 52 |
| IDE0028, IDE0300–IDE0303 | `new List<string>()` → `[]`, `new List<T>(items)` → `[.. items]`, `new[] { a, b }` → `[a, b]` | ~177 |
| IDE0019, IDE0020, IDE0038 | `var x = y as T; if (x != null)` → `if (y is T x)` | 46 |

The fixes were applied with `dotnet format style`, and all 81 changed files were normalised back to their original BOM and line endings.

## Deliberate choices
- **`dotnet_style_prefer_collection_expression = when_types_exactly_match`.** A collection expression is only suggested when the declared type is the type being created. For an interface target like `IEnumerable<T>`, `[...]` can produce a different runtime type (e.g. a read-only one), which would break any code that casts it back and mutates it. The looser default would have flagged those too.
- **IDE0305 (`.ToList()` → `[.. x]`) is left off:** the method call reads more clearly.
- **Legacy is exempt** via a `[src/Legacy/**.cs]` section, since it's frozen compatibility code, as for nullable (see `Legacy.csproj`). Only the naming rules apply there.

## Behaviour
No intended behaviour change. The one conversion that isn't purely syntactic is `new QuestList<T>(items)` / `new QuestDictionary<T>(items)` → `[.. items]`. The compiler builds that by calling `Add` for each item instead of the copying constructor. I checked this is equivalent for a freshly created `QuestList`/`QuestDictionary`: `Add` checks `Locked` (false), records undo only when an `UndoLog` is attached (none yet), and raises `Added` (no subscribers yet).

The constructors also treat a null source as empty, whereas a spread would throw. The compiler's nullable analysis flagged the two call sites whose source can be null, `ListCombine` and the function loader's parameter names, and those use `[.. items ?? []]` to keep the old behaviour. No constructor arguments other than the source collection were dropped (no comparers or capacities).

After merging, the squash commit should be added to `.git-blame-ignore-revs`.

## Test plan
- [x] `dotnet build --configuration Release`: clean, with the new rules as warnings-as-errors; Debug build also clean
- [x] `dotnet test --configuration Release`: all 403 tests pass
- [x] BOM / line endings preserved on every edited file
- [x] quest-e2e-tests corpus: golden snapshots from `main` (twice, for the noise floor) vs this branch. The branch differs from `main` in exactly the 15 games that also differ between two `main` runs, and no others
- [x] e2e: all 23 `verify-wasmplayer-*` and 60 `verify-appshell-*` scripts against local dev servers built from this branch — 82 of 83 pass; the remaining one, `verify-appshell-server-mode-no-create`, needs `PUBLIC_HAS_SERVER=true` and so can't pass against a default dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
