### PR TITLE
chore: remove stale commented-out code and TODOs

### DIFF
--- a/src/EditorCore/EditableList.cs
+++ b/src/EditorCore/EditableList.cs
@@ -112,13 +112,7 @@ public class EditableList<T> : IEditableList<T>, IDataWrapper, INotifyCollection
 
     public ValidationResult CanAdd(T item)
     {
-        // Commented this section out as it is valid to have the same item multiple times in a list,
-        // for example for walkthroughs.
-        //if (_source.Contains(item))
-        //{
-        //    return new ValidationResult { Valid = false, Message = ValidationMessage.ItemAlreadyExists };
-        //}
-
+        // Duplicates are allowed - a list can validly contain the same item more than once, e.g. walkthrough steps
         return new ValidationResult {Valid = true};
     }
 

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -1028,12 +1028,7 @@ public partial class WorldModel : IGame, IGameDebug
 
     private void loader_FilenameUpdated(string filename)
     {
-        // TODO: This previously did this...
-        // // Update base ASLX filename to original filename if we're loading a saved game
-        // m_saveFilename = m_filename;
-        // m_filename = filename;
-
-        // ... but we now only need it to do this, which could be more explicit:
+        // Only raised for a saved game, whose root <asl> element names the original game file
         _loadedFromSaved = true;
     }
 

--- a/src/PlayerCore/GameLauncher.cs
+++ b/src/PlayerCore/GameLauncher.cs
@@ -20,56 +20,10 @@ public class GameLauncher(WorldModelFactory worldModelFactory)
                 var game = new V4Game(gameData, saveData);
                 return game;
             case ".zip":
-                // TODO
+                // Zipped games aren't supported
                 throw new NotImplementedException();
-            // return GetGameFromZip(filename, libraryFolder, out tempDir);
             default:
                 return null;
         }
-    }
-
-    // For Zip files we previously used DotNetZip - should be able to use System.IO.Compression now:
-    // https://docs.microsoft.com/en-us/dotnet/standard/io/how-to-compress-and-extract-files
-    // https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile?view=net-9.0
-    // We already use this in WorldModel/WorldModel/GameLoader/PackageReader.cs
-
-    // private static IASL GetGameFromZip(string filename, string libraryFolder, out string tempDir)
-    // {
-    //     string gameFile = UnzipAndGetGameFile(filename, out tempDir);
-    //     if (gameFile == null) return null;
-    //     IASL result = GetGame(gameFile, libraryFolder, filename);
-    //     if (result != null)
-    //     {
-    //         result.TempFolder = tempDir;
-    //     }
-    //     return result;
-    // }
-
-    private static string UnzipAndGetGameFile(string zipFile, out string tempDir)
-    {
-        throw new NotImplementedException();
-
-        // // Unzips a file to a temp directory and returns the path of the ASL/CAS/ASLX file contained within it.
-        //
-        // tempDir = Path.Combine(Path.GetTempPath(), "Quest", Guid.NewGuid().ToString());
-        // Directory.CreateDirectory(tempDir);
-        // ZipFile zip = ZipFile.Read(zipFile);
-        // zip.ExtractAll(tempDir);
-        //
-        // return SearchForGameFile(tempDir, "aslx", "asl", "cas");
-    }
-
-    private static string? SearchForGameFile(string dir, params string[] exts)
-    {
-        foreach (var ext in exts)
-        {
-            var result = Directory.GetFiles(dir, "*." + ext, SearchOption.AllDirectories);
-            if (result.Any())
-            {
-                return result[0];
-            }
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
A small tidy of leftover commented-out code and stale TODOs, the follow-up to #2262 (which is kept separate so that one can go in `.git-blame-ignore-revs` and this one can't).

- **`GameLauncher`:** removes the unused `UnzipAndGetGameFile`/`SearchForGameFile` helpers (one only threw `NotImplementedException`) and the commented-out `GetGameFromZip`/DotNetZip scaffolding. `.zip` still throws as before, but without a TODO: no host passes zipped games to `GameLauncher` (WasmPlayer and WebPlayer load game files, and textadventures.co.uk extracts uploaded zips first), so it isn't something to implement.
- **`EditableList.CanAdd`:** the commented-out duplicate check is replaced by a one-line comment saying duplicates are allowed.
- **`WorldModel.loader_FilenameUpdated`:** the "TODO: This previously did this..." note and its commented-out Quest 5 body are replaced by a comment saying when the event fires.

The other TODOs in the codebase were left alone deliberately. They're real design notes, e.g. the ScriptDictionary XML format, the re-entrancy flag in `EditableScripts`, or `GetExternalStylesheets` still being needed for older games' frozen Core. Legacy's are left alone as frozen code.

No behaviour change.

## Test plan
- [x] `dotnet build`: clean (warnings as errors)
- [x] `dotnet test`: all 403 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
