### PR TITLE
chore: add #2262 to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -18,3 +18,6 @@ b6bae26e592fc44a0fc39230147720ea819d8e4e
 
 # chore: adopt Rider naming conventions for fields and enforce at build time (#2238)
 7f08ebdbb05d0b1c337e52ca71c8328b3b81ca71
+
+# refactor: enforce event invoke, collection expression and pattern matching style rules (#2262)
+c77270b362cca41d9305247d039cea0f24f79252


### PR DESCRIPTION
Adds the squash commit of #2262 (`dotnet format` applying the event invoke, collection expression and pattern matching rules across 81 files) to `.git-blame-ignore-revs`, so `git blame` skips it — as for #2238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)