### PR TITLE
refactor(EditorCore): remove dormant Quest 5 Simple Mode plumbing

### DIFF
--- a/docs/editor-progressive-disclosure.md
+++ b/docs/editor-progressive-disclosure.md
@@ -39,15 +39,17 @@ Two conventions for the flags themselves, established by the audit:
 - **Tab-level `<advanced/>` is ignored.** Hiding or demoting whole tabs re-introduces
   the "where did X go" problem; the Features tab already gates the noisiest ones.
 
-## Dormant EditorCore plumbing — keep it
+## Quest 5's Simple Mode — removed
 
-EditorCore still carries the full v5 Simple Mode plumbing, all deliberately dormant:
-`SimpleMode` / `SimpleModeChanged` on `EditorController`, the `_advancedTypes` tree
-filtering, `IsTabVisibleInSimpleMode` (`EditorTab.cs`), `IsControlVisibleInSimpleMode`
-(`EditorControl.cs` — this one *is* consulted, inverted, by `WasmEditorBridge` to
-populate the `Advanced` flags above), `IsVisibleInSimpleMode`
-(`EditableScriptFactory.cs`), and `GetCategories(simpleModeOnly, showAll)`.
+Quest 5 had a global Simple Mode toggle that hid advanced tree sections, tabs, controls and
+script commands. The new editor never exposed it, and the per-control and per-command
+`<advanced/>` behaviour above replaced it, so its dormant EditorCore plumbing has been removed:
+`EditorController.SimpleMode` / `SimpleModeChanged`, the `_advancedTypes` tree filtering,
+`IsTabVisibleInSimpleMode`, and `GetCategories(simpleModeOnly, showAll)`.
 
-Don't remove it. If a locked-down classroom deployment is ever wanted, this makes a
-global toggle cheap to add later (a bridge property plus UI conditionals, defaulted
-per-deployment via query param rather than per-user). Wait for actual demand.
+What remains is the `<advanced/>` flag itself, exposed as `IsAdvanced` on `EditorControl` and
+`EditableScriptData`, which `WasmEditorBridge` uses to populate the `Advanced` flags above.
+
+If a locked-down classroom deployment is ever wanted, a global toggle would need adding back: a
+bridge property plus UI conditionals, defaulted per deployment via a query param rather than per
+user. The old implementation is in git history.

--- a/src/EditorCore/EditableScriptFactory.cs
+++ b/src/EditorCore/EditableScriptFactory.cs
@@ -16,7 +16,7 @@ public class EditableScriptData
         Category = editor.Fields.GetString("category")!;
         CreateString = editor.Fields.GetString("create");
         AdderDisplayString = editor.Fields.GetString("add");
-        IsVisibleInSimpleMode = !editor.Fields.GetAsType<bool>("advanced");
+        IsAdvanced = editor.Fields.GetAsType<bool>("advanced");
         CommonButton = editor.Fields.GetString("common");
         var expression = editor.Fields.GetString("onlydisplayif");
         if (expression != null)
@@ -30,7 +30,7 @@ public class EditableScriptData
     public string Category { get; }
     public string? CreateString { get; private set; }
     public string? AdderDisplayString { get; private set; }
-    public bool IsVisibleInSimpleMode { get; }
+    public bool IsAdvanced { get; }
     public string? CommonButton { get; private set; }
     public int Order { get; private set; }
 

--- a/src/EditorCore/EditorControl.cs
+++ b/src/EditorCore/EditorControl.cs
@@ -33,7 +33,7 @@ internal class EditorControl : IEditorControl
         }
 
         _visibilityHelper = new EditorVisibilityHelper(parent, worldModel, source);
-        IsControlVisibleInSimpleMode = !source.Fields.GetAsType<bool>("advanced");
+        IsAdvanced = source.Fields.GetAsType<bool>("advanced");
         Id = source.Name;
 
         if (source.Fields.GetString("filtergroup") is { } filterGroup)
@@ -107,7 +107,7 @@ internal class EditorControl : IEditorControl
 
     public IEditorDefinition Parent => _parent;
 
-    public bool IsControlVisibleInSimpleMode { get; }
+    public bool IsAdvanced { get; }
 
     public string Id { get; }
 }

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -95,18 +95,6 @@ public sealed class EditorController : IDisposable
         {ValidationMessage.MismatchingQuotes, "Missing quote character (\")"}
     };
 
-    private readonly List<ElementType> _advancedTypes =
-    [
-        ElementType.DynamicTemplate,
-        ElementType.Function,
-        ElementType.IncludedLibrary,
-        ElementType.Javascript,
-        ElementType.ObjectType,
-        ElementType.Template,
-        ElementType.Timer,
-        ElementType.Walkthrough
-    ];
-
     private readonly Dictionary<string, EditorDefinition> _editorDefinitions = [];
     private readonly Dictionary<string, EditorDefinition> _expressionDefinitions = [];
 
@@ -134,7 +122,6 @@ public sealed class EditorController : IDisposable
     private bool _lastelementscutout;
     // Set by Initialise
     private ScriptFactory _scriptFactory = null!;
-    private bool _simpleMode;
 
     public EditorController()
     {
@@ -157,20 +144,6 @@ public sealed class EditorController : IDisposable
 
     // Set by Initialise
     public string Filename { get; set; } = null!;
-
-    public bool SimpleMode
-    {
-        get => _simpleMode;
-        set
-        {
-            if (_simpleMode != value)
-            {
-                _simpleMode = value;
-                UpdateTree();
-                SimpleModeChanged?.Invoke(this, new EventArgs());
-            }
-        }
-    }
 
     public EditorStyle EditorStyle { get; private set; } = EditorStyle.TextAdventure;
 
@@ -200,8 +173,6 @@ public sealed class EditorController : IDisposable
     public event EventHandler<ElementMovedEventArgs>? ElementMoved;
 
     public event EventHandler<ScriptClipboardUpdateEventArgs>? ScriptClipboardUpdated;
-
-    public event EventHandler? SimpleModeChanged;
 
     public event EventHandler<ElementUpdatedEventArgs>? ElementUpdated;
     public event EventHandler<ElementRefreshedEventArgs>? ElementRefreshed;
@@ -460,45 +431,39 @@ public sealed class EditorController : IDisposable
     {
         _elementTreeStructure = [];
 
-        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Object, "_objects", "Objects", null, false);
-        AddTreeHeader(EditorStyle.GameBook, ElementType.Object, "_objects", "Pages", null, false);
-        AddTreeHeader(null, null, "_advanced", "Advanced", null, false);
-        AddTreeHeader(null, ElementType.Function, "_functions", "Functions", "_advanced", false);
-        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Timer, "_timers", "Timers", "_advanced", false);
-        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Walkthrough, "_walkthrough", "Walkthrough", "_advanced",
-            false);
-        AddTreeHeader(null, ElementType.IncludedLibrary, "_include", "Included Libraries", "_advanced", false);
-        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Template, "_template", "Templates", "_advanced", false);
+        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Object, "_objects", "Objects", null);
+        AddTreeHeader(EditorStyle.GameBook, ElementType.Object, "_objects", "Pages", null);
+        AddTreeHeader(null, null, "_advanced", "Advanced", null);
+        AddTreeHeader(null, ElementType.Function, "_functions", "Functions", "_advanced");
+        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Timer, "_timers", "Timers", "_advanced");
+        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Walkthrough, "_walkthrough", "Walkthrough", "_advanced");
+        AddTreeHeader(null, ElementType.IncludedLibrary, "_include", "Included Libraries", "_advanced");
+        AddTreeHeader(EditorStyle.TextAdventure, ElementType.Template, "_template", "Templates", "_advanced");
         AddTreeHeader(EditorStyle.TextAdventure, ElementType.DynamicTemplate, "_dynamictemplate", "Dynamic Templates",
-            "_advanced", false);
-        AddTreeHeader(EditorStyle.TextAdventure, ElementType.ObjectType, "_objecttype", "Object Types", "_advanced",
-            false);
-        AddTreeHeader(null, ElementType.Javascript, "_javascript", "Javascript", "_advanced", false);
+            "_advanced");
+        AddTreeHeader(EditorStyle.TextAdventure, ElementType.ObjectType, "_objecttype", "Object Types", "_advanced");
+        AddTreeHeader(null, ElementType.Javascript, "_javascript", "Javascript", "_advanced");
     }
 
-    private void AddTreeHeader(EditorStyle? editorStyle, ElementType? type, string key, string title, string? parent,
-        bool simple)
+    private void AddTreeHeader(EditorStyle? editorStyle, ElementType? type, string key, string title, string? parent)
     {
         if (editorStyle.HasValue && EditorStyle != editorStyle)
         {
             return;
         }
 
-        if (simple || !SimpleMode)
+        var header = new TreeHeader {Key = key, Title = title};
+        if (type != null)
         {
-            var header = new TreeHeader {Key = key, Title = title};
-            if (type != null)
-            {
-                _elementTreeStructure.Add(type.Value, header);
-            }
-
-            AddedNode!(this,
-                new AddedNodeEventArgs
-                {
-                    Key = key, Text = title, Parent = parent, IsLibraryNode = false, Position = null,
-                    NodeType = "header"
-                });
+            _elementTreeStructure.Add(type.Value, header);
         }
+
+        AddedNode!(this,
+            new AddedNodeEventArgs
+            {
+                Key = key, Text = title, Parent = parent, IsLibraryNode = false, Position = null,
+                NodeType = "header"
+            });
     }
 
     public void UpdateTree()
@@ -577,7 +542,7 @@ public sealed class EditorController : IDisposable
                     NodeType = GetNodeType(o)
                 });
 
-            if (o.Name == "game" && !SimpleMode && EditorStyle == EditorStyle.TextAdventure)
+            if (o.Name == "game" && EditorStyle == EditorStyle.TextAdventure)
             {
                 AddedNode!(this,
                     new AddedNodeEventArgs
@@ -603,19 +568,6 @@ public sealed class EditorController : IDisposable
             return false;
         }
 
-        if (SimpleMode && _advancedTypes.Contains(e.ElemType))
-        {
-            return false;
-        }
-
-        if (SimpleMode)
-        {
-            if (e.ElemType == ElementType.Object && e.Type == ObjectType.Command)
-            {
-                return false;
-            }
-        }
-
         if (e.ElemType == ElementType.Template)
         {
             // Don't display verb templates (if the user wants to edit a verb's regex,
@@ -638,11 +590,6 @@ public sealed class EditorController : IDisposable
 
     private string? GetElementTreeParent(Element o)
     {
-        if (SimpleMode)
-        {
-            return o.Parent == null ? null : o.Parent.Name;
-        }
-
         if (o.Parent != null)
         {
             return o.Parent.Name;

--- a/src/EditorCore/EditorTab.cs
+++ b/src/EditorCore/EditorTab.cs
@@ -19,7 +19,6 @@ internal class EditorTab : IEditorTab
         HelpUrl = string.IsNullOrWhiteSpace(source.Fields.GetString("helpurl"))
             ? null
             : source.Fields.GetString("helpurl");
-        IsTabVisibleInSimpleMode = !source.Fields.GetAsType<bool>("advanced");
 
         foreach (var e in worldModel.Elements.GetElements(ElementType.EditorControl))
         {
@@ -43,6 +42,4 @@ internal class EditorTab : IEditorTab
     {
         return _visibilityHelper.IsVisible(data);
     }
-
-    public bool IsTabVisibleInSimpleMode { get; }
 }

--- a/src/EditorCore/IEditorControl.cs
+++ b/src/EditorCore/IEditorControl.cs
@@ -9,7 +9,7 @@ public interface IEditorControl
     string? Attribute { get; }
     bool Expand { get; }
     IEditorDefinition? Parent { get; }
-    bool IsControlVisibleInSimpleMode { get; }
+    bool IsAdvanced { get; }
     string? Id { get; }
     string? GetString(string tag);
     IEnumerable<string>? GetListString(string tag);

--- a/src/EditorCore/IEditorTab.cs
+++ b/src/EditorCore/IEditorTab.cs
@@ -11,6 +11,5 @@ public interface IEditorTab
     /// </summary>
     string? HelpUrl { get; }
     IEnumerable<IEditorControl> Controls { get; }
-    bool IsTabVisibleInSimpleMode { get; }
     Task<bool> IsTabVisible(IEditorData data);
 }

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -2155,16 +2155,16 @@ public partial class WasmEditorBridge
                 // Non-advanced commands first (in declared order), then advanced ones
                 // (also in declared order) — keeps a mixed category's everyday commands
                 // together at the top instead of interleaved with advanced ones.
-                g.OrderBy(kv => !kv.Value.IsVisibleInSimpleMode).ThenBy(kv => kv.Value.Order)
+                g.OrderBy(kv => kv.Value.IsAdvanced).ThenBy(kv => kv.Value.Order)
                     .Select(kv => new ScriptCommandInfo(
                         kv.Key,
                         kv.Value.DisplayString ?? kv.Key,
                         kv.Value.AdderDisplayString ?? kv.Key,
                         kv.Value.CreateString!,
-                        !kv.Value.IsVisibleInSimpleMode,
+                        kv.Value.IsAdvanced,
                         kv.Value.CommonButton
                     )).ToList(),
-                g.All(kv => !kv.Value.IsVisibleInSimpleMode)
+                g.All(kv => kv.Value.IsAdvanced)
             ))
             .ToList();
         var data = new ScriptCommandCategoriesData(grouped);
@@ -4266,7 +4266,7 @@ public partial class WasmEditorBridge
             options = dict?.Select(kv => new ControlOption(kv.Key, kv.Value)).ToList();
 
             return new ControlInfo(ctrl.Id, "filter", ctrl.Caption, options, null,
-                ctrl.GetString("filtergroupname"), Advanced: !ctrl.IsControlVisibleInSimpleMode, Width: ctrl.Width);
+                ctrl.GetString("filtergroupname"), Advanced: ctrl.IsAdvanced, Width: ctrl.Width);
         }
         else if (ctrl.ControlType == "objects")
         {
@@ -4299,7 +4299,7 @@ public partial class WasmEditorBridge
 
             var caption = ctrl.Caption ?? ctrl.GetString("selfcaption");
             return new ControlInfo(ctrl.Id, ctrl.ControlType, caption, options, subEditors, ctrl.Attribute,
-                multiTpCommands, Source: ctrl.GetString("source"), Advanced: !ctrl.IsControlVisibleInSimpleMode, CheckboxCaption: ctrl.GetString("checkbox"));
+                multiTpCommands, Source: ctrl.GetString("source"), Advanced: ctrl.IsAdvanced, CheckboxCaption: ctrl.GetString("checkbox"));
         }
         else if (ctrl.ControlType == "elementslist")
         {
@@ -4307,7 +4307,7 @@ public partial class WasmEditorBridge
                 ctrl.GetString("elementtype"),
                 ctrl.GetString("objecttype"),
                 ctrl.GetString("listfilter"),
-                Advanced: !ctrl.IsControlVisibleInSimpleMode);
+                Advanced: ctrl.IsAdvanced);
         }
 
         List<TextProcessorCommand>? textProcessorCommands = null;
@@ -4346,7 +4346,7 @@ public partial class WasmEditorBridge
 
         return new ControlInfo(attribute, ctrl.ControlType!, ctrl.Caption ?? ctrl.GetString("selfcaption"), options,
             null, null, textProcessorCommands, addPrompt, Source: source,
-            Advanced: !ctrl.IsControlVisibleInSimpleMode,
+            Advanced: ctrl.IsAdvanced,
             KeyPrompt: keyPrompt, ValuePrompt: valuePrompt, SourceExclude: sourceExclude, SourceType: sourceType,
             IsWalkthrough: isWalkthrough, Href: href, NewFile: newFile, LockedAfterCreate: lockedAfterCreate,
             Freetext: freetext,


### PR DESCRIPTION
Removes the dormant Quest 5 Simple Mode plumbing from EditorCore. Quest 5 had a global Simple/Advanced toggle. The new editor never exposed it: the per-control and per-command `<advanced/>` collapsed sections replaced it (see `docs/editor-progressive-disclosure.md`), so nothing ever set `EditorController.SimpleMode` and all its branches were unreachable.

## Removed
- **On `EditorController`:**
  - `SimpleMode`, its `_simpleMode` field and the `SimpleModeChanged` event;
  - the `_advancedTypes` list, only used when `SimpleMode` was true;
  - the `if (SimpleMode …)` branches in `IsElementVisible`, `GetElementTreeParent` and `AddElementToTree`;
  - `AddTreeHeader`'s `simple` parameter, which every call passed as `false`.
- **`IEditorTab.IsTabVisibleInSimpleMode`** and its implementation, which nothing read. Tab-level `<advanced/>` is deliberately ignored.

## Renamed
The `<advanced/>` flag itself is live: WasmEditor uses it for the collapsed advanced sections and for the add-script picker's ordering. It was exposed as "visible in Simple Mode" and negated back at every use, so it's now stated directly:
- `IEditorControl`/`EditorControl.IsControlVisibleInSimpleMode` → `IsAdvanced`
- `EditableScriptData.IsVisibleInSimpleMode` → `IsAdvanced`

The bridge's `Advanced: !ctrl.IsControlVisibleInSimpleMode` becomes `Advanced: ctrl.IsAdvanced`, and similarly for script commands. The JSON sent to AppShell is unchanged.

Unrelated, and unchanged: Core's `<simple>`/`<simpleeditor>` editor-definition tags and ScriptEditor's `inSimpleMode()`. These are the per-control "simple editor vs expression" switch, not the global mode.

## Docs
`docs/editor-progressive-disclosure.md` previously said to keep this plumbing in case a locked-down classroom deployment is ever wanted. That section now records that it was removed, what remains (`IsAdvanced`), and how a global toggle would be re-added if needed.

No behaviour change.

## Test plan
- [x] `dotnet build`: clean (warnings as errors)
- [x] `dotnet test`: all 403 tests pass
- [x] BOM / line endings preserved on every edited file
- [x] e2e: all 60 `verify-appshell-*` scripts against a local AppShell dev server with a WasmEditor build from this branch (covering the tree headers and the advanced sections/script picker) — 59 pass; the remaining one, `verify-appshell-server-mode-no-create`, needs `PUBLIC_HAS_SERVER=true` and so can't pass against a default dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
