### PR TITLE
chore: add #2266 to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -21,3 +21,6 @@ b6bae26e592fc44a0fc39230147720ea819d8e4e
 
 # refactor: enforce event invoke, collection expression and pattern matching style rules (#2262)
 c77270b362cca41d9305247d039cea0f24f79252
+
+# refactor: use expression bodies for single-line properties (#2266)
+53e15104c819fbe0aafe0493504436daedf9f323


### PR DESCRIPTION
Adds the squash commit of #2266 (`dotnet format` converting single-line property getters to expression bodies) to `.git-blame-ignore-revs`, so `git blame` skips it — as for #2238 and #2262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)