### PR TITLE
fix(Engine): don't write a byte order mark into published packages' game.aslx

### DIFF
--- a/src/Engine/GameLoader/Packager.cs
+++ b/src/Engine/GameLoader/Packager.cs
@@ -59,7 +59,7 @@ internal class Packager(WorldModel worldModel)
 
         var gameEntry = zip.CreateEntry("game.aslx", CompressionLevel.Optimal);
         using (var entryStream = gameEntry.Open())
-        using (var writer = new StreamWriter(entryStream, Encoding.UTF8))
+        using (var writer = new StreamWriter(entryStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
         {
             writer.Write(data);
         }

--- a/tests/EngineTests/PackagerTests.cs
+++ b/tests/EngineTests/PackagerTests.cs
@@ -88,6 +88,38 @@ public class PackagerTests
     }
 
     [TestMethod]
+    public async Task CreatePackage_WritesEntriesWithoutByteOrderMark()
+    {
+        var gameDataProvider = new FileGameDataProvider("savetest.aslx");
+        var gameData = await gameDataProvider.GetData();
+        var worldModel = Helpers.CreateWorldModel(gameData);
+        worldModel.LogError += ex => throw ex;
+
+        var player = new Mock<IPlayer>();
+        Assert.IsTrue(await worldModel.Initialise(player.Object), "Initialisation failed");
+
+        worldModel.Game.Fields.Set("gameid", "5d3c2a1b-0f9e-4d8c-b7a6-958473625140");
+
+        using var packageStream = new MemoryStream();
+        var success = worldModel.CreatePackage(null, includeWalkthrough: false, out var error,
+            Array.Empty<WorldModel.PackageIncludeFile>(), packageStream);
+        Assert.IsTrue(success, error);
+
+        packageStream.Position = 0;
+        using var zip = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
+        foreach (var name in (string[]) ["game.aslx", "metadata.iFiction"])
+        {
+            var entry = zip.GetEntry(name);
+            Assert.IsNotNull(entry, $"Published .quest should contain {name}");
+            using var entryStream = entry.Open();
+            using var entryBytes = new MemoryStream();
+            await entryStream.CopyToAsync(entryBytes);
+            Assert.IsFalse(entryBytes.ToArray().AsSpan().StartsWith(Encoding.UTF8.Preamble),
+                $"{name} should not start with a UTF-8 byte order mark");
+        }
+    }
+
+    [TestMethod]
     public async Task CreatePackage_EmbedsMetadataIFiction()
     {
         var gameDataProvider = new FileGameDataProvider("savetest.aslx");


### PR DESCRIPTION
Published `.quest` packages wrote their `game.aslx` entry with a UTF-8 byte order mark, via `new StreamWriter(entryStream, Encoding.UTF8)`. That's a classic .NET gotcha: the static `Encoding.UTF8` emits a BOM when a writer uses it, whereas `StreamWriter`'s own default UTF-8 doesn't. The `metadata.iFiction` entry written a few lines later already used `new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)`, so this was inconsistent rather than intentional.

`game.aslx` now uses the same BOM-less encoding. That's also consistent with everything else Quest Viva writes: editor saves and save games are serialised to a string and encoded without a BOM. The BOMs still found in older `.aslx` files came from Quest 5's desktop editor.

Package readers are unaffected: Quest Viva's package loader, Quest 5, and `GameQuery` all read `game.aslx` with XML readers that detect UTF-8 with or without a BOM.

## Test plan
- [x] New `PackagerTests.CreatePackage_WritesEntriesWithoutByteOrderMark` checks neither `game.aslx` nor `metadata.iFiction` starts with a BOM. Before the fix it failed with "game.aslx should not start with a UTF-8 byte order mark"; it passes after.
- [x] Existing `CreatePackage_RoundTripsGameAndAssets` still reloads the published package
- [x] `dotnet build --configuration Release`: clean; `dotnet test --configuration Release`: all 404 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
