### PR TITLE
fix(Engine): share one Random per WorldModel across all expressions

### DIFF
--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -21,7 +21,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
     public NcalcExpressionEvaluator(string expression, ScriptContext scriptContext)
     {
         _scriptContext = scriptContext;
-        _expressionOwner = new ExpressionOwner(scriptContext.WorldModel);
+        _expressionOwner = scriptContext.WorldModel.ExpressionOwner;
         _expression = Utility.ResolveElementName(expression);
 
         _nCalcExpression = new Expression(expression,

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -722,6 +722,27 @@ public class ExpressionTests
     }
 
     [TestMethod]
+    public async Task TestRandomFunctionsDrawFromWorldModelRandom()
+    {
+        // Every expression used to construct its own ExpressionOwner, each with its own unseeded
+        // Random, so reseeding the WorldModel's (as the quest-e2e-tests harness does to make
+        // transcripts reproducible) never reached GetRandomInt in game scripts. Separate
+        // expressions must share one sequence.
+        const int seed = 1234;
+        typeof(ExpressionOwner)
+            .GetField("_random", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(_worldModel.ExpressionOwner, new Random(seed));
+
+        var reference = new Random(seed);
+        for (var i = 0; i < 3; i++)
+        {
+            (await RunExpression<int>("GetRandomInt(1, 1000000)")).ShouldBe(reference.Next(1, 1000001));
+        }
+
+        (await RunExpressionGeneric("GetRandomDouble()")).ShouldBe(reference.NextDouble());
+    }
+
+    [TestMethod]
     public async Task TestStringEqualToObjectReturnsFalse()
     {
         // Cross-type equality (string vs Element) must return false, not throw IConvertible.


### PR DESCRIPTION
`NcalcExpressionEvaluator`'s constructor created a new `ExpressionOwner` for every expression, and each one had its own unseeded `Random`. So `GetRandomInt`/`GetRandomDouble` in game scripts never used the `Random` on `WorldModel.ExpressionOwner`.

For real play that makes no difference, since each `Random` was unseeded anyway. It does break anything that reseeds the WorldModel's `Random` to get reproducible runs. The quest-e2e-tests harness does exactly that, so 15 of its 58 games gave a different transcript on every run. That was blamed on async continuations running in a different order, but the engine never actually yields to another thread, so the unseeded `Random`s were the real cause.

Evaluators now use `scriptContext.WorldModel.ExpressionOwner`, which also saves an `ExpressionOwner` + `Random` allocation per expression. `ExpressionOwner` holds no other per-instance state, and `WorldModel`'s constructor assigns it before anything else.

## Test plan
- [x] New `ExpressionTests.TestRandomFunctionsDrawFromWorldModelRandom` seeds the WorldModel's `Random` and checks that separate expressions follow the same sequence. It fails before the fix and passes after.
- [x] `dotnet build --configuration Release`: clean. `dotnet test --configuration Release`: all tests pass.
- [x] quest-e2e-tests: three full-corpus runs with this change gave byte-identical transcripts for all 58 games. The only games that changed from the committed goldens were exactly the 15 previously non-deterministic ones. Those goldens will be re-recorded in that repo after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
