### PR TITLE
fix(WasmPlayer): don't stop accepting commands when a UI call throws

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -422,6 +422,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-getcssrule-fallback.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-ui-call-throws.mjs http://localhost:5175
+        working-directory: tests/e2e
 
   # WebPlayer (ASP.NET Core + Blazor Server), Development mode with Dev:Enabled
   # (appsettings.Development.json already sets this — see /dev/open's

--- a/src/PlayerCore/Resources/playercore.js
+++ b/src/PlayerCore/Resources/playercore.js
@@ -809,7 +809,11 @@ function setBackground(col) {
     colNameToHex = colourNameToHex(col);
     if (colNameToHex) col = colNameToHex;
     rgbCol = hexToRgb(col);
-    var cssBackground = "rgba(" + rgbCol.r + "," + rgbCol.g + "," + rgbCol.b + "," + _backgroundOpacity + ")";
+    /* Anything else CSS understands (rgb(...), a name missing from the table) can't take the
+       opacity, but should still apply rather than throw */
+    var cssBackground = rgbCol
+        ? "rgba(" + rgbCol.r + "," + rgbCol.g + "," + rgbCol.b + "," + _backgroundOpacity + ")"
+        : col;
     $("#gameBorder").css("background-color", cssBackground);
     $("#gamePanel").css("background-color", col);
     $("#gridPanel").css("background-color", col);
@@ -1537,6 +1541,7 @@ function colourNameToHex(colour) {
         "darkcyan": "#008b8b",
         "darkgoldenrod": "#b8860b",
         "darkgray": "#a9a9a9",
+        "darkgrey": "#a9a9a9",
         "darkgreen": "#006400",
         "darkkhaki": "#bdb76b",
         "darkmagenta": "#8b008b",
@@ -1548,11 +1553,13 @@ function colourNameToHex(colour) {
         "darkseagreen": "#8fbc8f",
         "darkslateblue": "#483d8b",
         "darkslategray": "#2f4f4f",
+        "darkslategrey": "#2f4f4f",
         "darkturquoise": "#00ced1",
         "darkviolet": "#9400d3",
         "deeppink": "#ff1493",
         "deepskyblue": "#00bfff",
         "dimgray": "#696969",
+        "dimgrey": "#696969",
         "dodgerblue": "#1e90ff",
         "firebrick": "#b22222",
         "floralwhite": "#fffaf0",
@@ -1563,6 +1570,7 @@ function colourNameToHex(colour) {
         "gold": "#ffd700",
         "goldenrod": "#daa520",
         "gray": "#808080",
+        "grey": "#808080",
         "green": "#008000",
         "greenyellow": "#adff2f",
         "honeydew": "#f0fff0",
@@ -1579,6 +1587,7 @@ function colourNameToHex(colour) {
         "lightcoral": "#f08080",
         "lightcyan": "#e0ffff",
         "lightgoldenrodyellow": "#fafad2",
+        "lightgray": "#d3d3d3",
         "lightgrey": "#d3d3d3",
         "lightgreen": "#90ee90",
         "lightpink": "#ffb6c1",
@@ -1586,6 +1595,7 @@ function colourNameToHex(colour) {
         "lightseagreen": "#20b2aa",
         "lightskyblue": "#87cefa",
         "lightslategray": "#778899",
+        "lightslategrey": "#778899",
         "lightsteelblue": "#b0c4de",
         "lightyellow": "#ffffe0",
         "lime": "#00ff00",
@@ -1638,6 +1648,7 @@ function colourNameToHex(colour) {
         "skyblue": "#87ceeb",
         "slateblue": "#6a5acd",
         "slategray": "#708090",
+        "slategrey": "#708090",
         "snow": "#fffafa",
         "springgreen": "#00ff7f",
         "steelblue": "#4682b4",

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -591,8 +591,22 @@ public partial class WasmPlayerBridge
             var actions = _uiBuffer.ToArray();
             _uiBuffer.Clear();
 
+            // Isolate each call, matching WebPlayer's runJs and Quest 5's one-call-at-a-time JS
+            // bridge: a single throwing UI function (e.g. setBackground given a colour name
+            // playercore.js doesn't know) must not skip every call queued after it - including
+            // the turn's scroll and timer request - which leaves the session unable to accept
+            // another command, with the exception lost inside a fire-and-forget turn task.
             foreach (var action in actions)
-                action();
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    JsConsoleError(ex.Message);
+                }
+            }
 
             if (_pendingTimerTick.HasValue)
             {

--- a/tests/e2e/fixtures/ui-call-throws-test.aslx
+++ b/tests/e2e/fixtures/ui-call-throws-test.aslx
@@ -1,0 +1,53 @@
+<asl version="580">
+
+  <include ref="English.aslx"/>
+  <include ref="Core.aslx"/>
+
+  <game name="UiCallThrowsTest">
+  </game>
+
+  <object name="room">
+    <inherit name="editor_room" />
+    <object name="player">
+      <inherit name="defaultplayer" />
+    </object>
+  </object>
+
+  <!-- Games saved with Quest 5.6-era Core carry an inlined SetBackgroundColour that uses
+       `request (Background, ...)` - IPlayer.SetBackground, WasmPlayer's typed setBackground
+       import - rather than today's JS.setBackground, which goes through the try/catch-wrapped
+       runScript. Xanadu - In the Compound - Revenge calls it with "LightGray". -->
+  <command name="lightgray">
+    <pattern>lightgray</pattern>
+    <script>
+      msg ("Background is now light gray.")
+      request (Background, "LightGray")
+    </script>
+  </command>
+
+  <command name="rgbbackground">
+    <pattern>rgbbackground</pattern>
+    <script>
+      msg ("Background is now rgb.")
+      request (Background, "rgb(10, 20, 30)")
+    </script>
+  </command>
+
+  <!-- A UI function that genuinely throws, independent of playercore.js's colour handling. -->
+  <command name="throwui">
+    <pattern>throwui</pattern>
+    <script>
+      JS.eval ("window.setBackground = function () { throw new Error('ui-call-throws-test'); };")
+      msg ("Still accepting commands after a throwing UI call.")
+      request (Background, "white")
+    </script>
+  </command>
+
+  <command name="ping">
+    <pattern>ping</pattern>
+    <script>
+      msg ("pong")
+    </script>
+  </command>
+
+</asl>

--- a/tests/e2e/verify-wasmplayer-ui-call-throws.mjs
+++ b/tests/e2e/verify-wasmplayer-ui-call-throws.mjs
@@ -1,0 +1,76 @@
+// Regression check for a user report against Xanadu - In the Compound - Revenge: after
+// `focus on light`, WasmPlayer printed the response but never scrolled, and wouldn't accept
+// another command - with nothing in the console.
+//
+// The game's inlined (Quest 5.6-era) SetBackgroundColour calls `request (Background,
+// "LightGray")`. playercore.js's colourNameToHex table only had "lightgrey", so hexToRgb
+// returned null and setBackground threw dereferencing it. Quest 5 threw too, but ran each JS
+// call on its own so nothing else was affected; WebPlayer's runJs wraps each call in
+// try/catch. WasmPlayerBridge.FlushBuffer ran the whole buffered turn in one unguarded loop,
+// so the throw skipped every UI call queued after it (scroll, timer request) and escaped into
+// the fire-and-forget turn task, where it was silently dropped.
+//
+// Covers both fixes: the missing CSS grey/gray spellings (plus a non-hex colour falling back
+// to the raw CSS value), and FlushBuffer isolating a UI function that genuinely throws.
+//
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+let browser;
+try {
+    browser = await chromium.launch();
+    const page = await browser.newPage();
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+        if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => consoleErrors.push(String(err)));
+
+    async function sendCommand(command, expectedText) {
+        await page.waitForFunction(() => window.canSendCommand === true, null, { timeout: 10000 })
+            .catch(() => { throw new Error(`can't send "${command}": player never became ready for a command`); });
+        await page.fill('#txtCommand', command);
+        await page.press('#txtCommand', 'Enter');
+        await page.waitForFunction(
+            (text) => document.querySelector('#divOutput').textContent.includes(text),
+            expectedText, { timeout: 10000 })
+            .catch(() => { throw new Error(`"${command}": output never showed "${expectedText}"`); });
+        console.log(`PASS: ${command} -> "${expectedText}"`);
+    }
+
+    const gameBorderBackground = () =>
+        page.$eval('#gameBorder', (el) => getComputedStyle(el).backgroundColor);
+
+    await page.goto(`${baseUrl}/?url=/e2e-fixtures/ui-call-throws-test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000, state: 'attached' });
+
+    await sendCommand('lightgray', 'Background is now light gray.');
+    await sendCommand('ping', 'pong');
+    const lightGray = await gameBorderBackground();
+    if (lightGray !== 'rgb(211, 211, 211)') {
+        throw new Error(`LightGray not applied to #gameBorder: got ${lightGray}`);
+    }
+    console.log(`PASS: LightGray applied (${lightGray})`);
+
+    await sendCommand('rgbbackground', 'Background is now rgb.');
+    const rgb = await gameBorderBackground();
+    if (rgb !== 'rgb(10, 20, 30)') {
+        throw new Error(`rgb() background not applied to #gameBorder: got ${rgb}`);
+    }
+    console.log(`PASS: rgb() background applied (${rgb})`);
+
+    const errorsBeforeThrow = consoleErrors.length;
+    await sendCommand('throwui', 'Still accepting commands after a throwing UI call.');
+    await sendCommand('ping', 'pong');
+    if (!consoleErrors.slice(errorsBeforeThrow).some((e) => e.includes('ui-call-throws-test'))) {
+        throw new Error(`throwing UI call wasn't reported to the console: ${JSON.stringify(consoleErrors)}`);
+    }
+    console.log('PASS: throwing UI call reported via console.error');
+} catch (e) {
+    console.error('FAIL:', e.message);
+    process.exitCode = 1;
+} finally {
+    await browser?.close();
+}


### PR DESCRIPTION
A user reported that XanMag's *Xanadu - In the Compound - Revenge* hangs on play.questviva.com after `focus on light`. The response text prints, but the output doesn't scroll, no further commands are accepted, and the console shows no error. The same game works in Quest 5.8.

## Cause
That object's focus script calls `SetBackgroundColour("LightGray")`. The game's inlined Quest 5.6-era Core implements it as `request (Background, colour)`, which reaches WasmPlayer's typed `setBackground` import. Today's `JS.setBackground` goes through the try/catch-wrapped `runScript` instead.

- **Why it throws:** `playercore.js`'s `colourNameToHex` table had `lightgrey` but not `lightgray`. So `hexToRgb` returned `null` and `setBackground` threw on `rgbCol.r`. Quest 5's copy throws the same way.
- **Why Quest 5 was fine:** it ran each JS call separately, so only the background change failed. WebPlayer's `runJs` wraps each script in try/catch.
- **Why WasmPlayer hangs:** `WasmPlayerBridge.FlushBuffer` ran all of a turn's buffered UI calls in one unguarded loop. The throw skipped every call queued after it, including the scroll and timer request, and escaped into the fire-and-forget turn task, where it was silently dropped.

## Changes
- **`WasmPlayerBridge.FlushBuffer`:** runs each buffered call in its own try/catch and reports failures via `console.error`, matching WebPlayer. One bad UI call can no longer stop the game accepting commands.
- **`playercore.js` colour table:** adds the CSS spellings it was missing: `lightgray`, `grey`, `darkgrey`, `dimgrey`, `darkslategrey`, `lightslategrey`, `slategrey`.
- **`setBackground`:** applies a colour `hexToRgb` can't parse (e.g. `rgb(...)`) as the raw CSS value instead of throwing. That value just doesn't take `_backgroundOpacity`.

One visible change: Xanadu's background now actually turns light gray at that point. In Quest 5 the throw meant it never did.

## Test plan
- [x] New `tests/e2e/verify-wasmplayer-ui-call-throws.mjs` with a synthetic fixture:
  - **`request (Background, "LightGray")`:** applies `rgb(211, 211, 211)` and the next command still works.
  - **`rgb(...)` background:** applied.
  - **A UI function that genuinely throws:** reported to the console, and the game still accepts commands.
- [x] Against a build without the fix, the script fails the way the user described: the text prints, then `ping` can't be sent. With the fix, all 8 checks pass.
- [x] The real game, loaded by id in a local WasmPlayer, plays the reporter's exact sequence (`z` ×4, `scratch itch`, `smell blood`, `focus on pennies`, `focus on light`, `focus on pitter`) with no console errors.
- [x] `dotnet build src/WasmPlayer/WasmPlayer.csproj`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
