### PR TITLE
chore: flag e2e scripts not yet wired into e2e.yml as soon as they're written

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; case \"$f\" in */tests/e2e/verify-*.mjs) out=$(node \"${f%/tests/e2e/*}/tests/e2e/check-workflow-manifest.mjs\" 2>&1) || { printf '%s\\n' \"$out\" >&2; exit 2; };; esac; }",
+            "statusMessage": "Checking e2e.yml wiring"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: verify
-description: How to runtime-verify changes in this repo (WasmPlayer/WebPlayer/AppShell/ElectronApp) via Playwright, no automated verify harness exists yet
+description: How to runtime-verify changes in this repo (WasmPlayer/WebPlayer/AppShell/ElectronApp) via Playwright scripts in tests/e2e, and wire new ones into the nightly e2e workflow
 ---
 
 # Verifying changes in Quest Viva
 
-No CI-integrated e2e suite. `tests/e2e/*.mjs` is a growing set of ad-hoc,
-hand-run Playwright scripts (`quest-e2e` package, `playwright` installed
-there) — one file per bug/feature, run directly with `node`, not via `npm
-test`. Follow that convention: write a new `verify-<topic>.mjs` there, run it
-with `node verify-<topic>.mjs`, leave it checked in for future regression
-reruns.
+`tests/e2e/verify-*.mjs` is a growing set of Playwright scripts (`quest-e2e`
+package, `playwright` installed there): one file per bug/feature, run directly
+with `node`, not via `npm test`. Follow that convention: write a new
+`verify-<topic>.mjs` there, run it with `node verify-<topic>.mjs`, and leave
+it checked in.
+
+**Every new script must also get a step in `.github/workflows/e2e.yml`**, in
+the job whose dev server it needs (`wasmplayer_chromium`, `appshell_chromium`,
+`webplayer_chromium`, `electron`, ...), copying a neighbouring step's `node
+verify-<topic>.mjs <baseUrl>` + `working-directory: tests/e2e` shape. The
+nightly run only runs listed scripts, and the required `check_e2e_manifest` PR
+check (`node tests/e2e/check-workflow-manifest.mjs`) fails otherwise. A
+`PostToolUse` hook in `.claude/settings.json` runs that check whenever you
+write a `verify-*.mjs` file, so its "Not wired into e2e.yml" message right
+after creating a script is expected: add the step, don't ignore it.
 
 ## Browser surface (WasmPlayer / WebPlayer / AppShell)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Tests use MSTest with Moq (mocking) and Shouldly (assertions).
 
 Playwright scripts (`verify-*.mjs`) exercise AppShell/WasmPlayer/WebPlayer/Electron end-to-end against a running dev server.
 
+- **Wire every new script into `.github/workflows/e2e.yml`** in the same commit that adds it: a `node verify-<topic>.mjs <baseUrl>` step in the job whose dev server it needs (e.g. `wasmplayer_chromium` for a WasmPlayer script). The nightly run only runs scripts listed there, and `check_e2e_manifest` (`tests/e2e/check-workflow-manifest.mjs`, a required check on every PR) fails the PR if one is missing. A `PostToolUse` hook in `.claude/settings.json` runs that check whenever a `verify-*.mjs` file is written, so an unwired script is flagged as soon as it's created.
 - **Assert for real.** Wrap steps in a `try`/`catch`/`finally`, `throw new Error(...)` on any mismatch, and set `process.exitCode = 1` in the `catch` — matching the ~55 existing scripts' convention. A script that only `console.log`s the actual value next to an "(expect X)" comment never compares them, so a regression prints PASS-shaped output and the script still exits 0.
 - Install any tooling a script needs (e.g. Playwright) inside this repo, never by borrowing a sibling repo's `node_modules`.
 - A stale DOM-shape assumption (e.g. a locator matching `input[type=text]` when a control was later changed to a `<textarea>`) is a common, easy-to-miss cause of a previously-passing script suddenly failing after an unrelated UI PR — check what UI changed before assuming a real regression.


### PR DESCRIPTION
New `tests/e2e/verify-*.mjs` scripts keep landing without a step in `.github/workflows/e2e.yml`. The required `check_e2e_manifest` PR check catches it, but only after CI runs, and each time it takes a follow-up "wire X into e2e.yml" commit (about ten so far, most recently on #2272).

The project's own `verify` skill made this more likely. It's the guidance Claude Code loads when writing a new script, and it still said "No CI-integrated e2e suite" and called the scripts "hand-run".

## Changes
- **`.claude/skills/verify/SKILL.md`:** replaces that stale intro. It now says every new script needs a `node verify-<topic>.mjs <baseUrl>` step in `e2e.yml`, and which job to add it to.
- **`CLAUDE.md`:** the same rule, as the first bullet under "e2e tests".
- **`.claude/settings.json`** (new, checked in): a `PostToolUse` hook on `Write|Edit`.
  - When the edited file is a `tests/e2e/verify-*.mjs`, it runs `check-workflow-manifest.mjs`.
  - If that check fails, its "Not wired into e2e.yml" output goes straight back to Claude, so the missing step is flagged the moment the script is created.
  - It finds the repo root from the edited file's own path, so it also works in worktrees.
  - It needs `jq`.

The hook only covers files Claude Code writes. The existing `check_e2e_manifest` PR check still covers everything else.

## Test plan
- [x] Hook command, fed the same JSON a Write/Edit would send it:
  - **new unlisted `verify-*.mjs`:** exits 2 with the "Not wired" message;
  - **already-listed script:** exits 0;
  - **unrelated file:** exits 0.
- [x] `jq -e` confirms the settings file parses and the hook is under `PostToolUse` / `Write|Edit`.
- [x] Live: writing a throwaway `tests/e2e/verify-zz-hook-probe.mjs` in a Claude Code session triggered the hook, and the "Not wired into e2e.yml" message came back to the model. The probe file was then deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
