### PR TITLE
chore: remove unused UIOption font/colour override plumbing

### DIFF
--- a/examples/blank.aslx
+++ b/examples/blank.aslx
@@ -3287,32 +3287,17 @@
   ]]></function>
   <function name="GetCurrentTextFormat" parameters="colour" type="string"><![CDATA[
     style = ""
-    if (UIOptionUseGameFont()) {
-      font = GetCurrentFontFamily()
-    }
-    else {
-      font = GetUIOption("OverrideFontName")
-    }
+    font = GetCurrentFontFamily()
     if (LengthOf(font) > 0) {
       style = style + "font-family:" + font + ";"
     }
     if (LengthOf(colour) = 0) {
-      if (UIOptionUseGameColours()) {
-        colour = game.defaultforeground
-      }
-      else {
-        colour = GetUIOption("OverrideForeground")
-      }
+      colour = game.defaultforeground
     }
     if (LengthOf(colour) > 0) {
       style = style + "color:" + colour + ";"
     }
-    if (UIOptionUseGameFont()) {
-      size = game.defaultfontsize
-    }
-    else {
-      size = ToDouble(GetUIOption("OverrideFontSize"))
-    }
+    size = game.defaultfontsize
     if (size > 0) {
       style = style + "font-size:" + ToString(size) + "pt;"
     }
@@ -3321,31 +3306,8 @@
   <function name="GetCurrentLinkTextFormat" type="string">
     return (GetCurrentTextFormat(GetLinkTextColour()))
   </function>
-  <function name="UIOptionUseGameFont" type="boolean">
-    value = GetUIOption("UseGameFont")
-    if (value = null or value = "true") {
-      return (true)
-    }
-    else {
-      return (false)
-    }
-  </function>
-  <function name="UIOptionUseGameColours" type="boolean">
-    value = GetUIOption("UseGameColours")
-    if (value = null or value = "true") {
-      return (true)
-    }
-    else {
-      return (false)
-    }
-  </function>
   <function name="GetLinkTextColour" type="string">
-    if (UIOptionUseGameColours()) {
-      return (game.defaultlinkforeground)
-    }
-    else {
-      return (GetUIOption("OverrideLinkForeground"))
-    }
+    return (game.defaultlinkforeground)
   </function>
   <function name="ProcessTextSection" parameters="text, data" type="string"><![CDATA[
     containsUnprocessedSection = false
@@ -3477,7 +3439,7 @@
       if (game.enablehyperlinks) {
         linkid = ProcessTextCommand_GetNextLinkId()
         colour = ""
-        if (HasString(object, "linkcolour") and GetUIOption("UseGameColours") = "true") {
+        if (HasString(object, "linkcolour")) {
           colour = object.linkcolour
         }
         else {

--- a/examples/gamebook.aslx
+++ b/examples/gamebook.aslx
@@ -102,32 +102,17 @@
   ]]></function>
   <function name="GetCurrentTextFormat" parameters="colour" type="string"><![CDATA[
     style = ""
-    if (UIOptionUseGameFont()) {
-      font = GetCurrentFontFamily()
-    }
-    else {
-      font = GetUIOption("OverrideFontName")
-    }
+    font = GetCurrentFontFamily()
     if (LengthOf(font) > 0) {
       style = style + "font-family:" + font + ";"
     }
     if (LengthOf(colour) = 0) {
-      if (UIOptionUseGameColours()) {
-        colour = game.defaultforeground
-      }
-      else {
-        colour = GetUIOption("OverrideForeground")
-      }
+      colour = game.defaultforeground
     }
     if (LengthOf(colour) > 0) {
       style = style + "color:" + colour + ";"
     }
-    if (UIOptionUseGameFont()) {
-      size = game.defaultfontsize
-    }
-    else {
-      size = ToDouble(GetUIOption("OverrideFontSize"))
-    }
+    size = game.defaultfontsize
     if (size > 0) {
       style = style + "font-size:" + ToString(size) + "pt;"
     }
@@ -136,31 +121,8 @@
   <function name="GetCurrentLinkTextFormat" type="string">
     return (GetCurrentTextFormat(GetLinkTextColour()))
   </function>
-  <function name="UIOptionUseGameFont" type="boolean">
-    value = GetUIOption("UseGameFont")
-    if (value = null or value = "true") {
-      return (true)
-    }
-    else {
-      return (false)
-    }
-  </function>
-  <function name="UIOptionUseGameColours" type="boolean">
-    value = GetUIOption("UseGameColours")
-    if (value = null or value = "true") {
-      return (true)
-    }
-    else {
-      return (false)
-    }
-  </function>
   <function name="GetLinkTextColour" type="string">
-    if (UIOptionUseGameColours()) {
-      return (game.defaultlinkforeground)
-    }
-    else {
-      return (GetUIOption("OverrideLinkForeground"))
-    }
+    return (game.defaultlinkforeground)
   </function>
   <function name="ProcessTextSection" parameters="text, data" type="string"><![CDATA[
     containsUnprocessedSection = false
@@ -292,7 +254,7 @@
       if (game.enablehyperlinks) {
         linkid = ProcessTextCommand_GetNextLinkId()
         colour = ""
-        if (HasString(object, "linkcolour") and GetUIOption("UseGameColours") = "true") {
+        if (HasString(object, "linkcolour")) {
           colour = object.linkcolour
         }
         else {

--- a/site/src/content/docs/reference/functions/internal-core.md
+++ b/site/src/content/docs/reference/functions/internal-core.md
@@ -858,16 +858,6 @@ Does not return a value.
 Tsplit(splittext)
 ```
 
-## UIOptionUseGameColours
-```quest
-UIOptionUseGameColours()
-```
-
-## UIOptionUseGameFont
-```quest
-UIOptionUseGameFont()
-```
-
 ## UnescapeQuotes
 ```quest
 UnescapeQuotes(s)

--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -79,7 +79,6 @@ public interface IPlayer
     void SetInterfaceString(string name, string text);
     void SetPanelContents(string html);
     void Log(string text);
-    string? GetUIOption(UIOption option);
     void SetTurnPending(bool pending);
 }
 
@@ -89,16 +88,6 @@ public enum ListType
     ExitsList,
     ObjectsList,
     ElementMenuVerbs
-}
-
-public enum UIOption
-{
-    UseGameColours,
-    UseGameFont,
-    OverrideForeground,
-    OverrideLinkForeground,
-    OverrideFontName,
-    OverrideFontSize
 }
 
 public class MenuData

--- a/src/Engine/Core/CoreFunctions.aslx
+++ b/src/Engine/Core/CoreFunctions.aslx
@@ -208,7 +208,7 @@
           optionText = GetDisplayAlias(option)
           optiontag = option.name
           colour = ""
-          if (HasString(option, "linkcolour") and GetUIOption("UseGameColours") = "true") {
+          if (HasString(option, "linkcolour")) {
             colour = option.linkcolour
           }
           else {

--- a/src/Engine/Core/CoreOutput.aslx
+++ b/src/Engine/Core/CoreOutput.aslx
@@ -42,35 +42,19 @@
   <function name="GetCurrentTextFormat" type="string" parameters="colour">
     style = ""
 
-    if (UIOptionUseGameFont()) {
-      font = GetCurrentFontFamily()
-    }
-    else {
-      font = GetUIOption("OverrideFontName")
-    }
-
+    font = GetCurrentFontFamily()
     if (LengthOf(font) > 0) {
       style = style + "font-family:" + font + ";"
     }
 
     if (LengthOf(colour) = 0) {
-      if (UIOptionUseGameColours()) {
-        colour = game.defaultforeground
-      }
-      else {
-        colour = GetUIOption("OverrideForeground")
-      }
+      colour = game.defaultforeground
     }
     if (LengthOf(colour) > 0) {
       style = style + "color:" + colour + ";"
     }
 
-    if (UIOptionUseGameFont()) {
-      size = game.defaultfontsize
-    }
-    else {
-      size = ToDouble(GetUIOption("OverrideFontSize"))
-    }
+    size = game.defaultfontsize
     if (size > 0) {
       style = style + "font-size:" + ToString(size) + "pt;"
     }
@@ -80,26 +64,6 @@
 
   <function name="GetCurrentLinkTextFormat" type="string">
     return (GetCurrentTextFormat(GetLinkTextColour()))
-  </function>
-
-  <function name="UIOptionUseGameFont" type="boolean">
-    value = GetUIOption("UseGameFont")
-    if (value = null or value = "true") {
-      return (true)
-    }
-    else {
-      return (false)
-    }
-  </function>
-
-  <function name="UIOptionUseGameColours" type="boolean">
-    value = GetUIOption("UseGameColours")
-    if (value = null or value = "true") {
-      return (true)
-    }
-    else {
-      return (false)
-    }
   </function>
 
   <function name="ParamsForTextProcessor" type="dictionary">
@@ -136,12 +100,7 @@
   </function>
 
   <function name="GetLinkTextColour" type="string">
-    if (UIOptionUseGameColours()) {
-      return (game.defaultlinkforeground)
-    }
-    else {
-      return (GetUIOption("OverrideLinkForeground"))
-    }
+    return (game.defaultlinkforeground)
   </function>
 
   <function name="ProcessText" type="string" parameters="text">
@@ -549,7 +508,7 @@
         if (game.enablehyperlinks) {
           linkid = ProcessTextCommand_GetNextLinkId()
           colour = ""
-          if (HasString(object, "linkcolour") and GetUIOption("UseGameColours") = "true") {
+          if (HasString(object, "linkcolour")) {
             colour = object.linkcolour
           }
           else {

--- a/src/Engine/Core/GamebookCore.aslx
+++ b/src/Engine/Core/GamebookCore.aslx
@@ -452,7 +452,7 @@
           optionText = GetDisplayAlias(option)
           optiontag = option.name
           colour = ""
-          if (HasString(option, "linkcolour") and GetUIOption("UseGameColours") = "true") {
+          if (HasString(option, "linkcolour")) {
             colour = option.linkcolour
           }
           else {

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -865,11 +865,6 @@ internal class ExpressionOwner(WorldModel worldModel)
     public string? GetUiOption(string? optionName)
     {
         ArgumentNullException.ThrowIfNull(optionName);
-        if (Enum.TryParse(optionName, out UIOption option))
-        {
-            return worldModel.PlayerUi.GetUIOption(option);
-        }
-
-        throw new Exception($"Unrecognised UI option name '{optionName}'");
+        return optionName is "UseGameFont" or "UseGameColours" ? "true" : null;
     }
 }

--- a/src/PlayerCore/GameQuery.cs
+++ b/src/PlayerCore/GameQuery.cs
@@ -390,11 +390,6 @@ public class GameQuery(string filename, byte[]? bytes = null)
         {
         }
 
-        public string? GetUIOption(UIOption option)
-        {
-            return null;
-        }
-
         public void SetTurnPending(bool pending)
         {
         }

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -871,9 +871,6 @@ public partial class WasmPlayerBridge
 
         void IPlayer.Log(string text) => JsConsoleLog(text);
 
-        string? IPlayer.GetUIOption(UIOption option) =>
-            option is UIOption.UseGameColours or UIOption.UseGameFont ? "true" : null;
-
         void IPlayer.SetTurnPending(bool pending) =>
             _uiBuffer.Add(() => JsSetTurnPending(pending));
     }

--- a/src/WebPlayer/Player.cs
+++ b/src/WebPlayer/Player.cs
@@ -274,16 +274,6 @@ public class Player : IPlayerHelperUI
         AddJavaScriptToBuffer("console.log", text);
     }
 
-    string? IPlayer.GetUIOption(UIOption option)
-    {
-        if (option == UIOption.UseGameColours || option == UIOption.UseGameFont)
-        {
-            return "true";
-        }
-
-        return null;
-    }
-
     void IPlayer.SetTurnPending(bool pending)
     {
         AddJavaScriptToBuffer("setTurnPending", pending);

--- a/tests/LegacyTests/TestPlayer.cs
+++ b/tests/LegacyTests/TestPlayer.cs
@@ -159,11 +159,6 @@ internal class TestPlayer : IPlayer
     {
     }
 
-    public string? GetUIOption(UIOption option)
-    {
-        return null;
-    }
-
     public void SetTurnPending(bool pending)
     {
     }


### PR DESCRIPTION
## Summary
- `IPlayer.GetUIOption` and the `UIOption` enum existed to support Quest 5 desktop's Options window, which let a player override a game's font/colour. Neither WebPlayer nor WasmPlayer exposes that UI; both hardcoded `GetUIOption` to always report "use the game's own colours/font", so the four `Override*` values and the Core.aslx branches that read them were permanently unreachable.
- Removed the `UIOption` enum and `IPlayer.GetUIOption` (and its four implementations) entirely, and simplified the now-unconditional `GetCurrentTextFormat`/`GetLinkTextColour`/`linkcolour` logic in `CoreOutput.aslx`, `CoreFunctions.aslx`, `GamebookCore.aslx`, and the two example game templates.
- The built-in `GetUiOption` script function in `ExpressionOwner.cs` stays — it isn't inlined per-game like Core.aslx, so already-published games' frozen Core.aslx snapshots still call it on every text/link render — but it now just hardcodes the same `UseGameFont`/`UseGameColours` → `"true"` answer directly instead of round-tripping through `IPlayer`. Backward-compatible: same answers as before for every option name.

## Test plan
- [x] `dotnet build --configuration Release`
- [x] `dotnet test --configuration Release` (all 5 test projects pass)
- [x] Verified no remaining references to `UIOption`/`GetUIOption` anywhere in `src`/`tests`/`examples`