### PR TITLE
fix(WasmPlayer): fix Windows argv-quoting bug breaking Electron release build

### DIFF
--- a/src/WasmPlayer/WasmPlayer.csproj
+++ b/src/WasmPlayer/WasmPlayer.csproj
@@ -59,7 +59,11 @@
         <Copy SourceFiles="@(_ImageAssets)" DestinationFolder="$(WasmAppDir)lib\images\"/>
         <Copy SourceFiles="@(_TranscriptViewerAssets)" DestinationFolder="$(WasmAppDir)TranscriptViewer\"/>
         <!-- Manifest of every non-_framework file for AppShell's zip HTML export —
-             keeps that list from drifting when assets are added/removed above. -->
-        <Exec Command="node scripts/write-export-manifest.mjs &quot;$(WasmAppDir)&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)"/>
+             keeps that list from drifting when assets are added/removed above.
+             $(WasmAppDir) ends in a directory separator; trim it before quoting —
+             a quoted arg ending "\" is mis-parsed by Windows' argv escaping rules
+             (the backslash escapes the closing quote instead of terminating it),
+             which broke the windows-latest Electron build (Exec: ENOENT AppBundle"). -->
+        <Exec Command="node scripts/write-export-manifest.mjs &quot;$(WasmAppDir.TrimEnd('\').TrimEnd('/'))&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)"/>
     </Target>
 </Project>


### PR DESCRIPTION
## Summary
- `v6.0.0-beta.60`'s `electron-publish` failed on every `windows-latest` matrix leg with `Exec: ENOENT ... AppBundle"` (see run [34647475730](https://github.com/textadventures/quest/actions/runs/34647475730))
- Cause: `$(WasmAppDir)` ends in a trailing directory separator, so `&quot;$(WasmAppDir)&quot;` produced a command ending in `\"`. Windows' `CommandLineToArgvW` argv-escaping rules treat a lone backslash before a closing quote as an escaped literal quote rather than the string terminator, so the quote never closes and a literal `"` gets appended to the path handed to `write-export-manifest.mjs`
- Fix: trim the trailing separator off `$(WasmAppDir)` before quoting it, so the quoted arg can never end in a backslash
- This only manifests on `windows-latest` (macOS/Linux use `/` separators, which aren't affected) — this Exec step was added in #2236 and this is its first run against the `windows-latest` leg of `electron-publish`

## Test plan
- [x] `dotnet build --configuration Release src/WasmPlayer/WasmPlayer.csproj` locally — `write-export-manifest.mjs` runs and writes `export-manifest.json` (34 shell files) with no errors
- [ ] CI `build_and_test` passes
- [ ] Next `electron-publish` run succeeds on `windows-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)