### PR TITLE
chore: switch prerelease numbering from beta to rc

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "release-type": "simple",
       "version-file": "VERSION",
       "versioning": "prerelease",
-      "prerelease-type": "beta",
+      "prerelease-type": "rc",
       "prerelease": true
     }
   }


### PR DESCRIPTION
## Summary
- No more feature work is planned before 6.0.0 — what's left is a batch of null-ref/edge-case bug fixes filed 2026-09-10 (#2240-#2258), which is exactly what "rc" is meant to signal rather than "beta"
- Flips `prerelease-type` from `beta` to `rc` in `release-please-config.json`
- release-please's prerelease versioning strategy starts a fresh counter on a type change rather than continuing the old one, so the next release will be `6.0.0-rc.1` (not an attempt to continue from `.61`) — regardless of what merges next
- No other files touched; `VERSION`/`.release-please-manifest.json` are release-please-owned and will be updated by its own release PR as usual

## Test plan
- [ ] Merge and confirm release-please's next standing release PR proposes `6.0.0-rc.1` before merging that PR
- [ ] Confirm the resulting tag/release/changelog read as `6.0.0-rc.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)