### PR TITLE
fix: harden Engine/EditorCore against null-input edge cases found by nullable audit

### DIFF
--- a/src/AppShell/src/components/AddElementModal.svelte
+++ b/src/AppShell/src/components/AddElementModal.svelte
@@ -68,7 +68,7 @@
     let error = $state("");
 
     $effect(() => {
-        const result = name ? validateName(name) : "";
+        const result = name ? validateName(name, elementType) : "";
         error = result === "ok" ? "" : result;
     });
 
@@ -86,7 +86,7 @@
 
     function confirm() {
         if (!name || error) return;
-        const result = validateName(name);
+        const result = validateName(name, elementType);
         if (result !== "ok") { error = result; return; }
         const target = elementType === "function" ? folderTarget
             : (elementType === "object" || elementType === "room") && objectParentOptions.length > 0 ? objectParentTarget

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -1602,8 +1602,8 @@ function refreshTree() {
 
 // ── Element creation / deletion ─────────────────────────────────────────────
 
-export function validateName(name: string): string {
-    return _bridge?.ValidateName(name) ?? "error";
+export function validateName(name: string, elementType = ""): string {
+    return _bridge?.ValidateName(name, elementType) ?? "error";
 }
 
 export function getUniqueName(baseName: string): string {

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -91,7 +91,7 @@ export interface WasmBridge {
   ChangeAttributeType(elementKey: string, attribute: string, newType: string): string
   SetPatternAttribute(elementKey: string, attribute: string, pattern: string): string
   // Element creation / deletion
-  ValidateName(name: string): string
+  ValidateName(name: string, elementType: string): string
   GetUniqueName(baseName: string): string
   CreateRoom(name: string, parent: string): string
   CreateObject(name: string, parent: string): string

--- a/src/Engine/Expressions/NcalcExpressionEvaluator.cs
+++ b/src/Engine/Expressions/NcalcExpressionEvaluator.cs
@@ -327,7 +327,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
         {
             if (right is IDictionary dictionary)
             {
-                var contains = dictionary.Contains(left!);
+                var contains = left != null && dictionary.Contains(left);
                 args.Result = args.BinaryExpression.Type == BinaryExpressionType.In ? contains : !contains;
             }
 
@@ -531,7 +531,7 @@ public class NcalcExpressionEvaluator<T> : IExpressionEvaluator<T>, IDynamicExpr
                 throw new Exception("IsDefined function expects 1 parameter");
             if (await args.Parameters.EvaluateAsync(0) is not string variableName)
                 throw new Exception("IsDefined function expects a string parameter");
-            return _context.Parameters!.ContainsKey(variableName);
+            return _context.Parameters?.ContainsKey(variableName) == true;
         }
 
         return await RunQuestProcedureAsync(name, args.Parameters.Count,

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -741,7 +741,9 @@ internal class ExpressionOwner(WorldModel worldModel)
 
     private QuestList<T> ListCombine<T>(QuestList<T>? list1, QuestList<T>? list2)
     {
-        return list1 == null ? [.. list2 ?? []] : list1.MergeLists(list2!);
+        if (list1 == null) return [.. list2 ?? []];
+        if (list2 == null) return [.. list1];
+        return list1.MergeLists(list2);
     }
 
     public QuestList<string> ListExclude(QuestList<string>? list, string? str)

--- a/src/Engine/GameLoader/ElementLoaders.cs
+++ b/src/Engine/GameLoader/ElementLoaders.cs
@@ -332,7 +332,7 @@ internal partial class GameLoader
         public override object? Load(XmlReader reader, ref Element? current)
         {
             var filename = GameLoader.GetTemplateAttribute(reader, "ref");
-            if (filename!.Length == 0)
+            if (string.IsNullOrEmpty(filename))
             {
                 return null;
             }
@@ -729,7 +729,14 @@ internal partial class GameLoader
                 throw new Exception("Current element is not set");
             }
 
-            current.Fields.LazyFields.AddType(reader.GetAttribute("name")!);
+            var name = reader.GetAttribute("name");
+            if (string.IsNullOrEmpty(name))
+            {
+                RaiseError("Expected 'name' attribute in inherit");
+                return null;
+            }
+
+            current.Fields.LazyFields.AddType(name);
             return null;
         }
     }
@@ -869,7 +876,7 @@ internal partial class GameLoader
             var jsRef = WorldModel.GetElementFactory(ElementType.Javascript).Create();
             jsRef.Fields[FieldDefinitions.Anonymous] = true;
             var file = GameLoader.GetTemplateAttribute(reader, "src");
-            if (file!.Length == 0)
+            if (string.IsNullOrEmpty(file))
             {
                 return null;
             }

--- a/src/Engine/QuestDictionary.cs
+++ b/src/Engine/QuestDictionary.cs
@@ -105,7 +105,7 @@ public class QuestDictionary<T> : IDictionary<string, T>, IDictionary, IMutableF
 
     internal string SaveString()
     {
-        return SaveString(v => v!.ToString());
+        return SaveString(v => v?.ToString() ?? string.Empty);
     }
 
     internal string SaveString(Func<T, string?> converter)

--- a/src/Engine/QuestList.cs
+++ b/src/Engine/QuestList.cs
@@ -276,7 +276,7 @@ public sealed class QuestList<T> : IMutableField, IQuestList, IList<T>, ICollect
 
     public QuestList<T> Exclude(T element)
     {
-        var enumerable = this.Where(x => !x!.Equals(element));
+        var enumerable = this.Where(x => !Equals(x, element));
         return [.. enumerable];
     }
 

--- a/src/Engine/Scripts/AskScript.cs
+++ b/src/Engine/Scripts/AskScript.cs
@@ -8,10 +8,10 @@ public class AskScriptConstructor : IScriptConstructor
 
     public IScript Create(string script, ScriptContext scriptContext)
     {
-        var param = Utility.GetParameter(script, out var afterExpr);
+        var param = Utility.GetRequiredParameter(script, out var afterExpr);
         var callback = Utility.GetScript(afterExpr!);
 
-        var parameters = Utility.SplitParameter(param!).ToArray();
+        var parameters = Utility.SplitParameter(param).ToArray();
         if (parameters.Count() != 1)
         {
             throw new Exception($"'ask' script should have 1 parameter: 'ask ({param})'");

--- a/src/Engine/Scripts/DoScript.cs
+++ b/src/Engine/Scripts/DoScript.cs
@@ -64,7 +64,13 @@ public class DoActionScript : ScriptBase
     public override async Task ExecuteAsync(Context c)
     {
         var obj = await _obj.ExecuteAsync(c);
-        var action = obj.GetAction(await _action.ExecuteAsync(c))!;
+        var actionName = await _action.ExecuteAsync(c);
+        var action = obj.GetAction(actionName);
+        if (action == null)
+        {
+            throw new Exception($"'{obj.Name}' has no action called '{actionName}'");
+        }
+
         if (_parameters == null)
         {
             await _worldModel.RunScriptAsync(action, obj);

--- a/src/Engine/Scripts/ForEachScript.cs
+++ b/src/Engine/Scripts/ForEachScript.cs
@@ -10,10 +10,10 @@ public class ForEachScriptConstructor : IScriptConstructor
     public IScript Create(string script, ScriptContext scriptContext)
     {
         string? afterExpr;
-        var param = Utility.GetParameter(script, out afterExpr);
+        var param = Utility.GetRequiredParameter(script, out afterExpr);
         var loop = Utility.GetScript(afterExpr!);
 
-        var parameters = Utility.SplitParameter(param!).ToArray();
+        var parameters = Utility.SplitParameter(param).ToArray();
         if (parameters.Count() != 2)
         {
             throw new Exception(string.Format("'foreach' script should have 2 parameters: 'foreach ({0})'", param));

--- a/src/Engine/Scripts/ForScript.cs
+++ b/src/Engine/Scripts/ForScript.cs
@@ -11,10 +11,10 @@ public class ForScriptConstructor : IScriptConstructor
     public IScript Create(string script, ScriptContext scriptContext)
     {
         string? afterExpr;
-        var param = Utility.GetParameter(script, out afterExpr);
+        var param = Utility.GetRequiredParameter(script, out afterExpr);
         var loop = Utility.GetScript(afterExpr!);
 
-        var parameters = Utility.SplitParameter(param!).ToArray();
+        var parameters = Utility.SplitParameter(param).ToArray();
         var loopScript = ScriptFactory.CreateScript(loop);
 
         if (parameters.Count() == 3)

--- a/src/Engine/Scripts/IfScript.cs
+++ b/src/Engine/Scripts/IfScript.cs
@@ -61,7 +61,7 @@ public class IfScriptConstructor : IScriptConstructor
     public IScript Create(string script, ScriptContext scriptContext)
     {
         string? afterExpr;
-        var expr = Utility.GetParameter(script, out afterExpr);
+        var expr = Utility.GetRequiredParameter(script, out afterExpr);
 
         if (afterExpr!.StartsWith(")"))
         {
@@ -73,7 +73,7 @@ public class IfScriptConstructor : IScriptConstructor
 
         var thenScript = ScriptFactory.CreateScript(then, scriptContext);
 
-        return new IfScript(new Expression<bool>(expr!, scriptContext), thenScript, scriptContext);
+        return new IfScript(new Expression<bool>(expr, scriptContext), thenScript, scriptContext);
     }
 
     public IScriptFactory ScriptFactory { get; set; } = null!;

--- a/src/Engine/Scripts/ScriptConstructorBase.cs
+++ b/src/Engine/Scripts/ScriptConstructorBase.cs
@@ -23,19 +23,9 @@ public abstract class ScriptConstructorBase : IScriptConstructor
 
     public IScript? Create(string script, ScriptContext scriptContext)
     {
-        List<string>? parameters = null;
         var param = Utility.GetParameter(script);
-
-        int numParams;
-        if (param == null)
-        {
-            numParams = 0;
-        }
-        else
-        {
-            parameters = Utility.SplitParameter(param);
-            numParams = parameters.Count;
-        }
+        List<string> parameters = param == null ? [] : Utility.SplitParameter(param);
+        var numParams = parameters.Count;
 
         if (ExpectedParameters.Count() > 0)
         {
@@ -46,8 +36,7 @@ public abstract class ScriptConstructorBase : IScriptConstructor
             }
         }
 
-        // Only null if the script had no parameter list at all, which ExpectedParameters has to allow
-        return CreateInt(parameters!, scriptContext);
+        return CreateInt(parameters, scriptContext);
     }
 
     public IScriptFactory ScriptFactory { get; set; } = null!;

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -10,10 +10,10 @@ public class ShowMenuScriptConstructor : IScriptConstructor
     public IScript Create(string script, ScriptContext scriptContext)
     {
         string? afterExpr;
-        var param = Utility.GetParameter(script, out afterExpr);
+        var param = Utility.GetRequiredParameter(script, out afterExpr);
         var callback = Utility.GetScript(afterExpr!);
 
-        var parameters = Utility.SplitParameter(param!).ToArray();
+        var parameters = Utility.SplitParameter(param).ToArray();
         if (parameters.Count() != 3)
         {
             throw new Exception(string.Format("'show menu' script should have 3 parameters: 'show menu ({0})'", param));

--- a/src/Engine/Scripts/SwitchScript.cs
+++ b/src/Engine/Scripts/SwitchScript.cs
@@ -9,11 +9,11 @@ public class SwitchScriptConstructor : IScriptConstructor
     public IScript Create(string script, ScriptContext scriptContext)
     {
         string? afterExpr;
-        var param = Utility.GetParameter(script, out afterExpr);
+        var param = Utility.GetRequiredParameter(script, out afterExpr);
         IScript? defaultScript;
         var cases = ProcessCases(Utility.GetScript(afterExpr!), out defaultScript, scriptContext);
 
-        return new SwitchScript(scriptContext, new ExpressionDynamic(param!, scriptContext), cases, defaultScript);
+        return new SwitchScript(scriptContext, new ExpressionDynamic(param, scriptContext), cases, defaultScript);
     }
 
     public IScriptFactory ScriptFactory { get; set; } = null!;
@@ -39,7 +39,7 @@ public class SwitchScriptConstructor : IScriptConstructor
             {
                 if (cases.StartsWith("case"))
                 {
-                    var expr = Utility.GetParameter(cases, out afterExpr)!;
+                    var expr = Utility.GetRequiredParameter(cases, out afterExpr);
                     var caseScript = Utility.GetScript(afterExpr!);
                     var script = ScriptFactory.CreateScript(caseScript, scriptContext);
 

--- a/src/Engine/Scripts/WhileScript.cs
+++ b/src/Engine/Scripts/WhileScript.cs
@@ -9,11 +9,11 @@ public class WhileScriptConstructor : IScriptConstructor
     public IScript Create(string script, ScriptContext scriptContext)
     {
         string? afterExpr;
-        var param = Utility.GetParameter(script, out afterExpr);
+        var param = Utility.GetRequiredParameter(script, out afterExpr);
         var loop = Utility.GetScript(afterExpr!);
         var loopScript = ScriptFactory.CreateScript(loop);
 
-        return new WhileScript(scriptContext, ScriptFactory, new Expression<bool>(param!, scriptContext), loopScript);
+        return new WhileScript(scriptContext, ScriptFactory, new Expression<bool>(param, scriptContext), loopScript);
     }
 
     public IScriptFactory ScriptFactory { get; set; } = null!;

--- a/src/Engine/Utility.cs
+++ b/src/Engine/Utility.cs
@@ -37,6 +37,21 @@ public static partial class Utility
         return GetParameterInt(script, '(', ')', out afterParameter);
     }
 
+    /// <summary>
+    ///     Like <see cref="GetParameter(string, out string?)" />, but throws a clear error instead of
+    ///     returning null when the script has no parameter list at all (e.g. a bare 'for' or 'while').
+    /// </summary>
+    public static string GetRequiredParameter(string script, out string? afterParameter)
+    {
+        var param = GetParameter(script, out afterParameter);
+        if (param == null)
+        {
+            throw new Exception($"Expected a parameter list in '{script}'");
+        }
+
+        return param;
+    }
+
     public static string GetScript(string script)
     {
         return GetScript(script, out _);

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -2308,14 +2308,17 @@ public partial class WasmEditorBridge
     // ── Element creation / deletion ───────────────────────────────────────────
 
     [JSExport]
-    public static string ValidateName(string name)
+    public static string ValidateName(string name, string elementType)
     {
         if (_controller == null)
         {
             return "Not initialised";
         }
 
-        var result = _controller.CanAdd(name);
+        // Templates don't get a name clash caught by CanAdd — a template's element key is
+        // auto-generated (e.g. "template12"), so the clash it needs to check for (matching an
+        // existing base template from the game file) is a different check. See #2255.
+        var result = elementType == "template" ? _controller.CanAddTemplate(name) : _controller.CanAdd(name);
         return result.Valid ? "ok" : EditorController.GetValidationError(result, name);
     }
 
@@ -2760,6 +2763,12 @@ public partial class WasmEditorBridge
         if (_controller == null)
         {
             return "error:Not initialised";
+        }
+
+        var validation = _controller.CanAddTemplate(name);
+        if (!validation.Valid)
+        {
+            return $"error:{EditorController.GetValidationError(validation, name)}";
         }
 
         try

--- a/tests/EditorCoreTests/TemplateCreationTests.cs
+++ b/tests/EditorCoreTests/TemplateCreationTests.cs
@@ -1,0 +1,51 @@
+using System.Text;
+using QuestViva.Common;
+using QuestViva.EditorCore;
+
+namespace QuestViva.EditorCoreTests;
+
+// Regression test for issue #2255: adding a template whose name clashes with one already
+// defined in the game file (a "base" template) used to fail with a bare null-reference error
+// from EditorController.CreateNewTemplate, instead of the validation message CanAddTemplate
+// already exists to provide.
+[TestClass]
+public class TemplateCreationTests
+{
+    private EditorController _controller = null!;
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        const string xml = """
+            <asl version="580">
+              <game name="Test Game"/>
+              <template name="UnknownObject">existing</template>
+            </asl>
+            """;
+
+        _controller = new EditorController();
+        var bytes = Encoding.UTF8.GetBytes(xml);
+        await _controller.Initialise(new ByteArrayGameDataProvider(bytes, "test.aslx"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _controller.Dispose();
+    }
+
+    [TestMethod]
+    public void CanAddTemplateRejectsNameClashingWithBaseTemplate()
+    {
+        var result = _controller.CanAddTemplate("UnknownObject");
+        Assert.IsFalse(result.Valid);
+        Assert.AreEqual(ValidationMessage.ElementAlreadyExists, result.Message);
+    }
+
+    [TestMethod]
+    public void CanAddTemplateAllowsNewName()
+    {
+        var result = _controller.CanAddTemplate("SomeOtherTemplate");
+        Assert.IsTrue(result.Valid);
+    }
+}

--- a/tests/EngineTests/DoActionScriptTests.cs
+++ b/tests/EngineTests/DoActionScriptTests.cs
@@ -1,0 +1,27 @@
+using QuestViva.Engine;
+using QuestViva.Engine.Scripts;
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+// Regression test for issue #2245: "do (obj, action)" with an action the object doesn't have
+// used to fail with a bare NullReferenceException instead of a clear error naming the object
+// and action.
+[TestClass]
+public class DoActionScriptTests
+{
+    [TestMethod]
+    public async Task DoWithMissingActionThrowsClearError()
+    {
+        var worldModel = Helpers.CreateWorldModel();
+        var scriptContext = new ScriptContext(worldModel);
+        var scriptFactory = new ScriptFactory(worldModel);
+        worldModel.GetElementFactory(ElementType.Object).Create("obj");
+
+        var script = scriptFactory.CreateScript("do (obj, \"missingaction\")", scriptContext);
+
+        var ex = await Should.ThrowAsync<Exception>(() => script.ExecuteAsync(new Context()));
+        ex.Message.ShouldContain("obj");
+        ex.Message.ShouldContain("missingaction");
+    }
+}

--- a/tests/EngineTests/ElementLoaderTests.cs
+++ b/tests/EngineTests/ElementLoaderTests.cs
@@ -1,0 +1,77 @@
+using System.Text;
+using Moq;
+using QuestViva.Common;
+using QuestViva.Engine;
+
+namespace QuestViva.EngineTests;
+
+[TestClass]
+public class ElementLoaderTests
+{
+    // Regression test for issue #2241: an <inherit> with no name attribute used to fail at
+    // resolve time with a confusing null-key ArgumentNullException rather than a load error
+    // pointing at the malformed element.
+    [TestMethod]
+    public async Task TestInheritWithNoNameIsAGracefulLoadError()
+    {
+        var (worldModel, ok) = await LoadGame("""
+            <object name="room">
+              <inherit />
+            </object>
+            """);
+
+        Assert.IsFalse(ok, "Game with a nameless <inherit> should fail to load");
+        Assert.IsTrue(
+            worldModel.Errors.Any(e => e.Contains("Expected 'name' attribute in inherit")),
+            "Expected a friendly missing-name error; got: " + string.Join("; ", worldModel.Errors));
+    }
+
+    // Regression test for issue #2251: an <include> with no ref attribute at all (as opposed to
+    // ref="") used to fail with a NullReferenceException.
+    [TestMethod]
+    public async Task TestIncludeWithNoRefDoesNotCrash()
+    {
+        var (_, ok) = await LoadGame("""
+            <include />
+            """);
+
+        Assert.IsTrue(ok, "A malformed <include> with no ref should be skipped, not crash the load");
+    }
+
+    // Regression test for issue #2251: a <javascript> with no src attribute at all used to fail
+    // with a NullReferenceException.
+    [TestMethod]
+    public async Task TestJavascriptWithNoSrcDoesNotCrash()
+    {
+        var (_, ok) = await LoadGame("""
+            <javascript />
+            """);
+
+        Assert.IsTrue(ok, "A malformed <javascript> with no src should be skipped, not crash the load");
+    }
+
+    private static async Task<(WorldModel worldModel, bool ok)> LoadGame(string extraXml)
+    {
+        var xml = $"""
+                   <asl version="580">
+                     <include ref="English.aslx" />
+                     <include ref="Core.aslx" />
+                     <game name="test"/>
+                     <object name="room2">
+                       <object name="player">
+                         <inherit name="defaultplayer" />
+                       </object>
+                     </object>
+                     {extraXml}
+                   </asl>
+                   """;
+
+        var provider = new ByteArrayGameDataProvider(Encoding.UTF8.GetBytes(xml), "test.aslx");
+        var gameData = await provider.GetData();
+        var worldModel = Helpers.CreateWorldModel(gameData);
+
+        var player = new Mock<IPlayer>();
+        var ok = await worldModel.Initialise(player.Object);
+        return (worldModel, ok);
+    }
+}

--- a/tests/EngineTests/ExpressionTests.cs
+++ b/tests/EngineTests/ExpressionTests.cs
@@ -371,6 +371,36 @@ public class ExpressionTests
     }
 
     [TestMethod]
+    public async Task TestListCombineWithNullSecondList()
+    {
+        // ListCombine(list, null) used to throw ArgumentNullException while
+        // ListCombine(null, list) worked - see issue #2240.
+        var list = new QuestList<string>(["a", "b"]);
+        var c = new Context { Parameters = new Parameters { { "mylist", list } } };
+
+        var result = await new ExpressionDynamic("ListCombine(mylist, null)", _scriptContext).ExecuteAsync(c);
+        var resultList = result.ShouldBeAssignableTo<QuestList<string>>()!;
+        resultList.Count.ShouldBe(2);
+        resultList[0].ShouldBe("a");
+        resultList[1].ShouldBe("b");
+    }
+
+    [TestMethod]
+    public async Task TestListExcludeWithNullItemInList()
+    {
+        // ListExclude used to throw NullReferenceException if the list contained a null item -
+        // see issue #2243.
+        var list = new QuestList<string>(["a", null!, "b"]);
+        var c = new Context { Parameters = new Parameters { { "mylist", list } } };
+
+        var result = await new ExpressionDynamic("ListExclude(mylist, \"a\")", _scriptContext).ExecuteAsync(c);
+        var resultList = result.ShouldBeAssignableTo<QuestList<string>>()!;
+        resultList.Count.ShouldBe(2);
+        resultList[0].ShouldBeNull();
+        resultList[1].ShouldBe("b");
+    }
+
+    [TestMethod]
     public async Task TestCustomStringListFunction()
     {
         var result = await RunExpressionGeneric("CustomStringListFunction(\"a\", \"b\")");
@@ -429,6 +459,18 @@ public class ExpressionTests
         (await new Expression<bool>("\"missing\" in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(false);
         (await new Expression<bool>("\"foo\" not in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(false);
         (await new Expression<bool>("\"missing\" not in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(true);
+    }
+
+    [TestMethod]
+    public async Task TestInOperatorOnDictionary_NullLeftOperand()
+    {
+        // A null left operand (e.g. an unset attribute or variable) should evaluate to "not
+        // contained" rather than throwing - see issue #2250.
+        var dict = new QuestDictionary<string> { { "foo", "bar" } };
+        var c = new Context { Parameters = new Parameters { { "mydict", dict }, { "nullvar", null } } };
+
+        (await new Expression<bool>("nullvar in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(false);
+        (await new Expression<bool>("nullvar not in mydict", _scriptContext).ExecuteAsync(c)).ShouldBe(true);
     }
 
     [TestMethod]
@@ -500,6 +542,11 @@ public class ExpressionTests
 
         var c2 = new Context { Parameters = [] };
         (await expr.ExecuteAsync(c2)).ShouldBeFalse();
+
+        // Parameters is null when an expression is evaluated outside a running script - see
+        // issue #2248. Should evaluate to false rather than throw.
+        var c3 = new Context();
+        (await expr.ExecuteAsync(c3)).ShouldBeFalse();
     }
 
     [TestMethod]

--- a/tests/EngineTests/QuestDictionaryTests.cs
+++ b/tests/EngineTests/QuestDictionaryTests.cs
@@ -36,4 +36,15 @@ public class QuestDictionaryTests
 
         viaForeach.ShouldBe(["a", "c", "d", "e"]);
     }
+
+    // Regression test for issue #2242: a string dictionary containing a null value used to throw
+    // a NullReferenceException when saved (SaveString/ToString called v!.ToString()).
+    [TestMethod]
+    public void SaveString_WithNullValue_DoesNotThrow()
+    {
+        var dict = new QuestDictionary<string> { { "a", "1" }, { "b", null! } };
+
+        dict.SaveString().ShouldBe("a = 1;b = ");
+        dict.ToString().ShouldBe("Dictionary: a = 1;b = ");
+    }
 }

--- a/tests/EngineTests/ScriptConstructorErrorTests.cs
+++ b/tests/EngineTests/ScriptConstructorErrorTests.cs
@@ -1,0 +1,97 @@
+using QuestViva.Engine;
+using QuestViva.Engine.Scripts;
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+// Regression tests for issue #2249: keyword script constructors that take a parameter list used
+// to fail with a NullReferenceException (rather than a clear error) when the line had no
+// parameter list at all, e.g. a bare "for" with no "(...)".
+[TestClass]
+public class ScriptConstructorErrorTests
+{
+    private ScriptFactory _scriptFactory = null!;
+    private ScriptContext _scriptContext = null!;
+    private WorldModel _worldModel = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _worldModel = Helpers.CreateWorldModel();
+        _scriptFactory = new ScriptFactory(_worldModel);
+        _scriptContext = new ScriptContext(_worldModel);
+    }
+
+    private T CreateConstructor<T>() where T : IScriptConstructor, new()
+    {
+        return new T { WorldModel = _worldModel, ScriptFactory = _scriptFactory };
+    }
+
+    [TestMethod]
+    public void ForWithNoParameterListThrowsClearError()
+    {
+        var constructor = CreateConstructor<ForScriptConstructor>();
+        Should.Throw<Exception>(() => constructor.Create("for", _scriptContext))
+            .Message.ShouldContain("Expected a parameter list");
+    }
+
+    [TestMethod]
+    public void ForEachWithNoParameterListThrowsClearError()
+    {
+        var constructor = CreateConstructor<ForEachScriptConstructor>();
+        Should.Throw<Exception>(() => constructor.Create("foreach", _scriptContext))
+            .Message.ShouldContain("Expected a parameter list");
+    }
+
+    [TestMethod]
+    public void WhileWithNoParameterListThrowsClearError()
+    {
+        var constructor = CreateConstructor<WhileScriptConstructor>();
+        Should.Throw<Exception>(() => constructor.Create("while", _scriptContext))
+            .Message.ShouldContain("Expected a parameter list");
+    }
+
+    [TestMethod]
+    public void IfWithNoParameterListThrowsClearError()
+    {
+        var constructor = CreateConstructor<IfScriptConstructor>();
+        Should.Throw<Exception>(() => constructor.Create("if", _scriptContext))
+            .Message.ShouldContain("Expected a parameter list");
+    }
+
+    [TestMethod]
+    public void SwitchWithNoParameterListThrowsClearError()
+    {
+        var constructor = CreateConstructor<SwitchScriptConstructor>();
+        Should.Throw<Exception>(() => constructor.Create("switch", _scriptContext))
+            .Message.ShouldContain("Expected a parameter list");
+    }
+
+    [TestMethod]
+    public void AskWithNoParameterListThrowsClearError()
+    {
+        var constructor = CreateConstructor<AskScriptConstructor>();
+        Should.Throw<Exception>(() => constructor.Create("ask", _scriptContext))
+            .Message.ShouldContain("Expected a parameter list");
+    }
+
+    [TestMethod]
+    public void ShowMenuWithNoParameterListThrowsClearError()
+    {
+        var constructor = CreateConstructor<ShowMenuScriptConstructor>();
+        Should.Throw<Exception>(() => constructor.Create("show menu", _scriptContext))
+            .Message.ShouldContain("Expected a parameter list");
+    }
+
+    // Regression test for issue #2246: rundelegate is the only ScriptConstructorBase-derived
+    // constructor with no ExpectedParameters, so a missing parameter list used to skip the
+    // parameter-count check entirely and fail inside CreateInt with a NullReferenceException
+    // instead of the intended "Expected at least 2 parameters" message.
+    [TestMethod]
+    public void RunDelegateWithNoParameterListThrowsClearError()
+    {
+        var constructor = new RunDelegateScriptConstructor { WorldModel = _worldModel, ScriptFactory = _scriptFactory };
+        Should.Throw<Exception>(() => constructor.Create("rundelegate", _scriptContext))
+            .Message.ShouldContain("Expected at least 2 parameters");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a batch of small null-handling bugs filed in the last day or so while enabling nullable reference types across Engine/EditorController (`refactor/nullable-engine-*`, `refactor/nullable-editorcontroller`). Each of these was deliberately left as-is by that refactor (to avoid a behaviour change hiding inside a pure typing PR) and filed as a follow-up issue instead. This PR fixes them all in one batch since none needs its own design discussion:

- Fixes #2240 — `ListCombine(list, null)` no longer throws `ArgumentNullException`
- Fixes #2241 — `<inherit>` with no `name` now reports a load error naming the problem instead of a confusing null-key exception
- Fixes #2242 — saving a string dictionary with a null value no longer throws
- Fixes #2243 — `ListExclude` no longer throws when the list contains a null item
- Fixes #2245 — `do (obj, action)` with a missing action now raises a clear error naming the object/action instead of a bare `NullReferenceException`
- Fixes #2246 — `rundelegate` with no parameter list now reports "Expected at least 2 parameters" instead of crashing
- Fixes #2248 — `IsDefined()` returns `false` (rather than throwing) when evaluated with no script parameters
- Fixes #2249 — `for`/`foreach`/`while`/`if`/`switch`/`ask`/`show menu` with no parameter list at all now raise a clear parse error instead of `NullReferenceException`
- Fixes #2250 — `x in dict` evaluates to `false`/`true` rather than throwing when `x` is null
- Fixes #2251 — `<include>` with no `ref` and `<javascript>` with no `src` are now skipped gracefully, matching the existing `ref=""` behaviour
- Fixes #2255 — adding a template whose name clashes with one already defined in the game file now shows an inline validation message instead of crashing with a null-reference error (both the WasmEditor bridge, which now calls `CanAddTemplate`, and AppShell's `AddElementModal`, which now validates template names through that same check)

## Test plan

- [x] `dotnet build --configuration Release` — clean, no warnings
- [x] `dotnet test --configuration Release` — all 423 tests pass, including new regression tests for each issue above (`ElementLoaderTests`, `ScriptConstructorErrorTests`, `DoActionScriptTests`, `TemplateCreationTests`, plus additions to `ExpressionTests`/`QuestDictionaryTests`)
- [x] `npm run check` and `npm run lint` in `src/AppShell` — clean
- [x] Manually verified in the AppShell editor (Playwright): creating a template via Advanced → Add Template works end-to-end with the new `ValidateName(name, elementType)` bridge call, with no console/page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)