### PR TITLE
fix(AppShell): validate expressions for mismatched brackets/quotes before saving

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -146,6 +146,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-appshell-exits-editor.mjs http://localhost:5174
         working-directory: tests/e2e
+      - run: node verify-appshell-expression-validation.mjs http://localhost:5174
+        working-directory: tests/e2e
       - run: node verify-appshell-game-status-attributes-scroll.mjs http://localhost:5174
         working-directory: tests/e2e
       - run: node verify-appshell-gamebook-mode.mjs http://localhost:5174

--- a/src/AppShell/src/components/ExpressionInput.svelte
+++ b/src/AppShell/src/components/ExpressionInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import Wand2 from "@lucide/svelte/icons/wand-2";
-    import { getExpressionFunctions } from "$lib/editor-store";
+    import { getExpressionFunctions, validateExpression } from "$lib/editor-store";
     import { t } from "$lib/i18n";
     import { measureTextPx } from "$lib/text-measure";
     import type { ExpressionFunctionInfo } from "$lib/types";
@@ -30,6 +30,14 @@
     // it below overrides the mirrored value until `value` itself changes, at which point it
     // resets to that (e.g. undo, or switching to a different control).
     let liveText = $derived(value);
+
+    // Mirrors Quest 5's ExpressionControl/WebEditor Element.cs: mismatched brackets or quotes are
+    // flagged as the user types and the commit below is refused until they're fixed, rather than
+    // silently storing a broken expression that only fails when the script runs. See #2257.
+    let error = $derived.by(() => {
+        const result = validateExpression(liveText);
+        return result === "ok" ? "" : result;
+    });
 
     let inputEl = $state<HTMLInputElement | undefined>();
 
@@ -180,74 +188,87 @@
     });
 </script>
 
-<div class="flex items-center gap-1 min-w-0">
-    <input
-        bind:this={inputEl}
-        type="text"
-        autocapitalize="off"
-        class={className || "input text-xs py-0.5 px-1.5 w-full"}
-        style={widthStyle}
-        value={liveText}
-        aria-label={ariaLabel}
-        oninput={(e) => (liveText = (e.target as HTMLInputElement).value)}
-        onchange={(e) => onchange((e.target as HTMLInputElement).value)}
-    />
-    <button
-        bind:this={buttonEl}
-        type="button"
-        class="btn btn-sm preset-outlined-primary-500 px-1 py-0.5 flex-shrink-0"
-        title={t("expressionInput.insertTitle")}
-        onclick={toggle}
-    ><Wand2 size={13} aria-hidden="true" /></button>
-    {#if open}
-        <div
-            bind:this={popoverRootEl}
-            use:portal
-            style={popoverStyle}
-            class="z-50 w-64 max-h-72 flex flex-col rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-lg"
-        >
-            <input
-                type="text"
-                autocapitalize="off"
-                placeholder={t("expressionInput.filterPlaceholder")}
-                class="input text-xs py-1 px-2 rounded-none border-0 border-b border-surface-200-800"
-                bind:value={filter}
-            />
-            <div class="overflow-y-auto flex-1">
-                {#if filteredObjects.length > 0}
-                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">{t("expressionInput.objectsHeading")}</div>
-                    {#each filteredObjects as name (name)}
-                        <button
-                            type="button"
-                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
-                            onclick={() => insertAtCursor(name)}
-                        >{name}</button>
-                    {/each}
-                {/if}
-                {#if filteredGameFunctions.length > 0}
-                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">{t("expressionInput.gameFunctionsHeading")}</div>
-                    {#each filteredGameFunctions as fn (fn.name)}
-                        <button
-                            type="button"
-                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
-                            onclick={() => insertFunction(fn)}
-                        >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
-                    {/each}
-                {/if}
-                {#if filteredLibraryFunctions.length > 0}
-                    <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">{t("expressionInput.libraryFunctionsHeading")}</div>
-                    {#each filteredLibraryFunctions as fn (fn.name)}
-                        <button
-                            type="button"
-                            class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
-                            onclick={() => insertFunction(fn)}
-                        >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
-                    {/each}
-                {/if}
-                {#if filteredObjects.length === 0 && filteredFunctions.length === 0}
-                    <p class="px-2 py-2 text-xs text-surface-600-400 italic">{t("expressionInput.noMatches")}</p>
-                {/if}
+<div class="flex flex-col gap-0.5 min-w-0">
+    <div class="flex items-center gap-1 min-w-0">
+        <input
+            bind:this={inputEl}
+            type="text"
+            autocapitalize="off"
+            class={(className || "input text-xs py-0.5 px-1.5 w-full") + (error ? " !border-error-500" : "")}
+            style={widthStyle}
+            value={liveText}
+            aria-label={ariaLabel}
+            aria-invalid={error ? "true" : undefined}
+            oninput={(e) => (liveText = (e.target as HTMLInputElement).value)}
+            onchange={(e) => {
+                const newValue = (e.target as HTMLInputElement).value;
+                // Refuse to commit an invalid expression (mismatched brackets/quotes) - the field
+                // keeps showing what was typed (liveText already holds it from oninput above) so
+                // the error stays visible and the user can fix it, matching Quest 5's behaviour.
+                if (validateExpression(newValue) !== "ok") return;
+                onchange(newValue);
+            }}
+        />
+        <button
+            bind:this={buttonEl}
+            type="button"
+            class="btn btn-sm preset-outlined-primary-500 px-1 py-0.5 flex-shrink-0"
+            title={t("expressionInput.insertTitle")}
+            onclick={toggle}
+        ><Wand2 size={13} aria-hidden="true" /></button>
+        {#if open}
+            <div
+                bind:this={popoverRootEl}
+                use:portal
+                style={popoverStyle}
+                class="z-50 w-64 max-h-72 flex flex-col rounded border border-surface-200-800 bg-white dark:bg-surface-800 shadow-lg"
+            >
+                <input
+                    type="text"
+                    autocapitalize="off"
+                    placeholder={t("expressionInput.filterPlaceholder")}
+                    class="input text-xs py-1 px-2 rounded-none border-0 border-b border-surface-200-800"
+                    bind:value={filter}
+                />
+                <div class="overflow-y-auto flex-1">
+                    {#if filteredObjects.length > 0}
+                        <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">{t("expressionInput.objectsHeading")}</div>
+                        {#each filteredObjects as name (name)}
+                            <button
+                                type="button"
+                                class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                                onclick={() => insertAtCursor(name)}
+                            >{name}</button>
+                        {/each}
+                    {/if}
+                    {#if filteredGameFunctions.length > 0}
+                        <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">{t("expressionInput.gameFunctionsHeading")}</div>
+                        {#each filteredGameFunctions as fn (fn.name)}
+                            <button
+                                type="button"
+                                class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                                onclick={() => insertFunction(fn)}
+                            >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
+                        {/each}
+                    {/if}
+                    {#if filteredLibraryFunctions.length > 0}
+                        <div class="px-2 pt-1.5 pb-0.5 text-[10px] font-semibold uppercase text-surface-600-400 sticky top-0 bg-white dark:bg-surface-800">{t("expressionInput.libraryFunctionsHeading")}</div>
+                        {#each filteredLibraryFunctions as fn (fn.name)}
+                            <button
+                                type="button"
+                                class="block w-full text-left px-2 py-1 text-xs hover:bg-surface-100-900 truncate"
+                                onclick={() => insertFunction(fn)}
+                            >{fn.name}<span class="text-surface-600-400">({fn.parameters.join(", ")})</span></button>
+                        {/each}
+                    {/if}
+                    {#if filteredObjects.length === 0 && filteredFunctions.length === 0}
+                        <p class="px-2 py-2 text-xs text-surface-600-400 italic">{t("expressionInput.noMatches")}</p>
+                    {/if}
+                </div>
             </div>
-        </div>
+        {/if}
+    </div>
+    {#if error}
+        <p class="text-xs text-error-500" role="alert">{error}</p>
     {/if}
 </div>

--- a/src/AppShell/src/lib/editor-store.ts
+++ b/src/AppShell/src/lib/editor-store.ts
@@ -1606,6 +1606,10 @@ export function validateName(name: string, elementType = ""): string {
     return _bridge?.ValidateName(name, elementType) ?? "error";
 }
 
+export function validateExpression(expression: string): string {
+    return _bridge?.ValidateExpression(expression) ?? "ok";
+}
+
 export function getUniqueName(baseName: string): string {
     return _bridge?.GetUniqueName(baseName) ?? baseName;
 }

--- a/src/AppShell/src/lib/wasm.ts
+++ b/src/AppShell/src/lib/wasm.ts
@@ -92,6 +92,7 @@ export interface WasmBridge {
   SetPatternAttribute(elementKey: string, attribute: string, pattern: string): string
   // Element creation / deletion
   ValidateName(name: string, elementType: string): string
+  ValidateExpression(expression: string): string
   GetUniqueName(baseName: string): string
   CreateRoom(name: string, parent: string): string
   CreateObject(name: string, parent: string): string

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -2323,6 +2323,18 @@ public partial class WasmEditorBridge
     }
 
     [JSExport]
+    public static string ValidateExpression(string expression)
+    {
+        if (_controller == null)
+        {
+            return "Not initialised";
+        }
+
+        var result = _controller.ValidateExpression(expression);
+        return result.Valid ? "ok" : EditorController.GetValidationError(result, expression);
+    }
+
+    [JSExport]
     public static string GetUniqueName(string baseName)
     {
         if (_controller == null)

--- a/tests/e2e/verify-appshell-expression-validation.mjs
+++ b/tests/e2e/verify-appshell-expression-validation.mjs
@@ -1,0 +1,124 @@
+// Regression/feature test for issue #2257: the editor never checked expressions for mismatched
+// brackets or quotes before saving them, even though Quest 5's desktop editor and WebEditor both
+// refused to save a broken expression and showed why (see EditorController.ValidateExpression,
+// covered by EditorCoreTests but never wired up to WasmEditor/AppShell). ExpressionInput.svelte
+// now calls the new WasmEditorBridge.ValidateExpression export live as the user types and refuses
+// to commit an invalid expression, showing an inline error the same way AddElementModal's name
+// field already does (see verify-rename-invalid-name.mjs for that precedent). Since every
+// expression-shaped control (if conditions, expression-type script parameters, expression-type
+// properties) renders through the single shared ExpressionInput component, this exercises the "if"
+// condition case as the representative path.
+//
+// Requires the AppShell dev server running locally (WasmEditor Debug build first):
+//   cd src/AppShell && npm run dev
+// Run: node tests/e2e/verify-appshell-expression-validation.mjs [baseUrl]
+import { chromium } from './lib/tracked-chromium.mjs';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+
+const browser = await chromium.launch();
+
+// This command's Script panel has its own visual/code toggle (distinct from the toolbar's
+// whole-game "Raw XML code view") - "Code view" switches the script in place to a CodeMirror
+// editor, and "Visual editor" switches it back. No modal involved.
+async function readRawCode(page) {
+    await page.click('button:has-text("Code view")');
+    const text = await page.locator('.cm-content').first().innerText();
+    await page.click('button:has-text("Visual editor")');
+    await page.waitForSelector('button:has-text("Code view")', { timeout: 5000 });
+    return text;
+}
+
+try {
+    const ctx = await browser.newContext({ viewport: { width: 1400, height: 1000 } });
+    const page = await ctx.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Expression Validation Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="Add element"]', { timeout: 30000 });
+    console.log('PASS: local draft created and opened in the editor');
+
+    // ── Build a Command with an If block, exercising the "if" condition's ExpressionInput ──
+    await page.locator('[data-value="room"][data-part="item"], [data-value="room"][data-part="branch-control"]').first().click();
+    await page.click('button[title="Add element"]');
+    await page.click('button:has-text("Add Command to")', { timeout: 5000 });
+    await page.waitForSelector('text=Command:', { timeout: 10000 });
+
+    const patternRow = page.getByText('Pattern:', { exact: true }).locator('xpath=../..');
+    const patternInput = patternRow.locator(':scope > input[type=text]');
+    await patternInput.waitFor({ state: 'visible', timeout: 5000 });
+    await patternInput.fill('test command');
+    await patternInput.blur();
+
+    await page.click('button:has-text("Add script")');
+    await page.waitForSelector('[role="dialog"]', { timeout: 5000 });
+    await page.getByRole('button', { name: 'If', exact: true }).click();
+    await page.waitForSelector('button:has-text("Add script")', { timeout: 5000 });
+    console.log('PASS: command with an If block created');
+
+    const ifRow = page.locator('div.flex.items-center.gap-1.flex-wrap').filter({ hasText: 'then' }).first();
+    // Freshly added, the "if" condition starts empty, which doesn't match any condition template
+    // (see expressionField in ScriptEditor.svelte), so it renders the raw ExpressionInput field
+    // directly rather than a template's own sub-controls.
+    const exprInput = ifRow.locator('input[type=text]').first();
+    await exprInput.waitFor({ state: 'visible', timeout: 5000 });
+
+    // ── Mismatched brackets: must be rejected, not silently saved ──────────────────────────
+    const badExpression = 'GetBoolean(game, "flag"';
+    await exprInput.fill(badExpression);
+    await exprInput.blur();
+
+    const bracketError = page.locator('p.text-error-500', { hasText: /brackets/i });
+    await bracketError.waitFor({ timeout: 5000 });
+    console.log(`PASS: mismatched-brackets error shown inline: "${await bracketError.textContent()}"`);
+
+    const borderClass = await exprInput.getAttribute('class');
+    if (!borderClass?.includes('border-error-500')) throw new Error('Expected the expression input to get an error border');
+    console.log('PASS: expression input gets an error border');
+
+    const valueAfterBlur = await exprInput.inputValue();
+    if (valueAfterBlur !== badExpression) throw new Error(`Expected the invalid text to remain in the field, got "${valueAfterBlur}"`);
+    console.log('PASS: invalid expression text stays in the field (not reverted) so it can be fixed');
+
+    const codeAfterBadExpr = await readRawCode(page);
+    if (codeAfterBadExpr.includes(badExpression)) throw new Error('The invalid expression must not have been committed to the saved script');
+    console.log('PASS: invalid expression was not committed to the underlying script');
+
+    // ── Mismatched quotes: same rejection ───────────────────────────────────────────────────
+    await exprInput.fill('"no end quote');
+    await exprInput.blur();
+    const quoteError = page.locator('p.text-error-500', { hasText: /quote/i });
+    await quoteError.waitFor({ timeout: 5000 });
+    console.log(`PASS: missing-quote error shown inline: "${await quoteError.textContent()}"`);
+
+    // ── A valid expression is accepted once fixed, clearing the error (no regression) ──────
+    const goodExpression = 'GetBoolean(game, "flag")';
+    await exprInput.fill(goodExpression);
+    await exprInput.blur();
+    await page.waitForSelector('p.text-error-500', { state: 'detached', timeout: 5000 });
+    console.log('PASS: error clears once the expression is fixed');
+
+    const borderClassAfterFix = await exprInput.getAttribute('class');
+    if (borderClassAfterFix?.includes('border-error-500')) throw new Error('Expected the error border to be removed once the expression is valid');
+    console.log('PASS: error border removed once valid');
+
+    const codeAfterGoodExpr = await readRawCode(page);
+    if (!codeAfterGoodExpr.includes(goodExpression)) throw new Error(`Expected the saved script to contain the valid expression, got:\n${codeAfterGoodExpr}`);
+    console.log('PASS: valid expression was committed to the underlying script');
+
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    try {
+        const pages = browser.contexts().flatMap(c => c.pages());
+        if (pages[0]) await pages[0].screenshot({ path: '/tmp/appshell-expression-validation-failure.png' });
+    } catch { /* best-effort */ }
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}

--- a/tests/e2e/verify-appshell-switch-cases-editor.mjs
+++ b/tests/e2e/verify-appshell-switch-cases-editor.mjs
@@ -158,10 +158,12 @@ try {
     // ── Remove the "buckler" case ────────────────────────────────────────────────────
     const bucklerCaseRowAfterReload = await caseKeyInput(switchRow, '"buckler"');
     if (!bucklerCaseRowAfterReload) throw new Error('"buckler" case not found after returning to the Scripts tab');
-    // Two levels up, not one - the case-key input is now wrapped in ExpressionInput's own
-    // "input + wand button" container (see issue #2070), so its immediate parent no longer has
-    // the row's × remove button as a sibling; the row container is one level above that.
-    const bucklerCaseRow = bucklerCaseRowAfterReload.locator('xpath=../..');
+    // Three levels up, not one - the case-key input is wrapped in ExpressionInput's own
+    // "input + wand button" container (see issue #2070), which is itself now wrapped in a
+    // column container that also holds its inline validation error (see issue #2257), so its
+    // immediate parent no longer has the row's × remove button as a sibling; the row container
+    // is two levels above that.
+    const bucklerCaseRow = bucklerCaseRowAfterReload.locator('xpath=../../..');
     await bucklerCaseRow.locator('button', { hasText: '×' }).click();
     await page.waitForTimeout(300);
 


### PR DESCRIPTION
## Summary
- Quest 5's desktop editor and WebEditor both refused to save an expression with mismatched brackets/quotes and explained why (`EditorController.ValidateExpression`, still present and covered by `EditorCoreTests`). Nothing in WasmEditor/AppShell called it, so a typo (e.g. a missing closing paren) was only ever discovered when the script ran.
- Adds `WasmEditorBridge.ValidateExpression` (mirroring `ValidateName`'s existing shape/return convention) and wires it into `ExpressionInput.svelte` — the single shared component every expression-shaped control renders through (if conditions, expression-type script parameters, expression-type properties).
- The field now validates live as the user types, refuses to commit an invalid expression (keeping the typed text visible so it can be fixed), and shows the error inline below the field the same way `AddElementModal`'s name field already does — with a matching error border.

Fixes #2257.

## Test plan
- [x] `dotnet test tests/EditorCoreTests` — existing `ValidateExpression` coverage still passes (49/49)
- [x] `dotnet build --configuration Release` — full solution builds clean
- [x] `npm run check` / `npm run lint` in `src/AppShell` — clean
- [x] New e2e script `tests/e2e/verify-appshell-expression-validation.mjs`, wired into `.github/workflows/e2e.yml`, run manually against a local dev server — covers mismatched brackets, mismatched quotes, the invalid text staying visible, the invalid expression not being committed, and a subsequent valid expression clearing the error and committing correctly
- [x] `node tests/e2e/find-affected-tests.mjs` — ran all AppShell scripts it flagged; fixed a stale DOM-depth assumption in `verify-appshell-switch-cases-editor.mjs` (`ExpressionInput`'s root gained one more wrapping level to hold the new inline error message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)