### PR TITLE
fix(AppShell): hide built-in default types from attributes editor's add-type list

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,6 +128,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-appshell-assetpicker-mobile-overflow.mjs http://localhost:5174
         working-directory: tests/e2e
+      - run: node verify-appshell-attributes-add-type-excludes-defaults.mjs http://localhost:5174
+        working-directory: tests/e2e
       - run: node verify-appshell-attributes-panel-pinned.mjs http://localhost:5174
         working-directory: tests/e2e
       - run: node verify-appshell-attributes-stack-scroll.mjs http://localhost:5174

--- a/src/EditorCore/EditorController.cs
+++ b/src/EditorCore/EditorController.cs
@@ -1106,6 +1106,11 @@ public sealed class EditorController : IDisposable
         return GetElements(elementType).Select(e => e.Name);
     }
 
+    public IEnumerable<string> GetAddableTypeNames()
+    {
+        return GetElementNames("type").Where(t => !IsDefaultTypeName(t));
+    }
+
     public object? GetElementDataAttribute(string elementName, string attribute)
     {
         var element = WorldModel.Elements.Get(elementName);

--- a/src/WasmEditor/WasmEditorBridge.cs
+++ b/src/WasmEditor/WasmEditorBridge.cs
@@ -3392,7 +3392,7 @@ public partial class WasmEditorBridge
             return "[]";
         }
 
-        var names = _controller.GetElementNames("type").ToList();
+        var names = _controller.GetAddableTypeNames().ToList();
         return JsonSerializer.Serialize(names, WasmEditorJsonContext.Default.ListString);
     }
 

--- a/tests/EditorCoreTests/AttributesEditorTypeListTests.cs
+++ b/tests/EditorCoreTests/AttributesEditorTypeListTests.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using QuestViva.Common;
+using QuestViva.EditorCore;
+
+namespace QuestViva.EditorCoreTests;
+
+// Regression coverage for issue #2258: the attributes editor's "add type" list was offering
+// Core's built-in default types (defaultobject, defaultexit, defaultcommand, defaultverb,
+// defaultgame), which the engine already applies implicitly to every element of the matching
+// kind - adding one explicitly is meaningless. Quest 5's desktop editor filtered these out with
+// EditorController.IsDefaultTypeName; WasmEditorBridge.GetTypeNames (browser-wasm only, not
+// unit-testable directly) now calls EditorController.GetAddableTypeNames, which is covered here.
+[TestClass]
+public class AttributesEditorTypeListTests
+{
+    [TestMethod]
+    public async Task TestGetAddableTypeNamesExcludesCoreDefaultTypes()
+    {
+        var controller = await LoadTemplateController("English");
+
+        controller.CreateNewType("MyCustomType");
+
+        var addableTypeNames = controller.GetAddableTypeNames().ToArray();
+
+        CollectionAssert.DoesNotContain(addableTypeNames, "defaultobject");
+        CollectionAssert.DoesNotContain(addableTypeNames, "defaultexit");
+        CollectionAssert.DoesNotContain(addableTypeNames, "defaultcommand");
+        CollectionAssert.DoesNotContain(addableTypeNames, "defaultverb");
+        CollectionAssert.DoesNotContain(addableTypeNames, "defaultgame");
+        CollectionAssert.Contains(addableTypeNames, "MyCustomType");
+
+        controller.Uninitialise();
+    }
+
+    // Mirrors EditorControllerRoomsAndPagesTests/IncludedLibraryTests/FunctionFolderTests' own
+    // helper of the same name - see FunctionFolderTests' file-level comment for why
+    // EditorControllerTestBase can't be used for element-creating tests like this one.
+    private static async Task<EditorController> LoadTemplateController(string templateName)
+    {
+        var templates = EditorController.GetAvailableTemplates();
+        var template = templates.Values.Single(t => t.TemplateName == templateName);
+        var initialFileText = EditorController.CreateNewGameFile(template.ResourceName, "Test");
+        var bytes = Encoding.UTF8.GetBytes(initialFileText);
+
+        var controller = new EditorController();
+        controller.ClearTree += (_, _) => { };
+        controller.BeginTreeUpdate += (_, _) => { };
+        controller.EndTreeUpdate += (_, _) => { };
+        controller.AddedNode += (_, _) => { };
+        controller.RemovedNode += (_, _) => { };
+        controller.RenamedNode += (_, _) => { };
+        controller.RetitledNode += (_, _) => { };
+        controller.ElementsUpdated += (_, _) => { };
+        controller.Dirty += (_, _) => { };
+
+        var ok = await controller.Initialise(new ByteArrayGameDataProvider(bytes, "test.aslx"));
+        Assert.IsTrue(ok, $"Initialisation failed for template '{templateName}'");
+
+        controller.UpdateTree();
+
+        return controller;
+    }
+}

--- a/tests/e2e/verify-appshell-attributes-add-type-excludes-defaults.mjs
+++ b/tests/e2e/verify-appshell-attributes-add-type-excludes-defaults.mjs
@@ -1,0 +1,48 @@
+// Regression test for issue #2258: the Attributes editor's "add type" list was offering Core's
+// built-in default types (defaultobject, defaultexit, defaultcommand, defaultverb, defaultgame),
+// which the engine already applies implicitly to every element of the matching kind - adding one
+// explicitly is meaningless. WasmEditorBridge.GetTypeNames now filters these out via
+// EditorController.GetAddableTypeNames (also covered by an EditorCoreTests unit test).
+import { chromium } from './lib/tracked-chromium.mjs';
+
+const baseUrl = process.argv[2] || 'http://localhost:5174';
+const defaultTypeNames = ['defaultobject', 'defaultexit', 'defaultcommand', 'defaultverb', 'defaultgame'];
+
+const browser = await chromium.launch();
+
+try {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    const page = await context.newPage();
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    page.on('console', msg => { if (msg.type() === 'error') console.log('[console.error]', msg.text()); });
+
+    await page.goto(`${baseUrl}/open`);
+    await page.waitForSelector('button:has-text("Create local draft")', { timeout: 30000 });
+    await page.fill('input[placeholder="Game name"]', `Add Type Defaults Test ${Date.now()}`);
+    await page.waitForSelector('text=Text adventure', { timeout: 10000 });
+    await page.click('button:has-text("Create local draft")');
+    await page.waitForSelector('button[title="More"]', { timeout: 30000 });
+
+    await page.click('text=room');
+    await page.getByRole('button', { name: /^Attributes$/ }).click();
+    await page.waitForSelector('text=Inherited types', { timeout: 5000 });
+
+    const addTypeSelect = page.locator('select').filter({ has: page.locator('option', { hasText: 'Add type…' }) });
+    await addTypeSelect.waitFor({ timeout: 5000 });
+    const optionValues = await addTypeSelect.locator('option').evaluateAll(opts => opts.map(o => o.value));
+
+    for (const defaultTypeName of defaultTypeNames) {
+        if (optionValues.includes(defaultTypeName)) {
+            throw new Error(`"add type" list should not offer built-in default type "${defaultTypeName}", got: ${optionValues.join(', ')}`);
+        }
+    }
+    console.log(`PASS: "add type" list excludes Core default types (offered: ${optionValues.filter(v => v).join(', ')})`);
+
+    await context.close();
+    console.log('PASS: all checks passed');
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
## Summary
- The attributes editor's "add type" dropdown was offering Core's built-in default types (`defaultobject`, `defaultexit`, `defaultcommand`, `defaultverb`, `defaultgame`), which the engine already applies implicitly to every element of the matching kind — adding one explicitly is meaningless and confusing.
- Added `EditorController.GetAddableTypeNames()`, mirroring Quest 5's desktop editor filter (`EditorController.IsDefaultTypeName`), and switched `WasmEditorBridge.GetTypeNames` to use it.
- `defaultplayer` is intentionally left visible, matching Quest 5's own behavior (per the issue).

Fixes #2258

## Test plan
- [x] `dotnet test --configuration Release` — full suite passes (424 tests)
- [x] New unit test `AttributesEditorTypeListTests.TestGetAddableTypeNamesExcludesCoreDefaultTypes` — verified it fails against the pre-fix code and passes with the fix
- [x] New e2e script `verify-appshell-attributes-add-type-excludes-defaults.mjs`, wired into `.github/workflows/e2e.yml`'s `appshell_chromium` job — ran manually against a local AppShell dev server, confirmed it fails pre-fix and passes post-fix
- [x] `node tests/e2e/check-workflow-manifest.mjs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)