### PR TITLE
docs: add help links for six commands, flesh out thin reference entries

### DIFF
--- a/site/scripts/build-docs-index.mjs
+++ b/site/scripts/build-docs-index.mjs
@@ -37,10 +37,29 @@ const outPath = join(repoRoot, "src", "AppShell", "src", "lib", "docs-index.gene
 const FUNCTIONS_SECTION = "reference/functions";
 
 // Keywords that name a script command but have no useful reference entry:
-// syntax rather than a command (`=`, `//`, `@failed`), or internal
-// pseudo-elements the editor uses to group the tree (`_objects`, ...).
-// Applied to the bare name, after any "(function)" prefix has been stripped.
+// syntax rather than a command (`@failed`), or internal pseudo-elements the
+// editor uses to group the tree (`_objects`, ...). Applied to the bare name,
+// after any "(function)" prefix has been stripped. A handful of *real*,
+// author-facing commands also fail this letter check because they're pure
+// punctuation (`=`, `//`, ...) - those are listed in manualTargets below
+// instead of being excluded here.
 const isInternalName = (name) => name.startsWith("_") || !/^[A-Za-z]/.test(name);
+
+// Script keywords that are pure punctuation/operators, so they have no
+// readable name a "## " heading could carry - findPage() below matches a
+// keyword to a heading by name, which doesn't work for "()" or "=>". Two of
+// them also describe concepts that live outside the reference/functions +
+// scripts docs this file otherwise indexes (a howto guide, the JS binding
+// page), so they're pointed at a fixed target instead of being discovered.
+// Where the target *is* in readHeadings()'s scope, `heading` is checked
+// against it so a rename doesn't silently leave this pointing at nothing.
+const manualTargets = {
+  "=": { path: "/scripts/#setting-variables", slug: "scripts", heading: "Setting variables" },
+  "=>": { path: "/scripts/#setting-variables", slug: "scripts", heading: "Setting variables" },
+  "//": { path: "/scripts/#comments", slug: "scripts", heading: "Comments" },
+  "()": { path: "/howto/tasks/about-functions/#using-functions" },
+  "JS.": { path: "/js/#calling-js-functions" },
+};
 
 // Element-type editors (<editor name="object">, etc.) rather than script
 // commands - they belong to the element reference, not the function reference.
@@ -176,13 +195,30 @@ function readHelpPageTitles() {
   return titles;
 }
 
+// Below this length (chars of prose, same measure as explanationLength), an
+// entry is reported as worth fleshing out - informational only, unlike
+// unmatched/undocumented it never changes the generated file or fails
+// --check. Picked to match the ad-hoc measurement in issue #2220 that first
+// surfaced this tail.
+const THIN_EXPLANATION_CHARS = 60;
+
 function build() {
   const headingsBySlug = readHeadings();
   const entries = [];
   const unmatched = [];
   const undocumented = [];
+  const thin = [];
 
   for (const keyword of [...readScriptKeywords()].sort()) {
+    const manual = manualTargets[keyword];
+    if (manual) {
+      if (manual.slug && headingsBySlug.get(manual.slug)?.get(manual.heading) === undefined) {
+        throw new Error(`manualTargets["${keyword}"]: no "## ${manual.heading}" heading on ${manual.slug} - is it stale?`);
+      }
+      entries.push({ keyword, path: manual.path });
+      continue;
+    }
+
     const isFunction = keyword.startsWith("(function)");
     const name = isFunction ? keyword.slice("(function)".length) : keyword;
     if (isInternalName(name) || elementTypeKeywords.has(name)) continue;
@@ -199,9 +235,13 @@ function build() {
       continue;
     }
     const [slug, heading] = match;
-    if (headingsBySlug.get(slug).get(heading) === 0) {
+    const length = headingsBySlug.get(slug).get(heading);
+    if (length === 0) {
       undocumented.push(`${keyword} (${slug}#${anchorFor(heading)})`);
       continue;
+    }
+    if (length < THIN_EXPLANATION_CHARS) {
+      thin.push(`${keyword} (${length} chars) - ${slug}#${anchorFor(heading)}`);
     }
     const entry = { keyword, path: `/${slug}/#${anchorFor(heading)}` };
     if (dual) {
@@ -214,10 +254,10 @@ function build() {
     entries.push(entry);
   }
 
-  return { entries, unmatched, undocumented };
+  return { entries, unmatched, undocumented, thin };
 }
 
-const { entries, unmatched, undocumented } = build();
+const { entries, unmatched, undocumented, thin } = build();
 const helpPageTitles = readHelpPageTitles();
 
 const lines = [
@@ -286,5 +326,12 @@ if (process.argv.includes("--check")) {
       "explanation -\nadd a line of prose to give them a help link:"
     );
     for (const k of undocumented) console.log(`  - ${k}`);
+  }
+  if (thin.length > 0) {
+    console.log(
+      `\n${thin.length} keyword(s) are linked but have a short explanation (under ${THIN_EXPLANATION_CHARS} ` +
+      "chars) that may be worth fleshing out:"
+    );
+    for (const k of thin) console.log(`  - ${k}`);
   }
 }

--- a/site/src/content/docs/js/index.md
+++ b/site/src/content/docs/js/index.md
@@ -4,6 +4,8 @@ sidebar:
   order: 27
 ---
 
+## Calling JS functions
+
 The `JS` object is how Quest Viva exposes the user interface. What this means is that we can use the JS object to call JavaScript functions that will modify what the player sees. The basic format is to append the JavaScript function name with a dot, so to call `addText` (the JavaScript function Quest Viva uses to show text on the screen), use something like this:
 
 ```quest

--- a/site/src/content/docs/reference/functions/core.md
+++ b/site/src/content/docs/reference/functions/core.md
@@ -49,7 +49,7 @@ Returns a [boolean](/types#boolean) - **true** if the player can see through the
 ChangePOV (object)
 ```
 
-Switches the player object.
+Switches the current player object (point of view) to the given object, which must already have a parent (e.g. be placed somewhere in the game world). Triggers `OnEnterRoom` for the new POV's location. See [Changing the player object](/howto/tasks/changing-the-player-object/) for a full walkthrough.
 
 ## CheckDarkness
 ```quest

--- a/site/src/content/docs/reference/functions/internal-core.md
+++ b/site/src/content/docs/reference/functions/internal-core.md
@@ -294,7 +294,7 @@ Grid_CalculateMapCoordinates(room)
 Grid_ClearCustomLayer ()
 ```
 
-Clears the custom grid drawing layer.
+Clears the custom grid drawing layer - everything drawn with [Grid_DrawLine](#grid_drawline), [Grid_DrawArrow](#grid_drawarrow), [Grid_DrawSquare](#grid_drawsquare) and similar - without affecting the auto-generated room/exit layout underneath it.
 
 ## Grid_DrawArrow
 ```quest
@@ -396,7 +396,7 @@ Grid_Redraw
 Grid_SetCentre (int x, int y)
 ```
 
-Centres the grid on the specified co-ordinates.
+Scrolls the grid map so that (x, y) is centred in the view, instead of automatically following the player.
 
 ## Grid_SetGridCoordinateForPlayer
 ```quest
@@ -419,7 +419,7 @@ Grid_SetScale(scale)
 Grid_ShowCustomLayer (boolean visible)
 ```
 
-Turn the custom grid drawing layer on or off.
+Shows or hides the custom grid drawing layer (see [Grid_ClearCustomLayer](#grid_clearcustomlayer)), independently of the auto-generated grid map layer underneath it.
 
 ## HandleCommand
 ```quest
@@ -477,6 +477,8 @@ HideOutputSection(name)
 ```quest
 HidePreviousTurnOutput()
 ```
+
+Hides the output that was shown for the previous turn, leaving only the current turn's text visible in the transcript.
 
 ## InitConjugation
 ```quest

--- a/site/src/content/docs/reference/functions/objects.md
+++ b/site/src/content/docs/reference/functions/objects.md
@@ -186,10 +186,10 @@ player.parent = lounge
 
 ## RemoveObject
 ```quest
-RemoveObject(objectobject1)
+RemoveObject(object object1)
 ```
 
-Removes an object from its parent.
+Removes an object from its parent, by setting its `parent` attribute to null - the object still exists, it just isn't contained anywhere, so it won't appear in room contents, inventory, etc. This is different from [destroy](/scripts/#destroy), which deletes the object completely.
 
 ## UnlockExit
 ```quest

--- a/site/src/content/docs/reference/functions/timers-turnscripts.md
+++ b/site/src/content/docs/reference/functions/timers-turnscripts.md
@@ -9,14 +9,14 @@ sidebar:
 DisableTimer (timer)
 ```
 
-Disables the specified timer.
+Disables the specified timer, by setting its `enabled` attribute to false. See [EnableTimer](#enabletimer) to turn it back on.
 
 ## DisableTurnScript
 ```quest
 DisableTurnScript (turn script)
 ```
 
-Disables the specified turn script.
+Disables the specified turnscript, by setting its `enabled` attribute to false. See [EnableTurnScript](#enableturnscript) to turn it back on.
 
 ## EnableTimer
 ```quest
@@ -30,7 +30,7 @@ Enables the specified timer. Note that this sets the `trigger` attribute as well
 EnableTurnScript (turn script)
 ```
 
-Enables the specified turn script.
+Enables the specified turnscript, by setting its `enabled` attribute to true. See [DisableTurnScript](#disableturnscript) to turn it off again.
 
 ## GetTimer
 ```quest
@@ -89,7 +89,7 @@ The name specifies the name of the timer to create. The anonymous version of thi
 SetTimerInterval (timer, interval)
 ```
 
-Sets the specified timer interval.
+Sets the specified timer's interval, in seconds, between each time it fires - equivalent to setting its `interval` attribute directly.
 
 ## SetTimerScript
 ```quest

--- a/site/src/content/docs/reference/functions/user-interface.md
+++ b/site/src/content/docs/reference/functions/user-interface.md
@@ -153,7 +153,7 @@ The usual `OutputTextRaw` adds an HTML "br" element to the end of the text, to i
 PrintCentered(string text)
 ```
 
-Prints the specified text centered.
+Prints the specified text the same way [msg](/scripts/#msg) does, just centered instead of left-aligned - the text can include HTML as usual.
 
 ## RemovePageLink
 ```quest

--- a/site/src/content/docs/scripts/index.md
+++ b/site/src/content/docs/scripts/index.md
@@ -12,7 +12,9 @@ if (someVariable = 3) {
 }
 ```
 
-Comments are denoted by //
+## Comments
+
+Comments are denoted by `//` - anything after it on the same line is ignored:
 
 ```quest
 // this line will be ignored
@@ -199,7 +201,7 @@ Stops running the current script and raises the specified error message.
 finish
 ```
 
-Finish the game.
+Ends the game - no further commands are accepted, and any pending timers, menus or other prompts are cancelled.
 
 ## firsttime
 ```quest
@@ -377,7 +379,13 @@ See [Using Lists](/howto/scripting/using-lists)
 msg (string message)
 ```
 
-Prints the specified text.
+Prints the specified text to the transcript.
+
+```quest
+msg ("You open the door.")
+```
+
+The text is a normal string expression, so it can be built up with concatenation, e.g. `msg ("Score: " + game.score)`, and can include HTML for formatting.
 
 ## on ready
 ```quest
@@ -399,7 +407,7 @@ Note that this does not wait for scripts attached to functions to work (such as 
 picture (string filename)
 ```
 
-Outputs the specified picture file.
+Outputs the specified picture file. The file must already have been added to the game as a resource - reference it by filename only (e.g. `"cave.jpg"`), not a full path.
 
 ## play sound
 ```quest
@@ -538,7 +546,7 @@ For more, see [here](/howto/tasks/multiple-choices-using-a-switch-script)
 undo
 ```
 
-Moves the game state backwards one transaction.
+Reverts the game state to how it was before the current transaction - see [start transaction](#start-transaction) for how transaction boundaries are controlled. Without any explicit `start transaction` calls, this means `undo` undoes the whole of the previous turn (every attribute change and every line of output) in one go, not just a single script line.
 
 ## wait
 ```quest
@@ -562,4 +570,14 @@ wait {
 while (expression) { script }
 ```
 
-Run a script while the given expression returns true.
+Runs a script repeatedly for as long as the given expression evaluates to true, checking the condition again before each pass.
+
+```quest
+count = 1
+while (count <= 5) {
+  msg (count)
+  count = count + 1
+}
+```
+
+Make sure something inside the script eventually makes the expression false - otherwise the loop (and the game) never moves on. For a fixed number of iterations, [for](#for) is usually clearer.

--- a/src/AppShell/src/lib/docs-index.generated.ts
+++ b/src/AppShell/src/lib/docs-index.generated.ts
@@ -13,6 +13,7 @@ export interface DocsIndexEntry {
 }
 
 export const DOCS_INDEX: Readonly<Record<string, DocsIndexEntry>> = {
+    "()": { path: "/howto/tasks/about-functions/#using-functions" },
     "(function)AddPageLink": { path: "/reference/functions/user-interface/#addpagelink", gamebookPath: "/reference/functions/gamebook/#addpagelink" },
     "(function)AddToInventory": { path: "/reference/functions/core/#addtoinventory" },
     "(function)Ask": { path: "/reference/functions/user-interface/#ask" },
@@ -49,6 +50,7 @@ export const DOCS_INDEX: Readonly<Record<string, DocsIndexEntry>> = {
     "(function)Grid_ShowCustomLayer": { path: "/reference/functions/internal-core/#grid_showcustomlayer" },
     "(function)HelperCloseObject": { path: "/reference/functions/core/#helpercloseobject" },
     "(function)HelperOpenObject": { path: "/reference/functions/core/#helperopenobject" },
+    "(function)HidePreviousTurnOutput": { path: "/reference/functions/internal-core/#hidepreviousturnoutput" },
     "(function)IncreaseCounter": { path: "/reference/functions/gamebook/#increasecounter" },
     "(function)IncreaseHealth": { path: "/reference/functions/attributes/#increasehealth" },
     "(function)IncreaseMoney": { path: "/reference/functions/attributes/#increasemoney" },
@@ -100,6 +102,10 @@ export const DOCS_INDEX: Readonly<Record<string, DocsIndexEntry>> = {
     "(function)TextFX_Unscramble": { path: "/reference/functions/user-interface/#textfx_unscramble" },
     "(function)UnlockExit": { path: "/reference/functions/objects/#unlockexit" },
     "(function)WaitForKeyPress": { path: "/reference/functions/user-interface/#waitforkeypress" },
+    "//": { path: "/scripts/#comments" },
+    "=": { path: "/scripts/#setting-variables" },
+    "=>": { path: "/scripts/#setting-variables" },
+    "JS.": { path: "/js/#calling-js-functions" },
     "ask": { path: "/scripts/#ask" },
     "create": { path: "/scripts/#create" },
     "create exit": { path: "/scripts/#create-exit" },

--- a/src/AppShell/src/lib/docs-links.ts
+++ b/src/AppShell/src/lib/docs-links.ts
@@ -49,7 +49,8 @@ export function scriptKeywordName(keyword: string): string {
 /**
  * Documentation URL for a script editor keyword (a script's <appliesto> value,
  * e.g. "msg" or "(function)OutputTextNoBr"), or null when that command has no
- * reference entry — syntax like `=` and `//`, and the `JS.` call prefix.
+ * reference entry at all (see build-docs-index.mjs's `unmatched`/`undocumented`
+ * reporting for why a given keyword might still be missing).
  *
  * isGamebook picks between the two same-named functions where the gamebook and
  * Text Adventure page APIs collide (AddPageLink and friends).


### PR DESCRIPTION
## Summary

Closes #2220.

**Part 1 — six commands with no help link:**
- `=`, `=>`, `//`, `()` and `JS.` don't start with a letter, so `build-docs-index.mjs`'s letter check (meant to exclude internal pseudo-elements like `_objects`) was also silently excluding these five real, author-facing commands. Added a `manualTargets` map for them:
  - `=` / `=>` → `/scripts/#setting-variables` (heading already existed)
  - `//` → new `## Comments` heading on the scripts page (the prose already existed, just wasn't under a heading)
  - `JS.` → new `## Calling JS functions` heading on the JS page (same situation)
  - `()` → the existing `## Using functions` section of the "How to use functions" howto guide
- `HidePreviousTurnOutput` had a heading but was documented by nothing but its signature, so it was deliberately skipped. Added one line of prose.

**Part 2 — thin explanations:**
Fleshed out the 19 entries under 60 characters that the issue's ad-hoc measurement flagged (`while`, `undo`, `msg`, `RemoveObject`, `ChangePOV`, the timer/turnscript enable/disable pairs, the `Grid_*` internal functions, etc.), mostly with a short example or a clarifying detail pulled from the actual implementation (e.g. `RemoveObject` vs `destroy`, `SetTimerInterval` being an `interval` attribute setter). Left the handful the issue itself called "arguably complete" (`ClearScreen`, `SetFontName`, `SetFontSize`, `stop sound`) alone. Also fixed a stale `object object1` signature typo in `RemoveObject` while in there.

Also added an informational (non-failing) "thin explanation" report to `build-docs-index.mjs`'s console output, per the issue's own suggestion, so this tail gets flagged automatically going forward instead of needing another ad-hoc script.

## Test plan
- [x] `node site/scripts/build-docs-index.mjs` — all 6 previously-missing keywords now resolve; regenerated `docs-index.generated.ts`
- [x] `node site/scripts/build-docs-index.mjs --check` passes
- [x] `node site/scripts/check-function-docs.mjs` and `check-editor-help-urls.mjs` pass
- [x] `npm run build` in `site/` succeeds; verified the new/changed anchors (`#comments`, `#calling-js-functions`, `#using-functions`, plus all edited reference entries) render at their expected ids in the built HTML
- [x] Spot-checked the changed pages in a live `astro dev` preview
- [x] `npm run check` and `npm run lint` in `src/AppShell` pass (consumes `docs-index.generated.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)