### PR TITLE
fix(Engine): name the drop script's "successful" parameter correctly in the editor label

### DIFF
--- a/src/Engine/Core/Languages/EditorEnglish.aslx
+++ b/src/Engine/Core/Languages/EditorEnglish.aslx
@@ -361,7 +361,7 @@
   <template name="EditorObjectInventoryDrop">Drop</template>
   <template name="EditorObjectInventoryDrop2">Drop</template>
   <template name="EditorObjectInventoryDropmessage">Drop message (leave blank for default)</template>
-  <template name="EditorObjectInventoryAfterdropping">Run script after (Boolean "success" will indicate if the object moved)</template>
+  <template name="EditorObjectInventoryAfterdropping">Run script after (Boolean "successful" will indicate if the object moved)</template>
   <template name="EditorObjectInventoryPrice">Price</template>
   <template name="EditorObjectInventoryInventorylimitation">Inventory limitation</template>
   <template name="EditorObjectInventorySetmaximum">Set "maximum objects" to 0 to allow unlimited inventory items.</template>


### PR DESCRIPTION
The object editor's _Inventory_ tab labels its "after dropping" script box with the variable name `success`:

```
Run script after (Boolean "success" will indicate if the object moved)
```

But `DoDrop` in `src/Engine/Core/CoreCommands.aslx` has always passed the parameter as `successful`:

```quest
do (object, "ondrop", QuickParams("successful", not oldparent = object.parent))
```

So an author who follows the label and writes `if (success) {...}` gets an undefined-variable error instead of the Boolean they were promised. `git log -L` on that line shows only whitespace/encoding churn since it was written — the engine has never passed `success`, so the label is the side that's wrong.

## Why fix the label rather than the engine

Passing both keys for compatibility was considered and rejected:

- It wouldn't reach already-published games anyway. A published `.quest` file inlines Core library code at publish time (see CLAUDE.md's "Core Library Semantics"), so every existing game carries its own frozen copy of `DoDrop` and is unaffected by either change.
- It would only take effect for games saved or created *after* the change — i.e. exactly the authors who'd be reading the corrected label — while entrenching the wrong name permanently.

The label fix is the narrower, lower-risk change.

## Other language files

`EditorDeutsch.aslx` and `EditorEspanol.aslx` have the same `EditorObjectInventoryAfterdropping` key, but their translations don't name the variable at all ("Nachdem das Objekt abgelegt wurde" / "Después de dejar el objeto"), so there's nothing to correct in them.

## Testing

`dotnet test tests/EngineTests --configuration Release` — 345 passed. No test or other file references the caption string.

## Follow-up not included here

The docs page that describes this variable (`site/src/content/docs/howto/world/taking-and-dropping.md`) carries a parenthetical noting that the label disagrees, which this change makes stale. That page only exists on the unmerged `docs/editor-tab-guides` branch, not on `main`, so removing the parenthetical belongs to that branch rather than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)