### PR TITLE
feat(Engine): render Ask/ShowMenu inline in the transcript for v600 games

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -392,6 +392,8 @@ jobs:
         working-directory: tests/e2e
       - run: node verify-wasmplayer-showmenu-long-options.mjs http://localhost:5175
         working-directory: tests/e2e
+      - run: node verify-wasmplayer-inline-sync-prompts.mjs http://localhost:5175
+        working-directory: tests/e2e
       - run: node verify-game-load-error.mjs http://localhost:5175
         working-directory: tests/e2e
       - run: node verify-wasmplayer-autoscroll.mjs http://localhost:5175

--- a/examples/sync-and-async/README.md
+++ b/examples/sync-and-async/README.md
@@ -1,3 +1,7 @@
 This folder contains some sample files which can be used to test "pausing" script execution (by waiting for the player to press a key, type some text, choose from a menu).
 
 The v410 and v500 examples demonstrate this. After v5.0, these "blocking" features were deprecated (but still supported), in favour of a "callback" style. This style is demonstrated in the v580 example.
+
+The v600 example shows both styles side by side at the current WorldModel version, where the
+synchronous forms are supported again and render their choices as numbered links in the
+transcript rather than in a dialog.

--- a/examples/sync-and-async/v600.aslx
+++ b/examples/sync-and-async/v600.aslx
@@ -1,0 +1,97 @@
+<asl version="600">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="v600">
+    <gameid>9f3e0f4a-2b57-4c41-9f22-6f5a1e7c1d03</gameid>
+    <version>1.0</version>
+    <description>Synchronous and callback input forms, side by side, at WorldModel version 600.</description>
+  </game>
+  <object name="room">
+    <inherit name="editor_room" />
+    <object name="player">
+      <inherit name="editor_object" />
+      <inherit name="defaultplayer" />
+    </object>
+  </object>
+
+  <!-- The synchronous expression forms. Re-enabled for v600 (they throw for v540-v580), and
+       since #2287 they draw their choices as numbered links in the transcript rather than
+       opening a dialog - so they look the same as the callback forms below. -->
+  <command>
+    <pattern>askfn</pattern>
+    <script><![CDATA[
+      if (Ask ("Buy dodgy watch?")) {
+        msg ("You hand over $50.")
+      }
+      else {
+        msg ("No thanks.")
+      }
+    ]]></script>
+  </command>
+
+  <command>
+    <pattern>menufn</pattern>
+    <script><![CDATA[
+      colour = ShowMenu ("What is your favourite colour?", Split("Red;Green;Blue;Yellow", ";"), false)
+      msg ("You chose " + colour)
+    ]]></script>
+  </command>
+
+  <!-- Cancellable: typing anything that isn't one of the option numbers dismisses the menu, and
+       ShowMenu returns an empty string. -->
+  <command>
+    <pattern>menufncancel</pattern>
+    <script><![CDATA[
+      colour = ShowMenu ("What is your favourite colour?", Split("Red;Green;Blue;Yellow", ";"), true)
+      if (colour = "") {
+        msg ("You didn't choose.")
+      }
+      else {
+        msg ("You chose " + colour)
+      }
+    ]]></script>
+  </command>
+
+  <!-- The callback forms, for comparison. -->
+  <command>
+    <pattern>ask</pattern>
+    <script><![CDATA[
+      Ask ("Buy dodgy watch?") {
+        if (result) {
+          msg ("You hand over $50.")
+        }
+        else {
+          msg ("No thanks.")
+        }
+      }
+    ]]></script>
+  </command>
+
+  <command>
+    <pattern>menu</pattern>
+    <script><![CDATA[
+      ShowMenu ("What is your favourite colour?", Split("Red;Green;Blue;Yellow", ";"), false) {
+        msg ("You chose " + result)
+      }
+    ]]></script>
+  </command>
+
+  <!-- The script-command forms, which take a callback but render through the same code as the
+       expression forms above. -->
+  <command>
+    <pattern>menucmd</pattern>
+    <script><![CDATA[
+      show menu ("What is your favourite colour?", Split("Red;Green;Blue;Yellow", ";"), false) {
+        msg ("You chose " + result)
+      }
+    ]]></script>
+  </command>
+
+  <command>
+    <pattern>inputfn</pattern>
+    <script><![CDATA[
+      name = GetInput()
+      msg ("Hello " + name)
+    ]]></script>
+  </command>
+</asl>

--- a/site/src/content/docs/howto/npcs/conversations.md
+++ b/site/src/content/docs/howto/npcs/conversations.md
@@ -59,7 +59,7 @@ For a more structured exchange - where the player picks from a fixed set of repl
     2: Ask about the Queen
     > 1
 
-Unlike a `ShowMenu`-based conversation, each choice is a complete, ordinary turn, so save, load and undo all keep working in the middle of a conversation.
+Unlike a `ShowMenu`-based conversation, each choice is a complete, ordinary turn with its own undo point, rather than the whole exchange happening inside the turn that opened the menu.
 
 [More here](/howto/npcs/dialogue-pages)
 

--- a/site/src/content/docs/howto/npcs/dialogue-pages.md
+++ b/site/src/content/docs/howto/npcs/dialogue-pages.md
@@ -10,7 +10,9 @@ The [Tutorial](/tutorial/using-pages) covers the basics of setting up a Pages di
 
 Quest Viva has several ways to let the player talk to a character - see [Introduction to conversations](/howto/npcs/conversations) for an overview. Pages are the right choice when you want a structured, multi-step exchange where each reply leads to a fixed set of further choices - the Text Adventure equivalent of a gamebook's branching passages. For a one-off list of topics with no follow-up, a [ShowMenu](/reference/functions/user-interface#showmenu)-based menu (see [Handling SPEAK TO](/howto/npcs/speak-to)) is simpler. For a free-form "ask about anything" system, use [Ask/Tell](/howto/npcs/ask-about) instead.
 
-The main practical advantage of Pages over `ShowMenu` is that each choice is a complete, ordinary turn - the game is never "waiting" on a menu callback, so save, load and undo all work in the middle of a conversation.
+The main practical advantage of Pages over `ShowMenu` is that each choice is a complete, ordinary turn, recorded as its own undo point, and the conversation is described as a graph of linked page objects instead of a callback nested inside another callback for every level of the exchange. The dialogue's whole state lives in ordinary game attributes, so a save taken mid-conversation restores without depending on the saved transcript's own markup.
+
+(Saving itself works during a `ShowMenu` callback too - the turn has ended by the time the menu is on screen. It's the `ShowMenu` *expression* form, and the `show menu` script command, that suspend the script mid-turn and make saving unavailable until the player answers.)
 
 ## The page object
 

--- a/site/src/content/docs/howto/npcs/speak-to.md
+++ b/site/src/content/docs/howto/npcs/speak-to.md
@@ -126,7 +126,7 @@ The first line of the script sets up the topics. They need to be a string list, 
 
 A switch statement is used to decide which response will be seen. Note that the key for each case must be exactly the same as the topic you listed before. The script for each case is set up just as the script for the first option.
 
-If you want a topic's response to lead on to a further set of choices, rather than a one-off menu, see [Building a conversation with Pages](/howto/npcs/dialogue-pages) - unlike `ShowMenu`, a Pages-based conversation doesn't block saving between choices.
+If you want a topic's response to lead on to a further set of choices, rather than a one-off menu, see [Building a conversation with Pages](/howto/npcs/dialogue-pages) - unlike `ShowMenu`, each choice there is an ordinary turn in its own right, so the conversation doesn't become a callback nested inside a callback and the player can undo back through it.
 
 
 ## Menu and varying?

--- a/site/src/content/docs/howto/scripting/blocks-and-scripts.md
+++ b/site/src/content/docs/howto/scripting/blocks-and-scripts.md
@@ -185,4 +185,4 @@ msg ("Really? A " + LCase(colour) + " " + LCase(animal) + " fan.")
 
 Because that is an ordinary expression rather than a script, the local variable problem above does not apply to it either - `this`, `object`, `text` and function parameters are all still in scope after it returns.
 
-The trade-off is that the expression form suspends the script in the middle of the turn, so the player can't save while the menu is up (the same trade-off `GetInput()` makes). The `ShowMenu (...) { }` form ends the turn before waiting, so save, load and undo stay available while the player is choosing.
+The trade-off is that the expression form suspends the script in the middle of the turn, so the player can't save while the menu is up (the same trade-off `GetInput()` makes). The `ShowMenu (...) { }` form ends the turn before waiting, so saving stays available while the player is choosing.

--- a/site/src/content/docs/howto/scripting/blocks-and-scripts.md
+++ b/site/src/content/docs/howto/scripting/blocks-and-scripts.md
@@ -175,7 +175,7 @@ ShowMenu ("What is your favourite colour?", options, false) {
 
 The same applies to any other waiting block or script, or combinations of them. You can have as many nested as you like - though it will get increasing difficult for you to track what belongs were.
 
-If you do not need the inline-link rendering that the `ShowMenu (...) { }` function form gives you, the [ShowMenu](/reference/functions/user-interface#showmenu) expression form avoids the nesting entirely - it pops the menu up as a dialog and hands back the chosen option, so one menu after another is just one line after another:
+The [ShowMenu](/reference/functions/user-interface#showmenu) expression form avoids the nesting entirely - it shows the same numbered links and hands back the chosen option, so one menu after another is just one line after another:
 
 ```quest
 colour = ShowMenu ("What is your favourite colour?", Split("Red;Green;Blue;Yellow", ";"), false)
@@ -184,3 +184,5 @@ msg ("Really? A " + LCase(colour) + " " + LCase(animal) + " fan.")
 ```
 
 Because that is an ordinary expression rather than a script, the local variable problem above does not apply to it either - `this`, `object`, `text` and function parameters are all still in scope after it returns.
+
+The trade-off is that the expression form suspends the script in the middle of the turn, so the player can't save while the menu is up (the same trade-off `GetInput()` makes). The `ShowMenu (...) { }` form ends the turn before waiting, so save, load and undo stay available while the player is choosing.

--- a/site/src/content/docs/howto/tasks/showing-a-menu.md
+++ b/site/src/content/docs/howto/tasks/showing-a-menu.md
@@ -4,11 +4,11 @@ sidebar:
   order: 22
 ---
 
-There are two ways to show a menu. To have a dialogue box pop-up, use the [show menu](/scripts#show-menu) script command. If you prefer to have an in-line menu with hyperlinks, use the [ShowMenu](/reference/functions/user-interface#showmenu) function. How you implement them is virtually the same.
+A menu is shown in the transcript as a numbered list of links - the player can click one or type its number. There are two ways to show one: the [ShowMenu](/reference/functions/user-interface#showmenu) function, which hands the chosen option straight back so the rest of your script carries on below it, and the older [show menu](/scripts#show-menu) script command, which runs a nested script instead. How you implement them is virtually the same.
 
 First, you need to create a string list of options - see [Using Lists](/howto/scripting/using-lists). Then call the "show menu" command or "ShowMenu" function to display the list to the user and run a nested script after the user has made their selection.
 
-Here is an example how to create a menu (in this case a pop-up menu). A new list is created, and then the entries 'female' and 'male' are added. If the player chooses an entry from the menu, that value goes into a variable called "result", and from that the variables playername and gender are set.
+Here is an example of how to create a menu. A new list is created, and then the entries 'female' and 'male' are added. If the player chooses an entry from the menu, that value goes into a variable called "result", and from that the variables playername and gender are set.
 
 ![](/images/ShowMenu.png)
 

--- a/site/src/content/docs/reference/functions/user-interface.md
+++ b/site/src/content/docs/reference/functions/user-interface.md
@@ -51,7 +51,7 @@ Ask ("Are you sure?") {
 }
 ```
 
-This form is still offered in the script editor. Both forms look the same to the player; the difference is that this one ends the turn before waiting, so the player can save, load and undo while choosing, whereas the plain `Ask (question)` form suspends the script mid-turn and save is unavailable until it is answered.
+This form is still offered in the script editor. Both forms look the same to the player; the difference is that this one ends the turn before waiting, so the player can save or load while choosing, whereas the plain `Ask (question)` form suspends the script mid-turn and saving is unavailable until it is answered.
 
 **Note:** The callback form is "non-blocking", and its script has no access to local variables. For a fuller discussion, see the note on [Blocks and Scripts](/howto/scripting/blocks-and-scripts). Neither caveat applies to the plain `Ask (question)` form above, which simply returns a value.
 
@@ -316,7 +316,9 @@ ShowMenu ("What is your favourite colour?", options, false) {
 }
 ```
 
-This form is still offered in the script editor. Both forms look the same to the player; the difference is that this one ends the turn before waiting, so the player can save, load and undo while choosing, whereas the plain `ShowMenu (...)` form suspends the script mid-turn and save is unavailable until it is answered.
+This form is still offered in the script editor. Both forms look the same to the player; the difference is that this one ends the turn before waiting, so the player can save or load while choosing, whereas the plain `ShowMenu (...)` form suspends the script mid-turn and saving is unavailable until it is answered.
+
+(Note that "save" here means saving is *available* - `undo` and any other command typed while the menu is open are still subject to the "allow cancel" rule above, so on an uncancellable menu they are ignored.)
 
 The callback form will also take an object list, or a list of objects and strings. Note that `result` will always be a string - in the case of an object, it will be the object's name.
 

--- a/site/src/content/docs/reference/functions/user-interface.md
+++ b/site/src/content/docs/reference/functions/user-interface.md
@@ -20,7 +20,7 @@ Ask (string question)
 
 <a href="/reference/functions/hardcoded" class="qv-badge">hard-coded</a>
 
-Asks the player the specified **question** as a Yes/No popup, and returns a [boolean](/types#boolean) - **true** if they answer "Yes". The script is suspended until they have answered, so the result can go straight into an `if`:
+Asks the player the specified **question**, showing "Yes" and "No" as numbered links in the transcript, and returns a [boolean](/types#boolean) - **true** if they answer "Yes". The player can click a link or type its number. The script is suspended until they have answered, so the result can go straight into an `if`:
 
 ```quest
 if (Ask ("Are you sure?")) {
@@ -35,7 +35,7 @@ This replaces the [ask](/scripts#ask) script command, which is no longer offered
 
 ### The callback form
 
-There is a second form, which takes a script and shows the two options as links in the transcript rather than as a popup:
+There is a second form, which takes a script to run once the player has answered:
 
 ```quest
 Ask (string question)  { script }
@@ -51,7 +51,7 @@ Ask ("Are you sure?") {
 }
 ```
 
-This form is still offered in the script editor, for when you want the inline links rather than a popup.
+This form is still offered in the script editor. Both forms look the same to the player; the difference is that this one ends the turn before waiting, so the player can save, load and undo while choosing, whereas the plain `Ask (question)` form suspends the script mid-turn and save is unavailable until it is answered.
 
 **Note:** The callback form is "non-blocking", and its script has no access to local variables. For a fuller discussion, see the note on [Blocks and Scripts](/howto/scripting/blocks-and-scripts). Neither caveat applies to the plain `Ask (question)` form above, which simply returns a value.
 
@@ -268,14 +268,14 @@ ShowMenu (string caption, stringdictionary or stringlist options, boolean allow 
 
 <a href="/reference/functions/hardcoded" class="qv-badge">hard-coded</a>
 
-Shows the specified options as a popup menu and returns the player's choice, as a [string](/types#string). If a dictionary of options is passed in, the values are displayed as options and the key is returned; if a list of options is passed in, the list item is returned. The script is suspended until the player has chosen, so the result can go straight into a variable:
+Shows the specified options as a numbered list of links in the transcript and returns the player's choice, as a [string](/types#string). The player can click an option or type its number. If a dictionary of options is passed in, the values are displayed as options and the key is returned; if a list of options is passed in, the list item is returned. The script is suspended until the player has chosen, so the result can go straight into a variable:
 
 ```quest
 colour = ShowMenu ("What is your favourite colour?", Split("Red;Green;Blue;Yellow", ";"), false)
 msg ("You chose " + colour)
 ```
 
-If the "allow cancel" parameter is set to **true**, the Cancel button is available, and cancelling returns an empty string. If it is set to **false**, the player must choose one entry of the menu.
+If the "allow cancel" parameter is set to **true**, entering any command other than one of the option numbers dismisses the menu, and `ShowMenu` returns an empty string (the dismissing command itself is discarded). If it is set to **false**, the player must choose one entry of the menu, and anything else they type is ignored.
 
 The [Split](/reference/functions/string#split) function can be useful to quickly get a list of options, whilst [switch](/scripts#switch) can be useful for dealing with the result. Because one call simply follows another, asking several questions in a row needs no nesting:
 
@@ -289,7 +289,7 @@ This replaces the [show menu](/scripts#show-menu) script command, which is no lo
 
 ### The callback form
 
-There is a second form, which takes a script and shows the options as numbered links in the transcript rather than as a popup:
+There is a second form, which takes a script to run once the player has chosen:
 
 ```quest
 ShowMenu (string caption, stringdictionary or list options, boolean allow ignore)  { script }
@@ -316,7 +316,7 @@ ShowMenu ("What is your favourite colour?", options, false) {
 }
 ```
 
-This form is still offered in the script editor, for when you want the inline links rather than a popup.
+This form is still offered in the script editor. Both forms look the same to the player; the difference is that this one ends the turn before waiting, so the player can save, load and undo while choosing, whereas the plain `ShowMenu (...)` form suspends the script mid-turn and save is unavailable until it is answered.
 
 The callback form will also take an object list, or a list of objects and strings. Note that `result` will always be a string - in the case of an object, it will be the object's name.
 

--- a/site/src/content/docs/scripts/index.md
+++ b/site/src/content/docs/scripts/index.md
@@ -51,9 +51,9 @@ variable => { script }
 ask (string question) {script}
 ```
 
-**Superseded:** this command is no longer offered when you add a script command - use the [Ask](/reference/functions/user-interface#ask) function instead, which asks the same question but hands the answer straight back, so it can go directly in an `if` and the script simply continues on the next line. `ask` still runs, and is still editable in games that already use it.
+**Superseded:** this command is no longer offered when you add a script command - use the [Ask](/reference/functions/user-interface#ask) function instead, which asks the same question the same way but hands the answer straight back, so it can go directly in an `if` and the script simply continues on the next line. `ask` still runs, and is still editable in games that already use it.
 
-Pops up a prompt for the user to choose Yes or No as the answer to the specified question, and then runs the nested script.
+Shows "Yes" and "No" as numbered links in the transcript for the user to answer the specified question, and then runs the nested script.
 
 The nested script can check the "result" boolean variable to see the user's response - true for "yes", false for "no".
 
@@ -498,13 +498,13 @@ You only need to use the "set" command if you are constructing the attribute nam
 show menu (string caption, stringdictionary or stringlist options, boolean allow cancel) {script}
 ```
 
-**Superseded:** this command is no longer offered when you add a script command - use the [ShowMenu](/reference/functions/user-interface#showmenu) function instead, which shows the same popup but returns the chosen option, so the rest of the script can just carry on below it. `show menu` still runs, and is still editable in games that already use it.
+**Superseded:** this command is no longer offered when you add a script command - use the [ShowMenu](/reference/functions/user-interface#showmenu) function instead, which shows the same menu but returns the chosen option, so the rest of the script can just carry on below it. `show menu` still runs, and is still editable in games that already use it.
 
-Shows a popup menu of options and then runs the nested script. The script can access the variable "result" which contains the result of the user selection - if a dictionary of options is passed in, the key is returned. If a list of options is passed in, the list item is returned.
+Shows the options as a numbered list of links in the transcript and then runs the nested script. The script can access the variable "result" which contains the result of the user selection - if a dictionary of options is passed in, the key is returned. If a list of options is passed in, the list item is returned.
 
-If the "allow cancel" parameter is set to **true**, the Cancel button is available. If "cancel" is pressed, the variable "result" returns [null](/types#null).
+If the "allow cancel" parameter is set to **true**, entering any command other than one of the option numbers dismisses the menu, and the variable "result" is [null](/types#null). If it is set to **false**, anything else the player types is ignored.
 
-For a menu shown as links in the transcript rather than a popup, use the [ShowMenu](/reference/functions/user-interface#showmenu) function's callback form, `ShowMenu (caption, options, allow cancel) { script }`.
+This command suspends the script mid-turn, so the player can't save while the menu is up. For a menu that ends the turn first, leaving save, load and undo available while the player chooses, use the [ShowMenu](/reference/functions/user-interface#showmenu) function's callback form, `ShowMenu (caption, options, allow cancel) { script }`.
 
 **example:**
 

--- a/site/src/content/docs/scripts/index.md
+++ b/site/src/content/docs/scripts/index.md
@@ -504,7 +504,7 @@ Shows the options as a numbered list of links in the transcript and then runs th
 
 If the "allow cancel" parameter is set to **true**, entering any command other than one of the option numbers dismisses the menu, and the variable "result" is [null](/types#null). If it is set to **false**, anything else the player types is ignored.
 
-This command suspends the script mid-turn, so the player can't save while the menu is up. For a menu that ends the turn first, leaving save, load and undo available while the player chooses, use the [ShowMenu](/reference/functions/user-interface#showmenu) function's callback form, `ShowMenu (caption, options, allow cancel) { script }`.
+This command suspends the script mid-turn, so the player can't save while the menu is up. For a menu that ends the turn first, leaving saving available while the player chooses, use the [ShowMenu](/reference/functions/user-interface#showmenu) function's callback form, `ShowMenu (caption, options, allow cancel) { script }`.
 
 **example:**
 

--- a/site/src/content/docs/tutorial/using-pages.md
+++ b/site/src/content/docs/tutorial/using-pages.md
@@ -6,7 +6,7 @@ sidebar:
 
 Bob is alive, and thanks to Ask/Tell he'll tell you about his heart attack if you ask him directly. But Ask/Tell only works if the player already knows what to ask about. Sometimes you want to offer the player a menu of things to say, and have Bob's replies lead on to further choices - a proper branching conversation.
 
-You could build this with `ShowMenu` (see [Handling SPEAK TO](/howto/npcs/speak-to)), but a menu-based conversation has a drawback: while the menu is open, the game is waiting on that one callback, so the player can't save or undo until they've picked an option. **Pages** solve this by turning every choice into a normal, complete turn - the same mechanism gamebooks use for their branching passages (see [Creating a gamebook](/tutorial/creating-a-gamebook)), but usable in a Text Adventure room. Nothing is "pending" between choices, so save, load and undo all work mid-conversation.
+You could build this with `ShowMenu` (see [Handling SPEAK TO](/howto/npcs/speak-to)), but a menu-based conversation has a drawback: the whole exchange happens inside the single turn that opened the menu, so the player can't undo their way back through the choices they made, and each further set of choices means another nested callback. **Pages** turn every choice into a normal, complete turn - the same mechanism gamebooks use for their branching passages (see [Creating a gamebook](/tutorial/creating-a-gamebook)), but usable in a Text Adventure room. Each choice is its own undo point, and the whole conversation is described as linked page objects rather than nested scripts.
 
 ## Creating a page
 

--- a/src/Common/IGame.cs
+++ b/src/Common/IGame.cs
@@ -53,7 +53,8 @@ public interface IPlayer
     void ShowMenu(MenuData menuData);
     void DoWait();
     void DoPause(int ms);
-    void ShowQuestion(string caption);
+    // inline: as MenuData.Inline - the engine has already drawn the Yes/No links itself.
+    void ShowQuestion(string caption, bool inline);
     void SetWindowMenu(MenuData menuData);
     Task PlaySoundAsync(string filename, bool synchronous, bool looped);
     void StopSound();
@@ -104,6 +105,12 @@ public class MenuData
     public IDictionary<string, string> Options { get; }
 
     public bool AllowCancel { get; }
+
+    // True when the engine has already drawn this menu as numbered links in the transcript
+    // (v600+ games - see WorldModel.ShowInlinePromptAsync). The call is then purely a
+    // notification that a menu is awaiting a response, which is what a headless IPlayer such as
+    // the walkthrough runner needs; players that draw their own UI should show nothing.
+    public bool Inline { get; init; }
 }
 
 public class ListData

--- a/src/Engine/Core/CoreEditorScriptsOutput.aslx
+++ b/src/Engine/Core/CoreEditorScriptsOutput.aslx
@@ -584,7 +584,7 @@
          what the engine is doing while the menu is up. This "ShowMenu (...) { }" form calls the
          ASLX ShowMenu function in CoreFunctions.aslx (the same one the parser's disambiguation
          prompt uses), which prints its links and returns: the turn ends normally, so the player
-         can save, load and undo while choosing. The expression form suspends the script
+         can still save while choosing. The expression form suspends the script
          mid-turn instead, which the players' turn-pending logic disables save around - the same
          trade-off GetInput() makes. Kept addable for the form that stays saveable. -->
     <appliesto>(function)ShowMenu</appliesto>

--- a/src/Engine/Core/CoreEditorScriptsOutput.aslx
+++ b/src/Engine/Core/CoreEditorScriptsOutput.aslx
@@ -579,13 +579,14 @@
 
   <editor>
     <!-- NOT superseded by the synchronous "ShowMenu(...)" expression form (reachable via the
-         "set variable" value field's "player's choice from a menu" template) - they render
-         differently, not just sync-vs-async. This "ShowMenu (...) { }" form calls the ASLX
-         ShowMenu function in CoreFunctions.aslx (the same one the parser's disambiguation
-         prompt uses), which prints numbered "cmdlink" hyperlinks inline in the transcript. The
-         expression form instead goes through ExpressionOwner.ShowMenu -> PlayerUi.ShowMenu,
-         a jQuery UI popup dialog - see docs/issue about modernising that popup. Kept addable so
-         authors can still reach the nicer inline-link rendering. -->
+         "set variable" value field's "player's choice from a menu" template). Since #2287 the
+         two render identically - numbered links in the transcript - but they still differ in
+         what the engine is doing while the menu is up. This "ShowMenu (...) { }" form calls the
+         ASLX ShowMenu function in CoreFunctions.aslx (the same one the parser's disambiguation
+         prompt uses), which prints its links and returns: the turn ends normally, so the player
+         can save, load and undo while choosing. The expression form suspends the script
+         mid-turn instead, which the players' turn-pending logic disables save around - the same
+         trade-off GetInput() makes. Kept addable for the form that stays saveable. -->
     <appliesto>(function)ShowMenu</appliesto>
     <display>Show a menu</display>
     <category>[EditorScriptsOutputOutput]</category>
@@ -663,9 +664,9 @@
     <!-- NOT superseded by the synchronous "Ask(...)" expression form (reachable via the
          if-condition builder's "player answers a yes/no question" template) - same reasoning as
          ShowMenu above (Ask's CoreFunctions.aslx implementation just calls ShowMenu internally
-         with Yes/No options): this "Ask (...) { }" form renders inline cmdlinks, the expression
-         form pops a jQuery UI dialog via ExpressionOwner.Ask -> PlayerUi.ShowQuestion. Kept
-         addable for the nicer inline rendering. -->
+         with Yes/No options): this "Ask (...) { }" form ends the turn before waiting, so the
+         game stays saveable, while the expression form suspends the script mid-turn. Kept
+         addable for the form that stays saveable. -->
     <appliesto>(function)Ask</appliesto>
     <display>Ask a question</display>
     <category>[EditorScriptsOutputOutput]</category>

--- a/src/Engine/Core/CorePages.aslx
+++ b/src/Engine/Core/CorePages.aslx
@@ -4,13 +4,22 @@
   Gamebook-style "Pages" for Text Adventure games: inline branching choices, primarily
   for NPC dialogue trees. This deliberately mirrors GamebookCore.aslx's DoPage /
   HandleCommand mechanism rather than being built on ShowMenu: a ShowMenu-based dialogue
-  parks a callback in game.menucallback, which leaves the game in an intercepted state
-  that the players' turn-pending logic disables save around. Here each option is just a
-  CommandLink that runs as an ordinary complete turn, so between choices the game is
-  fully idle and all dialogue state is plain game attributes - save, load and undo work
-  mid-dialogue for free. The one substitution from gamebook: a Text Adventure player
-  stays in their room, so the current page is tracked in game.currentpage instead of
-  player.parent.
+  runs the whole exchange inside the single turn that opened the menu, parking a callback
+  in game.menucallback and nesting another callback for every further level of choices.
+  Here each option is just a CommandLink that runs as an ordinary complete turn, so each
+  choice gets its own undo transaction (see HandlePageTextResponse), the dialogue is
+  described as linked page objects rather than nested scripts, and all dialogue state is
+  plain game attributes - so a save taken mid-dialogue restores without depending on the
+  saved transcript's own markup the way ShowMenu's ASLEvent links do.
+
+  Note that saving is *not* the difference: the ASLX ShowMenu callback form prints its
+  links and returns, so nothing is pending and the save button stays enabled there too
+  (game.menucallback serialises as a script attribute and does restore correctly). It is
+  ShowMenu's expression form and the 'show menu' script command that suspend the script
+  mid-turn and make saving unavailable.
+
+  The one substitution from gamebook: a Text Adventure player stays in their room, so the
+  current page is tracked in game.currentpage instead of player.parent.
   -->
 
   <type name="dialoguepage">

--- a/src/Engine/Functions/ExpressionOwner.cs
+++ b/src/Engine/Functions/ExpressionOwner.cs
@@ -500,10 +500,29 @@ internal class ExpressionOwner(WorldModel worldModel)
                 "The 'ShowMenu' function is not supported for games with WorldModel version 540–580. Use the 'show menu' script command instead, or set the game's WorldModel version to 600 or later.");
         }
 
-        await worldModel.PrintAsync(caption);
-        var menuData = new MenuData(caption, options, allowCancel);
-        worldModel.PlayerUi.ShowMenu(menuData);
+        var inline = worldModel.Version >= WorldModelVersion.v600;
+        if (inline && options.Count == 0)
+        {
+            // An inline menu with no options would leave nothing to click or type, and an
+            // uncancellable one swallows everything else - i.e. a wedged game. The 'show menu'
+            // script command has always rejected this; only the inline path is guarded here so
+            // pre-v600 games keep whatever the dialog did with it.
+            throw new Exception("No menu options specified");
+        }
+
+        var menuData = new MenuData(caption, options, allowCancel) {Inline = inline};
         var tcs = WorldModel.BeginPrompt(ref worldModel._menuTcs);
+        if (inline)
+        {
+            await worldModel.ShowInlinePromptAsync(caption, [.. options.Keys], [.. options.Values],
+                allowCancel, result => tcs.TrySetResult(result));
+        }
+        else
+        {
+            await worldModel.PrintAsync(caption);
+        }
+
+        worldModel.PlayerUi.ShowMenu(menuData);
         worldModel.BeginPendingCallback();
         worldModel.SignalTurnSuspended();
         try
@@ -514,6 +533,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         }
         finally
         {
+            await worldModel.EndInlinePromptAsync();
             await worldModel.EndPendingCallbackAsync();
             worldModel.SignalTurnSuspended();
         }
@@ -651,8 +671,14 @@ internal class ExpressionOwner(WorldModel worldModel)
                 "The 'Ask' function is not supported for games with WorldModel version 540–580. Use the 'ask' script command instead, or set the game's WorldModel version to 600 or later.");
         }
 
-        worldModel.PlayerUi.ShowQuestion(caption);
+        var inline = worldModel.Version >= WorldModelVersion.v600;
         var tcs = WorldModel.BeginPrompt(ref worldModel._questionTcs);
+        if (inline)
+        {
+            await worldModel.ShowInlineQuestionAsync(caption, result => tcs.TrySetResult(result));
+        }
+
+        worldModel.PlayerUi.ShowQuestion(caption, inline);
         worldModel.BeginPendingCallback();
         worldModel.SignalTurnSuspended();
         try
@@ -661,6 +687,7 @@ internal class ExpressionOwner(WorldModel worldModel)
         }
         finally
         {
+            await worldModel.EndInlinePromptAsync();
             await worldModel.EndPendingCallbackAsync();
             worldModel.SignalTurnSuspended();
         }

--- a/src/Engine/Scripts/AskScript.cs
+++ b/src/Engine/Scripts/AskScript.cs
@@ -48,8 +48,14 @@ public class AskScript(
     public override async Task ExecuteAsync(Context c)
     {
         var caption = await _caption.ExecuteAsync(c);
-        _worldModel.PlayerUi.ShowQuestion(caption);
-        WorldModel.BeginPrompt(ref _worldModel._questionTcs);
+        var inline = _worldModel.Version >= WorldModelVersion.v600;
+        var tcs = WorldModel.BeginPrompt(ref _worldModel._questionTcs);
+        if (inline)
+        {
+            await _worldModel.ShowInlineQuestionAsync(caption, result => tcs.TrySetResult(result));
+        }
+
+        _worldModel.PlayerUi.ShowQuestion(caption, inline);
         _worldModel.BeginDormantSuspension();
         _worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c);
@@ -71,6 +77,7 @@ public class AskScript(
         finally
         {
             if (!resolved) _worldModel.SignalCallbackResolving();
+            await _worldModel.EndInlinePromptAsync();
             await _worldModel.EndPendingCallbackAsync();
             _worldModel.SignalTurnSuspended();
         }

--- a/src/Engine/Scripts/ShowMenuScript.cs
+++ b/src/Engine/Scripts/ShowMenuScript.cs
@@ -83,11 +83,21 @@ public class ShowMenuScript : ScriptBase
             throw new Exception("Unknown menu options type");
         }
 
-        await _worldModel.PrintAsync(caption);
-        var menuData = new MenuData(caption, optionsDictionary, allowCancel);
+        var inline = _worldModel.Version >= WorldModelVersion.v600;
+        var menuData = new MenuData(caption, optionsDictionary, allowCancel) {Inline = inline};
+        var tcs = WorldModel.BeginPrompt(ref _worldModel._menuTcs);
+        if (inline)
+        {
+            await _worldModel.ShowInlinePromptAsync(caption, [.. optionsDictionary.Keys],
+                [.. optionsDictionary.Values], allowCancel, result => tcs.TrySetResult(result));
+        }
+        else
+        {
+            await _worldModel.PrintAsync(caption);
+        }
+
         _worldModel.PlayerUi.ShowMenu(menuData);
 
-        WorldModel.BeginPrompt(ref _worldModel._menuTcs);
         _worldModel.BeginDormantSuspension();
         _worldModel.SignalTurnSuspended();
         _ = AwaitResponseAndRunCallbackAsync(c, optionsDictionary);
@@ -111,6 +121,7 @@ public class ShowMenuScript : ScriptBase
         finally
         {
             if (!resolved) _worldModel.SignalCallbackResolving();
+            await _worldModel.EndInlinePromptAsync();
             await _worldModel.EndPendingCallbackAsync();
             _worldModel.SignalTurnSuspended();
         }

--- a/src/Engine/WorldModel.cs
+++ b/src/Engine/WorldModel.cs
@@ -70,6 +70,11 @@ public partial class WorldModel : IGame, IGameDebug
     internal TaskCompletionSource? _pauseTcs;
     private TaskCompletionSource _turnSuspendedTcs = new();
 
+    // The menu/question currently rendered inline in the transcript, if any - see
+    // ShowInlinePromptAsync. Only ever set for v600+ games; earlier ones keep going through
+    // PlayerUi.ShowMenu/ShowQuestion's dialog, where the player has no way to type at all.
+    private InlinePrompt? _inlinePrompt;
+
     // Every prompt (wait/menu/ask/get input) reuses a single TCS field, replacing it each time
     // it's shown. If a new prompt is triggered before a previous one resolves (e.g. via 'on ready'
     // reentrancy), the old field gets silently overwritten and whatever was awaiting it - along
@@ -433,7 +438,38 @@ public partial class WorldModel : IGame, IGameDebug
         var commandWasOverridden = false;
         try
         {
-            if (!_commandOverride)
+            if (_inlinePrompt != null)
+            {
+                // The same intercept CoreParser.aslx's HandleCommand does for game.menucallback,
+                // for the C#-side equivalent: a valid option number picks that option, and
+                // anything else either dismisses a cancellable prompt or is swallowed.
+                //
+                // Unlike the ASLX one, a cancelled prompt does not then run the typed command as
+                // an ordinary turn. It can't: resolving the prompt resumes a suspended script
+                // that may run for the rest of the turn (or suspend again on another prompt),
+                // and there is no safe point to start a second command in the middle of that.
+                // The prompt is dismissed and the command discarded - retyping it works.
+                var prompt = _inlinePrompt;
+                var index = int.TryParse(command, out var number) ? number : 0;
+                var chosen = index >= 1 && index <= prompt.Keys.Count ? prompt.Keys[index - 1] : null;
+                if (chosen != null || prompt.AllowCancel)
+                {
+                    commandWasOverridden = true;
+                    // Take the links away before resolving, not after: resolving resumes the
+                    // suspended script synchronously, and anything it goes on to print should
+                    // appear below the menu it replaces, not above it. ClearMenu-before-invoke in
+                    // CoreFunctions.aslx's ShowMenuResponse does the same thing for the same
+                    // reason. This also clears _inlinePrompt, so a second command arriving before
+                    // the resumed script settles is handled as an ordinary command rather than
+                    // being swallowed by a prompt that has already been answered.
+                    await EndInlinePromptAsync();
+                    prompt.Resolve(chosen);
+                }
+
+                // Anything else falls through to the finally with commandWasOverridden still
+                // false: the prompt stays up and the command is ignored, matching the ASLX form.
+            }
+            else if (!_commandOverride)
             {
                 if (Version < WorldModelVersion.v520)
                 {
@@ -1245,6 +1281,90 @@ public partial class WorldModel : IGame, IGameDebug
         // command reaches.
         TurnSuspended?.Invoke();
         _turnSuspendedTcs.TrySetResult();
+    }
+
+    // A menu or yes/no question drawn as numbered links in the transcript rather than as a
+    // player-UI dialog. Keys are the values the awaiting caller expects back, in the same order
+    // as the links the player sees, so a typed "2" resolves to Keys[1].
+    private sealed record InlinePrompt(
+        IReadOnlyList<string> Keys,
+        bool AllowCancel,
+        string? OutputSection,
+        Action<string?> Resolve);
+
+    // Renders a menu inline: the caption, then one numbered {command:N:text} link per option,
+    // wrapped in an output section so the links can be taken away again once a choice is made.
+    // This is deliberately the same shape as CoreFunctions.aslx's ShowMenu and CorePages.aslx's
+    // option list - printing through PrintAsync means it goes via the game's own OutputText, so
+    // the text processor, link colours, templates and transcript all behave exactly as they do
+    // for those, which is the whole point: the synchronous forms should be indistinguishable
+    // from the callback forms they sit alongside (#2287).
+    //
+    // A {command:} link sends its command as if the player had typed it, so clicking an option
+    // and typing its number are the same path - both land in the intercept at the top of
+    // HandleCommandAsyncInternal. That mirrors how CoreParser.aslx intercepts game.menucallback
+    // and game.currentpage, except that this prompt's state lives in C# because what it has to
+    // resolve is a TaskCompletionSource, not an ASLX callback script.
+    internal async Task ShowInlinePromptAsync(string? caption, IReadOnlyList<string> keys,
+        IReadOnlyList<string> optionTexts, bool allowCancel, Action<string?> resolve)
+    {
+        if (caption != null) await PrintAsync(caption);
+
+        var section = await StartOutputSectionAsync();
+        for (var i = 0; i < keys.Count; i++)
+        {
+            // The option text is the {command:} directive's own last segment, so a colon in it
+            // is harmless (everything after the first colon is the text). Braces would be
+            // reprocessed as a nested directive - exactly as they already are for the callback
+            // forms, which print their options through msg() the same way.
+            await PrintAsync($"{i + 1}: {{command:{i + 1}:{optionTexts[i]}}}");
+        }
+
+        await EndOutputSectionAsync(section);
+        _inlinePrompt = new InlinePrompt(keys, allowCancel, section, resolve);
+    }
+
+    // Ask()'s inline form. CoreFunctions.aslx's Ask is literally ShowMenu with Yes/No options, so
+    // this renders the same two numbered links - but it resolves _questionTcs rather than
+    // _menuTcs, so SetQuestionResponse (and a walkthrough's "answer:yes" step) still works.
+    // The template lookups are done here rather than printed as "[Yes]"/"[No]": template
+    // references in ASLX text are substituted at load time by GameLoader, not by the output
+    // pipeline, so text built at runtime has to resolve its own.
+    internal Task ShowInlineQuestionAsync(string caption, Action<bool> resolve)
+    {
+        return ShowInlinePromptAsync(caption, ["yes", "no"],
+            [Template.GetText("Yes", false) ?? "Yes", Template.GetText("No", false) ?? "No"],
+            false, result => resolve(result == "yes"));
+    }
+
+    // Takes the option links away again, whichever way the prompt was resolved - a click, a typed
+    // number, a cancel, SetMenuResponse/SetQuestionResponse from a walkthrough, or the whole
+    // prompt being cancelled by FinishGame. Callers pair this with ShowInlinePromptAsync in a
+    // finally, so there is no path that leaves dead links in the transcript.
+    internal async Task EndInlinePromptAsync()
+    {
+        var prompt = _inlinePrompt;
+        if (prompt == null) return;
+        _inlinePrompt = null;
+        if (prompt.OutputSection != null && State != GameState.Finished &&
+            Elements.ContainsKey(ElementType.Function, "HideOutputSection"))
+        {
+            await RunProcedureAsync("HideOutputSection",
+                new Parameters(new Dictionary<string, object> {{"name", prompt.OutputSection}}), false);
+        }
+    }
+
+    private async Task<string?> StartOutputSectionAsync()
+    {
+        if (!Elements.ContainsKey(ElementType.Function, "StartNewOutputSection")) return null;
+        return await RunProcedureAsync("StartNewOutputSection", null, true) as string;
+    }
+
+    private async Task EndOutputSectionAsync(string? section)
+    {
+        if (section == null || !Elements.ContainsKey(ElementType.Function, "EndOutputSection")) return;
+        await RunProcedureAsync("EndOutputSection",
+            new Parameters(new Dictionary<string, object> {{"name", section}}), false);
     }
 
     internal async Task DoWaitAsync()

--- a/src/Legacy/V4Game.cs
+++ b/src/Legacy/V4Game.cs
@@ -7356,7 +7356,8 @@ public partial class V4Game : IGame, IGameDebug
 
     private async Task<bool> ExecuteIfAskAsync(string question)
     {
-        _player.ShowQuestion(question);
+        // Quest 4 games have no WorldModel version, so never the v600 inline rendering.
+        _player.ShowQuestion(question, false);
         _waitTcs = new TaskCompletionSource();
         SignalTurnSuspended();
         await _waitTcs.Task;

--- a/src/PlayerCore/GameQuery.cs
+++ b/src/PlayerCore/GameQuery.cs
@@ -279,7 +279,7 @@ public class GameQuery(string filename, byte[]? bytes = null)
             throw new NotImplementedException();
         }
 
-        public void ShowQuestion(string caption)
+        public void ShowQuestion(string caption, bool inline)
         {
             throw new NotImplementedException();
         }

--- a/src/PlayerCore/WalkthroughRunner.cs
+++ b/src/PlayerCore/WalkthroughRunner.cs
@@ -140,7 +140,7 @@ public class WalkthroughRunner(IGameDebug game, string walkthrough)
         }
     }
 
-    public void ShowQuestion(string question)
+    public void ShowQuestion(string question, bool inline)
     {
         _showingQuestion = true;
         WriteLine("Question: " + question);

--- a/src/WasmPlayer/WasmPlayerBridge.cs
+++ b/src/WasmPlayer/WasmPlayerBridge.cs
@@ -687,6 +687,10 @@ public partial class WasmPlayerBridge
                 return;
             }
 
+            // v600+ games have already had their options drawn into the transcript by the engine
+            // (WorldModel.ShowInlinePromptAsync), so there is no dialog to open here.
+            if (menuData.Inline) return;
+
             FlushBeforeInteraction();
             JsShowMenu(menuData.Caption,
                 JsonSerializer.Serialize(
@@ -719,13 +723,15 @@ public partial class WasmPlayerBridge
             JsBeginPause(ms);
         }
 
-        void IPlayer.ShowQuestion(string caption)
+        void IPlayer.ShowQuestion(string caption, bool inline)
         {
             if (Runner != null)
             {
-                Runner.ShowQuestion(caption);
+                Runner.ShowQuestion(caption, inline);
                 return;
             }
+
+            if (inline) return;
 
             FlushBeforeInteraction();
             JsShowQuestion(caption);

--- a/src/WebPlayer/Player.cs
+++ b/src/WebPlayer/Player.cs
@@ -87,7 +87,7 @@ public class Player : IPlayerHelperUI
         {
             Runner.ShowMenu(menuData);
         }
-        else
+        else if (!menuData.Inline)
         {
             AddJavaScriptToBuffer("showMenu", menuData.Caption, menuData.Options, menuData.AllowCancel);
         }
@@ -117,13 +117,13 @@ public class Player : IPlayerHelperUI
         }
     }
 
-    void IPlayer.ShowQuestion(string caption)
+    void IPlayer.ShowQuestion(string caption, bool inline)
     {
         if (Runner != null)
         {
-            Runner.ShowQuestion(caption);
+            Runner.ShowQuestion(caption, inline);
         }
-        else
+        else if (!inline)
         {
             AddJavaScriptToBuffer("showQuestion", caption);
         }

--- a/tests/EngineTests/EngineTests.csproj
+++ b/tests/EngineTests/EngineTests.csproj
@@ -49,6 +49,9 @@
         <None Update="versiongatetest.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="inlineprompttest.aslx">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
         <None Update="dialoguepagetest.aslx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>

--- a/tests/EngineTests/InlinePromptTests.cs
+++ b/tests/EngineTests/InlinePromptTests.cs
@@ -1,0 +1,174 @@
+using Moq;
+using QuestViva.Common;
+using QuestViva.Engine;
+using Shouldly;
+
+namespace QuestViva.EngineTests;
+
+// Ask()/ShowMenu() and the 'ask'/'show menu' script commands used to render through
+// IPlayer.ShowQuestion/ShowMenu, which every player implements as a jQuery UI modal. For v600+
+// games the engine now draws them as numbered links in the transcript instead, matching the
+// callback forms in CoreFunctions.aslx that authors can already reach from the script adder
+// (#2287). Older games - including Quest 4 ones, which have no WorldModel version at all - keep
+// the dialog, because "allow cancel" and disambiguation menus behave differently there and a
+// published game's own inlined Core library can't be updated to match.
+[TestClass]
+public class InlinePromptTests
+{
+    [TestMethod]
+    public async Task ShowMenuFunction_V600_RendersOptionsInlineWithNoDialog()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        var output = await driver.SendCommandAsync("menufn");
+
+        output.ShouldContain("Pick one");
+        output.ShouldContain("1: Red");
+        output.ShouldContain("2: Green");
+        output.ShouldContain("3: Blue");
+        output.ShouldNotContain("menu: Red");
+
+        // The player is still told a menu is pending - a headless IPlayer such as the walkthrough
+        // runner needs that - but it is flagged as already drawn.
+        driver.PlayerMock.Verify(p => p.ShowMenu(It.Is<MenuData>(m => m.Inline)), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ShowMenuFunction_V600_TypedOptionNumberChoosesThatOption()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        await driver.SendCommandAsync("menufn");
+
+        var output = await driver.SendCommandAsync("2");
+        output.ShouldContain("menu: Green");
+    }
+
+    [TestMethod]
+    public async Task ShowMenuFunction_V600_SetMenuResponseStillResolves()
+    {
+        // Clicking an option sends its number as an ordinary command, but SetMenuResponse remains
+        // the programmatic path - it is what the walkthrough runner's "menu:" step calls.
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        await driver.SendCommandAsync("menufn");
+
+        var output = await driver.SetMenuResponseAsync("Blue");
+        output.ShouldContain("menu: Blue");
+    }
+
+    [TestMethod]
+    public async Task ShowMenuFunction_V600_NotCancellable_IgnoresOtherInput()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        await driver.SendCommandAsync("menufn");
+
+        var ignored = await driver.SendCommandAsync("ping");
+        ignored.ShouldBeEmpty();
+
+        // Out-of-range numbers are not options either.
+        var alsoIgnored = await driver.SendCommandAsync("9");
+        alsoIgnored.ShouldBeEmpty();
+
+        // The menu is still waiting.
+        var output = await driver.SendCommandAsync("1");
+        output.ShouldContain("menu: Red");
+    }
+
+    [TestMethod]
+    public async Task ShowMenuFunction_V600_Cancellable_OtherInputCancelsAndReturnsEmpty()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        await driver.SendCommandAsync("menufncancel");
+
+        var output = await driver.SendCommandAsync("ping");
+        // ShowMenu returned "" - the script's "menu: " line, trimmed by the test driver.
+        output.ShouldContain("menu:");
+        // The cancelling command itself is discarded rather than run as an ordinary turn.
+        output.ShouldNotContain("pong");
+
+        // ...and having been cancelled, the prompt no longer intercepts anything.
+        var afterwards = await driver.SendCommandAsync("ping");
+        afterwards.ShouldContain("pong");
+    }
+
+    [TestMethod]
+    public async Task AskFunction_V600_RendersYesNoInlineAndResolvesFromTypedNumber()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        var output = await driver.SendCommandAsync("askfn");
+
+        output.ShouldContain("Some question?");
+        output.ShouldContain("1: Yes");
+        output.ShouldContain("2: No");
+
+        var answered = await driver.SendCommandAsync("2");
+        answered.ShouldContain("ask: no");
+    }
+
+    [TestMethod]
+    public async Task AskFunction_V600_SetQuestionResponseStillResolves()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        await driver.SendCommandAsync("askfn");
+
+        var output = await driver.SetQuestionResponseAsync(true);
+        output.ShouldContain("ask: yes");
+    }
+
+    [TestMethod]
+    public async Task ShowMenuScriptCommand_V600_RendersOptionsInline()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        var output = await driver.SendCommandAsync("menucmd");
+
+        output.ShouldContain("1: Red");
+        driver.PlayerMock.Verify(p => p.ShowMenu(It.Is<MenuData>(m => m.Inline)), Times.Once);
+
+        var chosen = await driver.SendCommandAsync("3");
+        chosen.ShouldContain("menu: Blue");
+    }
+
+    [TestMethod]
+    public async Task AskScriptCommand_V600_RendersYesNoInline()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        var output = await driver.SendCommandAsync("askcmd");
+
+        output.ShouldContain("1: Yes");
+        driver.PlayerMock.Verify(p => p.ShowQuestion(It.IsAny<string>(), true), Times.Once);
+
+        var answered = await driver.SendCommandAsync("1");
+        answered.ShouldContain("ask: True");
+    }
+
+    // The expression forms throw for v540-v580 and pre-v540 output does not route through
+    // addText, so the script commands - available at every version - are what these two check
+    // the unchanged pre-v600 path with.
+    [TestMethod]
+    public async Task ShowMenuScriptCommand_BelowV600_StillUsesTheDialog()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        driver.Model.Version = WorldModelVersion.v550;
+
+        var output = await driver.SendCommandAsync("menucmd");
+        output.ShouldContain("Pick one");
+        output.ShouldNotContain("1: Red");
+        driver.PlayerMock.Verify(p => p.ShowMenu(It.Is<MenuData>(m => !m.Inline)), Times.Once);
+
+        // Typed input is not intercepted - there is nothing inline to intercept for.
+        var ignored = await driver.SendCommandAsync("1");
+        ignored.ShouldNotContain("menu: Red");
+
+        var output2 = await driver.SetMenuResponseAsync("Red");
+        output2.ShouldContain("menu: Red");
+    }
+
+    [TestMethod]
+    public async Task AskScriptCommand_BelowV600_StillUsesTheDialog()
+    {
+        var driver = await GameDriver.LoadAsync("inlineprompttest.aslx");
+        driver.Model.Version = WorldModelVersion.v550;
+
+        var output = await driver.SendCommandAsync("askcmd");
+        output.ShouldNotContain("1: Yes");
+        driver.PlayerMock.Verify(p => p.ShowQuestion(It.IsAny<string>(), false), Times.Once);
+    }
+}

--- a/tests/EngineTests/inlineprompttest.aslx
+++ b/tests/EngineTests/inlineprompttest.aslx
@@ -1,0 +1,67 @@
+<asl version="600">
+  <include ref="English.aslx" />
+  <include ref="Core.aslx" />
+  <game name="inlineprompttest"/>
+  <object name="start">
+    <object name="player">
+      <inherit name="defaultplayer" />
+    </object>
+  </object>
+
+  <!-- ExpressionOwner.ShowMenu(), not cancellable -->
+  <command name="cmd_menufn">
+    <pattern>menufn</pattern>
+    <script>
+      msg ("menu: " + ShowMenu("Pick one", Split("Red;Green;Blue", ";"), false))
+    </script>
+  </command>
+
+  <!-- ExpressionOwner.ShowMenu(), cancellable -->
+  <command name="cmd_menufncancel">
+    <pattern>menufncancel</pattern>
+    <script>
+      msg ("menu: " + ShowMenu("Pick one", Split("Red;Green;Blue", ";"), true))
+    </script>
+  </command>
+
+  <!-- ExpressionOwner.Ask() -->
+  <command name="cmd_askfn">
+    <pattern>askfn</pattern>
+    <script>
+      if (Ask("Some question?")) {
+        msg ("ask: yes")
+      }
+      else {
+        msg ("ask: no")
+      }
+    </script>
+  </command>
+
+  <!-- 'show menu' script command -->
+  <command name="cmd_menucmd">
+    <pattern>menucmd</pattern>
+    <script>
+      show menu ("Pick one", Split("Red;Green;Blue", ";"), false) {
+        msg ("menu: " + result)
+      }
+    </script>
+  </command>
+
+  <!-- 'ask' script command -->
+  <command name="cmd_askcmd">
+    <pattern>askcmd</pattern>
+    <script>
+      ask ("Some question?") {
+        msg ("ask: " + result)
+      }
+    </script>
+  </command>
+
+  <!-- An ordinary command, to check what a non-option response does while a prompt is open -->
+  <command name="cmd_ping">
+    <pattern>ping</pattern>
+    <script>
+      msg ("pong")
+    </script>
+  </command>
+</asl>

--- a/tests/LegacyTests/TestPlayer.cs
+++ b/tests/LegacyTests/TestPlayer.cs
@@ -38,7 +38,7 @@ internal class TestPlayer : IPlayer
         IsWaiting = true;
     }
 
-    public void ShowQuestion(string caption)
+    public void ShowQuestion(string caption, bool inline)
     {
         QuestionData = caption;
     }

--- a/tests/e2e/verify-wasmplayer-inline-sync-prompts.mjs
+++ b/tests/e2e/verify-wasmplayer-inline-sync-prompts.mjs
@@ -1,0 +1,158 @@
+// Ad-hoc manual verification: Ask()/ShowMenu() and the 'ask'/'show menu' script
+// commands used to open a jQuery UI modal for every game. For v600+ games the
+// engine now draws them as numbered links in the transcript instead, so the
+// synchronous forms look the same as the callback forms in CoreFunctions.aslx
+// (https://github.com/alexwarren/quest/issues/2287). Clicking a link and typing
+// its number are the same path - the link sends its number as a command.
+// Games below v600 (and Quest 4 games, which have no WorldModel version at all)
+// keep the dialog, which examples/test.aslx - version 530 - still covers.
+// Requires the WasmPlayer dev server running locally:
+//   node src/WasmPlayer/dev-server.mjs
+import { chromium } from 'playwright';
+
+const baseUrl = process.argv[2] || 'http://localhost:5175';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const pageErrors = [];
+page.on('pageerror', err => { pageErrors.push(err.message); console.log('[pageerror]', err.message); });
+
+const output = () => page.$eval('#divOutput', el => el.textContent);
+
+// Note there is no "> command" echo to wait on for a menu response: the prompt
+// intercepts the command before HandleCommand echoes it, exactly as CoreParser.aslx
+// does for the callback forms. So this just sends, and the assertions below do the
+// waiting - generously, since the engine is on the one WASM thread and the first
+// turn after boot is much slower than the rest.
+async function send(command) {
+    // runCommand() silently drops the keystroke if a turn is still in flight
+    // (canSendCommand), so wait for the engine to come back before typing.
+    await page.waitForFunction(() => window.canSendCommand === true, null, { timeout: 15000 });
+    await page.fill('#txtCommand', command);
+    await page.press('#txtCommand', 'Enter');
+    await page.waitForTimeout(300);
+}
+
+async function waitForText(label, text) {
+    try {
+        await page.waitForFunction(
+            expected => document.getElementById('divOutput').textContent.includes(expected),
+            text, { timeout: 15000 });
+    } catch {
+        throw new Error(`${label}: timed out waiting for "${text}", got tail: ${(await output()).slice(-200)}`);
+    }
+}
+
+// The menu links are ordinary transcript links, so "no dialog" means jQuery UI
+// never created its wrapper around #dialog/#msgbox.
+async function assertNoDialog(label) {
+    const visible = await page.evaluate(() => {
+        const dialogs = [...document.querySelectorAll('.ui-dialog')];
+        return dialogs.filter(d => d.offsetParent !== null).length;
+    });
+    if (visible !== 0) throw new Error(`${label}: expected no jQuery UI dialog, found ${visible}`);
+}
+
+// The command echo lands before the rest of the turn's output, so every positive
+// assertion waits rather than reading straight away.
+const assertContains = waitForText;
+
+async function assertNotContains(label, text) {
+    // Only meaningful once the turn has actually had a chance to produce output.
+    await page.waitForTimeout(500);
+    const actual = await output();
+    if (actual.includes(text)) {
+        throw new Error(`${label}: expected output NOT to contain "${text}", got tail: ${actual.slice(-200)}`);
+    }
+}
+
+async function run() {
+    await page.goto(`${baseUrl}/?url=/examples/sync-and-async/v600.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000 });
+    console.log('PASS: v600 game booted');
+
+    // ── ShowMenu() expression form ───────────────────────────────────────────
+    await send('menufn');
+    await assertNoDialog('ShowMenu()');
+    await assertContains('ShowMenu()', 'What is your favourite colour?');
+    for (const [n, colour] of [[1, 'Red'], [2, 'Green'], [3, 'Blue'], [4, 'Yellow']]) {
+        await assertContains('ShowMenu()', `${n}: ${colour}`);
+    }
+    console.log('PASS: ShowMenu() rendered four numbered options inline, no dialog');
+
+    // Each option is a link that sends its own number as a command.
+    const linkCount = await page.locator('#divOutput a.commandlink').count();
+    if (linkCount !== 4) throw new Error(`Expected 4 option links, found ${linkCount}`);
+    await page.locator('#divOutput a.commandlink').nth(2).click();
+    await assertContains('ShowMenu() click', 'You chose Blue');
+    console.log('PASS: clicking an option link resolved ShowMenu()');
+
+    // The links are taken away once the choice is made (HideOutputSection fades the
+    // section out before removing it).
+    await page.waitForTimeout(800);
+    const remaining = await page.locator('#divOutput a.commandlink:visible').count();
+    if (remaining !== 0) throw new Error(`Expected the option links to be removed, ${remaining} still visible`);
+    console.log('PASS: option links removed after choosing');
+
+    // ── Typing the option number ─────────────────────────────────────────────
+    await send('menufn');
+    await send('2');
+    await assertContains('ShowMenu() typed', 'You chose Green');
+    console.log('PASS: typing an option number resolved ShowMenu()');
+
+    // ── Not cancellable: other input is ignored ──────────────────────────────
+    await send('menufn');
+    await send('xyzzy');
+    await assertNotContains('ShowMenu() uncancellable', "I don't understand your command");
+    await send('1');
+    await assertContains('ShowMenu() uncancellable', 'You chose Red');
+    console.log('PASS: a non-option command was ignored while an uncancellable menu was open');
+
+    // ── Cancellable: other input dismisses the menu ──────────────────────────
+    await send('menufncancel');
+    await send('xyzzy');
+    await assertContains('ShowMenu() cancellable', "You didn't choose.");
+    console.log('PASS: a non-option command cancelled a cancellable menu');
+
+    // ── Ask() expression form ────────────────────────────────────────────────
+    await send('askfn');
+    await assertNoDialog('Ask()');
+    await assertContains('Ask()', 'Buy dodgy watch?');
+    await assertContains('Ask()', '1: Yes');
+    await assertContains('Ask()', '2: No');
+    await send('1');
+    await assertContains('Ask()', 'You hand over $50.');
+    console.log('PASS: Ask() rendered Yes/No inline and resolved from a typed number');
+
+    // ── 'show menu' script command ───────────────────────────────────────────
+    await send('menucmd');
+    await assertNoDialog('show menu');
+    await assertContains('show menu', '1: Red');
+    await send('4');
+    await assertContains('show menu', 'You chose Yellow');
+    console.log("PASS: the 'show menu' script command rendered inline too");
+
+    // ── A pre-v600 game still gets the dialog ────────────────────────────────
+    await page.goto(`${baseUrl}/?url=/examples/test.aslx`);
+    await page.waitForSelector('#txtCommand', { timeout: 30000 });
+    await send('menufn');
+    await page.waitForSelector('#dialogOptions option', { timeout: 10000 });
+    const dialogVisible = await page.evaluate(
+        () => [...document.querySelectorAll('.ui-dialog')].filter(d => d.offsetParent !== null).length);
+    if (dialogVisible !== 1) {
+        throw new Error(`v530 game: expected the ShowMenu dialog, found ${dialogVisible} visible dialogs`);
+    }
+    console.log('PASS: a v530 game still opens the ShowMenu dialog');
+
+    if (pageErrors.length > 0) throw new Error(`Page errors: ${pageErrors.join('; ')}`);
+    console.log('PASS: all checks passed');
+}
+
+try {
+    await run();
+} catch (err) {
+    console.error('FAIL:', err.message);
+    process.exitCode = 1;
+} finally {
+    await browser.close();
+}


### PR DESCRIPTION
Closes #2287.

## What changed

For **v600+ games only**, `Ask()` / `ShowMenu()` and the `ask` / `show menu` script commands now render as numbered links in the transcript instead of opening the jQuery UI modal. Everything below v600 takes exactly the code path it did before.

|  | Before | After (v600+) |
|---|---|---|
| `Ask (question)` | jQuery modal, Yes/No buttons | `1: Yes` / `2: No` links inline |
| `ShowMenu (caption, options, cancel)` | jQuery modal, `<select size=4>` + "Select" | numbered links inline |
| `ask` / `show menu` script commands | jQuery modal | numbered links inline |

## Why the gate is narrow

The same two JS functions are reached by four different callers, and the JS can't tell them apart:

- `ExpressionOwner.ShowMenu`/`.Ask` (v500–v530 and v600+)
- the `show menu`/`ask` script commands (every version)
- **Quest 4 disambiguation** — `new MenuData(...)` at `V4Game.cs:4825`, which has no WorldModel version at all
- Quest 4 `ask`

`allowCancel` doesn't mean the same thing in the two presentations, and a published `.quest` file carries its own frozen copy of the Core library, so old games can't be brought into line. Gating at v600 in the engine leaves all of that untouched by construction.

## How it works

Rendering goes through `PrintAsync` → the game's own `OutputText`, emitting `{command:N:text}` links inside an output section — so link colours, the text processor, templates, the transcript and `HideOutputSection` all behave exactly as they do for `CoreFunctions.aslx`'s `ShowMenu` and `CorePages.aslx`'s option lists. The markup produced is the same `<a class="cmdlink commandlink">` the callback forms produce.

Because a `{command:}` link sends its number as a command, **clicking an option and typing its number are one path** — intercepted at the top of `HandleCommandAsyncInternal`, next to the existing `_commandOverride` branch. That's the C# analogue of `CoreParser.aslx`'s `game.menucallback` intercept, living in C# because what it resolves is a `TaskCompletionSource`, not an ASLX callback script.

`PlayerUi.ShowMenu`/`ShowQuestion` are **still called**, now carrying an `Inline` flag that the two real players skip the dialog on. The walkthrough runner therefore keeps its notification, and `SetMenuResponse`/`SetQuestionResponse` still resolve a prompt — the existing `V600UndeprecationTests` pass unmodified, which is the proof.

## Notes for the reviewer

- **`allowCancel` has one deliberate deviation**, commented at the call site: a non-option command dismisses a cancellable prompt and `ShowMenu` returns `""`, but that command is then **discarded** rather than also run as an ordinary turn (which is what `CoreParser.aslx` does for the callback form). Resolving the prompt resumes a suspended script that may run for the rest of the turn or suspend again on another prompt, and there is no safe point to start a second command inside that. Retyping works.
- **Save is unavailable while a prompt is up.** The synchronous forms suspend mid-turn, so `SignalTurnSuspended` reports turn-pending and the Save button is disabled — the same trade-off `GetInput()` already makes behind an equally ordinary-looking command prompt.
- **Two remaining cosmetic differences** between the expression and callback forms, both pre-existing behaviour I chose not to change: the callback form removes the caption along with the options (it starts its output section before `msg(caption)`) whereas the expression form keeps it, and the expression form prints `- Green` after a choice. Easy to change either way if you'd prefer them identical.
- **`IPlayer.ShowQuestion` gained a `bool inline` parameter**, so all five implementations are touched.
- **Empty-options guard**: an inline menu with no options would leave nothing to click or type and, if uncancellable, swallow everything else — a wedged game. `ShowMenu` now throws "No menu options specified" on that path, as the `show menu` script command always has. Scoped to the inline path so pre-v600 behaviour is untouched.

## Two follow-up doc commits (please read — they correct existing claims)

Writing the docs for the above turned up a saveability claim in the tree that measurement doesn't support, so the last two commits fix it. Measured in a running WasmPlayer:

| Form | `_turnPending` | Save button |
|---|---|---|
| `ShowMenu (...) { }` / `Ask (...) { }` (ASLX callback form) | `false` | **enabled** |
| `ShowMenu(...)` / `Ask(...)` expression | `true` | disabled |
| `show menu` / `ask` script commands | `true` | disabled |
| Pages dialogue | `false` | **enabled** |

`CorePages.aslx` and four docs pages said a `ShowMenu`-based dialogue "leaves the game in an intercepted state that the players' turn-pending logic disables save around". It doesn't — the ASLX callback form prints its links and returns without calling `BeginPendingCallback`. And a save taken mid-menu genuinely restores: `game.menucallback` serialises as a script attribute via `FieldSaver.ScriptSaver`, `menuoptionskeys`/`menuoutputsection` come with it, and the restored menu can be answered by clicking a link or typing its number (both verified).

Undo is intercepted in *both*, not just in `ShowMenu`: an uncancellable menu swallows it, a Page dialogue answers `[PageDialogueChooseOption]`.

So Pages' advantages are restated as the structural ones that do hold: each choice is an ordinary turn with its own undo transaction (`CorePages.aslx`'s `HandlePageTextResponse` starts one, `CoreFunctions.aslx`'s `ShowMenuResponse` does not), the conversation is linked page objects rather than a callback nested per level, and its state is plain game attributes so a restore doesn't depend on the saved transcript's own `ASLEvent` markup.

## Verification

- 435 unit tests pass, including 11 new ones in `InlinePromptTests.cs`: both forms, both script commands, typed numbers, click-equivalence, ignore-vs-cancel, and that v550 still gets the dialog.
- New `tests/e2e/verify-wasmplayer-inline-sync-prompts.mjs` passes against a real WasmPlayer, including an assertion that a v530 game still opens the dialog. Wired into `e2e.yml`; `check_e2e_manifest` passes.
- The two existing `verify-wasmplayer-showmenu-*.mjs` scripts still pass **unmodified** — they run against `examples/test.aslx`, which is `version="530"`, so they've become the legacy-dialog regression cover for free.
- `verify-wasmplayer-dialogue-pages.mjs` still passes; `site` builds clean.
- **Not runtime-verified: WebPlayer.** Only WasmPlayer was driven. WebPlayer's change is a single `else if (!menuData.Inline)` guard around the buffered JS call; the inline output reaches it through the ordinary output buffer.

Docs updated for the four pages the issue listed, plus a new `examples/sync-and-async/v600.aslx` showing both styles side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)