### PR TITLE
test: drop the now-unreachable no-docs case in script-docs-links e2e

### DIFF
--- a/tests/e2e/verify-appshell-script-docs-links.mjs
+++ b/tests/e2e/verify-appshell-script-docs-links.mjs
@@ -79,17 +79,15 @@ async function run() {
         throw new Error('the Add Script modal closed - Enter on the link added the command instead of following it');
     }
 
-
-    // A command with no reference entry must show no link at all. "=" (set a
-    // variable) is syntax, deliberately absent from the generated index.
-    await page.fill('input[placeholder="Filter commands..."]', 'Set a variable or attribute');
-    const setRow = page.locator('[role="option"]:has-text("Set a variable or attribute")').first();
-    if (await setRow.count() !== 1) {
-        throw new Error('could not find the "Set a variable or attribute" command to check the no-docs case');
-    }
-    await setRow.click();
-    check('no "Learn more" link for a command with no docs entry (=)',
-        await page.locator('a:has-text("Learn more")').count(), 0);
+    // docsUrlForScriptKeyword()'s "no reference entry" branch (returns null,
+    // so AddScriptModal renders no "Learn more" link at all) has no live
+    // command left to exercise it against: build-docs-index.mjs's own
+    // completeness audit (`node site/scripts/build-docs-index.mjs`, the
+    // unmatched/undocumented report) currently reports every one of the 130
+    // indexed keywords as documented - "=" and "//" used to be the gap this
+    // checked, until docs PR #2283 filled them in via manualTargets. Picking
+    // another keyword here would just be one PR away from the same false
+    // failure. If a real gap reappears, re-add a case here naming it.
 
     await page.locator('button:has-text("Cancel")').click();
 


### PR DESCRIPTION
## What

Last night's scheduled e2e run failed in `verify-appshell-script-docs-links.mjs`, on the assertion that the `=` (Set a variable) command shows no "Learn more" link in the Add Script modal.

## Why it failed (not a regression)

[#2283](https://github.com/textadventures/quest/pull/2283) ("docs: add help links for six commands, flesh out thin reference entries") added a "Setting variables" section to the scripts docs page, which the generator picked up into `docs-index.generated.ts` as a `manualTargets` entry for `=`. The Add Script modal now correctly shows a "Learn more" link for `=` — the feature is working as intended, the test's premise was just stale.

I checked whether another keyword could stand in for the "no docs" case: running `node site/scripts/build-docs-index.mjs` now reports **0 unmatched / 0 undocumented** keywords out of all 130 real, addable script commands. The docs work has closed every gap, including the other punctuation keywords (`//`, `=>`, `()`) via `manualTargets`. Swapping in another keyword would just set up the same flake for whenever docs coverage catches up to it next.

## Fix

Removed the "no docs" assertion from the e2e script and left a comment explaining why (there's currently no live command that exercises `docsUrlForScriptKeyword()`'s null branch through the UI), so a future contributor doesn't have to re-derive this. All other assertions in the script are untouched and still pass — re-ran the full script against a local dev server (8/8 pass).

Test-only change, titled `test:` per the repo's conventional-commits changelog convention (no user-visible behavior changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)