### PR TITLE
fix: stop homepage title tag rendering as duplicate "Quest Viva | Quest Viva"

### DIFF
--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -3,6 +3,9 @@ title: Quest Viva
 description: Create text adventure games and interactive fiction - free, open source, and no programming required
 template: splash
 editUrl: false
+head:
+  - tag: title
+    content: Quest Viva - Create text adventure games and interactive fiction
 hero:
   tagline: Create your own text adventure games and interactive fiction. Free, open source, and no programming required.
   image:


### PR DESCRIPTION
## Summary
- The questviva.com homepage's `<title>` tag rendered as "Quest Viva | Quest Viva" — Starlight always appends the site title to the page title with no dedup check, and the homepage's frontmatter `title` happened to match the site title.
- Overrides just the `<title>` tag via `head` frontmatter so it now reads "Quest Viva - Create text adventure games and interactive fiction", while the hero heading and `og:title` stay as plain "Quest Viva".

## Test plan
- [x] Ran the docs site dev server and confirmed `document.title`, the hero `<h1>`, and `og:title` all render correctly